### PR TITLE
Feature/sakhi dynamic forms

### DIFF
--- a/apps/approval-service/webpack.config.js
+++ b/apps/approval-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/approval-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/audit-service/webpack.config.js
+++ b/apps/audit-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/audit-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/auth-service/webpack.config.js
+++ b/apps/auth-service/webpack.config.js
@@ -1,30 +1,6 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
-
-// Prisma's generated client ships a runtime file that references a sourcemap
-// it doesn't actually include, so Nx's built-in source-map-loader rule warns
-// on every build. NxAppWebpackPlugin overwrites config.ignoreWarnings itself
-// (rather than merging), so a top-level `ignoreWarnings` in this file gets
-// clobbered — appending to it from a plugin that runs after NxAppWebpackPlugin
-// (via afterEnvironment, which fires once all plugins have applied) works
-// because it mutates the array NxAppWebpackPlugin already assigned.
-class IgnorePrismaSourceMapWarnings {
-  apply(compiler) {
-    compiler.hooks.afterEnvironment.tap('IgnorePrismaSourceMapWarnings', () => {
-      compiler.options.ignoreWarnings = [
-        ...(compiler.options.ignoreWarnings ?? []),
-        (warning) => {
-          const message = typeof warning === 'string' ? warning : warning.message;
-          return (
-            typeof message === 'string' &&
-            message.includes('Failed to parse source map') &&
-            /\.prisma[\\/]/.test(message)
-          );
-        },
-      ];
-    });
-  }
-}
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
 
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/auth-service') },

