### PR TITLE
feat(auth-service): extend PATCH /users/:id to update credentials, role scope, and Sakhi profile

### DIFF
--- a/apps/auth-service/src/auth/auth.controller.ts
+++ b/apps/auth-service/src/auth/auth.controller.ts
@@ -217,17 +217,20 @@ export function createAuthRouter(service: AuthService, signer: TokenSigner) {
   doc.patch(
     '/users/:id',
     {
-      summary: 'Update a user (displayName/mobileNumber/email/status; ADMIN only)',
+      summary:
+        'Update a user — identity/contact/status/credentials (users), project/geography scope ' +
+        'for an existing role (user_roles), and Sakhi profile fields (sakhi_profiles); ADMIN only',
       tags: ['Users'],
       params: userIdParamsSchema,
       responses: {
-        200: { description: 'User updated', schema: envelope(createdUserSchema) },
+        200: { description: 'User updated', schema: envelope(userProfileSchema) },
         400: errorResponse(400, { message: 'At least one field must be provided.' }),
         401: errorResponse(401),
         403: errorResponse(403),
         404: errorResponse(404, { message: 'User not found.' }),
         409: errorResponse(409, {
-          message: 'A user with this mobile number or email already exists.',
+          message:
+            'A user with this username, mobile number, email, or employee code already exists.',
         }),
         500: errorResponse(500),
       },

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -182,8 +182,13 @@ export class AuthRepository {
   }
 
   /**
-   * Applies the `users`/`user_roles`/`sakhi_profiles` portions of an update in
-   * one transaction — either every requested field lands, or none does.
+   * Applies the `users`/`user_roles`/`sakhi_profiles` portions of an update,
+   * and — when `revokeSessions` is set — the session revocation that must
+   * accompany a username/password change, all in one transaction: either
+   * everything requested lands (including revocation), or none of it does.
+   * Revocation is folded in here rather than issued as a separate call after
+   * this transaction commits, so a credential change can never land without
+   * its accompanying forced-logout also landing.
    * `userRoleId`/`sakhiProfileId` are pre-resolved by the caller (service),
    * which already validated they exist, so this only ever writes to rows
    * known to exist.
@@ -194,6 +199,7 @@ export class AuthRepository {
       user: Record<string, unknown>;
       userRole?: { id: string; data: Record<string, unknown> };
       sakhiProfile?: { id: string; data: Record<string, unknown> };
+      revokeSessions?: boolean;
     },
   ) {
     return this.prisma.$transaction(async (tx) => {
@@ -209,6 +215,12 @@ export class AuthRepository {
           data: fields.sakhiProfile.data,
         });
       }
+      if (fields.revokeSessions) {
+        await tx.userSession.updateMany({
+          where: { userId: id, revokedAt: null },
+          data: { revokedAt: new Date() },
+        });
+      }
       return tx.user.findUnique({
         where: { id },
         include: {
@@ -220,13 +232,6 @@ export class AuthRepository {
           sakhiProfile: true,
         },
       });
-    });
-  }
-
-  revokeAllSessionsForUser(userId: string) {
-    return this.prisma.userSession.updateMany({
-      where: { userId, revokedAt: null },
-      data: { revokedAt: new Date() },
     });
   }
 }

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -1,5 +1,4 @@
 import type { PrismaService } from '../prisma/prisma.service';
-import type { UpdateUserInput } from './dto/update-user.dto';
 
 /** Data access for authentication: users, their role assignments, and sessions. */
 export class AuthRepository {
@@ -163,11 +162,71 @@ export class AuthRepository {
     });
   }
 
-  /** Returns null if `id` doesn't exist or is soft-deleted; caller maps that to a 404. */
-  async updateUser(id: string, data: UpdateUserInput) {
-    const existing = await this.prisma.user.findFirst({ where: { id, isDeleted: false } });
-    if (!existing) return null;
+  findProjectById(projectId: string) {
+    return this.prisma.project.findFirst({ where: { projectId, isDeleted: false } });
+  }
 
-    return this.prisma.user.update({ where: { id }, data });
+  /**
+   * Finds the user's currently-active `user_roles` row for `roleCode` — the
+   * row {@link updateUserTransaction} will update. Returns null if the user
+   * holds no such active role (caller maps that to a 404).
+   */
+  findActiveUserRole(userId: string, roleCode: string) {
+    return this.prisma.userRole.findFirst({
+      where: { userId, status: 'ACTIVE', isDeleted: false, role: { roleCode } },
+    });
+  }
+
+  findSakhiProfileByUserId(userId: string) {
+    return this.prisma.sakhiProfile.findFirst({ where: { userId, isDeleted: false } });
+  }
+
+  /**
+   * Applies the `users`/`user_roles`/`sakhi_profiles` portions of an update in
+   * one transaction — either every requested field lands, or none does.
+   * `userRoleId`/`sakhiProfileId` are pre-resolved by the caller (service),
+   * which already validated they exist, so this only ever writes to rows
+   * known to exist.
+   */
+  updateUserTransaction(
+    id: string,
+    fields: {
+      user: Record<string, unknown>;
+      userRole?: { id: string; data: Record<string, unknown> };
+      sakhiProfile?: { id: string; data: Record<string, unknown> };
+    },
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      if (Object.keys(fields.user).length > 0) {
+        await tx.user.update({ where: { id }, data: fields.user });
+      }
+      if (fields.userRole) {
+        await tx.userRole.update({ where: { id: fields.userRole.id }, data: fields.userRole.data });
+      }
+      if (fields.sakhiProfile) {
+        await tx.sakhiProfile.update({
+          where: { id: fields.sakhiProfile.id },
+          data: fields.sakhiProfile.data,
+        });
+      }
+      return tx.user.findUnique({
+        where: { id },
+        include: {
+          userRoles: {
+            where: { status: 'ACTIVE', isDeleted: false },
+            orderBy: { createdAt: 'asc' },
+            include: { role: true, project: true },
+          },
+          sakhiProfile: true,
+        },
+      });
+    });
+  }
+
+  revokeAllSessionsForUser(userId: string) {
+    return this.prisma.userSession.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
   }
 }

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -33,6 +33,29 @@ const ACTIVE_USER = {
   ],
 };
 
