### PR TITLE
feat(auth-service): admin user-creation API and role/admin seed bootstrap

### DIFF
--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -3,22 +3,10 @@ PORT=3002
 LOG_LEVEL=debug
 DATABASE_URL=postgresql://armman:armman@localhost:5432/arogya?schema=auth-service
 CORS_ORIGINS=http://localhost:5173
-
-# RS256 keypair for signing access/refresh tokens (PKCS8 private / SPKI public,
-# PEM, newlines escaped as \n). Local keypair for now; swap for AWS KMS in
-# staging/production behind the TokenSigner interface — no other code changes.
-# Generate a local dev pair with:
-#   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out private.pem
-#   openssl pkey -in private.pem -pubout -out public.pem
 JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_ME\n-----END PRIVATE KEY-----"
 JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nREPLACE_ME\n-----END PUBLIC KEY-----"
 JWT_ACCESS_TOKEN_TTL=15m
 JWT_REFRESH_TOKEN_TTL=30d
-
 REDIS_URL=redis://localhost:6379
-
-# Initial ADMIN user bootstrapped by `prisma db seed`. If either is unset the
-# admin seed is skipped. Set real values per environment (in production, source
-# these from a secret store, never commit them). Mobile must be +91 + 10 digits.
 ADMIN_MOBILE_NUMBER=+910000000000
 ADMIN_PASSWORD=ChangeMe@123

--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -1,12 +1,14 @@
+# auth-service environment — copy to .env and fill in real values per environment.
 NODE_ENV=development
 PORT=3002
 LOG_LEVEL=debug
-DATABASE_URL=postgresql://armman:armman@localhost:5432/arogya?schema=auth-service
 CORS_ORIGINS=http://localhost:5173
+DATABASE_URL=postgresql://armman:armman@localhost:5432/arogya?schema=auth-service
+DIRECT_URL=postgresql://armman:armman@localhost:5432/arogya?schema=auth-service
+REDIS_URL=redis://localhost:6379
 JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_ME\n-----END PRIVATE KEY-----"
 JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nREPLACE_ME\n-----END PUBLIC KEY-----"
 JWT_ACCESS_TOKEN_TTL=15m
 JWT_REFRESH_TOKEN_TTL=30d
-REDIS_URL=redis://localhost:6379
 ADMIN_MOBILE_NUMBER=+910000000000
 ADMIN_PASSWORD=ChangeMe@123

--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -16,3 +16,9 @@ JWT_ACCESS_TOKEN_TTL=15m
 JWT_REFRESH_TOKEN_TTL=30d
 
 REDIS_URL=redis://localhost:6379
+
+# Initial ADMIN user bootstrapped by `prisma db seed`. If either is unset the
+# admin seed is skipped. Set real values per environment (in production, source
+# these from a secret store, never commit them). Mobile must be +91 + 10 digits.
+ADMIN_MOBILE_NUMBER=+910000000000
+ADMIN_PASSWORD=ChangeMe@123

--- a/apps/auth-service/prisma/seed.ts
+++ b/apps/auth-service/prisma/seed.ts
@@ -3,6 +3,12 @@ import { PrismaClient } from '../../../node_modules/.prisma/client-auth-service'
 
 const prisma = new PrismaClient();
 