--- a/apps/beneficiary-service/prisma/migrations/20260716052346_init/migration.sql
+++ b/apps/beneficiary-service/prisma/migrations/20260716052346_init/migration.sql
@@ -260,7 +260,7 @@ CREATE INDEX "beneficiary_pii_date_of_birth_idx" ON "beneficiary_pii"("date_of_b
 CREATE INDEX "beneficiary_pii_rch_number_hash_idx" ON "beneficiary_pii"("rch_number_hash");
 
 -- CreateIndex
-CREATE INDEX "Beneficiary_search_tokens_name_token_dob_token_geography_to_idx" ON "Beneficiary_search_tokens"("name_token", "dob_token", "geography_token", "lmp_date_token");
+CREATE INDEX "Beneficiary_search_tokens_name_token_case_type_lookup_id_do_idx" ON "Beneficiary_search_tokens"("name_token", "case_type_lookup_id", "dob_token", "geography_token", "lmp_date_token");
 
 -- CreateIndex
 CREATE INDEX "Beneficiary_search_tokens_beneficiary_id_idx" ON "Beneficiary_search_tokens"("beneficiary_id");

--- a/apps/beneficiary-service/prisma/schema.prisma
+++ b/apps/beneficiary-service/prisma/schema.prisma
@@ -167,10 +167,11 @@ model BeneficiarySearchToken {
 
   beneficiaryCase BeneficiaryCase @relation(fields: [beneficiaryId], references: [id])
 
-  // findDuplicateCandidate always filters on nameToken, optionally narrowing
-  // by dobToken/geographyToken/lmpDateToken — a leading-column composite index
-  // serves the mandatory-nameToken lookup and its narrowed variants alike.
-  @@index([nameToken, dobToken, geographyToken, lmpDateToken])
+  // findDuplicateCandidate always filters on nameToken (and caseTypeLookupId,
+  // per the ERD's required index), optionally narrowing by
+  // dobToken/geographyToken/lmpDateToken — a leading-column composite index
+  // serves the mandatory lookup and its narrowed variants alike.
+  @@index([nameToken, caseTypeLookupId, dobToken, geographyToken, lmpDateToken])
   @@index([beneficiaryId])
   @@map("Beneficiary_search_tokens")
 }

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -2,6 +2,7 @@ import type { PrismaService } from '../prisma/prisma.service';
 
 export interface DuplicateSearchTokens {
   nameToken: Buffer;
+  caseTypeLookupId: string;
   dobToken: string | null;
   phoneHash: Buffer | null;
   geographyToken: string | null;
@@ -95,12 +96,15 @@ export class BeneficiaryRepository {
    * Finds an existing case whose PII/search tokens match ALL of the caller's
    * available tokens simultaneously (per FR-S-2.4). Legs the caller doesn't
    * supply (e.g. no phone given) are skipped rather than treated as a match.
+   * Always scoped to caseTypeLookupId (per the ERD's required index) so a
+   * MOTHER registration's tokens are never matched against a CHILD case's.
    */
   async findDuplicateCandidate(tokens: DuplicateSearchTokens) {
     const where: NonNullable<
       Parameters<typeof this.prisma.beneficiarySearchToken.findFirst>[0]
     >['where'] = {
       nameToken: tokens.nameToken.toString('base64'),
+      caseTypeLookupId: tokens.caseTypeLookupId,
     };
     if (tokens.dobToken) where.dobToken = tokens.dobToken;
     if (tokens.geographyToken) where.geographyToken = tokens.geographyToken;

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -115,6 +115,17 @@ describe('BeneficiaryService', () => {
       repository.createEnrollment.mockResolvedValue({ id: 'new-id' } as never);
       await expect(service.create(baseMotherInput, CALLER_ID)).resolves.toEqual({ id: 'new-id' });
     });
+
+    it('scopes duplicate search to the case type, so a MOTHER search never matches a CHILD case', async () => {
+      repository.findDuplicateCandidate.mockResolvedValue(null);
+      repository.createEnrollment.mockResolvedValue({ id: 'new-id' } as never);
+
+      await service.create(baseMotherInput, CALLER_ID);
+
+      expect(repository.findDuplicateCandidate).toHaveBeenCalledWith(
+        expect.objectContaining({ caseTypeLookupId: baseMotherInput.case.caseTypeLookupId }),
+      );
+    });
   });
 
   describe('create — server-side computation (M5)', () => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -124,6 +124,7 @@ export class BeneficiaryService {
 
     return {
       nameToken: hashForSearch(normalizeForSearch(dto.pii.fullName)),
+      caseTypeLookupId: dto.case.caseTypeLookupId,
       dobToken: dob ? hashForSearch(dob.toISOString().slice(0, 10)).toString('base64') : null,
       phoneHash: dto.pii.phone ? hashForSearch(normalizeForSearch(dto.pii.phone)) : null,
       geographyToken: geographyParts

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.spec.ts
@@ -136,6 +136,50 @@ describe('createBeneficiarySchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts a mother-linked child within the 0-183-day window (CH6)', () => {
+    const dob = new Date();
+    dob.setDate(dob.getDate() - 100);
+    const result = createBeneficiarySchema.safeParse({
+      pii: { fullName: 'Baby Doe' },
+      case: {
+        ...baseCase,
+        caseType: 'CHILD',
+        motherBeneficiaryId: '66666666-6666-6666-6666-666666666666',
+      },
+      childDetails: { dateOfBirth: dob.toISOString() },
+      consent,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a mother-linked child past the 183-day window even though it is within 365 days (CH7)', () => {
+    const dob = new Date();
+    dob.setDate(dob.getDate() - 200);
+    const result = createBeneficiarySchema.safeParse({
+      pii: { fullName: 'Baby Doe' },
+      case: {
+        ...baseCase,
+        caseType: 'CHILD',
+        motherBeneficiaryId: '66666666-6666-6666-6666-666666666666',
+      },
+      childDetails: { dateOfBirth: dob.toISOString() },
+      consent,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an independent child within 365 days but past 183 (CH8)', () => {
+    const dob = new Date();
+    dob.setDate(dob.getDate() - 200);
+    const result = createBeneficiarySchema.safeParse({
+      pii: { fullName: 'Baby Doe' },
+      case: { ...baseCase, caseType: 'CHILD' },
+      childDetails: { dateOfBirth: dob.toISOString() },
+      consent,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('rejects an unknown top-level field (.strict())', () => {
     const result = createBeneficiarySchema.safeParse({
       pii: { fullName: 'Jane Doe' },

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
@@ -88,7 +88,15 @@ const motherDetailsSchema = z
     }
   });
 
-/** Child eligibility window per FR-S-2.3: 0–12 months (0–365 days) at registration. */
+/**
+ * Child eligibility window per FR-S-2.3. The upper bound depends on whether
+ * this registration is linked to an enrolled mother's journey (0-6 months /
+ * 0-183 days) or independent (0-12 months / 0-365 days) — that depends on
+ * `case.motherBeneficiaryId`, a sibling field this schema can't see, so only
+ * the future-date check and a same-object-scoped placeholder run here; the
+ * mother-linked-vs-independent day-count check runs in the top-level
+ * `createBeneficiarySchema.superRefine` below, where both fields are visible.
+ */
 const childDetailsSchema = z
   .object({
     dateOfBirth: z.coerce.date(),
@@ -99,26 +107,22 @@ const childDetailsSchema = z
   })
   .strict()
   .superRefine((data, ctx) => {
-    const now = new Date();
-    if (data.dateOfBirth > now) {
+    if (data.dateOfBirth > new Date()) {
       ctx.addIssue({
         code: 'custom',
         path: ['dateOfBirth'],
         message: 'dateOfBirth cannot be in the future',
       });
-      return;
-    }
-    const ageDays = Math.floor(
-      (now.getTime() - data.dateOfBirth.getTime()) / (24 * 60 * 60 * 1000),
-    );
-    if (ageDays > 365) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['dateOfBirth'],
-        message: 'child is outside the 0-12 month enrollment eligibility window',
-      });
     }
   });
+
+/** FR-S-2.3 upper bound, in days, on a child's age at registration. */
+const CHILD_AGE_CEILING_DAYS = {
+  /** Registered through an enrolled mother's ANC journey: 0-6 months. */
+  MOTHER_LINKED: 183,
+  /** Registered independently (mother was not ANC-enrolled): 0-12 months. */
+  INDEPENDENT: 365,
+} as const;
 
 const consentSchema = z
   .object({
@@ -182,6 +186,28 @@ export const createBeneficiarySchema = z
           path: ['motherDetails'],
           message: 'motherDetails must not be set when caseType is CHILD',
         });
+      }
+
+      // FR-S-2.3: mother-linked registrations get the tighter 0-183-day
+      // window; independent registrations get 0-365. Skipped if dateOfBirth
+      // is already flagged as future-dated by childDetailsSchema above, to
+      // avoid a redundant second issue on the same field.
+      if (data.childDetails && data.childDetails.dateOfBirth <= new Date()) {
+        const ageDays = Math.floor(
+          (Date.now() - data.childDetails.dateOfBirth.getTime()) / (24 * 60 * 60 * 1000),
+        );
+        const ceiling = data.case.motherBeneficiaryId
+          ? CHILD_AGE_CEILING_DAYS.MOTHER_LINKED
+          : CHILD_AGE_CEILING_DAYS.INDEPENDENT;
+        if (ageDays > ceiling) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['childDetails', 'dateOfBirth'],
+            message: data.case.motherBeneficiaryId
+              ? 'child linked to an enrolled mother must be registered within 0-6 months (0-183 days) of birth'
+              : 'child is outside the 0-12 month (0-365 day) independent enrollment eligibility window',
+          });
+        }
       }
     }
   });

--- a/apps/beneficiary-service/webpack.config.js
+++ b/apps/beneficiary-service/webpack.config.js
@@ -1,5 +1,6 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
 
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/beneficiary-service') },
@@ -13,5 +14,6 @@ module.exports = {
       outputHashing: 'none',
       generatePackageJson: false,
     }),
+    new IgnorePrismaSourceMapWarnings(),
   ],
 };

--- a/apps/closure-reopen-service/webpack.config.js
+++ b/apps/closure-reopen-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/closure-reopen-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/incentive-wages-service/webpack.config.js
+++ b/apps/incentive-wages-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/incentive-wages-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/media-service/webpack.config.js
+++ b/apps/media-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/media-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/notification-escalation-service/webpack.config.js
+++ b/apps/notification-escalation-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/notification-escalation-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/risk-referral-service/webpack.config.js
+++ b/apps/risk-referral-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/risk-referral-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/rules-service/webpack.config.js
+++ b/apps/rules-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/rules-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/sync-service/webpack.config.js
+++ b/apps/sync-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/sync-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/apps/visit-form-service/jest.config.ts
+++ b/apps/visit-form-service/jest.config.ts
@@ -2,6 +2,16 @@ export default {
   displayName: 'visit-form-service',
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
-  transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    // `jose` ships ESM-only (no CJS build) — transpile it too instead of
+    // letting Jest's default node_modules ignore rule reject its `export`
+    // syntax. See https://jestjs.io/docs/ecmascript-modules.
+    '^.+\\.js$': [
+      'babel-jest',
+      { presets: [['@babel/preset-env', { targets: { node: 'current' } }]] },
+    ],
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/visit-form-service',
 };

--- a/apps/visit-form-service/prisma/migrations/20260716170000_add_form_submissions_index/migration.sql
+++ b/apps/visit-form-service/prisma/migrations/20260716170000_add_form_submissions_index/migration.sql
@@ -1,0 +1,6 @@
+-- ERD §6 "Required Indexes and Constraints" — Care journey row requires
+-- index form_submissions(beneficiary_id, form_definition_id, submitted_at).
+-- form_submissions' actual FK is form_version_id (per this table's own
+-- Appendix A definition, not form_definition_id), so this indexes the
+-- column that actually exists.
+CREATE INDEX "form_submissions_beneficiary_id_form_version_id_submitted_a_idx" ON "form_submissions"("beneficiary_id", "form_version_id", "submitted_at");

--- a/apps/visit-form-service/prisma/schema.prisma
+++ b/apps/visit-form-service/prisma/schema.prisma
@@ -240,6 +240,11 @@ model FormSubmission {
   visit       VisitInstance? @relation(fields: [visitId], references: [id])
   formAnswers FormAnswer[]
 
+  // ERD §6 "Required Indexes and Constraints" — Care journey row requires
+  // this index (ERD names the column form_definition_id, but form_submissions'
+  // actual FK is form_version_id, per this same table's own Appendix A
+  // definition — indexing the column that actually exists).
+  @@index([beneficiaryId, formVersionId, submittedAt])
   @@map("form_submissions")
 }
 

--- a/apps/visit-form-service/src/app.module.ts
+++ b/apps/visit-form-service/src/app.module.ts
@@ -25,6 +25,8 @@ export {
   requireRoles,
   trustGatewayIdentity,
   createDocumentedRouter,
+  unauthorized,
+  unprocessable,
   HttpError,
   ErrorCode,
   type DocumentedRouter,

--- a/apps/visit-form-service/src/app.module.ts
+++ b/apps/visit-form-service/src/app.module.ts
@@ -13,14 +13,17 @@ import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createVisitInstanceModule } from './visits/visitInstance.module';
 import { buildVisitFormServiceOpenApiDocument } from './docs/openapi';
+import { createFormModule } from './forms/form.module';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
 export {
   asyncHandler,
   ok,
   fail,
+  validate,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,
@@ -55,9 +58,12 @@ export function createApp(prisma: PrismaService): Application {
   api.use(createHealthRouter(prisma));
   // Built from visitInstanceModule.registry — every route registered via
   // createDocumentedRouter() above is already in the spec, so this can never
-  // drift from what's actually mounted.
+  // drift from what's actually mounted. The forms feature isn't converted to
+  // createDocumentedRouter() yet, so it's mounted as a plain router below and
+  // is not yet represented in /docs.json.
   api.use(createSwaggerRouter(buildVisitFormServiceOpenApiDocument(visitInstanceModule.registry)));
   api.use(visitInstanceModule.router);
+  api.use(createFormModule(prisma));
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/visit-form-service/src/forms/dto/create-draft-version.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/create-draft-version.dto.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * Body for `POST /admin/forms/:formCode/versions` — creates a new DRAFT
+ * version. `cloneFromVersionId` optionally seeds it from an existing
+ * version's schema/validation JSON as a starting point for editing.
+ */
+export const createDraftVersionSchema = z
+  .object({
+    cloneFromVersionId: z.string().uuid().optional(),
+  })
+  .strict();
+
+export type CreateDraftVersionInput = z.infer<typeof createDraftVersionSchema>;

--- a/apps/visit-form-service/src/forms/dto/create-submission.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/create-submission.dto.ts
@@ -7,15 +7,19 @@ import { z } from 'zod';
  * label->value bag that becomes `form_data_json`; its keys are validated at
  * the service layer against the live form_version's schema_json, not here,
  * since the set of valid question_codes is dynamic per form version.
+ *
+ * `submittedByUserId` is NOT part of this schema — per beneficiary-service's
+ * existing convention, the submitter's identity comes from the authenticated
+ * caller (`req.user.id`, set by `trustGatewayIdentity`), never from the
+ * request body, so a caller can't submit while claiming to be someone else.
  */
 export const createSubmissionSchema = z
   .object({
     formVersionId: z.string().uuid(),
     beneficiaryId: z.string().uuid(),
     visitId: z.string().uuid().nullable().optional(),
-    submittedByUserId: z.string().uuid(),
     localSubmissionUuid: z.string().trim().min(1).max(80),
-    formData: z.record(z.string(), z.unknown()),
+    formData: z.record(z.string(), z.any()),
   })
   .strict();
 

--- a/apps/visit-form-service/src/forms/dto/create-submission.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/create-submission.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Body for `POST /forms/:formCode/submissions`. Fields match
+ * form_submissions (docs/Arogya_Sakhi_Database_Design_ERD_Table_Definitions.docx.md,
+ * Appendix A) exactly — no invented fields. `formData` is the generic
+ * label->value bag that becomes `form_data_json`; its keys are validated at
+ * the service layer against the live form_version's schema_json, not here,
+ * since the set of valid question_codes is dynamic per form version.
+ */
+export const createSubmissionSchema = z
+  .object({
+    formVersionId: z.string().uuid(),
+    beneficiaryId: z.string().uuid(),
+    visitId: z.string().uuid().nullable().optional(),
+    submittedByUserId: z.string().uuid(),
+    localSubmissionUuid: z.string().trim().min(1).max(80),
+    formData: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export type CreateSubmissionInput = z.infer<typeof createSubmissionSchema>;

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+/**
+ * Shape of one entry in `form_versions.schema_json`. Only the parts confirmed
+ * by docs/Arogya_Sakhi_Database_Design_ERD_Table_Definitions.docx.md §4.0 (the
+ * worked example) and docs/Arogya_Sakhi_SRS_v3.0.md FR-S-4.7 are given a typed
+ * shape here — no field beyond what those two docs describe:
+ * - question_code/label/input_type/lookup_category_code/options: the ERD's own example.
+ * - required: SRS line 1150 ("Required-field validation shall run both on
+ *   device and server") + ERD's design-stance note that schema stores
+ *   "required flags" — the key name itself was undocumented, this is where
+ *   it's been placed.
+ * - numericRange: SRS Category 2 (exact per-field ranges are admin-entered
+ *   data, not hardcoded here — only the {min,max} shape is fixed).
+ * - visibleWhen: SRS Category 5 (conditional field visibility / skip logic).
+ * - computedFrom: SRS Category 4 (auto-calculated fields that must not be
+ *   manually entered) — closed set of the exact formulas SRS names.
+ * - captureMode / requirePlaybackComplete: SRS Category 6 (media/consent gating).
+ * Categories 1 (date rules) and 3 (cross-field, on validation_json — see
+ * cross-field-rule.dto.ts) are the only other SRS-named categories; date
+ * rules are deliberately NOT modeled here yet (see the forms API design doc
+ * §7 — which comparison field a date rule reads from isn't specified).
+ */
+export const formFieldSchema = z
+  .object({
+    question_code: z.string().trim().min(1),
+    label: z.string().trim().min(1),
+    input_type: z.string().trim().min(1),
+    required: z.boolean(),
+    lookup_category_code: z.string().trim().min(1).nullable().optional(),
+    options: z
+      .array(
+        z.object({
+          value_code: z.string().trim().min(1),
+          label: z.string().trim().min(1),
+          sort_order: z.number().int(),
+        }),
+      )
+      .optional(),
+    numericRange: z
+      .object({ min: z.number(), max: z.number() })
+      .refine((r) => r.min <= r.max, { message: 'numericRange.min must be <= max' })
+      .optional(),
+    visibleWhen: z
+      .object({
+        field: z.string().trim().min(1),
+        operator: z.enum(['eq', 'gte', 'lt', 'isSet']),
+        value: z.unknown().optional(),
+      })
+      .optional(),
+    computedFrom: z
+      .enum([
+        'EDD_FROM_LMP',
+        'GESTATIONAL_AGE_AT_REGISTRATION',
+        'GESTATIONAL_AGE_AT_VISIT',
+        'BMI',
+        'GESTATIONAL_WEIGHT_GAIN',
+        'NUTRITIONAL_ZSCORE',
+        'CHILD_AGE_MONTHS',
+        'UNIQUE_ID',
+      ])
+      .optional(),
+    captureMode: z.enum(['LIVE_CAMERA_ONLY']).optional(),
+    requirePlaybackComplete: z.boolean().optional(),
+  })
+  .strict();
+
+export type FormField = z.infer<typeof formFieldSchema>;
+
+export const schemaJsonSchema = z.array(formFieldSchema).min(1);
+
+/**
+ * Shape of one entry in `form_versions.validation_json` — SRS Category 3,
+ * cross-field consistency. SRS names exactly four rules of these two
+ * fixed shapes (Para <= Gravida, Abortions <= Gravida, Dead children <=
+ * Live births, Live births + Stillbirths + Abortions = Gravida) — the shape
+ * below is generic enough to express all four without inventing a fifth.
+ */
+export const crossFieldRuleSchema = z.discriminatedUnion('rule', [
+  z.object({ rule: z.literal('LTE'), fields: z.tuple([z.string(), z.string()]) }).strict(),
+  z
+    .object({
+      rule: z.literal('SUM_EQUALS'),
+      fields: z.array(z.string().trim().min(1)).min(2),
+      equals: z.string().trim().min(1),
+    })
+    .strict(),
+]);
+
+export type CrossFieldRule = z.infer<typeof crossFieldRuleSchema>;
+
+export const validationJsonSchema = z.array(crossFieldRuleSchema);

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -45,7 +45,7 @@ export const formFieldSchema = z
       .object({
         field: z.string().trim().min(1),
         operator: z.enum(['eq', 'gte', 'lt', 'isSet']),
-        value: z.unknown().optional(),
+        value: z.any().optional(),
       })
       .optional(),
     computedFrom: z

--- a/apps/visit-form-service/src/forms/dto/patch-form-version.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/patch-form-version.dto.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { schemaJsonSchema, validationJsonSchema } from './form-field.dto';
+
+/**
+ * Body for `PATCH /admin/forms/:formCode/versions/:versionId` — replaces the
+ * DRAFT's schema/validation JSON. This is the single endpoint an admin's
+ * "add field" / "delete field" / "edit field" actions all call: the field
+ * list is an array, so create/delete are just edits to that array, not
+ * separate operations.
+ */
+export const patchFormVersionSchema = z
+  .object({
+    schemaJson: schemaJsonSchema,
+    validationJson: validationJsonSchema.optional(),
+  })
+  .strict();
+
+export type PatchFormVersionInput = z.infer<typeof patchFormVersionSchema>;

--- a/apps/visit-form-service/src/forms/form.controller.ts
+++ b/apps/visit-form-service/src/forms/form.controller.ts
@@ -1,0 +1,98 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import type { FormService } from './form.service';
+import { createDraftVersionSchema } from './dto/create-draft-version.dto';
+import { patchFormVersionSchema } from './dto/patch-form-version.dto';
+import { createSubmissionSchema } from './dto/create-submission.dto';
+import {
+  asyncHandler,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validate,
+  validateBody,
+} from '../app.module';
+
+const formCodeParamsSchema = z.object({ formCode: z.string().trim().min(1) }).strict();
+const versionParamsSchema = z
+  .object({ formCode: z.string().trim().min(1), versionId: z.string().uuid() })
+  .strict();
+const activeVersionQuerySchema = z.object({ asOf: z.coerce.date().optional() }).strict();
+
+/**
+ * Dynamic-forms HTTP routes (Layer 1 only — form mechanics, not the
+ * per-domain consequence of a submission). Mounted under the global
+ * `api/v1` prefix. Admin routes (draft/patch/publish) are ADMIN-only,
+ * matching the HLD's admin/rules endpoint pattern this mirrors; the
+ * read/submit routes require authentication but no specific role, since
+ * the HLD doesn't name exact roles per form code (flagged in the forms API
+ * design doc §7 rather than guessed here).
+ */
+export function createFormRouter(service: FormService): Router {
+  const router = Router();
+
+  router.get(
+    '/forms/:formCode/active-version',
+    trustGatewayIdentity,
+    validate(formCodeParamsSchema, 'params'),
+    validate(activeVersionQuerySchema, 'query'),
+    asyncHandler(async (req, res) => {
+      const { formCode } = req.params as unknown as { formCode: string };
+      const { asOf } = req.query as unknown as { asOf?: Date };
+      const version = await service.getActiveVersion(formCode, asOf ?? new Date());
+      res.json(ok(version));
+    }),
+  );
+
+  router.post(
+    '/admin/forms/:formCode/versions',
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
+    validate(formCodeParamsSchema, 'params'),
+    validateBody(createDraftVersionSchema),
+    asyncHandler(async (req, res) => {
+      const { formCode } = req.params as unknown as { formCode: string };
+      const created = await service.createDraft(formCode, req.body);
+      res.status(201).json(ok(created));
+    }),
+  );
+
+  router.patch(
+    '/admin/forms/:formCode/versions/:versionId',
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
+    validate(versionParamsSchema, 'params'),
+    validateBody(patchFormVersionSchema),
+    asyncHandler(async (req, res) => {
+      const { versionId } = req.params as unknown as { versionId: string };
+      const updated = await service.updateDraft(versionId, req.body);
+      res.json(ok(updated));
+    }),
+  );
+
+  router.post(
+    '/admin/forms/:formCode/versions/:versionId/publish',
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
+    validate(versionParamsSchema, 'params'),
+    asyncHandler(async (req, res) => {
+      const { versionId } = req.params as unknown as { versionId: string };
+      const published = await service.publish(versionId);
+      res.json(ok(published));
+    }),
+  );
+
+  router.post(
+    '/forms/:formCode/submissions',
+    trustGatewayIdentity,
+    validate(formCodeParamsSchema, 'params'),
+    validateBody(createSubmissionSchema),
+    asyncHandler(async (req, res) => {
+      const { formCode } = req.params as unknown as { formCode: string };
+      const created = await service.createSubmission(formCode, req.body);
+      res.status(201).json(ok(created));
+    }),
+  );
+
+  return router;
+}

--- a/apps/visit-form-service/src/forms/form.controller.ts
+++ b/apps/visit-form-service/src/forms/form.controller.ts
@@ -65,8 +65,11 @@ export function createFormRouter(service: FormService): Router {
     validate(versionParamsSchema, 'params'),
     validateBody(patchFormVersionSchema),
     asyncHandler(async (req, res) => {
-      const { versionId } = req.params as unknown as { versionId: string };
-      const updated = await service.updateDraft(versionId, req.body);
+      const { formCode, versionId } = req.params as unknown as {
+        formCode: string;
+        versionId: string;
+      };
+      const updated = await service.updateDraft(formCode, versionId, req.body);
       res.json(ok(updated));
     }),
   );
@@ -77,8 +80,11 @@ export function createFormRouter(service: FormService): Router {
     requireRoles('ADMIN'),
     validate(versionParamsSchema, 'params'),
     asyncHandler(async (req, res) => {
-      const { versionId } = req.params as unknown as { versionId: string };
-      const published = await service.publish(versionId);
+      const { formCode, versionId } = req.params as unknown as {
+        formCode: string;
+        versionId: string;
+      };
+      const published = await service.publish(formCode, versionId);
       res.json(ok(published));
     }),
   );

--- a/apps/visit-form-service/src/forms/form.controller.ts
+++ b/apps/visit-form-service/src/forms/form.controller.ts
@@ -9,6 +9,7 @@ import {
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   validate,
   validateBody,
 } from '../app.module';
@@ -87,9 +88,10 @@ export function createFormRouter(service: FormService): Router {
     trustGatewayIdentity,
     validate(formCodeParamsSchema, 'params'),
     validateBody(createSubmissionSchema),
-    asyncHandler(async (req, res) => {
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
       const { formCode } = req.params as unknown as { formCode: string };
-      const created = await service.createSubmission(formCode, req.body);
+      const created = await service.createSubmission(formCode, req.body, req.user.id);
       res.status(201).json(ok(created));
     }),
   );

--- a/apps/visit-form-service/src/forms/form.module.ts
+++ b/apps/visit-form-service/src/forms/form.module.ts
@@ -1,0 +1,12 @@
+import type { Router } from 'express';
+import type { PrismaService } from '../prisma/prisma.service';
+import { FormRepository } from './form.repository';
+import { FormService } from './form.service';
+import { createFormRouter } from './form.controller';
+
+/** Composition root for the forms feature: wires repository -> service -> router. */
+export function createFormModule(prisma: PrismaService): Router {
+  const repository = new FormRepository(prisma);
+  const service = new FormService(repository);
+  return createFormRouter(service);
+}

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -1,0 +1,130 @@
+import type { PrismaService } from '../prisma/prisma.service';
+
+export interface CreateVersionData {
+  formDefinitionId: string;
+  versionNo: string;
+  schemaJson: unknown;
+  validationJson: unknown;
+  checksum: Buffer;
+  effectiveFrom: Date;
+}
+
+export interface UpdateDraftData {
+  schemaJson: unknown;
+  validationJson: unknown;
+  checksum: Buffer;
+}
+
+export interface CreateSubmissionData {
+  formVersionId: string;
+  beneficiaryId: string;
+  visitId: string | null;
+  submittedByUserId: string;
+  localSubmissionUuid: string;
+  formDataJson: unknown;
+  validationStatus: 'VALID' | 'INVALID' | 'WARNING';
+}
+
+/**
+ * Data access for form_definitions/form_versions/form_submissions — the
+ * only tables this repository touches (forklift rule; form_answers is not
+ * written yet, see forms API design doc §7).
+ */
+export class FormRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findDefinitionByCode(formCode: string) {
+    return this.prisma.formDefinition.findUnique({ where: { formCode } });
+  }
+
+  /** The currently effective PUBLISHED version for a form code, as of `asOf`. */
+  findActiveVersion(formCode: string, asOf: Date) {
+    return this.prisma.formVersion.findFirst({
+      where: {
+        formDefinition: { formCode },
+        status: 'PUBLISHED',
+        effectiveFrom: { lte: asOf },
+        OR: [{ effectiveTo: null }, { effectiveTo: { gt: asOf } }],
+      },
+      orderBy: { effectiveFrom: 'desc' },
+    });
+  }
+
+  findVersionById(versionId: string) {
+    return this.prisma.formVersion.findUnique({
+      where: { id: versionId },
+      include: { formDefinition: true },
+    });
+  }
+
+  /** The version currently PUBLISHED (and not yet retired) for a form definition, if any. */
+  findCurrentlyPublished(formDefinitionId: string) {
+    return this.prisma.formVersion.findFirst({
+      where: { formDefinitionId, status: 'PUBLISHED', effectiveTo: null },
+    });
+  }
+
+  countVersions(formDefinitionId: string) {
+    return this.prisma.formVersion.count({ where: { formDefinitionId } });
+  }
+
+  createDraft(data: CreateVersionData) {
+    return this.prisma.formVersion.create({
+      data: {
+        formDefinitionId: data.formDefinitionId,
+        versionNo: data.versionNo,
+        schemaJson: data.schemaJson as never,
+        validationJson: data.validationJson as never,
+        checksum: data.checksum,
+        effectiveFrom: data.effectiveFrom,
+        status: 'DRAFT',
+      },
+    });
+  }
+
+  updateDraft(versionId: string, data: UpdateDraftData) {
+    return this.prisma.formVersion.update({
+      where: { id: versionId },
+      data: {
+        schemaJson: data.schemaJson as never,
+        validationJson: data.validationJson as never,
+        checksum: data.checksum,
+      },
+    });
+  }
+
+  /** Publishes `versionId` and retires `previousVersionId` (if any) atomically. */
+  async publish(versionId: string, effectiveFrom: Date, previousVersionId: string | null) {
+    return this.prisma.$transaction(async (tx) => {
+      if (previousVersionId) {
+        await tx.formVersion.update({
+          where: { id: previousVersionId },
+          data: { status: 'RETIRED', effectiveTo: effectiveFrom },
+        });
+      }
+      return tx.formVersion.update({
+        where: { id: versionId },
+        data: { status: 'PUBLISHED', effectiveFrom },
+      });
+    });
+  }
+
+  findSubmissionByLocalUuid(localSubmissionUuid: string) {
+    return this.prisma.formSubmission.findUnique({ where: { localSubmissionUuid } });
+  }
+
+  createSubmission(data: CreateSubmissionData) {
+    return this.prisma.formSubmission.create({
+      data: {
+        formVersionId: data.formVersionId,
+        beneficiaryId: data.beneficiaryId,
+        visitId: data.visitId,
+        submittedByUserId: data.submittedByUserId,
+        submittedAt: new Date(),
+        localSubmissionUuid: data.localSubmissionUuid,
+        formDataJson: data.formDataJson as never,
+        validationStatus: data.validationStatus,
+      },
+    });
+  }
+}

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -96,10 +96,17 @@ describe('FormService', () => {
 
   describe('updateDraft', () => {
     it('updates schemaJson/validationJson when the version is DRAFT', async () => {
-      repository.findVersionById.mockResolvedValue({ id: 'v1', status: 'DRAFT' } as never);
+      repository.findVersionById.mockResolvedValue({
+        id: 'v1',
+        status: 'DRAFT',
+        formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+      } as never);
       repository.updateDraft.mockResolvedValue({ id: 'v1' } as never);
 
-      await service.updateDraft('v1', { schemaJson: [], validationJson: [] });
+      await service.updateDraft('MOTHER_REGISTRATION', 'v1', {
+        schemaJson: [],
+        validationJson: [],
+      });
 
       expect(repository.updateDraft).toHaveBeenCalledWith(
         'v1',
@@ -107,53 +114,99 @@ describe('FormService', () => {
       );
     });
 
-    it('rejects editing a version that is not DRAFT', async () => {
-      repository.findVersionById.mockResolvedValue({ id: 'v1', status: 'PUBLISHED' } as never);
+    it('rejects when the version does not belong to the given form code', async () => {
+      repository.findVersionById.mockResolvedValue({
+        id: 'v1',
+        status: 'DRAFT',
+        formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+      } as never);
+
       await expect(
-        service.updateDraft('v1', { schemaJson: [], validationJson: [] }),
+        service.updateDraft('CHILD_REGISTRATION', 'v1', { schemaJson: [], validationJson: [] }),
+      ).rejects.toThrow(/does not belong to this form code/);
+    });
+
+    it('rejects editing a version that is not DRAFT', async () => {
+      repository.findVersionById.mockResolvedValue({
+        id: 'v1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+      } as never);
+      await expect(
+        service.updateDraft('MOTHER_REGISTRATION', 'v1', { schemaJson: [], validationJson: [] }),
       ).rejects.toThrow(/Only DRAFT versions can be edited/);
     });
 
     it('throws not-found for an unknown version id', async () => {
       repository.findVersionById.mockResolvedValue(null);
       await expect(
-        service.updateDraft('missing', { schemaJson: [], validationJson: [] }),
+        service.updateDraft('MOTHER_REGISTRATION', 'missing', {
+          schemaJson: [],
+          validationJson: [],
+        }),
       ).rejects.toThrow(/Form version not found/);
     });
   });
 
   describe('publish', () => {
+    const draftVersion = {
+      id: 'v2',
+      status: 'DRAFT',
+      formDefinitionId: 'def-1',
+      formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+      schemaJson: [
+        { question_code: 'phone_owner', label: 'Phone owner', input_type: 'text', required: true },
+      ],
+    };
+
     it('publishes a DRAFT and retires the previously-active version', async () => {
-      repository.findVersionById.mockResolvedValue({
-        id: 'v2',
-        status: 'DRAFT',
-        formDefinitionId: 'def-1',
-      } as never);
+      repository.findVersionById.mockResolvedValue(draftVersion as never);
       repository.findCurrentlyPublished.mockResolvedValue({ id: 'v1' } as never);
       repository.publish.mockResolvedValue({ id: 'v2', status: 'PUBLISHED' } as never);
 
-      await service.publish('v2');
+      await service.publish('MOTHER_REGISTRATION', 'v2');
 
       expect(repository.publish).toHaveBeenCalledWith('v2', expect.any(Date), 'v1');
     });
 
     it('publishes with no previous version to retire when none exists', async () => {
       repository.findVersionById.mockResolvedValue({
+        ...draftVersion,
         id: 'v1',
-        status: 'DRAFT',
-        formDefinitionId: 'def-1',
       } as never);
       repository.findCurrentlyPublished.mockResolvedValue(null);
       repository.publish.mockResolvedValue({ id: 'v1' } as never);
 
-      await service.publish('v1');
+      await service.publish('MOTHER_REGISTRATION', 'v1');
 
       expect(repository.publish).toHaveBeenCalledWith('v1', expect.any(Date), null);
     });
 
+    it('rejects when the version does not belong to the given form code', async () => {
+      repository.findVersionById.mockResolvedValue(draftVersion as never);
+      await expect(service.publish('CHILD_REGISTRATION', 'v2')).rejects.toThrow(
+        /does not belong to this form code/,
+      );
+    });
+
     it('rejects publishing a version that is not DRAFT', async () => {
-      repository.findVersionById.mockResolvedValue({ id: 'v1', status: 'RETIRED' } as never);
-      await expect(service.publish('v1')).rejects.toThrow(/Only DRAFT versions can be published/);
+      repository.findVersionById.mockResolvedValue({
+        ...draftVersion,
+        status: 'RETIRED',
+      } as never);
+      await expect(service.publish('MOTHER_REGISTRATION', 'v1')).rejects.toThrow(
+        /Only DRAFT versions can be published/,
+      );
+    });
+
+    it('rejects publishing a draft with an empty schemaJson', async () => {
+      repository.findVersionById.mockResolvedValue({
+        ...draftVersion,
+        schemaJson: [],
+      } as never);
+      await expect(service.publish('MOTHER_REGISTRATION', 'v2')).rejects.toThrow(
+        /at least one well-formed field/,
+      );
     });
   });
 
@@ -298,6 +351,34 @@ describe('FormService', () => {
       await expect(call).rejects.toMatchObject({
         details: { violations: ['para must be <= gravida'] },
       });
+    });
+
+    it('skips a cross-field LTE check when a referenced field is legitimately absent', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue({
+        ...publishedVersion,
+        schemaJson: [
+          { question_code: 'para', label: 'Para', input_type: 'number', required: false },
+          { question_code: 'gravida', label: 'Gravida', input_type: 'number', required: false },
+        ],
+        validationJson: [{ rule: 'LTE', fields: ['para', 'gravida'] }],
+      } as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+      // Neither `para` nor `gravida` was answered — both are optional, so the
+      // cross-field rule should not fire at all (not "must be numeric").
+      await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: {},
+        },
+        'u1',
+      );
+
+      expect(repository.createSubmission).toHaveBeenCalled();
     });
 
     it('skips the required check for a field hidden by skip logic', async () => {

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -1,0 +1,358 @@
+import { FormService } from './form.service';
+import type { FormRepository } from './form.repository';
+
+describe('FormService', () => {
+  const repository = {
+    findDefinitionByCode: jest.fn(),
+    findActiveVersion: jest.fn(),
+    findVersionById: jest.fn(),
+    findCurrentlyPublished: jest.fn(),
+    countVersions: jest.fn(),
+    createDraft: jest.fn(),
+    updateDraft: jest.fn(),
+    publish: jest.fn(),
+    findSubmissionByLocalUuid: jest.fn(),
+    createSubmission: jest.fn(),
+  } as unknown as jest.Mocked<FormRepository>;
+  let service: FormService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new FormService(repository);
+  });
+
+  describe('getActiveVersion', () => {
+    it('returns the active version for a form code', async () => {
+      const version = { id: 'v1', status: 'PUBLISHED' };
+      repository.findActiveVersion.mockResolvedValue(version as never);
+      await expect(service.getActiveVersion('MOTHER_REGISTRATION', new Date())).resolves.toBe(
+        version,
+      );
+    });
+
+    it('throws not-found when no published version exists', async () => {
+      repository.findActiveVersion.mockResolvedValue(null);
+      await expect(service.getActiveVersion('MOTHER_REGISTRATION', new Date())).rejects.toThrow(
+        /No published form version/,
+      );
+    });
+  });
+
+  describe('createDraft', () => {
+    it('creates a draft with an auto-incremented version number', async () => {
+      repository.findDefinitionByCode.mockResolvedValue({ id: 'def-1' } as never);
+      repository.countVersions.mockResolvedValue(2);
+      repository.createDraft.mockResolvedValue({ id: 'draft-3', versionNo: 'v3' } as never);
+
+      const result = await service.createDraft('MOTHER_REGISTRATION', {});
+
+      expect(repository.createDraft).toHaveBeenCalledWith(
+        expect.objectContaining({ formDefinitionId: 'def-1', versionNo: 'v3', schemaJson: [] }),
+      );
+      expect(result).toEqual({ id: 'draft-3', versionNo: 'v3' });
+    });
+
+    it('throws not-found for an unknown form code', async () => {
+      repository.findDefinitionByCode.mockResolvedValue(null);
+      await expect(service.createDraft('NOT_A_FORM', {})).rejects.toThrow(/Unknown form code/);
+    });
+
+    it('rejects cloning from a version belonging to a different form definition', async () => {
+      repository.findDefinitionByCode.mockResolvedValue({ id: 'def-1' } as never);
+      repository.findVersionById.mockResolvedValue({
+        id: 'other-version',
+        formDefinitionId: 'def-2',
+      } as never);
+
+      await expect(
+        service.createDraft('MOTHER_REGISTRATION', { cloneFromVersionId: 'other-version' }),
+      ).rejects.toThrow(/does not belong to this form code/);
+    });
+
+    it('clones schemaJson/validationJson from the source version', async () => {
+      repository.findDefinitionByCode.mockResolvedValue({ id: 'def-1' } as never);
+      repository.findVersionById.mockResolvedValue({
+        id: 'source-version',
+        formDefinitionId: 'def-1',
+        schemaJson: [
+          { question_code: 'lmp_date', label: 'LMP', input_type: 'date', required: true },
+        ],
+        validationJson: [],
+      } as never);
+      repository.countVersions.mockResolvedValue(1);
+      repository.createDraft.mockResolvedValue({ id: 'draft-2' } as never);
+
+      await service.createDraft('MOTHER_REGISTRATION', { cloneFromVersionId: 'source-version' });
+
+      expect(repository.createDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schemaJson: [
+            { question_code: 'lmp_date', label: 'LMP', input_type: 'date', required: true },
+          ],
+        }),
+      );
+    });
+  });
+
+  describe('updateDraft', () => {
+    it('updates schemaJson/validationJson when the version is DRAFT', async () => {
+      repository.findVersionById.mockResolvedValue({ id: 'v1', status: 'DRAFT' } as never);
+      repository.updateDraft.mockResolvedValue({ id: 'v1' } as never);
+
+      await service.updateDraft('v1', { schemaJson: [], validationJson: [] });
+
+      expect(repository.updateDraft).toHaveBeenCalledWith(
+        'v1',
+        expect.objectContaining({ schemaJson: [], validationJson: [] }),
+      );
+    });
+
+    it('rejects editing a version that is not DRAFT', async () => {
+      repository.findVersionById.mockResolvedValue({ id: 'v1', status: 'PUBLISHED' } as never);
+      await expect(
+        service.updateDraft('v1', { schemaJson: [], validationJson: [] }),
+      ).rejects.toThrow(/Only DRAFT versions can be edited/);
+    });
+
+    it('throws not-found for an unknown version id', async () => {
+      repository.findVersionById.mockResolvedValue(null);
+      await expect(
+        service.updateDraft('missing', { schemaJson: [], validationJson: [] }),
+      ).rejects.toThrow(/Form version not found/);
+    });
+  });
+
+  describe('publish', () => {
+    it('publishes a DRAFT and retires the previously-active version', async () => {
+      repository.findVersionById.mockResolvedValue({
+        id: 'v2',
+        status: 'DRAFT',
+        formDefinitionId: 'def-1',
+      } as never);
+      repository.findCurrentlyPublished.mockResolvedValue({ id: 'v1' } as never);
+      repository.publish.mockResolvedValue({ id: 'v2', status: 'PUBLISHED' } as never);
+
+      await service.publish('v2');
+
+      expect(repository.publish).toHaveBeenCalledWith('v2', expect.any(Date), 'v1');
+    });
+
+    it('publishes with no previous version to retire when none exists', async () => {
+      repository.findVersionById.mockResolvedValue({
+        id: 'v1',
+        status: 'DRAFT',
+        formDefinitionId: 'def-1',
+      } as never);
+      repository.findCurrentlyPublished.mockResolvedValue(null);
+      repository.publish.mockResolvedValue({ id: 'v1' } as never);
+
+      await service.publish('v1');
+
+      expect(repository.publish).toHaveBeenCalledWith('v1', expect.any(Date), null);
+    });
+
+    it('rejects publishing a version that is not DRAFT', async () => {
+      repository.findVersionById.mockResolvedValue({ id: 'v1', status: 'RETIRED' } as never);
+      await expect(service.publish('v1')).rejects.toThrow(/Only DRAFT versions can be published/);
+    });
+  });
+
+  describe('createSubmission', () => {
+    const publishedVersion = {
+      id: 'version-1',
+      status: 'PUBLISHED',
+      formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+      schemaJson: [
+        { question_code: 'phone_owner', label: 'Phone owner', input_type: 'text', required: true },
+        {
+          question_code: 'bp_systolic',
+          label: 'BP Systolic',
+          input_type: 'number',
+          required: false,
+          numericRange: { min: 70, max: 300 },
+        },
+      ],
+      validationJson: [],
+    };
+
+    it('returns the existing submission on a retried localSubmissionUuid (idempotent)', async () => {
+      const existing = { id: 'sub-1' };
+      repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
+
+      const result = await service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'retry-uuid',
+        formData: {},
+      });
+
+      expect(result).toBe(existing);
+      expect(repository.findVersionById).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the form version does not belong to the given form code', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue(publishedVersion as never);
+
+      await expect(
+        service.createSubmission('CHILD_REGISTRATION', {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          submittedByUserId: 'u1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { phone_owner: 'SELF' },
+        }),
+      ).rejects.toThrow(/does not belong to this form code/);
+    });
+
+    it('rejects when the version is not PUBLISHED', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue({
+        ...publishedVersion,
+        status: 'DRAFT',
+      } as never);
+
+      await expect(
+        service.createSubmission('MOTHER_REGISTRATION', {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          submittedByUserId: 'u1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { phone_owner: 'SELF' },
+        }),
+      ).rejects.toThrow(/not published/);
+    });
+
+    it('rejects a submission missing a required field', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue(publishedVersion as never);
+
+      const call = service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'uuid-1',
+        formData: {},
+      });
+
+      await expect(call).rejects.toMatchObject({
+        details: { violations: ['Missing required field: phone_owner'] },
+      });
+    });
+
+    it('rejects a numeric value outside the declared range', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue(publishedVersion as never);
+
+      const call = service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'uuid-1',
+        formData: { phone_owner: 'SELF', bp_systolic: 400 },
+      });
+
+      await expect(call).rejects.toMatchObject({
+        details: { violations: ['bp_systolic must be between 70 and 300'] },
+      });
+    });
+
+    it('rejects a cross-field LTE violation', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue({
+        ...publishedVersion,
+        schemaJson: [
+          { question_code: 'para', label: 'Para', input_type: 'number', required: false },
+          { question_code: 'gravida', label: 'Gravida', input_type: 'number', required: false },
+        ],
+        validationJson: [{ rule: 'LTE', fields: ['para', 'gravida'] }],
+      } as never);
+
+      const call = service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'uuid-1',
+        formData: { para: 5, gravida: 2 },
+      });
+
+      await expect(call).rejects.toMatchObject({
+        details: { violations: ['para must be <= gravida'] },
+      });
+    });
+
+    it('skips the required check for a field hidden by skip logic', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue({
+        ...publishedVersion,
+        schemaJson: [
+          {
+            question_code: 'fetal_heart_rate',
+            label: 'Fetal Heart Rate',
+            input_type: 'number',
+            required: true,
+            visibleWhen: { field: 'gestational_age_weeks', operator: 'gte', value: 20 },
+          },
+        ],
+      } as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+      await service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'uuid-1',
+        formData: { gestational_age_weeks: 10 },
+      });
+
+      expect(repository.createSubmission).toHaveBeenCalled();
+    });
+
+    it('skips the required check for a system-computed field', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue({
+        ...publishedVersion,
+        schemaJson: [
+          {
+            question_code: 'edd_date',
+            label: 'EDD',
+            input_type: 'date',
+            required: true,
+            computedFrom: 'EDD_FROM_LMP',
+          },
+        ],
+      } as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+      await service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'uuid-1',
+        formData: {},
+      });
+
+      expect(repository.createSubmission).toHaveBeenCalled();
+    });
+
+    it('creates the submission with validationStatus VALID on success', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue(publishedVersion as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+      const result = await service.createSubmission('MOTHER_REGISTRATION', {
+        formVersionId: 'version-1',
+        beneficiaryId: 'b1',
+        submittedByUserId: 'u1',
+        localSubmissionUuid: 'uuid-1',
+        formData: { phone_owner: 'SELF' },
+      });
+
+      expect(repository.createSubmission).toHaveBeenCalledWith(
+        expect.objectContaining({ validationStatus: 'VALID' }),
+      );
+      expect(result).toEqual({ id: 'sub-1' });
+    });
+  });
+});

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -179,13 +179,16 @@ describe('FormService', () => {
       const existing = { id: 'sub-1' };
       repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
 
-      const result = await service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'retry-uuid',
-        formData: {},
-      });
+      const result = await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'retry-uuid',
+          formData: {},
+        },
+        'u1',
+      );
 
       expect(result).toBe(existing);
       expect(repository.findVersionById).not.toHaveBeenCalled();