+/** Row shape returned by `updateUserTransaction` — same shape `toUserProfile` maps. */
+function updatedUserRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'user-1',
+    username: 'test.sakhi',
+    displayName: 'Test Sakhi',
+    mobileNumber: '+919876543210',
+    email: 'test.sakhi@example.org',
+    status: 'ACTIVE' as const,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    userRoles: [
+      {
+        projectId: 'project-1',
+        geographyUnitId: 'geo-1',
+        role: { roleCode: 'SAKHI' },
+        project: { projectName: 'GEP-2324' },
+      },
+    ],
+    sakhiProfile: null,
+    ...overrides,
+  };
+}
+
 describe('AuthService', () => {
   const repository = {
     findUserByUsername: jest.fn(),
@@ -47,7 +70,11 @@ describe('AuthService', () => {
     revokeSessionByRefreshTokenHash: jest.fn(),
     findRoleByCode: jest.fn(),
     createUserWithRole: jest.fn(),
-    updateUser: jest.fn(),
+    findProjectById: jest.fn(),
+    findActiveUserRole: jest.fn(),
+    findSakhiProfileByUserId: jest.fn(),
+    updateUserTransaction: jest.fn(),
+    revokeAllSessionsForUser: jest.fn(),
   } as unknown as jest.Mocked<AuthRepository>;
 
   const signer = {
@@ -502,52 +529,278 @@ describe('AuthService', () => {
   });
 
   describe('updateUser', () => {
-    const UPDATED_USER = {
-      id: 'user-1',
-      username: 'test.sakhi',
-      mobileNumber: '+919876543210',
-      displayName: 'Renamed Sakhi',
-      email: 'test.sakhi@example.org',
-      status: 'ACTIVE' as const,
-      createdAt: new Date('2026-01-01T00:00:00.000Z'),
-    };
+    beforeEach(() => {
+      repository.findUserById.mockResolvedValue(ACTIVE_USER as never);
+    });
 
-    it('updates the user and returns the projected fields', async () => {
-      repository.updateUser.mockResolvedValue(UPDATED_USER as never);
+    it('updates displayName only and returns the full profile', async () => {
+      repository.updateUserTransaction.mockResolvedValue(
+        updatedUserRow({ displayName: 'Renamed Sakhi' }) as never,
+      );
 
       const result = await service.updateUser('user-1', { displayName: 'Renamed Sakhi' });
 
-      expect(repository.updateUser).toHaveBeenCalledWith('user-1', {
-        displayName: 'Renamed Sakhi',
+      expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+        user: { displayName: 'Renamed Sakhi' },
+        userRole: undefined,
+        sakhiProfile: undefined,
       });
-      expect(result).toEqual({
-        id: 'user-1',
-        username: 'test.sakhi',
-        mobileNumber: '+919876543210',
-        displayName: 'Renamed Sakhi',
-        email: 'test.sakhi@example.org',
-        status: 'ACTIVE',
-        createdAt: UPDATED_USER.createdAt,
-      });
+      expect(result.displayName).toBe('Renamed Sakhi');
+      expect(repository.revokeAllSessionsForUser).not.toHaveBeenCalled();
     });
 
     it('throws 404 when the user does not exist or is soft-deleted', async () => {
-      repository.updateUser.mockResolvedValue(null);
+      repository.findUserById.mockResolvedValue(null);
       await expect(service.updateUser('missing', { displayName: 'X' })).rejects.toMatchObject({
+        status: 404,
+      });
+      expect(repository.updateUserTransaction).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 for a soft-deleted user', async () => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, isDeleted: true } as never);
+      await expect(service.updateUser('user-1', { displayName: 'X' })).rejects.toMatchObject({
         status: 404,
       });
     });
 
-    it('maps a duplicate mobile number or email to a 409 conflict', async () => {
-      repository.updateUser.mockRejectedValue({ code: 'P2002' });
+    it('maps a duplicate username/mobile/email/employeeCode to a 409 conflict', async () => {
+      repository.updateUserTransaction.mockRejectedValue({ code: 'P2002' });
       await expect(
         service.updateUser('user-1', { mobileNumber: '+919876543210' }),
       ).rejects.toMatchObject({ status: 409 });
     });
 
     it('propagates unrelated repository errors unchanged', async () => {
-      repository.updateUser.mockRejectedValue(new Error('db down'));
+      repository.updateUserTransaction.mockRejectedValue(new Error('db down'));
       await expect(service.updateUser('user-1', { displayName: 'X' })).rejects.toThrow('db down');
+    });
+
+    describe('username', () => {
+      it('updates username and revokes all active sessions', async () => {
+        repository.updateUserTransaction.mockResolvedValue(
+          updatedUserRow({ username: 'new.username' }) as never,
+        );
+
+        const result = await service.updateUser('user-1', { username: 'new.username' });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: { username: 'new.username' },
+          userRole: undefined,
+          sakhiProfile: undefined,
+        });
+        expect(repository.revokeAllSessionsForUser).toHaveBeenCalledWith('user-1');
+        expect(result.username).toBe('new.username');
+      });
+
+      it('maps a duplicate username to a 409 conflict', async () => {
+        repository.updateUserTransaction.mockRejectedValue({ code: 'P2002' });
+        await expect(
+          service.updateUser('user-1', { username: 'taken.username' }),
+        ).rejects.toMatchObject({ status: 409 });
+      });
+    });
+
+    describe('password', () => {
+      it('hashes the new password, sets passwordChangedAt, and revokes all active sessions', async () => {
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', { password: 'NewStr0ngPass!' });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {
+            passwordHash: 'hashed(NewStr0ngPass!)',
+            passwordChangedAt: expect.any(Date),
+          },
+          userRole: undefined,
+          sakhiProfile: undefined,
+        });
+        expect(repository.revokeAllSessionsForUser).toHaveBeenCalledWith('user-1');
+      });
+
+      it('never includes passwordHash or plaintext password in the returned profile', async () => {
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        const result = await service.updateUser('user-1', { password: 'NewStr0ngPass!' });
+
+        expect(result).not.toHaveProperty('passwordHash');
+        expect(result).not.toHaveProperty('password');
+      });
+    });
+
+    describe('role/project/geography scope', () => {
+      it('updates projectId and geographyUnitId on the matching active role row', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+        repository.findProjectById.mockResolvedValue({ projectId: 'project-2' } as never);
+        repository.updateUserTransaction.mockResolvedValue(
+          updatedUserRow({
+            userRoles: [
+              {
+                projectId: 'project-2',
+                geographyUnitId: 'geo-2',
+                role: { roleCode: 'SAKHI' },
+                project: { projectName: 'GEP-2425' },
+              },
+            ],
+          }) as never,
+        );
+
+        await service.updateUser('user-1', {
+          roleCode: 'SAKHI',
+          projectId: 'project-2',
+          geographyUnitId: 'geo-2',
+        });
+
+        expect(repository.findActiveUserRole).toHaveBeenCalledWith('user-1', 'SAKHI');
+        expect(repository.findProjectById).toHaveBeenCalledWith('project-2');
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: {
+            id: 'user-role-1',
+            data: { projectId: 'project-2', geographyUnitId: 'geo-2' },
+          },
+          sakhiProfile: undefined,
+        });
+      });
+
+      it('throws 404 when the user has no active role matching roleCode', async () => {
+        repository.findActiveUserRole.mockResolvedValue(null);
+
+        await expect(
+          service.updateUser('user-1', { roleCode: 'MANAGER', projectId: 'project-2' }),
+        ).rejects.toMatchObject({ status: 404 });
+        expect(repository.updateUserTransaction).not.toHaveBeenCalled();
+      });
+
+      it('throws 404 when projectId does not reference an existing project', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+        repository.findProjectById.mockResolvedValue(null);
+
+        await expect(
+          service.updateUser('user-1', { roleCode: 'SAKHI', projectId: 'missing-project' }),
+        ).rejects.toMatchObject({ status: 404 });
+        expect(repository.updateUserTransaction).not.toHaveBeenCalled();
+      });
+
+      it('allows clearing projectId to null on the matching role row', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', { roleCode: 'SAKHI', projectId: null });
+
+        expect(repository.findProjectById).not.toHaveBeenCalled();
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: { id: 'user-role-1', data: { projectId: null } },
+          sakhiProfile: undefined,
+        });
+      });
+    });
+
+    describe('Sakhi profile fields', () => {
+      it('updates employeeCode (cardNumber) for a SAKHI user', async () => {
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(
+          updatedUserRow({
+            sakhiProfile: { employeeCode: 'EMP-00999', bankAccountToken: null, supervisorId: null },
+          }) as never,
+        );
+
+        const result = await service.updateUser('user-1', { employeeCode: 'EMP-00999' });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: undefined,
+          sakhiProfile: { id: 'sakhi-profile-1', data: { employeeCode: 'EMP-00999' } },
+        });
+        expect(result.cardNumber).toBe('EMP-00999');
+      });
+
+      it('throws 404 for a non-SAKHI user with no Sakhi profile', async () => {
+        repository.findSakhiProfileByUserId.mockResolvedValue(null);
+
+        await expect(
+          service.updateUser('user-1', { employeeCode: 'EMP-00999' }),
+        ).rejects.toMatchObject({ status: 404 });
+        expect(repository.updateUserTransaction).not.toHaveBeenCalled();
+      });
+
+      it('maps a duplicate employeeCode to a 409 conflict', async () => {
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockRejectedValue({ code: 'P2002' });
+
+        await expect(
+          service.updateUser('user-1', { employeeCode: 'EMP-00999' }),
+        ).rejects.toMatchObject({ status: 409 });
+      });
+
+      it('updates supervisorId as a plain scalar with no FK validation', async () => {
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', { supervisorId: 'supervisor-2' });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: undefined,
+          sakhiProfile: { id: 'sakhi-profile-1', data: { supervisorId: 'supervisor-2' } },
+        });
+      });
+
+      it('encrypts panNumber/aadhaarNumber/bankAccountNumber before persisting, never storing plaintext', async () => {
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', {
+          panNumber: 'ABCDE1234F',
+          aadhaarNumber: '123456789012',
+          bankAccountNumber: '000111222333',
+        });
+
+        const call = repository.updateUserTransaction.mock.calls[0][1] as {
+          sakhiProfile: { data: Record<string, unknown> };
+        };
+        expect(call.sakhiProfile.data.panToken).toBeInstanceOf(Buffer);
+        expect(call.sakhiProfile.data.aadhaarToken).toBeInstanceOf(Buffer);
+        expect(call.sakhiProfile.data.bankAccountToken).toBeInstanceOf(Buffer);
+        expect((call.sakhiProfile.data.panToken as Buffer).toString()).not.toContain('ABCDE1234F');
+      });
+
+      it('updates activeFrom/activeTo as Date objects', async () => {
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', { activeFrom: '2026-01-01', activeTo: '2026-12-31' });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: undefined,
+          sakhiProfile: {
+            id: 'sakhi-profile-1',
+            data: { activeFrom: new Date('2026-01-01'), activeTo: new Date('2026-12-31') },
+          },
+        });
+      });
+    });
+
+    it('applies users, user_roles, and sakhi_profiles updates together in one call', async () => {
+      repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+      repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+      repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+      await service.updateUser('user-1', {
+        username: 'new.username',
+        roleCode: 'SAKHI',
+        geographyUnitId: 'geo-2',
+        employeeCode: 'EMP-00999',
+      });
+
+      expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+        user: { username: 'new.username' },
+        userRole: { id: 'user-role-1', data: { geographyUnitId: 'geo-2' } },
+        sakhiProfile: { id: 'sakhi-profile-1', data: { employeeCode: 'EMP-00999' } },
+      });
+      expect(repository.revokeAllSessionsForUser).toHaveBeenCalledWith('user-1');
     });
   });
 });

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -74,7 +74,6 @@ describe('AuthService', () => {
     findActiveUserRole: jest.fn(),
     findSakhiProfileByUserId: jest.fn(),
     updateUserTransaction: jest.fn(),
-    revokeAllSessionsForUser: jest.fn(),
   } as unknown as jest.Mocked<AuthRepository>;
 
   const signer = {
@@ -544,9 +543,9 @@ describe('AuthService', () => {
         user: { displayName: 'Renamed Sakhi' },
         userRole: undefined,
         sakhiProfile: undefined,
+        revokeSessions: false,
       });
       expect(result.displayName).toBe('Renamed Sakhi');
-      expect(repository.revokeAllSessionsForUser).not.toHaveBeenCalled();
     });
 
     it('throws 404 when the user does not exist or is soft-deleted', async () => {
@@ -577,7 +576,7 @@ describe('AuthService', () => {
     });
 
     describe('username', () => {
-      it('updates username and revokes all active sessions', async () => {
+      it('updates username and revokes all active sessions in the same transaction', async () => {
         repository.updateUserTransaction.mockResolvedValue(
           updatedUserRow({ username: 'new.username' }) as never,
         );
@@ -588,8 +587,8 @@ describe('AuthService', () => {
           user: { username: 'new.username' },
           userRole: undefined,
           sakhiProfile: undefined,
+          revokeSessions: true,
         });
-        expect(repository.revokeAllSessionsForUser).toHaveBeenCalledWith('user-1');
         expect(result.username).toBe('new.username');
       });
 
@@ -602,7 +601,7 @@ describe('AuthService', () => {
     });
 
     describe('password', () => {
-      it('hashes the new password, sets passwordChangedAt, and revokes all active sessions', async () => {
+      it('hashes the new password, sets passwordChangedAt, and revokes all active sessions in the same transaction', async () => {
         repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
 
         await service.updateUser('user-1', { password: 'NewStr0ngPass!' });
@@ -614,8 +613,8 @@ describe('AuthService', () => {
           },
           userRole: undefined,
           sakhiProfile: undefined,
+          revokeSessions: true,
         });
-        expect(repository.revokeAllSessionsForUser).toHaveBeenCalledWith('user-1');
       });
 
       it('never includes passwordHash or plaintext password in the returned profile', async () => {
@@ -660,6 +659,7 @@ describe('AuthService', () => {
             data: { projectId: 'project-2', geographyUnitId: 'geo-2' },
           },
           sakhiProfile: undefined,
+          revokeSessions: false,
         });
       });
 
@@ -693,6 +693,7 @@ describe('AuthService', () => {
           user: {},
           userRole: { id: 'user-role-1', data: { projectId: null } },
           sakhiProfile: undefined,
+          revokeSessions: false,
         });
       });
     });
@@ -712,6 +713,7 @@ describe('AuthService', () => {
           user: {},
           userRole: undefined,
           sakhiProfile: { id: 'sakhi-profile-1', data: { employeeCode: 'EMP-00999' } },
+          revokeSessions: false,
         });
         expect(result.cardNumber).toBe('EMP-00999');
       });
@@ -744,6 +746,7 @@ describe('AuthService', () => {
           user: {},
           userRole: undefined,
           sakhiProfile: { id: 'sakhi-profile-1', data: { supervisorId: 'supervisor-2' } },
+          revokeSessions: false,
         });
       });
 
