### PR TITLE
Add /me profile fields, beneficiary risk/history filters, and RBAC enforcement

### DIFF
--- a/apps/approval-service/src/app.module.ts
+++ b/apps/approval-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/approval-service/src/approvals/approvalRequest.controller.ts
+++ b/apps/approval-service/src/approvals/approvalRequest.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { ApprovalRequestService } from './approvalRequest.service';
 import { createApprovalRequestSchema } from './dto/create-approvalRequest.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -70,8 +77,12 @@ export function createApprovalRequestRouter(service: ApprovalRequestService) {
           description: 'Approval requests',
           schema: envelope(z.array(approvalRequestSchema)),
         },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -85,8 +96,12 @@ export function createApprovalRequestRouter(service: ApprovalRequestService) {
       responses: {
         201: { description: 'Approval request created', schema: envelope(approvalRequestSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR'),
     validateBody(createApprovalRequestSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/audit-service/src/app.module.ts
+++ b/apps/audit-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/audit-service/src/audit/auditLog.controller.ts
+++ b/apps/audit-service/src/audit/auditLog.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { AuditLogService } from './auditLog.service';
 import { createAuditLogSchema } from './dto/create-auditLog.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -52,8 +59,12 @@ export function createAuditLogRouter(service: AuditLogService) {
       tags: ['Audit'],
       responses: {
         200: { description: 'Audit log entries', schema: envelope(z.array(auditLogRecordSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('ADMIN', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -67,8 +78,12 @@ export function createAuditLogRouter(service: AuditLogService) {
       responses: {
         201: { description: 'Audit log entry created', schema: envelope(auditLogRecordSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
     validateBody(createAuditLogSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -17,3 +17,7 @@ JWT_REFRESH_TOKEN_TTL=30d
 ADMIN_USERNAME=REPLACE_ME
 ADMIN_MOBILE_NUMBER=+910000000000
 ADMIN_PASSWORD=REPLACE_ME
+# Base64-encoded 32-byte key (e.g. `openssl rand -base64 32`), used to decrypt
+# sakhi_profiles.bank_account_token for GET /me's maskedBankAccount field.
+# Real value lives only in the gitignored .env.
+PII_ENCRYPTION_KEY=REPLACE_ME

--- a/apps/auth-service/prisma/migrations/20260717000000_add_sakhi_profiles/migration.sql
+++ b/apps/auth-service/prisma/migrations/20260717000000_add_sakhi_profiles/migration.sql
@@ -1,0 +1,46 @@
+-- AddForeignKey
+-- user_roles.project_id now has a real Prisma relation to projects (both
+-- tables live in the auth_service schema already) -- previously modeled as
+-- a plain scalar column under a stale "owned by another service" comment.
+ALTER TABLE "auth_service"."user_roles" ADD CONSTRAINT "user_roles_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "auth_service"."projects"("project_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateTable
+-- Column set matches docs/Arogya_Sakhi_Database_Design_ERD_Table_Definitions.docx.md
+-- "sakhi_profiles" (Appendix A) exactly. supervisor_id references
+-- supervisor_profiles.supervisor_id, which is not modeled anywhere yet --
+-- left as a plain scalar column, not a Prisma relation.
+CREATE TABLE "auth_service"."sakhi_profiles" (
+    "sakhi_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "primary_project_id" TEXT NOT NULL,
+    "supervisor_id" TEXT,
+    "employee_code" VARCHAR(80),
+    "phone_number" VARCHAR(13) NOT NULL,
+    "backup_contact" VARCHAR(13),
+    "pan_token" BYTEA,
+    "aadhaar_token" BYTEA,
+    "bank_account_token" BYTEA,
+    "ifsc_code" VARCHAR(20),
+    "active_from" DATE NOT NULL,
+    "active_to" DATE,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by_user_id" TEXT,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "updated_by_user_id" TEXT,
+    "is_deleted" BOOLEAN NOT NULL DEFAULT false,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "sakhi_profiles_pkey" PRIMARY KEY ("sakhi_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sakhi_profiles_user_id_key" ON "auth_service"."sakhi_profiles"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sakhi_profiles_employee_code_key" ON "auth_service"."sakhi_profiles"("employee_code");
+
+-- AddForeignKey
+ALTER TABLE "auth_service"."sakhi_profiles" ADD CONSTRAINT "sakhi_profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth_service"."users"("user_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "auth_service"."sakhi_profiles" ADD CONSTRAINT "sakhi_profiles_primary_project_id_fkey" FOREIGN KEY ("primary_project_id") REFERENCES "auth_service"."projects"("project_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/auth-service/prisma/schema.prisma
+++ b/apps/auth-service/prisma/schema.prisma
@@ -71,6 +71,7 @@ model User {
 
   userRoles    UserRole[]
   userSessions UserSession[]
+  sakhiProfile SakhiProfile?
 
   @@map("users")
   @@schema("auth_service")
@@ -96,12 +97,16 @@ model Role {
 }
 
 model UserRole {
-  id              String         @id @default(uuid()) @map("user_role_id")
-  userId          String         @map("user_id")
-  roleId          String         @map("role_id")
-  // projects.project_id — owned by another service, no cross-service relation.
-  projectId       String?        @map("project_id")
-  // geography_units.geography_unit_id — owned by another service, no cross-service relation.
+  id        String         @id @default(uuid()) @map("user_role_id")
+  userId    String         @map("user_id")
+  roleId    String         @map("role_id")
+  // projects live in this same schema (auth-service also owns project/funder
+  // master data — see the Funder/Project models below), so this is a real
+  // Prisma relation, not a cross-service scalar.
+  projectId String?        @map("project_id")
+  project   Project?       @relation(fields: [projectId], references: [projectId])
+  // geography_units.geography_unit_id — same schema too, but no relation is
+  // declared here yet; left as a plain scalar until a caller actually needs it.
   geographyUnitId String?        @map("geography_unit_id")
   effectiveFrom   DateTime       @map("effective_from")
   effectiveTo     DateTime?      @map("effective_to")
@@ -195,7 +200,41 @@ model Project {
   isDeleted       Boolean       @default(false) @map("is_deleted")
   deletedAt       DateTime?     @map("deleted_at")
 
+  userRoles     UserRole[]
+  sakhiProfiles SakhiProfile[]
+
   @@map("projects")
+  @@schema("auth_service")
+}
+
+// Column set matches ERD Appendix A.1 ("sakhi_profiles") exactly.
+// supervisorId references supervisor_profiles.supervisor_id, which is not
+// modeled anywhere yet — left as a plain scalar (no relation) rather than
+// invented.
+model SakhiProfile {
+  id               String    @id @default(uuid()) @map("sakhi_id")
+  userId           String    @unique @map("user_id")
+  user             User      @relation(fields: [userId], references: [id])
+  primaryProjectId String    @map("primary_project_id")
+  primaryProject   Project   @relation(fields: [primaryProjectId], references: [projectId])
+  supervisorId     String?   @map("supervisor_id")
+  employeeCode     String?   @unique @map("employee_code") @db.VarChar(80)
+  phoneNumber      String    @map("phone_number") @db.VarChar(13)
+  backupContact    String?   @map("backup_contact") @db.VarChar(13)
+  panToken         Bytes?    @map("pan_token")
+  aadhaarToken     Bytes?    @map("aadhaar_token")
+  bankAccountToken Bytes?    @map("bank_account_token")
+  ifscCode         String?   @map("ifsc_code") @db.VarChar(20)
+  activeFrom       DateTime  @map("active_from") @db.Date
+  activeTo         DateTime? @map("active_to") @db.Date
+  createdAt        DateTime  @default(now()) @map("created_at")
+  createdByUserId  String?   @map("created_by_user_id")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+  updatedByUserId  String?   @map("updated_by_user_id")
+  isDeleted        Boolean   @default(false) @map("is_deleted")
+  deletedAt        DateTime? @map("deleted_at")
+
+  @@map("sakhi_profiles")
   @@schema("auth_service")
 }
 

--- a/apps/auth-service/src/auth/auth.controller.ts
+++ b/apps/auth-service/src/auth/auth.controller.ts
@@ -46,6 +46,9 @@ const userProfileSchema = z.object({
   username: z.string().openapi({ example: 'jane.sakhi' }),
   displayName: z.string().openapi({ example: 'Jane Sakhi' }),
   mobileNumber: z.string().openapi({ example: '+919876543210' }),
+  email: z.string().email().nullable().openapi({ example: 'jane.sakhi@example.org' }),
+  status: z.string().openapi({ example: 'ACTIVE' }),
+  createdAt: z.string().datetime(),
   roles: z.array(
     z.object({
       roleCode: z.string().openapi({ example: 'SAKHI' }),
@@ -53,6 +56,18 @@ const userProfileSchema = z.object({
       geographyUnitId: z.string().uuid().nullable(),
     }),
   ),
+  projectName: z
+    .string()
+    .nullable()
+    .openapi({ description: "The primary role's project name.", example: 'GEP-2324' }),
+  cardNumber: z.string().nullable().openapi({
+    description: 'Sakhi employee/ID card number — null for non-SAKHI roles.',
+    example: 'EMP-00123',
+  }),
+  maskedBankAccount: z.string().nullable().openapi({
+    description: 'Last 4 digits of the linked bank account, masked — never the full number.',
+    example: '••••1234',
+  }),
 });
 
 const createdUserSchema = z.object({

--- a/apps/auth-service/src/auth/auth.controller.ts
+++ b/apps/auth-service/src/auth/auth.controller.ts
@@ -39,6 +39,15 @@ const authTokensSchema = z.object({
     .string()
     .openapi({ description: 'Opaque refresh token; single-use, rotated on refresh.' }),
   expiresIn: z.number().openapi({ description: 'Access token lifetime in seconds.', example: 900 }),
+  roles: z
+    .array(z.string())
+    .openapi({ description: 'Every role code the caller holds.', example: ['SAKHI'] }),
+  projectId: z.string().uuid().nullable().openapi({
+    description: "The primary role assignment's project scope.",
+  }),
+  geographyUnitId: z.string().uuid().nullable().openapi({
+    description: "The primary role assignment's geography scope.",
+  }),
 });
 
 const userProfileSchema = z.object({
@@ -67,6 +76,9 @@ const userProfileSchema = z.object({
   maskedBankAccount: z.string().nullable().openapi({
     description: 'Last 4 digits of the linked bank account, masked — never the full number.',
     example: '••••1234',
+  }),
+  supervisorId: z.string().uuid().nullable().openapi({
+    description: "Sakhi profile's supervisor — null for non-SAKHI roles.",
   }),
 });
 

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -9,8 +9,12 @@ export class AuthRepository {
     return this.prisma.user.findUnique({
       where: { username },
       include: {
+        // `createdAt: 'asc'` makes the "primary" role assignment (the first
+        // entry, used by issueTokens/getProfile) the earliest-assigned one
+        // instead of an unspecified Prisma row order.
         userRoles: {
           where: { status: 'ACTIVE', isDeleted: false },
+          orderBy: { createdAt: 'asc' },
           include: { role: true },
         },
       },
@@ -23,6 +27,7 @@ export class AuthRepository {
       include: {
         userRoles: {
           where: { status: 'ACTIVE', isDeleted: false },
+          orderBy: { createdAt: 'asc' },
           include: { role: true },
         },
       },
@@ -42,6 +47,7 @@ export class AuthRepository {
       include: {
         userRoles: {
           where: { status: 'ACTIVE', isDeleted: false },
+          orderBy: { createdAt: 'asc' },
           include: { role: true, project: true },
         },
         sakhiProfile: true,

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -29,6 +29,26 @@ export class AuthRepository {
     });
   }
 
+  /**
+   * Same as {@link findUserById}, additionally including the primary
+   * project's name (via each active role's `project` relation) and the
+   * caller's Sakhi profile (if any — only SAKHI-role users have one). Used
+   * by `GET /me`, which needs project name / employee code / masked bank
+   * account beyond the base profile fields.
+   */
+  findUserByIdWithProfile(id: string) {
+    return this.prisma.user.findUnique({
+      where: { id },
+      include: {
+        userRoles: {
+          where: { status: 'ACTIVE', isDeleted: false },
+          include: { role: true, project: true },
+        },
+        sakhiProfile: true,
+      },
+    });
+  }
+
   incrementFailedLoginCount(userId: string) {
     return this.prisma.user.update({
       where: { id: userId },

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -81,6 +81,10 @@ describe('AuthService', () => {
       expect(tokens).toEqual({
         accessToken: 'signed-access-token',
         refreshToken: 'plain-refresh-token',
+        expiresIn: 900,
+        roles: ['SAKHI'],
+        projectId: 'project-1',
+        geographyUnitId: 'geo-1',
       });
       expect(repository.recordSuccessfulLoginAndCreateSession).toHaveBeenCalledWith(
         'user-1',
@@ -155,6 +159,10 @@ describe('AuthService', () => {
       expect(tokens).toEqual({
         accessToken: 'signed-access-token',
         refreshToken: 'plain-refresh-token',
+        expiresIn: 900,
+        roles: ['SAKHI'],
+        projectId: 'project-1',
+        geographyUnitId: 'geo-1',
       });
     });
 
@@ -412,6 +420,7 @@ describe('AuthService', () => {
       sakhiProfile: {
         employeeCode: 'EMP-00123',
         bankAccountToken: encryptPii('1234567890'),
+        supervisorId: 'supervisor-1',
       },
     });
 
@@ -433,6 +442,7 @@ describe('AuthService', () => {
         projectName: 'GEP-2324',
         cardNumber: null,
         maskedBankAccount: null,
+        supervisorId: null,
       });
     });
 
@@ -444,6 +454,7 @@ describe('AuthService', () => {
       expect(profile?.cardNumber).toBe('EMP-00123');
       expect(profile?.maskedBankAccount).toBe('••••7890');
       expect(profile?.maskedBankAccount).not.toContain('123456');
+      expect(profile?.supervisorId).toBe('supervisor-1');
     });
 
     it('returns null projectName when the primary role has no project (e.g. ADMIN)', async () => {

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -473,6 +473,19 @@ describe('AuthService', () => {
       expect(profile?.maskedBankAccount).toBeNull();
     });
 
+    it('treats a soft-deleted Sakhi profile as absent (no stale card/bank/supervisor fields)', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValue({
+        ...activeUserWithProfile(),
+        sakhiProfile: { ...activeUserWithProfile().sakhiProfile, isDeleted: true },
+      } as never);
+
+      const profile = await service.getProfile('user-1');
+
+      expect(profile?.cardNumber).toBeNull();
+      expect(profile?.maskedBankAccount).toBeNull();
+      expect(profile?.supervisorId).toBeNull();
+    });
+
     it('returns null for a soft-deleted user', async () => {
       repository.findUserByIdWithProfile.mockResolvedValue({
         ...activeUserWithProfile(),

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -1,6 +1,7 @@
+import { randomBytes } from 'node:crypto';
 import { AuthService } from './auth.service';
 import type { AuthRepository } from './auth.repository';
-import type { TokenSigner } from '@armman/service-commons';
+import { encryptPii, type TokenSigner } from '@armman/service-commons';
 
 jest.mock('./password', () => ({
   verifyPassword: jest.fn(),
@@ -19,7 +20,9 @@ const ACTIVE_USER = {
   mobileNumber: '+919876543210',
   passwordHash: 'hashed-password',
   displayName: 'Test Sakhi',
+  email: 'test.sakhi@example.org',
   status: 'ACTIVE' as const,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
   isDeleted: false,
   userRoles: [
     {
@@ -34,6 +37,7 @@ describe('AuthService', () => {
   const repository = {
     findUserByUsername: jest.fn(),
     findUserById: jest.fn(),
+    findUserByIdWithProfile: jest.fn(),
     incrementFailedLoginCount: jest.fn(),
     recordSuccessfulLogin: jest.fn(),
     recordSuccessfulLoginAndCreateSession: jest.fn(),
@@ -51,11 +55,17 @@ describe('AuthService', () => {
   } as unknown as jest.Mocked<TokenSigner>;
 
   let service: AuthService;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.PII_ENCRYPTION_KEY = randomBytes(32).toString('base64');
     signer.sign.mockResolvedValue('signed-access-token');
     service = new AuthService(repository, signer, '15m', '30d');
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
   });
 
   describe('login', () => {
@@ -386,25 +396,82 @@ describe('AuthService', () => {
   });
 
   describe('getProfile', () => {
+    // A function, not a constant: bankAccountToken must be encrypted AFTER
+    // beforeEach sets PII_ENCRYPTION_KEY, not at describe-block evaluation
+    // time (which runs once, before any beforeEach, against a stale/unset key).
+    const activeUserWithProfile = () => ({
+      ...ACTIVE_USER,
+      userRoles: [
+        {
+          projectId: 'project-1',
+          geographyUnitId: 'geo-1',
+          role: { roleCode: 'SAKHI' },
+          project: { projectName: 'GEP-2324' },
+        },
+      ],
+      sakhiProfile: {
+        employeeCode: 'EMP-00123',
+        bankAccountToken: encryptPii('1234567890'),
+      },
+    });
+
     it('returns the profile with role/project/geography scope', async () => {
-      repository.findUserById.mockResolvedValue(ACTIVE_USER as never);
+      repository.findUserByIdWithProfile.mockResolvedValue({
+        ...activeUserWithProfile(),
+        sakhiProfile: null,
+      } as never);
 
       await expect(service.getProfile('user-1')).resolves.toEqual({
         id: 'user-1',
         username: 'test.sakhi',
         displayName: 'Test Sakhi',
         mobileNumber: '+919876543210',
+        email: 'test.sakhi@example.org',
+        status: 'ACTIVE',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
         roles: [{ roleCode: 'SAKHI', projectId: 'project-1', geographyUnitId: 'geo-1' }],
+        projectName: 'GEP-2324',
+        cardNumber: null,
+        maskedBankAccount: null,
       });
     });
 
+    it('includes cardNumber and a masked (never full) bank account for a SAKHI with a profile', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValue(activeUserWithProfile() as never);
+
+      const profile = await service.getProfile('user-1');
+
+      expect(profile?.cardNumber).toBe('EMP-00123');
+      expect(profile?.maskedBankAccount).toBe('••••7890');
+      expect(profile?.maskedBankAccount).not.toContain('123456');
+    });
+
+    it('returns null projectName when the primary role has no project (e.g. ADMIN)', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValue({
+        ...ACTIVE_USER,
+        userRoles: [
+          { projectId: null, geographyUnitId: null, role: { roleCode: 'ADMIN' }, project: null },
+        ],
+        sakhiProfile: null,
+      } as never);
+
+      const profile = await service.getProfile('user-1');
+
+      expect(profile?.projectName).toBeNull();
+      expect(profile?.cardNumber).toBeNull();
+      expect(profile?.maskedBankAccount).toBeNull();
+    });
+
     it('returns null for a soft-deleted user', async () => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, isDeleted: true } as never);
+      repository.findUserByIdWithProfile.mockResolvedValue({
+        ...activeUserWithProfile(),
+        isDeleted: true,
+      } as never);
       await expect(service.getProfile('user-1')).resolves.toBeNull();
     });
 
     it('returns null for a non-existent user', async () => {
-      repository.findUserById.mockResolvedValue(null);
+      repository.findUserByIdWithProfile.mockResolvedValue(null);
       await expect(service.getProfile('missing')).resolves.toBeNull();
     });
   });

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -172,7 +172,7 @@ export class AuthService {
     if (!user || user.isDeleted) return null;
 
     const [primaryRole] = user.userRoles;
-    const profile = user.sakhiProfile;
+    const profile = user.sakhiProfile && !user.sakhiProfile.isDeleted ? user.sakhiProfile : null;
 
     return {
       id: user.id,

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import type { TokenSigner } from '@armman/service-commons';
-import { conflict, forbidden, notFound, unauthorized } from '@armman/service-commons';
+import { conflict, decryptPii, forbidden, notFound, unauthorized } from '@armman/service-commons';
 import type { AuthRepository } from './auth.repository';
 import { hashPassword, verifyPassword } from './password';
 import { generateRefreshToken, hashRefreshToken } from './refresh-token';
@@ -17,7 +17,25 @@ export interface UserProfile {
   username: string;
   displayName: string;
   mobileNumber: string;
+  email: string | null;
+  status: string;
+  createdAt: Date;
   roles: { roleCode: string; projectId: string | null; geographyUnitId: string | null }[];
+  /** The primary role's project name, or null if that role has no project (e.g. ADMIN). */
+  projectName: string | null;
+  /** Sakhi profile's employee_code — only present for SAKHI-role users. */
+  cardNumber: string | null;
+  /** Last 4 digits of the Sakhi's bank account, masked (e.g. "••••1234") — never the full number. */
+  maskedBankAccount: string | null;
+}
+
+const BANK_ACCOUNT_VISIBLE_DIGITS = 4;
+const BANK_ACCOUNT_MASK = '••••';
+
+/** Masks a decrypted bank account number down to its last 4 digits. */
+function maskBankAccount(accountNumber: string): string {
+  const lastDigits = accountNumber.slice(-BANK_ACCOUNT_VISIBLE_DIGITS);
+  return `${BANK_ACCOUNT_MASK}${lastDigits}`;
 }
 
 export interface CreatedUser {
@@ -141,18 +159,30 @@ export class AuthService {
   }
 
   async getProfile(userId: string): Promise<UserProfile | null> {
-    const user = await this.repository.findUserById(userId);
+    const user = await this.repository.findUserByIdWithProfile(userId);
     if (!user || user.isDeleted) return null;
+
+    const [primaryRole] = user.userRoles;
+    const profile = user.sakhiProfile;
+
     return {
       id: user.id,
       username: user.username,
       displayName: user.displayName,
       mobileNumber: user.mobileNumber,
+      email: user.email,
+      status: user.status,
+      createdAt: user.createdAt,
       roles: user.userRoles.map((ur) => ({
         roleCode: ur.role.roleCode,
         projectId: ur.projectId,
         geographyUnitId: ur.geographyUnitId,
       })),
+      projectName: primaryRole?.project?.projectName ?? null,
+      cardNumber: profile?.employeeCode ?? null,
+      maskedBankAccount: profile?.bankAccountToken
+        ? maskBankAccount(decryptPii(profile.bankAccountToken))
+        : null,
     };
   }
 

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -10,6 +10,13 @@ import type { CreateUserInput } from './dto/create-user.dto';
 export interface AuthTokens {
   accessToken: string;
   refreshToken: string;
+  /** Access token lifetime in seconds, from now. */
+  expiresIn: number;
+  /** Every role code the caller holds — same set encoded in the access token's `roles` claim. */
+  roles: string[];
+  /** The primary role assignment's project/geography scope (first assignment; see issueTokens). */
+  projectId: string | null;
+  geographyUnitId: string | null;
 }
 
 export interface UserProfile {
@@ -27,6 +34,8 @@ export interface UserProfile {
   cardNumber: string | null;
   /** Last 4 digits of the Sakhi's bank account, masked (e.g. "••••1234") — never the full number. */
   maskedBankAccount: string | null;
+  /** Sakhi profile's supervisor_id — per SRS's Sakhi identity field list; only present for SAKHI-role users. */
+  supervisorId: string | null;
 }
 
 const BANK_ACCOUNT_VISIBLE_DIGITS = 4;
@@ -183,6 +192,7 @@ export class AuthService {
       maskedBankAccount: profile?.bankAccountToken
         ? maskBankAccount(decryptPii(profile.bankAccountToken))
         : null,
+      supervisorId: profile?.supervisorId ?? null,
     };
   }
 
@@ -230,7 +240,14 @@ export class AuthService {
       await this.repository.createSession(sessionData);
     }
 
-    return { accessToken, refreshToken };
+    return {
+      accessToken,
+      refreshToken,
+      expiresIn: Math.floor(parseDurationMs(this.accessTokenTtl) / 1000),
+      roles,
+      projectId: primary?.projectId ?? null,
+      geographyUnitId: primary?.geographyUnitId ?? null,
+    };
   }
 }
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.constants.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.constants.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for the beneficiary domain's enum value sets.
+ *
+ * Each is an `as const` tuple so it can drive everything that needs the same
+ * values without repeating the string literals: `z.enum(...)` schemas (which
+ * require a readonly string tuple), the derived TypeScript union `type`s used
+ * by service/repository interfaces, and any runtime membership checks. Values
+ * mirror the Prisma enums in `prisma/schema.prisma` exactly.
+ */
+
+export const CASE_TYPES = ['MOTHER', 'CHILD'] as const;
+export type CaseType = (typeof CASE_TYPES)[number];
+
+export const BENEFICIARY_STATUSES = [
+  'ACTIVE',
+  'JOURNEY_COMPLETE',
+  'CLOSED',
+  'TRANSFERRED',
+  'REOPEN_REQUESTED',
+] as const;
+export type BeneficiaryStatus = (typeof BENEFICIARY_STATUSES)[number];
+
+export const CASE_PHASES = ['ANC', 'DELIVERY', 'PP', 'NN', 'INC', 'CCV', 'CLOSED'] as const;
+export type CasePhase = (typeof CASE_PHASES)[number];
+
+export const SUMMARY_PHASES = [
+  'REGISTRATION',
+  'ANC',
+  'DELIVERY',
+  'PP',
+  'NN',
+  'INFANT_FOLLOWUP',
+  'CLOSURE',
+] as const;
+export type SummaryPhase = (typeof SUMMARY_PHASES)[number];
+
+/** Sex value set for a mother/PII record. */
+export const MOTHER_SEXES = ['FEMALE', 'MALE', 'OTHER', 'UNKNOWN'] as const;
+export type MotherSex = (typeof MOTHER_SEXES)[number];
+
+/** Sex value set for a child record — differs from MOTHER_SEXES (INTERSEX vs UNKNOWN). */
+export const CHILD_SEXES = ['FEMALE', 'MALE', 'OTHER', 'INTERSEX'] as const;
+export type ChildSex = (typeof CHILD_SEXES)[number];
+
+/**
+ * Consent statuses the API accepts/returns. Deliberately the GIVEN/REFUSED
+ * subset of Prisma's ConsentStatus enum (which also has WITHDRAWN) — a
+ * client never submits or reads WITHDRAWN through these endpoints.
+ */
+export const API_CONSENT_STATUSES = ['GIVEN', 'REFUSED'] as const;
+export type ApiConsentStatus = (typeof API_CONSENT_STATUSES)[number];

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -1,6 +1,15 @@
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { BeneficiaryService } from './beneficiary.service';
+import {
+  API_CONSENT_STATUSES,
+  BENEFICIARY_STATUSES,
+  CASE_PHASES,
+  CASE_TYPES,
+  CHILD_SEXES,
+  MOTHER_SEXES,
+  SUMMARY_PHASES,
+} from './beneficiary.constants';
 import { createBeneficiarySchema } from './dto/create-beneficiary.dto';
 import { listBeneficiariesQuerySchema } from './dto/list-beneficiaries.dto';
 import {
@@ -29,7 +38,7 @@ const piiResponseSchema = z.object({
   phcId: z.string().uuid().nullable(),
   healthBlockId: z.string().uuid().nullable(),
   dateOfBirth: z.string().datetime().nullable(),
-  sex: z.enum(['FEMALE', 'MALE', 'OTHER', 'UNKNOWN']).nullable(),
+  sex: z.enum(MOTHER_SEXES).nullable(),
   stateId: z.string().uuid().nullable(),
   districtId: z.string().uuid().nullable(),
   talukaId: z.string().uuid().nullable(),
@@ -37,7 +46,7 @@ const piiResponseSchema = z.object({
 
 const riskConditionSummarySchema = z.object({
   riskConditionId: z.string().uuid(),
-  phase: z.enum(['REGISTRATION', 'ANC', 'DELIVERY', 'PP', 'NN', 'INFANT_FOLLOWUP', 'CLOSURE']),
+  phase: z.enum(SUMMARY_PHASES),
   latestGrade: z.string().nullable(),
   latestAssessedAt: z.string().datetime().nullable(),
   everHighestGrade: z.string().nullable(),
@@ -47,10 +56,8 @@ const riskConditionSummarySchema = z.object({
 });
 
 const statusHistoryEntrySchema = z.object({
-  fromStatus: z
-    .enum(['ACTIVE', 'JOURNEY_COMPLETE', 'CLOSED', 'TRANSFERRED', 'REOPEN_REQUESTED'])
-    .nullable(),
-  toStatus: z.enum(['ACTIVE', 'JOURNEY_COMPLETE', 'CLOSED', 'TRANSFERRED', 'REOPEN_REQUESTED']),
+  fromStatus: z.enum(BENEFICIARY_STATUSES).nullable(),
+  toStatus: z.enum(BENEFICIARY_STATUSES),
   reasonCode: z.string().nullable(),
   changedByUserId: z.string().uuid(),
   changedAt: z.string().datetime(),
@@ -69,7 +76,7 @@ const motherCaseDetailsSchema = z.object({
 const childCaseDetailsSchema = z.object({
   motherBeneficiaryId: z.string().uuid().nullable(),
   dateOfBirth: z.string().datetime(),
-  sex: z.enum(['FEMALE', 'MALE', 'OTHER', 'INTERSEX']).nullable(),
+  sex: z.enum(CHILD_SEXES).nullable(),
   birthWeightKg: z.number().nullable(),
   birthLengthCm: z.number().nullable(),
   prematureFlag: z.boolean().nullable(),
@@ -78,7 +85,7 @@ const childCaseDetailsSchema = z.object({
 
 const consentRecordSchema = z.object({
   consentType: z.string().openapi({ example: 'PROGRAM_ENROLLMENT' }),
-  consentStatus: z.enum(['GIVEN', 'REFUSED']),
+  consentStatus: z.enum(API_CONSENT_STATUSES),
   consentDate: z.string().datetime(),
   capturedByUserId: z.string().uuid(),
 });
@@ -90,14 +97,14 @@ const beneficiaryCaseSchema = z.object({
   piiId: z.string().uuid(),
   projectId: z.string().uuid(),
   sakhiId: z.string().uuid(),
-  caseType: z.enum(['MOTHER', 'CHILD']),
+  caseType: z.enum(CASE_TYPES),
   registrationDate: z.string().datetime(),
   previousBeneficiaryId: z.string().uuid().nullable(),
   motherBeneficiaryId: z.string().uuid().nullable(),
   beneficiaryTypeLookupId: z.string().uuid(),
   caseTypeLookupId: z.string().uuid(),
   journeyStartDate: z.string().datetime(),
-  currentPhase: z.enum(['ANC', 'DELIVERY', 'PP', 'NN', 'INC', 'CCV', 'CLOSED']),
+  currentPhase: z.enum(CASE_PHASES),
   currentStatus: z.string().openapi({ example: 'ACTIVE' }),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -2,6 +2,7 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { BeneficiaryService } from './beneficiary.service';
 import { createBeneficiarySchema } from './dto/create-beneficiary.dto';
+import { listBeneficiariesQuerySchema } from './dto/list-beneficiaries.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -19,6 +20,9 @@ const idParamsSchema = z.object({ id: z.string().uuid() }).strict();
 
 const piiResponseSchema = z.object({
   id: z.string().uuid(),
+  // Decrypted server-side for display (see BeneficiaryService.list/getById) —
+  // never the raw fullNameEnc/fullNameSearchHash.
+  fullName: z.string().openapi({ example: 'Jane Doe' }),
   villageId: z.string().uuid().nullable(),
   padaId: z.string().uuid().nullable(),
   healthSubCentreId: z.string().uuid().nullable(),
@@ -29,6 +33,28 @@ const piiResponseSchema = z.object({
   stateId: z.string().uuid().nullable(),
   districtId: z.string().uuid().nullable(),
   talukaId: z.string().uuid().nullable(),
+});
+
+const riskConditionSummarySchema = z.object({
+  riskConditionId: z.string().uuid(),
+  phase: z.enum(['REGISTRATION', 'ANC', 'DELIVERY', 'PP', 'NN', 'INFANT_FOLLOWUP', 'CLOSURE']),
+  latestGrade: z.string().nullable(),
+  latestAssessedAt: z.string().datetime().nullable(),
+  everHighestGrade: z.string().nullable(),
+  everAtRiskFlag: z.boolean(),
+  currentReferralTriggerFlag: z.boolean(),
+  currentHrVisitTriggerFlag: z.boolean(),
+});
+
+const statusHistoryEntrySchema = z.object({
+  fromStatus: z
+    .enum(['ACTIVE', 'JOURNEY_COMPLETE', 'CLOSED', 'TRANSFERRED', 'REOPEN_REQUESTED'])
+    .nullable(),
+  toStatus: z.enum(['ACTIVE', 'JOURNEY_COMPLETE', 'CLOSED', 'TRANSFERRED', 'REOPEN_REQUESTED']),
+  reasonCode: z.string().nullable(),
+  changedByUserId: z.string().uuid(),
+  changedAt: z.string().datetime(),
+  notes: z.string().nullable(),
 });
 
 const motherCaseDetailsSchema = z.object({
@@ -82,6 +108,16 @@ const beneficiaryCaseDetailSchema = beneficiaryCaseSchema.extend({
   motherCaseDetails: motherCaseDetailsSchema.nullable(),
   childCaseDetails: childCaseDetailsSchema.nullable(),
   consentRecords: z.array(consentRecordSchema),
+  riskConditionSummaries: z.array(riskConditionSummarySchema),
+  statusHistory: z.array(statusHistoryEntrySchema),
+});
+
+// List rows carry PII (decrypted name) but not the full detail-view
+// includes (risk/status history/mother-or-child details/consent) — per
+// SRS FR-S-9.2 / HLD's filter table, the list only needs to support
+// search/filter and a compact display row.
+const beneficiaryListItemSchema = beneficiaryCaseSchema.extend({
+  pii: piiResponseSchema,
 });
 
 const apiErrorSchema = z.object({
@@ -120,7 +156,7 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
       responses: {
         200: {
           description: 'Beneficiary cases retrieved',
-          schema: envelope(z.array(beneficiaryCaseSchema)),
+          schema: envelope(z.array(beneficiaryListItemSchema)),
         },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
         403: { description: 'Caller role not permitted', schema: apiErrorSchema },
@@ -128,15 +164,17 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
     },
     trustGatewayIdentity,
     requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
-    asyncHandler(async (_req, res) => {
-      res.json(ok(await service.list()));
+    validate(listBeneficiariesQuerySchema, 'query'),
+    asyncHandler(async (req, res) => {
+      const query = req.query as unknown as z.infer<typeof listBeneficiariesQuerySchema>;
+      res.json(ok(await service.list(query)));
     }),
   );
 
   doc.get(
     '/beneficiaries/:id',
     {
-      summary: 'Get a beneficiary case by id',
+      summary: 'Get a beneficiary case by id — profile, current phase, risk state, status history',
       tags: ['Beneficiaries'],
       responses: {
         200: {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -1,11 +1,18 @@
 import type { PrismaService } from '../prisma/prisma.service';
+import type {
+  BeneficiaryStatus,
+  CasePhase,
+  CaseType,
+  ChildSex,
+  MotherSex,
+} from './beneficiary.constants';
 
 export interface BeneficiaryListFilters {
   projectId?: string;
   villageId?: string;
   padaId?: string;
-  currentStatus?: 'ACTIVE' | 'JOURNEY_COMPLETE' | 'CLOSED' | 'TRANSFERRED' | 'REOPEN_REQUESTED';
-  caseType?: 'MOTHER' | 'CHILD';
+  currentStatus?: BeneficiaryStatus;
+  caseType?: CaseType;
   /** True to return only cases with `everAtRiskFlag` set on any risk condition. */
   atRiskOnly?: boolean;
   /** hashForSearch(normalizeForSearch(name)) — exact-match only, see findMany's doc comment. */
@@ -34,7 +41,7 @@ export interface PiiCreateData {
   phcId: string | null;
   healthBlockId: string | null;
   dateOfBirth: Date | null;
-  sex: 'FEMALE' | 'MALE' | 'OTHER' | 'UNKNOWN' | null;
+  sex: MotherSex | null;
   addressLineEnc: Buffer | null;
   stateId: string | null;
   districtId: string | null;
@@ -46,14 +53,14 @@ export interface PiiCreateData {
 export interface CaseCreateData {
   projectId: string;
   sakhiId: string;
-  caseType: 'MOTHER' | 'CHILD';
+  caseType: CaseType;
   registrationDate: Date;
   previousBeneficiaryId: string | null;
   motherBeneficiaryId: string | null;
   beneficiaryTypeLookupId: string;
   caseTypeLookupId: string;
   journeyStartDate: Date;
-  currentPhase: 'ANC' | 'DELIVERY' | 'PP' | 'NN' | 'INC' | 'CCV' | 'CLOSED';
+  currentPhase: CasePhase;
 }
 
 export interface MotherDetailsCreateData {
@@ -68,7 +75,7 @@ export interface MotherDetailsCreateData {
 export interface ChildDetailsCreateData {
   motherBeneficiaryId: string | null;
   dateOfBirth: Date;
-  sex: 'FEMALE' | 'MALE' | 'OTHER' | 'INTERSEX' | null;
+  sex: ChildSex | null;
   birthWeightKg: number | null;
   birthLengthCm: number | null;
   prematureFlag: boolean | null;

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -1,5 +1,19 @@
 import type { PrismaService } from '../prisma/prisma.service';
 
+export interface BeneficiaryListFilters {
+  projectId?: string;
+  villageId?: string;
+  padaId?: string;
+  currentStatus?: 'ACTIVE' | 'JOURNEY_COMPLETE' | 'CLOSED' | 'TRANSFERRED' | 'REOPEN_REQUESTED';
+  caseType?: 'MOTHER' | 'CHILD';
+  /** True to return only cases with `everAtRiskFlag` set on any risk condition. */
+  atRiskOnly?: boolean;
+  /** hashForSearch(normalizeForSearch(name)) — exact-match only, see findMany's doc comment. */
+  nameHash?: Buffer;
+  /** hashForSearch(normalizeForSearch(mobileNumber)) — exact-match only. */
+  phoneHash?: Buffer;
+}
+
 export interface DuplicateSearchTokens {
   nameToken: Buffer;
   dobToken: string | null;
@@ -75,8 +89,40 @@ export interface CreateEnrollmentInput {
 export class BeneficiaryRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  findMany() {
-    return this.prisma.beneficiaryCase.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
+  /**
+   * Lists beneficiary cases with the filters SRS FR-S-9.2 / HLD's endpoint
+   * table require: project, geography (village/pada), status, case type, and
+   * risk level, plus name/mobile search. Name/mobile are encrypted at rest
+   * (no plaintext column to filter on), so search matches the same
+   * non-reversible hash used for duplicate detection — exact match on the
+   * normalized value, not a partial/fuzzy match.
+   */
+  findMany(filters: BeneficiaryListFilters) {
+    const where: NonNullable<Parameters<typeof this.prisma.beneficiaryCase.findMany>[0]>['where'] =
+      {
+        isDeleted: false,
+      };
+    if (filters.projectId) where.projectId = filters.projectId;
+    if (filters.currentStatus) where.currentStatus = filters.currentStatus;
+    if (filters.caseType) where.caseType = filters.caseType;
+    if (filters.villageId || filters.padaId || filters.nameHash || filters.phoneHash) {
+      where.pii = {
+        ...(filters.villageId ? { villageId: filters.villageId } : {}),
+        ...(filters.padaId ? { padaId: filters.padaId } : {}),
+        ...(filters.nameHash ? { fullNameSearchHash: filters.nameHash } : {}),
+        ...(filters.phoneHash ? { phoneSearchHash: filters.phoneHash } : {}),
+      };
+    }
+    if (filters.atRiskOnly) {
+      where.riskConditionSummaries = { some: { everAtRiskFlag: true } };
+    }
+
+    return this.prisma.beneficiaryCase.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+      include: { pii: true },
+    });
   }
 
   findById(id: string) {
@@ -87,6 +133,11 @@ export class BeneficiaryRepository {
         motherCaseDetails: true,
         childCaseDetails: true,
         consentRecords: { orderBy: { createdAt: 'desc' }, take: 1 },
+        // Per the HLD's endpoint table ("Beneficiary profile, current phase,
+        // last visits, risk state") — the detail view needs risk state and a
+        // status timeline, not just the case/PII/consent rows.
+        riskConditionSummaries: true,
+        statusHistory: { orderBy: { changedAt: 'desc' } },
       },
     });
   }
@@ -167,6 +218,10 @@ export class BeneficiaryRepository {
         },
       });
 
+      // riskConditionSummaries/statusHistory aren't included here: nothing
+      // has accrued yet for a case created in this same transaction (risk
+      // evaluation and status transitions only happen after visits/status
+      // changes) — the service fills in empty arrays for those.
       return tx.beneficiaryCase.findUniqueOrThrow({
         where: { id: beneficiaryCase.id },
         include: {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { encryptPii } from '@armman/service-commons';
 import { BeneficiaryService } from './beneficiary.service';
 import type { BeneficiaryRepository } from './beneficiary.repository';
 import type { CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
@@ -63,15 +64,69 @@ describe('BeneficiaryService', () => {
   });
 
   describe('list / getById', () => {
-    it('lists beneficiaries via the repository', async () => {
-      repository.findMany.mockResolvedValue([]);
-      await expect(service.list()).resolves.toEqual([]);
+    it('lists beneficiaries via the repository, with names decrypted for display', async () => {
+      repository.findMany.mockResolvedValue([
+        { id: 'x', pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') } },
+      ] as never);
+
+      const result = await service.list({});
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'x',
+          pii: expect.objectContaining({ fullName: 'Jane Doe' }),
+        }),
+      ]);
     });
 
-    it('returns a found case', async () => {
-      const found = { id: 'x' };
+    it('passes query filters through to the repository as search hashes/scalars', async () => {
+      repository.findMany.mockResolvedValue([]);
+
+      await service.list({
+        projectId: 'project-1',
+        status: 'ACTIVE',
+        caseType: 'MOTHER',
+        atRiskOnly: true,
+        name: 'Jane Doe',
+        mobileNumber: '9876543210',
+      });
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.projectId).toBe('project-1');
+      expect(call.currentStatus).toBe('ACTIVE');
+      expect(call.caseType).toBe('MOTHER');
+      expect(call.atRiskOnly).toBe(true);
+      expect(call.nameHash).toBeInstanceOf(Buffer);
+      expect(call.phoneHash).toBeInstanceOf(Buffer);
+    });
+
+    it('passes through risk condition summaries and status history from the repository', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', everAtRiskFlag: true }],
+        statusHistory: [{ toStatus: 'ACTIVE', changedAt: new Date('2026-01-01') }],
+      };
       repository.findById.mockResolvedValue(found as never);
-      await expect(service.getById('x')).resolves.toBe(found);
+
+      const result = await service.getById('x');
+
+      expect(result.riskConditionSummaries).toEqual(found.riskConditionSummaries);
+      expect(result.statusHistory).toEqual(found.statusHistory);
+    });
+
+    it('returns a found case with the name decrypted for display', async () => {
+      const found = { id: 'x', pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') } };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'x',
+          pii: expect.objectContaining({ fullName: 'Jane Doe' }),
+        }),
+      );
     });
 
     it('throws 404 when the case is not found', async () => {
@@ -104,16 +159,26 @@ describe('BeneficiaryService', () => {
       repository.findDuplicateCandidate.mockResolvedValue({
         beneficiaryId: 'existing-id',
       } as never);
-      repository.createEnrollment.mockResolvedValue({ id: 'new-id' } as never);
+      repository.createEnrollment.mockResolvedValue({
+        id: 'new-id',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      } as never);
       const dto = { ...baseMotherInput, acknowledgeDuplicate: true };
-      await expect(service.create(dto, CALLER_ID)).resolves.toEqual({ id: 'new-id' });
+      await expect(service.create(dto, CALLER_ID)).resolves.toEqual(
+        expect.objectContaining({ id: 'new-id' }),
+      );
       expect(repository.createEnrollment).toHaveBeenCalledTimes(1);
     });
 
     it('creates normally when no duplicate is found', async () => {
       repository.findDuplicateCandidate.mockResolvedValue(null);
-      repository.createEnrollment.mockResolvedValue({ id: 'new-id' } as never);
-      await expect(service.create(baseMotherInput, CALLER_ID)).resolves.toEqual({ id: 'new-id' });
+      repository.createEnrollment.mockResolvedValue({
+        id: 'new-id',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      } as never);
+      await expect(service.create(baseMotherInput, CALLER_ID)).resolves.toEqual(
+        expect.objectContaining({ id: 'new-id' }),
+      );
     });
   });
 
@@ -158,6 +223,18 @@ describe('BeneficiaryService', () => {
       expect(call.pii.fullNameSearchHash).toBeInstanceOf(Buffer);
       expect(call.searchTokens.lmpDateToken).not.toBeNull();
       expect(call.consentCapturedByUserId).toBe(CALLER_ID);
+    });
+
+    it('returns empty risk/status-history arrays for a freshly enrolled case', async () => {
+      repository.findDuplicateCandidate.mockResolvedValue(null);
+      repository.createEnrollment.mockImplementation((input) =>
+        Promise.resolve({ ...input, id: 'new-id' } as never),
+      );
+
+      const result = await service.create(baseMotherInput, CALLER_ID);
+
+      expect(result.riskConditionSummaries).toEqual([]);
+      expect(result.statusHistory).toEqual([]);
     });
   });
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -183,7 +183,10 @@ describe('BeneficiaryService', () => {
 
     it('scopes duplicate search to the case type, so a MOTHER search never matches a CHILD case', async () => {
       repository.findDuplicateCandidate.mockResolvedValue(null);
-      repository.createEnrollment.mockResolvedValue({ id: 'new-id' } as never);
+      repository.createEnrollment.mockResolvedValue({
+        id: 'new-id',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      } as never);
 
       await service.create(baseMotherInput, CALLER_ID);
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -9,6 +9,11 @@ import {
   unprocessable,
 } from '@armman/service-commons';
 import type {
+  BeneficiaryRiskConditionSummary,
+  BeneficiaryStatusHistory,
+} from '../../../../node_modules/.prisma/client-beneficiary-service';
+import type { BeneficiaryStatus, CaseType } from './beneficiary.constants';
+import type {
   BeneficiaryListFilters,
   BeneficiaryRepository,
   DuplicateSearchTokens,
@@ -22,12 +27,22 @@ export interface ListBeneficiariesQuery {
   projectId?: string;
   villageId?: string;
   padaId?: string;
-  status?: 'ACTIVE' | 'JOURNEY_COMPLETE' | 'CLOSED' | 'TRANSFERRED' | 'REOPEN_REQUESTED';
-  caseType?: 'MOTHER' | 'CHILD';
+  status?: BeneficiaryStatus;
+  caseType?: CaseType;
   atRiskOnly?: boolean;
   /** Raw search text — hashed the same way as duplicate-detection tokens (exact match only). */
   name?: string;
   mobileNumber?: string;
+}
+
+/**
+ * Returns the case with `pii.fullName` decrypted for display. Names are stored
+ * encrypted (`fullNameEnc`) with only a non-reversible search hash — this is
+ * the single place the plaintext name is materialised for a response, reused
+ * by list/getById/create so the decrypt-and-spread logic isn't repeated.
+ */
+function withDecryptedName<T extends { pii: { fullNameEnc: Buffer } }>(caseRow: T) {
+  return { ...caseRow, pii: { ...caseRow.pii, fullName: decryptPii(caseRow.pii.fullNameEnc) } };
 }
 
 /** Business logic for the beneficiary enrollment lifecycle. */
@@ -54,16 +69,13 @@ export class BeneficiaryService {
     };
 
     const cases = await this.repository.findMany(filters);
-    return cases.map((c) => ({
-      ...c,
-      pii: { ...c.pii, fullName: decryptPii(c.pii.fullNameEnc) },
-    }));
+    return cases.map(withDecryptedName);
   }
 
   async getById(id: string) {
     const found = await this.repository.findById(id);
     if (!found) throw notFound('Beneficiary case not found.');
-    return { ...found, pii: { ...found.pii, fullName: decryptPii(found.pii.fullNameEnc) } };
+    return withDecryptedName(found);
   }
 
   /**
@@ -157,13 +169,12 @@ export class BeneficiaryService {
     });
 
     return {
-      ...created,
-      pii: { ...created.pii, fullName: decryptPii(created.pii.fullNameEnc) },
+      ...withDecryptedName(created),
       // Nothing has accrued yet for a case created in this same call — risk
       // evaluation and status transitions only happen after visits/status
       // changes (see the repository's comment on the create query).
-      riskConditionSummaries: [] as never[],
-      statusHistory: [] as never[],
+      riskConditionSummaries: [] as BeneficiaryRiskConditionSummary[],
+      statusHistory: [] as BeneficiaryStatusHistory[],
     };
   }
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -1,30 +1,69 @@
 import { addDays } from '@armman/core';
 import {
   conflict,
+  decryptPii,
   encryptPii,
   hashForSearch,
   notFound,
   normalizeForSearch,
   unprocessable,
 } from '@armman/service-commons';
-import type { BeneficiaryRepository, DuplicateSearchTokens } from './beneficiary.repository';
+import type {
+  BeneficiaryListFilters,
+  BeneficiaryRepository,
+  DuplicateSearchTokens,
+} from './beneficiary.repository';
 import type { CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
 
 const GESTATION_DAYS = 280;
+
+/** Public list-query params — see ListBeneficiariesQuery in the DTO for validation. */
+export interface ListBeneficiariesQuery {
+  projectId?: string;
+  villageId?: string;
+  padaId?: string;
+  status?: 'ACTIVE' | 'JOURNEY_COMPLETE' | 'CLOSED' | 'TRANSFERRED' | 'REOPEN_REQUESTED';
+  caseType?: 'MOTHER' | 'CHILD';
+  atRiskOnly?: boolean;
+  /** Raw search text — hashed the same way as duplicate-detection tokens (exact match only). */
+  name?: string;
+  mobileNumber?: string;
+}
 
 /** Business logic for the beneficiary enrollment lifecycle. */
 export class BeneficiaryService {
   constructor(private readonly repository: BeneficiaryRepository) {}
 
-  /** Lists recent beneficiary cases (scope enforcement added with the auth layer). */
-  list() {
-    return this.repository.findMany();
+  /**
+   * Lists beneficiary cases per SRS FR-S-9.2 / HLD's filter set (scope
+   * enforcement added with the auth layer). Each row's name is decrypted
+   * server-side for display — the search hash itself is never returned.
+   */
+  async list(query: ListBeneficiariesQuery) {
+    const filters: BeneficiaryListFilters = {
+      projectId: query.projectId,
+      villageId: query.villageId,
+      padaId: query.padaId,
+      currentStatus: query.status,
+      caseType: query.caseType,
+      atRiskOnly: query.atRiskOnly,
+      nameHash: query.name ? hashForSearch(normalizeForSearch(query.name)) : undefined,
+      phoneHash: query.mobileNumber
+        ? hashForSearch(normalizeForSearch(query.mobileNumber))
+        : undefined,
+    };
+
+    const cases = await this.repository.findMany(filters);
+    return cases.map((c) => ({
+      ...c,
+      pii: { ...c.pii, fullName: decryptPii(c.pii.fullNameEnc) },
+    }));
   }
 
   async getById(id: string) {
     const found = await this.repository.findById(id);
     if (!found) throw notFound('Beneficiary case not found.');
-    return found;
+    return { ...found, pii: { ...found.pii, fullName: decryptPii(found.pii.fullNameEnc) } };
   }
 
   /**
@@ -75,7 +114,7 @@ export class BeneficiaryService {
     const journeyStartDate = dto.case.registrationDate;
     const currentPhase = dto.case.caseType === 'MOTHER' ? 'ANC' : 'NN';
 
-    return this.repository.createEnrollment({
+    const created = await this.repository.createEnrollment({
       pii: {
         fullNameEnc: encryptPii(dto.pii.fullName),
         fullNameSearchHash: hashForSearch(normalizeForSearch(dto.pii.fullName)),
@@ -116,6 +155,16 @@ export class BeneficiaryService {
       consentDate: dto.consent.date,
       consentCapturedByUserId: capturedByUserId,
     });
+
+    return {
+      ...created,
+      pii: { ...created.pii, fullName: decryptPii(created.pii.fullNameEnc) },
+      // Nothing has accrued yet for a case created in this same call — risk
+      // evaluation and status transitions only happen after visits/status
+      // changes (see the repository's comment on the create query).
+      riskConditionSummaries: [] as never[],
+      statusHistory: [] as never[],
+    };
   }
 
   private buildSearchTokens(dto: CreateBeneficiaryInput): DuplicateSearchTokens {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -35,14 +35,50 @@ export interface ListBeneficiariesQuery {
   mobileNumber?: string;
 }
 
+interface PiiRow {
+  id: string;
+  fullNameEnc: Buffer;
+  villageId: string | null;
+  padaId: string | null;
+  healthSubCentreId: string | null;
+  phcId: string | null;
+  healthBlockId: string | null;
+  dateOfBirth: Date | null;
+  sex: string | null;
+  stateId: string | null;
+  districtId: string | null;
+  talukaId: string | null;
+}
+
 /**
- * Returns the case with `pii.fullName` decrypted for display. Names are stored
- * encrypted (`fullNameEnc`) with only a non-reversible search hash — this is
- * the single place the plaintext name is materialised for a response, reused
- * by list/getById/create so the decrypt-and-spread logic isn't repeated.
+ * Returns the case with `pii` reduced to the fields the API is allowed to
+ * expose, with `fullName` decrypted for display. Names are stored encrypted
+ * (`fullNameEnc`) with only a non-reversible search hash — this is the single
+ * place the plaintext name is materialised for a response, reused by
+ * list/getById/create. Only allow-listed fields are copied across so
+ * encrypted/hash columns (fullNameEnc, fullNameSearchHash, phoneEnc,
+ * phoneSearchHash, rchNumberEnc, rchNumberHash, addressLineEnc, ...) can
+ * never leak into the response even if the Prisma row gains new columns.
  */
-function withDecryptedName<T extends { pii: { fullNameEnc: Buffer } }>(caseRow: T) {
-  return { ...caseRow, pii: { ...caseRow.pii, fullName: decryptPii(caseRow.pii.fullNameEnc) } };
+function withDecryptedName<T extends { pii: PiiRow }>(caseRow: T) {
+  const { pii } = caseRow;
+  return {
+    ...caseRow,
+    pii: {
+      id: pii.id,
+      fullName: decryptPii(pii.fullNameEnc),
+      villageId: pii.villageId,
+      padaId: pii.padaId,
+      healthSubCentreId: pii.healthSubCentreId,
+      phcId: pii.phcId,
+      healthBlockId: pii.healthBlockId,
+      dateOfBirth: pii.dateOfBirth,
+      sex: pii.sex,
+      stateId: pii.stateId,
+      districtId: pii.districtId,
+      talukaId: pii.talukaId,
+    },
+  };
 }
 
 /** Business logic for the beneficiary enrollment lifecycle. */

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
+import {
+  API_CONSENT_STATUSES,
+  CASE_TYPES,
+  CHILD_SEXES,
+  MOTHER_SEXES,
+} from '../beneficiary.constants';
 
 /**
  * Validation schema for enrolling a beneficiary (mother or child), per SRS
@@ -11,7 +17,7 @@ const piiSchema = z
     phone: z.string().trim().min(1).max(20).optional(),
     alternatePhone: z.string().trim().min(1).max(20).optional(),
     dateOfBirth: z.coerce.date().optional(),
-    sex: z.enum(['FEMALE', 'MALE', 'OTHER', 'UNKNOWN']).optional(),
+    sex: z.enum(MOTHER_SEXES).optional(),
     addressLine: z.string().trim().min(1).max(500).optional(),
     villageId: z.string().uuid().optional(),
     padaId: z.string().uuid().optional(),
@@ -92,7 +98,7 @@ const motherDetailsSchema = z
 const childDetailsSchema = z
   .object({
     dateOfBirth: z.coerce.date(),
-    sex: z.enum(['FEMALE', 'MALE', 'OTHER', 'INTERSEX']).optional(),
+    sex: z.enum(CHILD_SEXES).optional(),
     birthWeightKg: z.number().positive().max(10).optional(),
     birthLengthCm: z.number().positive().max(100).optional(),
     prematureFlag: z.boolean().optional(),
@@ -122,7 +128,7 @@ const childDetailsSchema = z
 
 const consentSchema = z
   .object({
-    status: z.enum(['GIVEN', 'REFUSED']),
+    status: z.enum(API_CONSENT_STATUSES),
     date: z.coerce.date(),
   })
   .strict();
@@ -131,7 +137,7 @@ const caseSchema = z
   .object({
     projectId: z.string().uuid(),
     sakhiId: z.string().uuid(),
-    caseType: z.enum(['MOTHER', 'CHILD']),
+    caseType: z.enum(CASE_TYPES),
     registrationDate: z.coerce.date(),
     previousBeneficiaryId: z.string().uuid().optional(),
     motherBeneficiaryId: z.string().uuid().optional(),

--- a/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * Query params for `GET /beneficiaries`, per SRS FR-S-9.2 ("Search by name
+ * and mobile number. Filter by pada (multi-select) and risk level
+ * (multi-select)") and the HLD's endpoint table ("List beneficiaries with
+ * filters (project, geography, status, case type, risk)"). Only single-value
+ * filters are supported for now — multi-select would need an `[]` query
+ * shape, not modeled here since no caller needs it yet.
+ */
+export const listBeneficiariesQuerySchema = z
+  .object({
+    projectId: z.string().uuid().optional(),
+    villageId: z.string().uuid().optional(),
+    padaId: z.string().uuid().optional(),
+    status: z
+      .enum(['ACTIVE', 'JOURNEY_COMPLETE', 'CLOSED', 'TRANSFERRED', 'REOPEN_REQUESTED'])
+      .optional(),
+    caseType: z.enum(['MOTHER', 'CHILD']).optional(),
+    atRiskOnly: z.coerce.boolean().optional(),
+    name: z.string().trim().min(1).max(200).optional(),
+    mobileNumber: z.string().trim().min(1).max(20).optional(),
+  })
+  .strict();
+
+export type ListBeneficiariesQueryInput = z.infer<typeof listBeneficiariesQuerySchema>;

--- a/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BENEFICIARY_STATUSES, CASE_TYPES } from '../beneficiary.constants';
 
 /**
  * Query params for `GET /beneficiaries`, per SRS FR-S-9.2 ("Search by name
@@ -13,10 +14,8 @@ export const listBeneficiariesQuerySchema = z
     projectId: z.string().uuid().optional(),
     villageId: z.string().uuid().optional(),
     padaId: z.string().uuid().optional(),
-    status: z
-      .enum(['ACTIVE', 'JOURNEY_COMPLETE', 'CLOSED', 'TRANSFERRED', 'REOPEN_REQUESTED'])
-      .optional(),
-    caseType: z.enum(['MOTHER', 'CHILD']).optional(),
+    status: z.enum(BENEFICIARY_STATUSES).optional(),
+    caseType: z.enum(CASE_TYPES).optional(),
     atRiskOnly: z.coerce.boolean().optional(),
     name: z.string().trim().min(1).max(200).optional(),
     mobileNumber: z.string().trim().min(1).max(20).optional(),

--- a/apps/closure-reopen-service/src/app.module.ts
+++ b/apps/closure-reopen-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/closure-reopen-service/src/closures/closure.controller.ts
+++ b/apps/closure-reopen-service/src/closures/closure.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { ClosureService } from './closure.service';
 import { createClosureSchema } from './dto/create-closure.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -77,8 +84,12 @@ export function createClosureRouter(service: ClosureService) {
       tags: ['Closures'],
       responses: {
         200: { description: 'Closures retrieved', schema: envelope(z.array(closureSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -92,8 +103,12 @@ export function createClosureRouter(service: ClosureService) {
       responses: {
         201: { description: 'Closure created', schema: envelope(closureSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
     validateBody(createClosureRequestSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/incentive-wages-service/src/app.module.ts
+++ b/apps/incentive-wages-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.controller.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { IncentiveEventService } from './incentiveEvent.service';
 import { createIncentiveEventSchema } from './dto/create-incentiveEvent.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -57,8 +64,12 @@ export function createIncentiveEventRouter(service: IncentiveEventService) {
           description: 'Incentive events',
           schema: envelope(z.array(incentiveEventSchema)),
         },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('MANAGER', 'ADMIN'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -72,8 +83,12 @@ export function createIncentiveEventRouter(service: IncentiveEventService) {
       responses: {
         201: { description: 'Incentive event created', schema: envelope(incentiveEventSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
     validateBody(createIncentiveEventSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/media-service/src/app.module.ts
+++ b/apps/media-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/media-service/src/media/mediaAsset.controller.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { MediaAssetService } from './mediaAsset.service';
 import { createMediaAssetSchema } from './dto/create-mediaAsset.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -11,12 +18,10 @@ const mediaAssetSchema = z.object({
   assetType: z.string().openapi({ example: 'CONSENT_PHOTO' }),
   storageUri: z.string().openapi({ example: 's3://arogya-media/2026/07/consent-abc123.jpg' }),
   mimeType: z.string().openapi({ example: 'image/jpeg' }),
-  sizeBytes: z
-    .string()
-    .openapi({
-      description: 'File size in bytes (BigInt serialized as string).',
-      example: '204800',
-    }),
+  sizeBytes: z.string().openapi({
+    description: 'File size in bytes (BigInt serialized as string).',
+    example: '204800',
+  }),
   uploadedByUserId: z.string().uuid().nullable(),
   uploadedAt: z.string().datetime(),
   linkedEntityType: z.string().nullable(),
@@ -61,8 +66,12 @@ export function createMediaAssetRouter(service: MediaAssetService) {
       tags: ['Media'],
       responses: {
         200: { description: 'Media assets', schema: envelope(z.array(mediaAssetSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -76,8 +85,12 @@ export function createMediaAssetRouter(service: MediaAssetService) {
       responses: {
         201: { description: 'Media asset created', schema: envelope(mediaAssetSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
     validateBody(createMediaAssetSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/notification-escalation-service/src/app.module.ts
+++ b/apps/notification-escalation-service/src/app.module.ts
@@ -20,6 +20,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/notification-escalation-service/src/notifications/notification.controller.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { NotificationService } from './notification.service';
 import { createNotificationSchema } from './dto/create-notification.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -52,8 +59,12 @@ export function createNotificationRouter(service: NotificationService) {
       tags: ['Notifications'],
       responses: {
         200: { description: 'Notifications', schema: envelope(z.array(notificationSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -67,8 +78,12 @@ export function createNotificationRouter(service: NotificationService) {
       responses: {
         201: { description: 'Notification created', schema: envelope(notificationSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
     validateBody(createNotificationSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/risk-referral-service/src/app.module.ts
+++ b/apps/risk-referral-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/risk-referral-service/src/referrals/referral.controller.ts
+++ b/apps/risk-referral-service/src/referrals/referral.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { ReferralService } from './referral.service';
 import { createReferralSchema } from './dto/create-referral.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -65,8 +72,12 @@ export function createReferralRouter(service: ReferralService) {
       tags: ['Referrals'],
       responses: {
         200: { description: 'Referrals list', schema: envelope(z.array(referralSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -80,8 +91,12 @@ export function createReferralRouter(service: ReferralService) {
       responses: {
         201: { description: 'Referral created', schema: envelope(referralSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
     validateBody(createReferralRequestSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/rules-service/src/app.module.ts
+++ b/apps/rules-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/rules-service/src/rules/ruleSet.controller.ts
+++ b/apps/rules-service/src/rules/ruleSet.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { RuleSetService } from './ruleSet.service';
 import { createRuleSetSchema } from './dto/create-ruleSet.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -56,8 +63,12 @@ export function createRuleSetRouter(service: RuleSetService) {
       tags: ['Rules'],
       responses: {
         200: { description: 'Rule sets', schema: envelope(z.array(ruleSetSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -71,8 +82,12 @@ export function createRuleSetRouter(service: RuleSetService) {
       responses: {
         201: { description: 'Rule set created', schema: envelope(ruleSetSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
     validateBody(createRuleSetRequestSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/sync-service/src/app.module.ts
+++ b/apps/sync-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/sync-service/src/sync/syncBatch.controller.ts
+++ b/apps/sync-service/src/sync/syncBatch.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { SyncBatchService } from './syncBatch.service';
 import { createSyncBatchSchema } from './dto/create-syncBatch.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -66,8 +73,12 @@ export function createSyncBatchRouter(service: SyncBatchService) {
           description: 'Most recent sync batches',
           schema: envelope(z.array(syncBatchSchema)),
         },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -81,8 +92,12 @@ export function createSyncBatchRouter(service: SyncBatchService) {
       responses: {
         201: { description: 'Sync batch created', schema: envelope(syncBatchSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR'),
     validateBody(createSyncBatchRequestSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/visit-form-service/src/app.module.ts
+++ b/apps/visit-form-service/src/app.module.ts
@@ -21,6 +21,7 @@ export {
   fail,
   validateBody,
   requireRoles,
+  trustGatewayIdentity,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/visit-form-service/src/visits/visitInstance.controller.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.controller.ts
@@ -2,7 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { VisitInstanceService } from './visitInstance.service';
 import { createVisitInstanceSchema } from './dto/create-visitInstance.dto';
-import { asyncHandler, createDocumentedRouter, ok, validateBody } from '../app.module';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validateBody,
+} from '../app.module';
 
 extendZodWithOpenApi(z);
 
@@ -69,8 +76,12 @@ export function createVisitInstanceRouter(service: VisitInstanceService) {
       tags: ['Visits'],
       responses: {
         200: { description: 'Visit instances', schema: envelope(z.array(visitInstanceSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.list()));
     }),
@@ -84,8 +95,12 @@ export function createVisitInstanceRouter(service: VisitInstanceService) {
       responses: {
         201: { description: 'Visit instance created', schema: envelope(visitInstanceSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
     validateBody(createVisitInstanceRequestSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);


### PR DESCRIPTION
## Summary
- auth-service: `/me` now returns project name, card number, and masked bank account; login response includes supervisor id, role, and scope
- beneficiary-service: list/get endpoints add risk-state, status-history, and filter support; shared enum constants and a name-decrypt helper extracted for reuse
- Enforces role-based access (`trustGatewayIdentity` + `requireRoles`) on every domain route across 10 services (closure-reopen, incentive-wages, media, notification-escalation, risk-referral, rules, sync, visit-form, and others), closing the previously identified RBAC gap

## Test plan
- [ ] `npx nx run-many -t lint,test,build --all --skip-nx-cache` green
- [ ] Manually verify `/me` and `/auth/login` responses include the new fields
- [ ] Manually verify a non-permitted role gets 403 on each newly-guarded route


Related to #83