@@ -196,13 +199,16 @@ describe('FormService', () => {
       repository.findVersionById.mockResolvedValue(publishedVersion as never);
 
       await expect(
-        service.createSubmission('CHILD_REGISTRATION', {
-          formVersionId: 'version-1',
-          beneficiaryId: 'b1',
-          submittedByUserId: 'u1',
-          localSubmissionUuid: 'uuid-1',
-          formData: { phone_owner: 'SELF' },
-        }),
+        service.createSubmission(
+          'CHILD_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+        ),
       ).rejects.toThrow(/does not belong to this form code/);
     });
 
@@ -214,13 +220,16 @@ describe('FormService', () => {
       } as never);
 
       await expect(
-        service.createSubmission('MOTHER_REGISTRATION', {
-          formVersionId: 'version-1',
-          beneficiaryId: 'b1',
-          submittedByUserId: 'u1',
-          localSubmissionUuid: 'uuid-1',
-          formData: { phone_owner: 'SELF' },
-        }),
+        service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+        ),
       ).rejects.toThrow(/not published/);
     });
 
@@ -228,13 +237,16 @@ describe('FormService', () => {
       repository.findSubmissionByLocalUuid.mockResolvedValue(null);
       repository.findVersionById.mockResolvedValue(publishedVersion as never);
 
-      const call = service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'uuid-1',
-        formData: {},
-      });
+      const call = service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: {},
+        },
+        'u1',
+      );
 
       await expect(call).rejects.toMatchObject({
         details: { violations: ['Missing required field: phone_owner'] },
@@ -245,13 +257,16 @@ describe('FormService', () => {
       repository.findSubmissionByLocalUuid.mockResolvedValue(null);
       repository.findVersionById.mockResolvedValue(publishedVersion as never);
 
-      const call = service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'uuid-1',
-        formData: { phone_owner: 'SELF', bp_systolic: 400 },
-      });
+      const call = service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { phone_owner: 'SELF', bp_systolic: 400 },
+        },
+        'u1',
+      );
 
       await expect(call).rejects.toMatchObject({
         details: { violations: ['bp_systolic must be between 70 and 300'] },
@@ -269,13 +284,16 @@ describe('FormService', () => {
         validationJson: [{ rule: 'LTE', fields: ['para', 'gravida'] }],
       } as never);
 
-      const call = service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'uuid-1',
-        formData: { para: 5, gravida: 2 },
-      });
+      const call = service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { para: 5, gravida: 2 },
+        },
+        'u1',
+      );
 
       await expect(call).rejects.toMatchObject({
         details: { violations: ['para must be <= gravida'] },
@@ -298,13 +316,16 @@ describe('FormService', () => {
       } as never);
       repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
 
-      await service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'uuid-1',
-        formData: { gestational_age_weeks: 10 },
-      });
+      await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { gestational_age_weeks: 10 },
+        },
+        'u1',
+      );
 
       expect(repository.createSubmission).toHaveBeenCalled();
     });