@@ -779,11 +782,12 @@ describe('AuthService', () => {
             id: 'sakhi-profile-1',
             data: { activeFrom: new Date('2026-01-01'), activeTo: new Date('2026-12-31') },
           },
+          revokeSessions: false,
         });
       });
     });
 
-    it('applies users, user_roles, and sakhi_profiles updates together in one call', async () => {
+    it('applies users, user_roles, sakhi_profiles, and session revocation together in one transaction', async () => {
       repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
       repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
       repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
@@ -799,8 +803,8 @@ describe('AuthService', () => {
         user: { username: 'new.username' },
         userRole: { id: 'user-role-1', data: { geographyUnitId: 'geo-2' } },
         sakhiProfile: { id: 'sakhi-profile-1', data: { employeeCode: 'EMP-00999' } },
+        revokeSessions: true,
       });
-      expect(repository.revokeAllSessionsForUser).toHaveBeenCalledWith('user-1');
     });
   });
 });

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -200,12 +200,9 @@ export class AuthService {
             }
           : undefined,
         sakhiProfile: sakhiProfileId ? { id: sakhiProfileId, data: sakhiProfileFields } : undefined,
+        revokeSessions: input.username !== undefined || input.password !== undefined,
       });
       if (!user) throw notFound('User not found.');