+interface SeedResult {
+  step: string;
+  created: boolean;
+  message: string;
+}
+
 /**
  * Role master data (docs/Arogya_Sakhi_Database_Design_ERD_Table_Definitions.docx.md,
  * Appendix A.1 "roles", line 337). This is real reference data required in
@@ -42,35 +48,41 @@ const ROLES: { roleCode: string; roleName: string; description: string }[] = [
   },
 ];
 
-async function seedRoles(): Promise<void> {
+async function seedRoles(): Promise<SeedResult> {
   // Only seed when the roles table is empty (e.g. first boot on a fresh DB).
   // Once roles exist, leave them untouched so runtime edits are never reverted.
   const existingCount = await prisma.role.count();
   if (existingCount > 0) {
-    console.log(`Roles already present (${existingCount}) — skipping role seed.`);
-    return;
+    return {
+      step: 'roles',
+      created: false,
+      message: `Roles already present (${existingCount}) — skipped.`,
+    };
   }
 
   await prisma.role.createMany({ data: ROLES });
-  console.log(`Seeded ${ROLES.length} roles.`);
+  return { step: 'roles', created: true, message: `Seeded ${ROLES.length} roles.` };
 }
 
 /**
  * Bootstraps the initial ADMIN user from environment variables so no admin
  * credential is ever hardcoded in the repo. Runs in every environment
  * (including production) when both ADMIN_MOBILE_NUMBER and ADMIN_PASSWORD are
- * set; if either is missing it logs a notice and skips, so a fresh env is
+ * set; if either is missing it returns a skipped result, so a fresh env is
  * never blocked from seeding. Only creates the admin when no user with that
  * mobile number exists yet — an existing user is left untouched (never
  * re-created and never has its password rotated by the seed).
  */
-async function seedAdminUser(): Promise<void> {
+async function seedAdminUser(): Promise<SeedResult> {
   const mobileNumber = process.env.ADMIN_MOBILE_NUMBER;
   const password = process.env.ADMIN_PASSWORD;
 
   if (!mobileNumber || !password) {
-    console.log('ADMIN_MOBILE_NUMBER / ADMIN_PASSWORD not set — skipping admin bootstrap.');
-    return;
+    return {
+      step: 'admin',
+      created: false,
+      message: 'ADMIN_MOBILE_NUMBER / ADMIN_PASSWORD not set — skipped.',
+    };
   }
 
   if (!/^\+91\d{10}$/.test(mobileNumber)) {
@@ -80,8 +92,11 @@ async function seedAdminUser(): Promise<void> {
   // Seed only when this admin does not already exist.
   const existing = await prisma.user.findUnique({ where: { mobileNumber } });
   if (existing) {
-    console.log(`Admin user ${mobileNumber} already exists — skipping admin bootstrap.`);
-    return;
+    return {
+      step: 'admin',
+      created: false,
+      message: `Admin user ${mobileNumber} already exists — skipped.`,
+    };
   }
 
   const passwordHash = await argon2.hash(password);
@@ -102,17 +117,16 @@ async function seedAdminUser(): Promise<void> {
     });
   });
 
-  console.log(`Seeded ADMIN user ${mobileNumber}.`);
+  return { step: 'admin', created: true, message: `Seeded ADMIN user ${mobileNumber}.` };
 }
 
 /**
  * A single local-login test user, gated to non-production environments only.
  * Never runs against production — this is test data, not master data.
  */
-async function seedTestUser(): Promise<void> {
+async function seedTestUser(): Promise<SeedResult> {
   if (process.env.NODE_ENV === 'production') {
-    console.log('NODE_ENV=production — skipping test user seed.');
-    return;
+    return { step: 'testUser', created: false, message: 'NODE_ENV=production — skipped.' };
   }
 
   const mobileNumber = '+919000000001';
@@ -120,8 +134,11 @@ async function seedTestUser(): Promise<void> {
   // Seed only when this test user does not already exist.
   const existing = await prisma.user.findUnique({ where: { mobileNumber } });
   if (existing) {
-    console.log(`Test user ${mobileNumber} already exists — skipping test user seed.`);
-    return;
+    return {
+      step: 'testUser',
+      created: false,
+      message: `Test user ${mobileNumber} already exists — skipped.`,
+    };
   }
 
   const passwordHash = await argon2.hash('Test@1234');
@@ -141,13 +158,23 @@ async function seedTestUser(): Promise<void> {
     });
   });
 