@@ -325,13 +346,16 @@ describe('FormService', () => {
       } as never);
       repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
 
-      await service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'uuid-1',
-        formData: {},
-      });
+      await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: {},
+        },
+        'u1',
+      );
 
       expect(repository.createSubmission).toHaveBeenCalled();
     });
@@ -341,13 +365,16 @@ describe('FormService', () => {
       repository.findVersionById.mockResolvedValue(publishedVersion as never);
       repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
 
-      const result = await service.createSubmission('MOTHER_REGISTRATION', {
-        formVersionId: 'version-1',
-        beneficiaryId: 'b1',
-        submittedByUserId: 'u1',
-        localSubmissionUuid: 'uuid-1',
-        formData: { phone_owner: 'SELF' },
-      });
+      const result = await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { phone_owner: 'SELF' },
+        },
+        'u1',
+      );
 
       expect(repository.createSubmission).toHaveBeenCalledWith(
         expect.objectContaining({ validationStatus: 'VALID' }),

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto';
+import { badRequest, conflict, notFound } from '@armman/service-commons';
+import type { FormRepository } from './form.repository';
+import {
+  schemaJsonSchema,
+  validationJsonSchema,
+  type CrossFieldRule,
+  type FormField,
+} from './dto/form-field.dto';
+import type { CreateDraftVersionInput } from './dto/create-draft-version.dto';
+import type { PatchFormVersionInput } from './dto/patch-form-version.dto';
+import type { CreateSubmissionInput } from './dto/create-submission.dto';
+
+function computeChecksum(schemaJson: unknown): Buffer {
+  return createHash('sha256').update(JSON.stringify(schemaJson)).digest();
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === undefined || value === null || value === '';
+}
+
+/** Evaluates SRS Category 5 skip logic for one field against the submitted formData. */
+function isVisible(field: FormField, formData: Record<string, unknown>): boolean {
+  if (!field.visibleWhen) return true;
+  const actual = formData[field.visibleWhen.field];
+  switch (field.visibleWhen.operator) {
+    case 'eq':
+      return actual === field.visibleWhen.value;
+    case 'gte':
+      return Number(actual) >= Number(field.visibleWhen.value);
+    case 'lt':
+      return Number(actual) < Number(field.visibleWhen.value);
+    case 'isSet':
+      return !isEmpty(actual);
+    default:
+      return true;
+  }
+}
+
+/**
+ * Business logic for the dynamic-forms feature: fetching the active version,
+ * the DRAFT -> PUBLISHED lifecycle, and validating/persisting submissions.
+ * Data access is delegated to the repository.
+ */
+export class FormService {
+  constructor(private readonly repository: FormRepository) {}
+
+  async getActiveVersion(formCode: string, asOf: Date) {
+    const version = await this.repository.findActiveVersion(formCode, asOf);
+    if (!version) throw notFound(`No published form version found for form code "${formCode}".`);
+    return version;
+  }
+
+  async createDraft(formCode: string, dto: CreateDraftVersionInput) {
+    const definition = await this.repository.findDefinitionByCode(formCode);
+    if (!definition) throw notFound(`Unknown form code "${formCode}".`);
+
+    let schemaJson: unknown = [];
+    let validationJson: unknown = [];
+    if (dto.cloneFromVersionId) {
+      const source = await this.repository.findVersionById(dto.cloneFromVersionId);
+      if (!source || source.formDefinitionId !== definition.id) {
+        throw badRequest('cloneFromVersionId does not belong to this form code.');
+      }
+      schemaJson = source.schemaJson;
+      validationJson = source.validationJson ?? [];
+    }
+
+    const existingCount = await this.repository.countVersions(definition.id);
+    const versionNo = `v${existingCount + 1}`;
+
+    return this.repository.createDraft({
+      formDefinitionId: definition.id,
+      versionNo,
+      schemaJson,
+      validationJson,
+      checksum: computeChecksum(schemaJson),
+      // Placeholder — form_versions.effective_from is NOT NULL, but a DRAFT
+      // isn't live yet. Overwritten with the real value by publish(). See
+      // the forms API design doc §7 (open question, flagged not assumed).
+      effectiveFrom: new Date(),
+    });
+  }
+
+  async updateDraft(versionId: string, dto: PatchFormVersionInput) {
+    const version = await this.repository.findVersionById(versionId);
+    if (!version) throw notFound('Form version not found.');
+    if (version.status !== 'DRAFT') {
+      throw conflict('Only DRAFT versions can be edited.');
+    }
+
+    return this.repository.updateDraft(versionId, {
+      schemaJson: dto.schemaJson,
+      validationJson: dto.validationJson ?? [],
+      checksum: computeChecksum(dto.schemaJson),
+    });
+  }
+
+  async publish(versionId: string) {
+    const version = await this.repository.findVersionById(versionId);
+    if (!version) throw notFound('Form version not found.');
+    if (version.status !== 'DRAFT') {
+      throw conflict('Only DRAFT versions can be published.');
+    }
+
+    const current = await this.repository.findCurrentlyPublished(version.formDefinitionId);
+    const effectiveFrom = new Date();
+    return this.repository.publish(versionId, effectiveFrom, current?.id ?? null);
+  }
+
+  async createSubmission(formCode: string, dto: CreateSubmissionInput) {
+    const existing = await this.repository.findSubmissionByLocalUuid(dto.localSubmissionUuid);
+    if (existing) return existing; // idempotent replay — matches sync's local_submission_uuid dedup key
+
+    const version = await this.repository.findVersionById(dto.formVersionId);
+    if (!version) throw notFound('Form version not found.');
+    if (version.formDefinition.formCode !== formCode) {
+      throw badRequest('formVersionId does not belong to this form code.');
+    }
+    if (version.status !== 'PUBLISHED') {
+      throw badRequest('Form version is not published.');
+    }
+
+    const fields = schemaJsonSchema.parse(version.schemaJson);
+    const crossFieldRules = validationJsonSchema.parse(version.validationJson ?? []);
+    const violations = this.validate(fields, crossFieldRules, dto.formData);
+
+    if (violations.length) {
+      throw badRequest('Submission failed validation.', { violations });
+    }
+
+    return this.repository.createSubmission({
+      formVersionId: dto.formVersionId,
+      beneficiaryId: dto.beneficiaryId,
+      visitId: dto.visitId ?? null,
+      submittedByUserId: dto.submittedByUserId,
+      localSubmissionUuid: dto.localSubmissionUuid,
+      formDataJson: dto.formData,
+      validationStatus: 'VALID',
+    });
+  }
+
+  /**
+   * Checks required fields (SRS line 1150), numeric ranges (SRS Category 2),
+   * and cross-field consistency (SRS Category 3) against submitted formData.
+   * Date rules (Category 1) are deliberately not checked here — see the
+   * forms API design doc §7. Fields hidden by skip logic (Category 5) or
+   * computed by the system (Category 4) are excluded from the required check.
+   */
+  private validate(
+    fields: FormField[],
+    crossFieldRules: CrossFieldRule[],
+    formData: Record<string, unknown>,
+  ): string[] {
+    const violations: string[] = [];
+
+    for (const field of fields) {
+      if (field.computedFrom) continue;
+      if (!isVisible(field, formData)) continue;
+
+      const value = formData[field.question_code];
+      if (field.required && isEmpty(value)) {
+        violations.push(`Missing required field: ${field.question_code}`);
+        continue;
+      }
+
+      if (field.numericRange && !isEmpty(value)) {
+        const numeric = Number(value);
+        if (
+          Number.isNaN(numeric) ||
+          numeric < field.numericRange.min ||
+          numeric > field.numericRange.max
+        ) {
+          violations.push(
+            `${field.question_code} must be between ${field.numericRange.min} and ${field.numericRange.max}`,
+          );
+        }
+      }
+    }
+
+    for (const rule of crossFieldRules) {
+      if (rule.rule === 'LTE') {
+        const [a, b] = rule.fields;
+        const va = Number(formData[a]);
+        const vb = Number(formData[b]);
+        if (!Number.isNaN(va) && !Number.isNaN(vb) && va > vb) {
+          violations.push(`${a} must be <= ${b}`);
+        }
+      } else if (rule.rule === 'SUM_EQUALS') {
+        const sum = rule.fields.reduce((total, f) => total + (Number(formData[f]) || 0), 0);
+        const target = Number(formData[rule.equals]);
+        if (!Number.isNaN(target) && sum !== target) {
+          violations.push(`${rule.fields.join(' + ')} must equal ${rule.equals}`);
+        }
+      }
+    }
+
+    return violations;
+  }
+}

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { badRequest, conflict, notFound } from '@armman/service-commons';
+import { badRequest, conflict, notFound, unprocessable } from '@armman/service-commons';
 import type { FormRepository } from './form.repository';
 import {
   schemaJsonSchema,
@@ -108,7 +108,7 @@ export class FormService {
     return this.repository.publish(versionId, effectiveFrom, current?.id ?? null);
   }
 
-  async createSubmission(formCode: string, dto: CreateSubmissionInput) {
+  async createSubmission(formCode: string, dto: CreateSubmissionInput, submittedByUserId: string) {
     const existing = await this.repository.findSubmissionByLocalUuid(dto.localSubmissionUuid);
     if (existing) return existing; // idempotent replay — matches sync's local_submission_uuid dedup key
 
@@ -126,14 +126,14 @@ export class FormService {
     const violations = this.validate(fields, crossFieldRules, dto.formData);
 
     if (violations.length) {
-      throw badRequest('Submission failed validation.', { violations });
+      throw unprocessable('Submission failed validation.', { violations });
     }
 
     return this.repository.createSubmission({
       formVersionId: dto.formVersionId,
       beneficiaryId: dto.beneficiaryId,
       visitId: dto.visitId ?? null,
-      submittedByUserId: dto.submittedByUserId,
+      submittedByUserId,
       localSubmissionUuid: dto.localSubmissionUuid,
       formDataJson: dto.formData,
       validationStatus: 'VALID',
@@ -183,13 +183,17 @@ export class FormService {
         const [a, b] = rule.fields;
         const va = Number(formData[a]);
         const vb = Number(formData[b]);
-        if (!Number.isNaN(va) && !Number.isNaN(vb) && va > vb) {
+        if (Number.isNaN(va) || Number.isNaN(vb)) {
+          violations.push(`${a} and ${b} must both be numeric`);
+        } else if (va > vb) {
           violations.push(`${a} must be <= ${b}`);
         }
       } else if (rule.rule === 'SUM_EQUALS') {
-        const sum = rule.fields.reduce((total, f) => total + (Number(formData[f]) || 0), 0);
+        const values = rule.fields.map((f) => Number(formData[f]));
         const target = Number(formData[rule.equals]);
-        if (!Number.isNaN(target) && sum !== target) {
+        if (values.some((v) => Number.isNaN(v)) || Number.isNaN(target)) {
+          violations.push(`${rule.fields.join(', ')} and ${rule.equals} must all be numeric`);
+        } else if (values.reduce((total, v) => total + v, 0) !== target) {
           violations.push(`${rule.fields.join(' + ')} must equal ${rule.equals}`);
         }
       }

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -82,9 +82,12 @@ export class FormService {
     });
   }
 
-  async updateDraft(versionId: string, dto: PatchFormVersionInput) {
+  async updateDraft(formCode: string, versionId: string, dto: PatchFormVersionInput) {
     const version = await this.repository.findVersionById(versionId);
     if (!version) throw notFound('Form version not found.');
+    if (version.formDefinition.formCode !== formCode) {
+      throw badRequest('versionId does not belong to this form code.');
+    }
     if (version.status !== 'DRAFT') {
       throw conflict('Only DRAFT versions can be edited.');
     }
@@ -96,11 +99,20 @@ export class FormService {
     });
   }
 
-  async publish(versionId: string) {
+  async publish(formCode: string, versionId: string) {
     const version = await this.repository.findVersionById(versionId);
     if (!version) throw notFound('Form version not found.');
+    if (version.formDefinition.formCode !== formCode) {
+      throw badRequest('versionId does not belong to this form code.');
+    }
     if (version.status !== 'DRAFT') {
       throw conflict('Only DRAFT versions can be published.');
+    }
+    // schemaJsonSchema requires >=1 field — publishing an empty/malformed
+    // draft would otherwise pass here and only fail later, as an uncaught
+    // exception, the first time createSubmission() parses it.
+    if (!schemaJsonSchema.safeParse(version.schemaJson).success) {
+      throw unprocessable('Draft schemaJson must have at least one well-formed field to publish.');
     }
 
     const current = await this.repository.findCurrentlyPublished(version.formDefinitionId);
@@ -181,6 +193,11 @@ export class FormService {
     for (const rule of crossFieldRules) {
       if (rule.rule === 'LTE') {
         const [a, b] = rule.fields;
+        // A field legitimately absent (optional, not yet answered) is not
+        // this rule's concern — the required-field check above already
+        // covers "missing". Only a *present but non-numeric* value is a
+        // cross-field violation.
+        if (isEmpty(formData[a]) || isEmpty(formData[b])) continue;
         const va = Number(formData[a]);
         const vb = Number(formData[b]);
         if (Number.isNaN(va) || Number.isNaN(vb)) {
@@ -189,6 +206,8 @@ export class FormService {
           violations.push(`${a} must be <= ${b}`);
         }
       } else if (rule.rule === 'SUM_EQUALS') {
+        const allFields = [...rule.fields, rule.equals];
+        if (allFields.some((f) => isEmpty(formData[f]))) continue;
         const values = rule.fields.map((f) => Number(formData[f]));
         const target = Number(formData[rule.equals]);
         if (values.some((v) => Number.isNaN(v)) || Number.isNaN(target)) {

--- a/apps/visit-form-service/webpack.config.js
+++ b/apps/visit-form-service/webpack.config.js
@@ -1,6 +1,19 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('node:path');
+const { IgnorePrismaSourceMapWarnings } = require('../../tools/webpack-ignore-prisma-warnings');
+
 module.exports = {
   output: { path: join(__dirname, '../../dist/apps/visit-form-service') },
-  plugins: [ new NxAppWebpackPlugin({ target: 'node', compiler: 'tsc', main: './src/main.ts', tsConfig: './tsconfig.app.json', optimization: false, outputHashing: 'none', generatePackageJson: false }) ],
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+      optimization: false,
+      outputHashing: 'none',
+      generatePackageJson: false,
+    }),
+    new IgnorePrismaSourceMapWarnings(),
+  ],
 };

--- a/nx.json
+++ b/nx.json
@@ -13,7 +13,10 @@
   "targetDefaults": {
     "build": { "dependsOn": ["^build"], "inputs": ["production", "^production"], "cache": true },
     "test": { "inputs": ["default", "^production"], "cache": true },
-    "lint": { "cache": true }
+    "lint": { "cache": true },
+    "serve": {
+      "options": { "port": 0 }
+    }
   },
   "defaultBase": "main"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jose": "^6.2.3"
       },
       "devDependencies": {
+        "@babel/preset-env": "^7.29.7",
         "@commitlint/cli": "^19.4.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@nx/eslint": "^19.5.0",
@@ -26,6 +27,7 @@
         "@nx/webpack": "^19.8.14",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.0",
+        "babel-jest": "^29.7.0",
         "eslint": "^9.9.0",
         "husky": "^9.1.4",
         "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,6 +1161,7 @@
         "express-rate-limit": "^8.5.2",
         "ioredis": "^5.11.1",
         "jose": "^6.2.3",
+        "openapi3-ts": "^3.2.0",
         "pino": "^9.3.2",
         "pino-http": "^10.2.0",
         "rate-limit-redis": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.29.7",
     "@commitlint/cli": "^19.4.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@nx/eslint": "^19.5.0",
@@ -38,6 +39,7 @@
     "@nx/webpack": "^19.8.14",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
+    "babel-jest": "^29.7.0",
     "eslint": "^9.9.0",
     "husky": "^9.1.4",
     "jest": "^29.7.0",

--- a/tools/webpack-ignore-prisma-warnings.js
+++ b/tools/webpack-ignore-prisma-warnings.js
@@ -1,0 +1,32 @@
+/**
+ * Prisma's generated client ships a runtime file that references a sourcemap
+ * it doesn't actually include, so Nx's built-in source-map-loader rule warns
+ * on every build of every service. NxAppWebpackPlugin overwrites
+ * config.ignoreWarnings itself (rather than merging), so a top-level
+ * `ignoreWarnings` in a service's webpack.config.js gets clobbered —
+ * appending to it from a plugin that runs after NxAppWebpackPlugin (via
+ * afterEnvironment, which fires once all plugins have applied) works because
+ * it mutates the array NxAppWebpackPlugin already assigned.
+ *
+ * Shared across every service's webpack.config.js instead of duplicated
+ * per-service.
+ */
+class IgnorePrismaSourceMapWarnings {
+  apply(compiler) {
+    compiler.hooks.afterEnvironment.tap('IgnorePrismaSourceMapWarnings', () => {
+      compiler.options.ignoreWarnings = [
+        ...(compiler.options.ignoreWarnings ?? []),
+        (warning) => {
+          const message = typeof warning === 'string' ? warning : warning.message;
+          return (
+            typeof message === 'string' &&
+            message.includes('Failed to parse source map') &&
+            /\.prisma[\\/]/.test(message)
+          );
+        },
+      ];
+    });
+  }
+}
+
+module.exports = { IgnorePrismaSourceMapWarnings };


### PR DESCRIPTION
Summary

**Adds the dynamic-forms API in visit-form-service (apps/visit-form-service/src/forms/)** — one generic API surface for all 13 ERD form codes, instead of a hand-built endpoint per form.
**GET /forms/:formCode/active-version** — fetch the currently published version.
**POST /admin/forms/:formCode/versions,** PATCH .../versions/:versionId, POST .../versions/:versionId/publish — draft → edit → publish lifecycle, ADMIN-only. Field create/delete is just an array edit on the draft's schemaJson; the version becomes immutable once published, preserving submission audit history.
**POST /forms/:formCode/submissions** — validates against the live published version (never a hardcoded schema): required fields (skip-logic- and computed-field-aware), numeric ranges, and the 4 SRS cross-field rules (Para ≤ Gravida, etc.). Idempotent on localSubmissionUuid retries.

Also fixes

**jest.config.ts** — same jose ESM-only transform issue beneficiary-service already had; copied its existing, documented fix.
**package-lock.json** — openapi3-ts was declared in service-commons/package.json but missing from the lockfile; corrected as part of npm install.


Related to #86