-
-      if (input.username !== undefined || input.password !== undefined) {
-        await this.repository.revokeAllSessionsForUser(id);
-      }
 
       return toUserProfile(user);
     } catch (err) {

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import type { TokenSigner } from '@armman/service-commons';
-import { conflict, forbidden, notFound, unauthorized } from '@armman/service-commons';
+import { conflict, notFound, forbidden, unauthorized, encryptPii } from '@armman/service-commons';
 import type { AuthRepository } from './auth.repository';
 import { hashPassword, verifyPassword } from './password';
 import { generateRefreshToken, hashRefreshToken } from './refresh-token';
@@ -123,22 +123,96 @@ export class AuthService {
     }
   }
 
-  async updateUser(id: string, input: UpdateUserInput): Promise<CreatedUser> {
+  /**
+   * Updates a user across `users`, the caller's currently-active `user_roles`
+   * row (project/geography scope only), and `sakhi_profiles` in one request —
+   * per product decision, one endpoint rather than four. All three writes
+   * happen in a single transaction (see `AuthRepository.updateUserTransaction`):
+   * either everything requested lands, or nothing does.
+   *
+   * `roleCode`/`employeeCode` existence and target-row lookups happen here
+   * (not in the transaction) so a 404 can be thrown before any write starts.
+   */
+  async updateUser(id: string, input: UpdateUserInput): Promise<UserProfile> {
+    const existing = await this.repository.findUserById(id);
+    if (!existing || existing.isDeleted) throw notFound('User not found.');
+
+    let userRoleId: string | undefined;
+    if (input.roleCode) {
+      const activeRole = await this.repository.findActiveUserRole(id, input.roleCode);
+      if (!activeRole) {
+        throw notFound(`User has no active ${input.roleCode} role assignment.`);
+      }
+      if (input.projectId) {
+        const project = await this.repository.findProjectById(input.projectId);
+        if (!project) throw notFound('Project not found.');
+      }
+      userRoleId = activeRole.id;
+    }
+
+    let sakhiProfileId: string | undefined;
+    const sakhiProfileFields: Record<string, unknown> = {};
+    if (input.employeeCode !== undefined) sakhiProfileFields.employeeCode = input.employeeCode;
+    if (input.supervisorId !== undefined) sakhiProfileFields.supervisorId = input.supervisorId;
+    if (input.phoneNumber !== undefined) sakhiProfileFields.phoneNumber = input.phoneNumber;
+    if (input.backupContact !== undefined) sakhiProfileFields.backupContact = input.backupContact;
+    if (input.ifscCode !== undefined) sakhiProfileFields.ifscCode = input.ifscCode;
+    if (input.activeFrom !== undefined) sakhiProfileFields.activeFrom = new Date(input.activeFrom);
+    if (input.activeTo !== undefined) {
+      sakhiProfileFields.activeTo = input.activeTo ? new Date(input.activeTo) : null;
+    }
+    if (input.panNumber !== undefined) sakhiProfileFields.panToken = encryptPii(input.panNumber);
+    if (input.aadhaarNumber !== undefined) {
+      sakhiProfileFields.aadhaarToken = encryptPii(input.aadhaarNumber);
+    }
+    if (input.bankAccountNumber !== undefined) {
+      sakhiProfileFields.bankAccountToken = encryptPii(input.bankAccountNumber);
+    }
+    if (Object.keys(sakhiProfileFields).length > 0) {
+      const profile = await this.repository.findSakhiProfileByUserId(id);
+      if (!profile) throw notFound('User has no Sakhi profile.');
+      sakhiProfileId = profile.id;
+    }
+
+    const userFields: Record<string, unknown> = {};
+    if (input.username !== undefined) userFields.username = input.username;
+    if (input.displayName !== undefined) userFields.displayName = input.displayName;
+    if (input.mobileNumber !== undefined) userFields.mobileNumber = input.mobileNumber;
+    if (input.email !== undefined) userFields.email = input.email;
+    if (input.status !== undefined) userFields.status = input.status;
+    if (input.password !== undefined) {
+      userFields.passwordHash = await hashPassword(input.password);
+      userFields.passwordChangedAt = new Date();
+    }
+
     try {
-      const user = await this.repository.updateUser(id, input);
+      const user = await this.repository.updateUserTransaction(id, {
+        user: userFields,
+        userRole: userRoleId
+          ? {
+              id: userRoleId,
+              data: {
+                ...(input.projectId !== undefined && { projectId: input.projectId }),
+                ...(input.geographyUnitId !== undefined && {
+                  geographyUnitId: input.geographyUnitId,
+                }),
+              },
+            }
+          : undefined,
+        sakhiProfile: sakhiProfileId ? { id: sakhiProfileId, data: sakhiProfileFields } : undefined,
+      });
       if (!user) throw notFound('User not found.');
-      return {
-        id: user.id,
-        username: user.username,
-        mobileNumber: user.mobileNumber,
-        displayName: user.displayName,
-        email: user.email,
-        status: user.status,
-        createdAt: user.createdAt,
-      };
+
+      if (input.username !== undefined || input.password !== undefined) {
+        await this.repository.revokeAllSessionsForUser(id);
+      }
+
+      return toUserProfile(user);
     } catch (err) {
       if (isUniqueConstraintViolation(err)) {
-        throw conflict('A user with this mobile number or email already exists.');
+        throw conflict(
+          'A user with this username, mobile number, email, or employee code already exists.',
+        );
       }
       throw err;
     }

--- a/apps/auth-service/src/auth/dto/update-user.dto.spec.ts
+++ b/apps/auth-service/src/auth/dto/update-user.dto.spec.ts
@@ -1,0 +1,121 @@
+import { updateUserSchema } from './update-user.dto';
+
+describe('updateUserSchema', () => {
+  it('rejects an empty body', () => {
+    const result = updateUserSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown field', () => {
+    const result = updateUserSchema.safeParse({ displayName: 'X', notAField: true });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts displayName alone', () => {
+    expect(updateUserSchema.safeParse({ displayName: 'Renamed Sakhi' }).success).toBe(true);
+  });
+
+  it('accepts email set to null', () => {
+    expect(updateUserSchema.safeParse({ email: null }).success).toBe(true);
+  });
+
+  it('rejects an invalid status enum value', () => {
+    expect(updateUserSchema.safeParse({ status: 'NOT_A_STATUS' }).success).toBe(false);
+  });
+
+  describe('username', () => {
+    it('accepts a valid username', () => {
+      expect(updateUserSchema.safeParse({ username: 'new.username' }).success).toBe(true);
+    });
+
+    it('rejects a username with disallowed characters', () => {
+      expect(updateUserSchema.safeParse({ username: 'bad@user' }).success).toBe(false);
+    });
+  });
+
+  describe('password', () => {
+    it('rejects a password shorter than 8 characters', () => {
+      expect(updateUserSchema.safeParse({ password: 'short' }).success).toBe(false);
+    });
+
+    it('rejects a password longer than 200 characters', () => {
+      expect(updateUserSchema.safeParse({ password: 'a'.repeat(201) }).success).toBe(false);
+    });
+
+    it('accepts a valid password', () => {
+      expect(updateUserSchema.safeParse({ password: 'NewStr0ngPass!' }).success).toBe(true);
+    });
+  });
+
+  describe('role/project/geography scope', () => {
+    it('rejects projectId without roleCode', () => {
+      const result = updateUserSchema.safeParse({
+        projectId: 'a35c5e7e-83a0-4a2c-9e9b-9b0a4b3c1a11',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects geographyUnitId without roleCode', () => {
+      const result = updateUserSchema.safeParse({
+        geographyUnitId: 'a35c5e7e-83a0-4a2c-9e9b-9b0a4b3c1a11',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects roleCode alone with neither projectId nor geographyUnitId', () => {
+      expect(updateUserSchema.safeParse({ roleCode: 'SAKHI' }).success).toBe(false);
+    });
+
+    it('accepts roleCode with projectId', () => {
+      const result = updateUserSchema.safeParse({
+        roleCode: 'SAKHI',
+        projectId: 'a35c5e7e-83a0-4a2c-9e9b-9b0a4b3c1a11',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts roleCode with projectId explicitly cleared to null', () => {
+      expect(updateUserSchema.safeParse({ roleCode: 'SAKHI', projectId: null }).success).toBe(true);
+    });
+
+    it('rejects a non-UUID projectId', () => {
+      expect(
+        updateUserSchema.safeParse({ roleCode: 'SAKHI', projectId: 'not-a-uuid' }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe('Sakhi profile fields', () => {
+    it('accepts employeeCode alone', () => {
+      expect(updateUserSchema.safeParse({ employeeCode: 'EMP-00999' }).success).toBe(true);
+    });
+
+    it('rejects an invalid phoneNumber format', () => {
+      expect(updateUserSchema.safeParse({ phoneNumber: '9876543210' }).success).toBe(false);
+    });
+
+    it('accepts backupContact set to null', () => {
+      expect(updateUserSchema.safeParse({ backupContact: null }).success).toBe(true);
+    });
+
+    it('rejects activeTo before activeFrom', () => {
+      const result = updateUserSchema.safeParse({
+        activeFrom: '2026-06-01',
+        activeTo: '2026-01-01',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts activeTo on or after activeFrom', () => {
+      const result = updateUserSchema.safeParse({
+        activeFrom: '2026-01-01',
+        activeTo: '2026-06-01',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts activeTo set to null with no activeFrom comparison', () => {
+      expect(updateUserSchema.safeParse({ activeTo: null }).success).toBe(true);
+    });
+  });
+});

--- a/apps/auth-service/src/auth/dto/update-user.dto.ts
+++ b/apps/auth-service/src/auth/dto/update-user.dto.ts
@@ -1,25 +1,68 @@
 import { z } from 'zod';
 import { mobileNumberSchema } from './mobile-number';
+import { usernameSchema } from './username';
 
 /**
  * Partial update — every field optional, but at least one must be present.
- * `username`, `password`, and role/project/geography assignment are
- * intentionally excluded: username is the login identifier (changing it is
- * riskier and out of scope here), password changes belong on their own
- * dedicated flow, and role/project/geography reassignment is a separate
- * concern since a user can hold multiple role rows over time.
+ * Spans three tables in one request (per product decision — no separate
+ * endpoints): `users` (identity/contact/status/credentials), the caller's
+ * currently-active `user_roles` row selected by `roleCode` (project/geography
+ * scope only — `roleCode` itself is immutable here; a role change is a new
+ * grant, not an edit), and `sakhi_profiles` (SAKHI-only identity/bank
+ * fields). `panNumber`/`aadhaarNumber`/`bankAccountNumber` are accepted as
+ * plaintext and encrypted server-side before storage — never persisted or
+ * echoed back in plaintext.
  */
 export const updateUserSchema = z
   .object({
+    // users
+    username: usernameSchema,
+    password: z.string().min(8).max(200),
     displayName: z.string().trim().min(1).max(160),
     mobileNumber: mobileNumberSchema,
     email: z.string().trim().email().max(254).nullable(),
     status: z.enum(['ACTIVE', 'INACTIVE', 'LOCKED', 'PAUSED', 'DELETED']),
+
+    // user_roles scope (identifies which active role row to update)
+    roleCode: z.string().trim().min(1).max(50),
+    projectId: z.string().uuid().nullable(),
+    geographyUnitId: z.string().uuid().nullable(),
+
+    // sakhi_profiles
+    employeeCode: z.string().trim().min(1).max(80),
+    supervisorId: z.string().uuid().nullable(),
+    phoneNumber: mobileNumberSchema,
+    backupContact: mobileNumberSchema.nullable(),
+    ifscCode: z.string().trim().min(1).max(20),
+    panNumber: z.string().trim().min(1),
+    aadhaarNumber: z.string().trim().min(1),
+    bankAccountNumber: z.string().trim().min(1),
+    activeFrom: z.string().trim().date(),
+    activeTo: z.string().trim().date().nullable(),
   })
   .partial()
   .strict()
   .refine((data) => Object.keys(data).length > 0, {
     message: 'At least one field must be provided.',
-  });
+  })
+  .refine(
+    (data) =>
+      !((data.projectId !== undefined || data.geographyUnitId !== undefined) && !data.roleCode),
+    {
+      message: 'roleCode: Required when updating projectId or geographyUnitId.',
+    },
+  )
+  .refine(
+    (data) =>
+      !(data.roleCode && data.projectId === undefined && data.geographyUnitId === undefined),
+    {
+      message: 'projectId or geographyUnitId: Required when roleCode is provided.',
+    },
+  )
+  .refine(
+    (data) =>
+      !(data.activeFrom && data.activeTo && new Date(data.activeTo) < new Date(data.activeFrom)),
+    { message: 'activeTo: Must not be before activeFrom.' },
+  );
 
 export type UpdateUserInput = z.infer<typeof updateUserSchema>;


### PR DESCRIPTION
## Summary
- Extends the existing `PATCH /users/:id` endpoint (no new endpoints, per decision) to accept, in one request, at least one of:
  - **`users`**: `username`, `password` — added alongside the existing `displayName`/`mobileNumber`/`email`/`status`
  - **`user_roles`**: `projectId`/`geographyUnitId` on the caller's currently-active role row selected by `roleCode` (`roleCode` itself stays immutable — a role change is a new grant, not an edit)
  - **`sakhi_profiles`**: `employeeCode`, `supervisorId`, `phoneNumber`, `backupContact`, `ifscCode`, `panNumber`/`aadhaarNumber`/`bankAccountNumber` (plaintext in, encrypted at rest via `encryptPii`), `activeFrom`/`activeTo`
- All three tables update in a single Prisma transaction — either every requested field lands, or none does.
- Changing `username` or `password` revokes all of that user's active sessions, forcing re-login.
- Response now returns the full profile (same shape as `GET /me`) instead of the slim `CreatedUser` projection, since the endpoint can now touch role/project/geography/profile fields.

## Validation rules
- At least one field required.
- `projectId`/`geographyUnitId` require `roleCode` to be present (and vice versa) — a role-scope update needs both "which role" and "what to change".
- `roleCode` must match a role the user currently holds an active assignment for → 404 otherwise.
- `projectId` must reference an existing, non-deleted project → 404 otherwise.
- Any Sakhi-profile field requires the target user to already have a `SakhiProfile` row → 404 otherwise.
- `activeTo` must not be before `activeFrom`.

## Test plan
- [x] `nx lint auth-service` — clean
- [x] `nx test auth-service` — 162/162 passing
- [x] `nx build auth-service` — clean
- New tests cover: username/password update + session revocation, role/project/geography scope update (including the "no active role" and "no such project" 404 paths), Sakhi profile field updates (including PAN/Aadhaar/bank-account encryption and 404 for users without a profile), and combined multi-table updates in a single request.
- DTO-level tests (`update-user.dto.spec.ts`) cover the cross-field validation rules above.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


Related to #72