-  console.log(`Seeded test user ${mobileNumber} (password: Test@1234) with SAKHI role.`);
+  return {
+    step: 'testUser',
+    created: true,
+    message: `Seeded test user ${mobileNumber} (password: Test@1234) with SAKHI role.`,
+  };
 }
 
 async function main(): Promise<void> {
-  await seedRoles();
-  await seedAdminUser();
-  await seedTestUser();
+  const results = [await seedRoles(), await seedAdminUser(), await seedTestUser()];
+
+  console.log('\nSeed summary:');
+  for (const r of results) {
+    console.log(`  [${r.created ? 'created' : 'skipped'}] ${r.step}: ${r.message}`);
+  }
+
+  const createdCount = results.filter((r) => r.created).length;
+  console.log(`\n${createdCount}/${results.length} step(s) created new data.`);
 }
 
 main()

--- a/apps/auth-service/prisma/seed.ts
+++ b/apps/auth-service/prisma/seed.ts
@@ -43,14 +43,66 @@ const ROLES: { roleCode: string; roleName: string; description: string }[] = [
 ];
 
 async function seedRoles(): Promise<void> {
-  for (const role of ROLES) {
-    await prisma.role.upsert({
-      where: { roleCode: role.roleCode },
-      update: { roleName: role.roleName, description: role.description },
-      create: role,
-    });
+  // Only seed when the roles table is empty (e.g. first boot on a fresh DB).
+  // Once roles exist, leave them untouched so runtime edits are never reverted.
+  const existingCount = await prisma.role.count();
+  if (existingCount > 0) {
+    console.log(`Roles already present (${existingCount}) — skipping role seed.`);
+    return;
   }
+
+  await prisma.role.createMany({ data: ROLES });
   console.log(`Seeded ${ROLES.length} roles.`);
+}
+
+/**
+ * Bootstraps the initial ADMIN user from environment variables so no admin
+ * credential is ever hardcoded in the repo. Runs in every environment
+ * (including production) when both ADMIN_MOBILE_NUMBER and ADMIN_PASSWORD are
+ * set; if either is missing it logs a notice and skips, so a fresh env is
+ * never blocked from seeding. Only creates the admin when no user with that
+ * mobile number exists yet — an existing user is left untouched (never
+ * re-created and never has its password rotated by the seed).
+ */
+async function seedAdminUser(): Promise<void> {
+  const mobileNumber = process.env.ADMIN_MOBILE_NUMBER;
+  const password = process.env.ADMIN_PASSWORD;
+
+  if (!mobileNumber || !password) {
+    console.log('ADMIN_MOBILE_NUMBER / ADMIN_PASSWORD not set — skipping admin bootstrap.');
+    return;
+  }
+
+  if (!/^\+91\d{10}$/.test(mobileNumber)) {
+    throw new Error('ADMIN_MOBILE_NUMBER must be in the format +91XXXXXXXXXX.');
+  }
+
+  // Seed only when this admin does not already exist.
+  const existing = await prisma.user.findUnique({ where: { mobileNumber } });
+  if (existing) {
+    console.log(`Admin user ${mobileNumber} already exists — skipping admin bootstrap.`);
+    return;
+  }
+
+  const passwordHash = await argon2.hash(password);
+  const adminRole = await prisma.role.findUniqueOrThrow({ where: { roleCode: 'ADMIN' } });
+
+  // Create the user and their ADMIN role assignment atomically.
+  await prisma.$transaction(async (tx) => {
+    const user = await tx.user.create({
+      data: {
+        mobileNumber,
+        passwordHash,
+        displayName: 'System Administrator',
+        status: 'ACTIVE',
+      },
+    });
+    await tx.userRole.create({
+      data: { userId: user.id, roleId: adminRole.id, effectiveFrom: new Date(), status: 'ACTIVE' },
+    });
+  });
+
+  console.log(`Seeded ADMIN user ${mobileNumber}.`);
 }
 
 /**
@@ -63,38 +115,38 @@ async function seedTestUser(): Promise<void> {
     return;
   }
 
-  const mobileNumber = '+919999999999';
+  const mobileNumber = '+919000000001';
+
+  // Seed only when this test user does not already exist.
+  const existing = await prisma.user.findUnique({ where: { mobileNumber } });
+  if (existing) {
+    console.log(`Test user ${mobileNumber} already exists — skipping test user seed.`);
+    return;
+  }
+
   const passwordHash = await argon2.hash('Test@1234');
-
-  const user = await prisma.user.upsert({
-    where: { mobileNumber },
-    update: {},
-    create: {
-      mobileNumber,
-      passwordHash,
-      displayName: 'Test Sakhi',
-      status: 'ACTIVE',
-    },
-  });
-
   const sakhiRole = await prisma.role.findUniqueOrThrow({ where: { roleCode: 'SAKHI' } });
 
-  // user_roles has no unique constraint on (userId, roleId) in the schema, so
-  // this is a plain find-or-create rather than an upsert.
-  const existingAssignment = await prisma.userRole.findFirst({
-    where: { userId: user.id, roleId: sakhiRole.id },
-  });
-  if (!existingAssignment) {
-    await prisma.userRole.create({
+  await prisma.$transaction(async (tx) => {
+    const user = await tx.user.create({
+      data: {
+        mobileNumber,
+        passwordHash,
+        displayName: 'Test Sakhi',
+        status: 'ACTIVE',
+      },
+    });
+    await tx.userRole.create({
       data: { userId: user.id, roleId: sakhiRole.id, effectiveFrom: new Date(), status: 'ACTIVE' },
     });
-  }
+  });
 
   console.log(`Seeded test user ${mobileNumber} (password: Test@1234) with SAKHI role.`);
 }
 
 async function main(): Promise<void> {
   await seedRoles();
+  await seedAdminUser();
   await seedTestUser();
 }
 

--- a/apps/auth-service/prisma/tsconfig.json
+++ b/apps/auth-service/prisma/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/apps/auth-service/src/auth/auth.controller.ts
+++ b/apps/auth-service/src/auth/auth.controller.ts
@@ -2,7 +2,15 @@ import { Router } from 'express';
 import type { AuthService } from './auth.service';
 import { loginSchema } from './dto/login.dto';
 import { refreshSchema } from './dto/refresh.dto';
-import { asyncHandler, authenticate, ok, unauthorized, validateBody } from '../app.module';
+import { createUserSchema } from './dto/create-user.dto';
+import {
+  asyncHandler,
+  authenticate,
+  ok,
+  requireRoles,
+  unauthorized,
+  validateBody,
+} from '../app.module';
 import type { TokenSigner } from '@armman/service-commons';
 
 /** Auth HTTP routes. Mounted under the global `api/v1` prefix. */
@@ -34,6 +42,17 @@ export function createAuthRouter(service: AuthService, signer: TokenSigner): Rou
     asyncHandler(async (req, res) => {
       await service.logout(req.body.refreshToken);
       res.status(200).json(ok({ loggedOut: true }));
+    }),
+  );
+
+  router.post(
+    '/users',
+    authenticate(signer),
+    requireRoles('ADMIN'),
+    validateBody(createUserSchema),
+    asyncHandler(async (req, res) => {
+      const user = await service.createUser(req.body);
+      res.status(201).json(ok(user));
     }),
   );
 

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -71,4 +71,40 @@ export class AuthRepository {
       data: { revokedAt: new Date() },
     });
   }
+
+  findRoleByCode(roleCode: string) {
+    return this.prisma.role.findUnique({ where: { roleCode } });
+  }
+
+  /** Creates the user and their initial role assignment atomically. */
+  createUserWithRole(data: {
+    mobileNumber: string;
+    passwordHash: string;
+    displayName: string;
+    email: string | null;
+    roleId: string;
+    projectId: string | null;
+    geographyUnitId: string | null;
+  }) {
+    return this.prisma.$transaction(async (tx) => {
+      const user = await tx.user.create({
+        data: {
+          mobileNumber: data.mobileNumber,
+          passwordHash: data.passwordHash,
+          displayName: data.displayName,
+          email: data.email,
+        },
+      });
+      await tx.userRole.create({
+        data: {
+          userId: user.id,
+          roleId: data.roleId,
+          projectId: data.projectId,
+          geographyUnitId: data.geographyUnitId,
+          effectiveFrom: new Date(),
+        },
+      });
+      return user;
+    });
+  }
 }

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -4,6 +4,7 @@ import type { TokenSigner } from '@armman/service-commons';
 
 jest.mock('./password', () => ({
   verifyPassword: jest.fn(),
+  hashPassword: jest.fn((plain: string) => Promise.resolve(`hashed(${plain})`)),
 }));
 jest.mock('./refresh-token', () => ({
   generateRefreshToken: jest.fn(() => 'plain-refresh-token'),
@@ -38,6 +39,8 @@ describe('AuthService', () => {
     findActiveSessionByRefreshTokenHash: jest.fn(),
     revokeSession: jest.fn(),
     revokeSessionByRefreshTokenHash: jest.fn(),
+    findRoleByCode: jest.fn(),
+    createUserWithRole: jest.fn(),
   } as unknown as jest.Mocked<AuthRepository>;
 
   const signer = {
@@ -193,6 +196,104 @@ describe('AuthService', () => {
     it('is idempotent when the token is already revoked or unknown', async () => {
       repository.revokeSessionByRefreshTokenHash.mockResolvedValue({ count: 0 } as never);
       await expect(service.logout('already-logged-out-token')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('createUser', () => {
+    const ACTIVE_ROLE = { id: 'role-1', roleCode: 'SAKHI', isActive: true };
+    const CREATED_USER = {
+      id: 'user-2',
+      mobileNumber: '+919876543211',
+      displayName: 'New Sakhi',
+      email: null,
+      status: 'ACTIVE' as const,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+
+    it('hashes the password, creates the user and role assignment', async () => {
+      repository.findRoleByCode.mockResolvedValue(ACTIVE_ROLE as never);
+      repository.createUserWithRole.mockResolvedValue(CREATED_USER as never);
+
+      const result = await service.createUser({
+        mobileNumber: '+919876543211',
+        password: 'Str0ngPass!',
+        displayName: 'New Sakhi',
+        roleCode: 'SAKHI',
+      });
+
+      expect(repository.findRoleByCode).toHaveBeenCalledWith('SAKHI');
+      expect(repository.createUserWithRole).toHaveBeenCalledWith({
+        mobileNumber: '+919876543211',
+        passwordHash: 'hashed(Str0ngPass!)',
+        displayName: 'New Sakhi',
+        email: null,
+        roleId: 'role-1',
+        projectId: null,
+        geographyUnitId: null,
+      });
+      expect(result).toEqual({
+        id: 'user-2',
+        mobileNumber: '+919876543211',
+        displayName: 'New Sakhi',
+        email: null,
+        status: 'ACTIVE',
+        createdAt: CREATED_USER.createdAt,
+      });
+    });
+
+    it('rejects an unknown role code without creating a user', async () => {
+      repository.findRoleByCode.mockResolvedValue(null);
+
+      await expect(
+        service.createUser({
+          mobileNumber: '+919876543211',
+          password: 'Str0ngPass!',
+          displayName: 'New Sakhi',
+          roleCode: 'NOT_A_ROLE',
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.createUserWithRole).not.toHaveBeenCalled();
+    });
+
+    it('rejects an inactive role code', async () => {
+      repository.findRoleByCode.mockResolvedValue({ ...ACTIVE_ROLE, isActive: false } as never);
+
+      await expect(
+        service.createUser({
+          mobileNumber: '+919876543211',
+          password: 'Str0ngPass!',
+          displayName: 'New Sakhi',
+          roleCode: 'SAKHI',
+        }),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('maps a duplicate mobile number/email to a 409 conflict', async () => {
+      repository.findRoleByCode.mockResolvedValue(ACTIVE_ROLE as never);
+      repository.createUserWithRole.mockRejectedValue({ code: 'P2002' });
+
+      await expect(
+        service.createUser({
+          mobileNumber: '+919876543211',
+          password: 'Str0ngPass!',
+          displayName: 'New Sakhi',
+          roleCode: 'SAKHI',
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('propagates unrelated repository errors unchanged', async () => {
+      repository.findRoleByCode.mockResolvedValue(ACTIVE_ROLE as never);
+      repository.createUserWithRole.mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.createUser({
+          mobileNumber: '+919876543211',
+          password: 'Str0ngPass!',
+          displayName: 'New Sakhi',
+          roleCode: 'SAKHI',
+        }),
+      ).rejects.toThrow('db down');
     });
   });
 

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -1,10 +1,11 @@
 import type { TokenSigner } from '@armman/service-commons';
-import { unauthorized } from '@armman/service-commons';
+import { conflict, notFound, unauthorized } from '@armman/service-commons';
 import type { AuthRepository } from './auth.repository';
 import { hashPassword, verifyPassword } from './password';
 import { generateRefreshToken, hashRefreshToken } from './refresh-token';
 import { parseDurationMs } from './duration';
 import type { LoginInput } from './dto/login.dto';
+import type { CreateUserInput } from './dto/create-user.dto';
 
 export interface AuthTokens {
   accessToken: string;
@@ -17,6 +18,18 @@ export interface UserProfile {
   mobileNumber: string;
   roles: { roleCode: string; projectId: string | null; geographyUnitId: string | null }[];
 }
+
+export interface CreatedUser {
+  id: string;
+  mobileNumber: string;
+  displayName: string;
+  email: string | null;
+  status: string;
+  createdAt: Date;
+}
+
+/** Prisma unique-constraint violation code (mobileNumber/email/roleCode etc). */
+const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
 
 export class AuthService {
   constructor(
@@ -69,6 +82,43 @@ export class AuthService {
     // Idempotent by design — revoking an already-revoked/non-existent session
     // is a no-op (updateMany matches zero rows), not an error.
     await this.repository.revokeSessionByRefreshTokenHash(tokenHash);
+  }
+
+  /**
+   * Admin-provisioned account creation (no self-service signup exists per
+   * the HLD §4.2 auth flow — only /auth/login, /auth/refresh, /auth/logout,
+   * /me are public/self-service endpoints).
+   */
+  async createUser(input: CreateUserInput): Promise<CreatedUser> {
+    const role = await this.repository.findRoleByCode(input.roleCode);
+    if (!role || !role.isActive) throw notFound(`Unknown role code: ${input.roleCode}`);
+
+    const passwordHash = await hashPassword(input.password);
+
+    try {
+      const user = await this.repository.createUserWithRole({
+        mobileNumber: input.mobileNumber,
+        passwordHash,
+        displayName: input.displayName,
+        email: input.email ?? null,
+        roleId: role.id,
+        projectId: input.projectId ?? null,
+        geographyUnitId: input.geographyUnitId ?? null,
+      });
+      return {
+        id: user.id,
+        mobileNumber: user.mobileNumber,
+        displayName: user.displayName,
+        email: user.email,
+        status: user.status,
+        createdAt: user.createdAt,
+      };
+    } catch (err) {
+      if (isUniqueConstraintViolation(err)) {
+        throw conflict('A user with this mobile number or email already exists.');
+      }
+      throw err;
+    }
   }
 
   async getProfile(userId: string): Promise<UserProfile | null> {
@@ -125,6 +175,16 @@ export class AuthService {
 
     return { accessToken, refreshToken };
   }
+}
+
+/** Narrows a caught Prisma error to a unique-constraint violation (P2002). */
+function isUniqueConstraintViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === PRISMA_UNIQUE_CONSTRAINT_CODE
+  );
 }
 
 export { hashPassword };

--- a/apps/auth-service/src/auth/dto/create-user.dto.ts
+++ b/apps/auth-service/src/auth/dto/create-user.dto.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { mobileNumberSchema } from './mobile-number';
+
+/**
+ * Validation schema for creating a user. Fields match `users`
+ * (docs/Arogya_Sakhi_Database_Design_ERD_Table_Definitions.docx.md,
+ * Appendix A.1) — no invented fields. `passwordHash`, `status`,
+ * `lastLoginAt`, `failedLoginCount`, `passwordChangedAt`, and the audit
+ * columns are server-set, not client input; `password` is the plaintext
+ * input the server hashes before persisting.
+ * `roleCode` is not a `users` column — it selects the `roles` row to link
+ * via an initial `user_roles` assignment, mirroring how the seed script
+ * provisions a user with a role in one step.
+ * `.strict()` rejects unknown fields, matching the previous global
+ * ValidationPipe `forbidNonWhitelisted: true`.
+ */
+export const createUserSchema = z
+  .object({
+    mobileNumber: mobileNumberSchema,
+    password: z.string().min(8).max(200),
+    displayName: z.string().trim().min(1).max(160),
+    email: z.string().trim().email().max(254).optional(),
+    roleCode: z.string().trim().min(1).max(50),
+    projectId: z.string().uuid().optional(),
+    geographyUnitId: z.string().uuid().optional(),
+  })
+  .strict();
+
+export type CreateUserInput = z.infer<typeof createUserSchema>;

--- a/apps/auth-service/src/auth/dto/login.dto.ts
+++ b/apps/auth-service/src/auth/dto/login.dto.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod';
-
-/** Indian mobile number in normalized E.164-like format, e.g. +919876543210. */
-const mobileNumberSchema = z
-  .string()
-  .regex(/^\+91\d{10}$/, 'mobileNumber must be in the format +91XXXXXXXXXX');
+import { mobileNumberSchema } from './mobile-number';
 
 export const loginSchema = z
   .object({

--- a/apps/auth-service/src/auth/dto/mobile-number.ts
+++ b/apps/auth-service/src/auth/dto/mobile-number.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+/** Indian mobile number in normalized E.164-like format, e.g. +919876543210. */
+export const mobileNumberSchema = z
+  .string()
+  .regex(/^\+91\d{10}$/, 'mobileNumber must be in the format +91XXXXXXXXXX');


### PR DESCRIPTION
## What

Adds admin-provisioned user creation to `auth-service` plus a seed bootstrap for roles and the initial admin.

### API
- **`POST /api/v1/users`** — admin-only (`authenticate` + `requireRoles('ADMIN')`). Creates a user and their initial role assignment in one transaction.
  - Request: `{ mobileNumber, password, displayName, email?, roleCode, projectId?, geographyUnitId? }`
  - Fields follow the `users` table (ERD Appendix A.1); `roleCode`/`projectId`/`geographyUnitId` drive the `user_roles` insert.
  - Duplicate mobile/email → `409`; unknown/inactive role → `404`; `passwordHash` is never returned.
- Extracted the shared `mobileNumber` zod schema so login and create-user validate identically.

### Seed (`prisma/seed.ts`)
- **Roles**: seeded only when the `roles` table is empty (7 codes from the ERD `roles.role_code` enum). Left untouched once present.
- **Admin bootstrap**: initial admin created from `ADMIN_MOBILE_NUMBER` / `ADMIN_PASSWORD` env vars, only when that user doesn't already exist; never rotates an existing admin's password. Skips gracefully if the env vars are unset.
- **Test user**: distinct number + same create-if-absent guard.
- `.env.example` documents the new admin env vars (placeholder values only; `.env` stays gitignored).

## Verification
- `nx run-many -t build/test/lint` — **all 18 projects pass** (fresh Prisma clients, `--skip-nx-cache`).
- auth-service: **20/20** unit tests (5 new for `createUser`).
- Verified end-to-end against a local DB: roles + admin seeded, admin login returns a valid `ADMIN`-scoped JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related to #87
