### PR TITLE
feat: Sakhi lookups, inventory item/transaction CRUD, and ADMIN full access

### DIFF
--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -54,6 +54,9 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
   { prefix: '/lookups', target: appConfig.AUTH_SERVICE_URL, requiresAuth: true },
   { prefix: '/geography-units', target: appConfig.AUTH_SERVICE_URL, requiresAuth: true },
   { prefix: '/master-data', target: appConfig.AUTH_SERVICE_URL, requiresAuth: true },
+  // Sakhi profile reads (list under a project, single lookup) — used by the
+  // Supervisor's Sakhi picker/detail header on inventory/meeting screens.
+  { prefix: '/sakhis', target: appConfig.AUTH_SERVICE_URL, requiresAuth: true },
   // NOTE: `/docs` is NOT proxied here. The gateway serves ONE aggregated
   // Swagger UI at `/api/v1/docs` (see docs/docs.controller.ts) that merges
   // every service's own `/docs.json` into a single page — there is no single

--- a/apps/auth-service/src/app.module.ts
+++ b/apps/auth-service/src/app.module.ts
@@ -19,6 +19,7 @@ import { createProjectModule } from './projects/project.module';
 import { createLookupModule } from './lookups/lookup.module';
 import { createGeographyModule } from './geography/geography.module';
 import { createMasterDataModule } from './master-data/master-data.module';
+import { createSakhiModule } from './sakhis/sakhi.module';
 import { buildAuthServiceOpenApiDocument } from './docs/openapi';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
@@ -89,6 +90,7 @@ export function createApp(prisma: PrismaService, signer: TokenSigner, redis: Red
   const lookupModule = createLookupModule(prisma, signer);
   const geographyModule = createGeographyModule(prisma, signer);
   const masterDataModule = createMasterDataModule(prisma, signer);
+  const sakhiModule = createSakhiModule(prisma, signer);
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();
@@ -104,6 +106,7 @@ export function createApp(prisma: PrismaService, signer: TokenSigner, redis: Red
         lookupModule.registry,
         geographyModule.registry,
         masterDataModule.registry,
+        sakhiModule.registry,
       ),
     ),
   );
@@ -114,6 +117,7 @@ export function createApp(prisma: PrismaService, signer: TokenSigner, redis: Red
   api.use(lookupModule.router);
   api.use(geographyModule.router);
   api.use(masterDataModule.router);
+  api.use(sakhiModule.router);
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/auth-service/src/sakhis/sakhi.controller.ts
+++ b/apps/auth-service/src/sakhis/sakhi.controller.ts
@@ -1,0 +1,103 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { TokenSigner } from '@armman/service-commons';
+import type { SakhiService } from './sakhi.service';
+import {
+  asyncHandler,
+  authenticate,
+  createDocumentedRouter,
+  errorResponse,
+  ok,
+  requireRoles,
+  unauthorized,
+  validate,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const projectIdParamsSchema = z
+  .object({
+    projectId: z.string().uuid().openapi({ example: '70ca545d-298a-4c02-bba2-d5c4c9bb9acd' }),
+  })
+  .strict();
+
+const sakhiIdParamsSchema = z
+  .object({
+    sakhiId: z.string().uuid().openapi({ example: 'c9f8e2b1-6a3d-4f0e-9b1a-2d4e5f6a7b8c' }),
+  })
+  .strict();
+
+const sakhiSchema = z.object({
+  sakhiId: z.string().uuid().openapi({ example: 'c9f8e2b1-6a3d-4f0e-9b1a-2d4e5f6a7b8c' }),
+  displayName: z.string().openapi({ example: 'Priya Sharma' }),
+  mobileNumber: z.string().openapi({ example: '+919000000123' }),
+  status: z.enum(['ACTIVE', 'INACTIVE', 'LOCKED', 'PAUSED', 'DELETED']).openapi({
+    example: 'ACTIVE',
+  }),
+  employeeCode: z.string().nullable().openapi({ example: 'EMP-00123' }),
+  primaryProjectId: z.string().uuid().openapi({ example: '70ca545d-298a-4c02-bba2-d5c4c9bb9acd' }),
+  supervisorId: z.string().uuid().nullable(),
+  activeFrom: z.string().datetime().openapi({ example: '2026-04-01T00:00:00.000Z' }),
+  activeTo: z.string().datetime().nullable(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Sakhi profile read HTTP routes. Mounted under the global `api/v1` prefix.
+ * Restricted to SUPERVISOR/MANAGER/ADMIN — a Sakhi does not look up other
+ * Sakhis; these endpoints back the Supervisor's Sakhi picker and detail
+ * header (e.g. the Assign/Issue Item screen).
+ */
+export function createSakhiRouter(service: SakhiService, signer: TokenSigner) {
+  const doc = createDocumentedRouter();
+
+  doc.get(
+    '/projects/:projectId/sakhis',
+    {
+      summary: 'List Sakhis assigned to a project',
+      tags: ['Sakhis'],
+      params: projectIdParamsSchema,
+      responses: {
+        200: { description: 'Sakhis under this project', schema: envelope(z.array(sakhiSchema)) },
+        401: errorResponse(401),
+        403: errorResponse(403),
+        500: errorResponse(500),
+      },
+    },
+    authenticate(signer),
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(projectIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.listByProject(req.params.projectId, req.user)));
+    }),
+  );
+
+  doc.get(
+    '/sakhis/:sakhiId',
+    {
+      summary: 'Get a Sakhi by id',
+      tags: ['Sakhis'],
+      params: sakhiIdParamsSchema,
+      responses: {
+        200: { description: 'Sakhi detail', schema: envelope(sakhiSchema) },
+        401: errorResponse(401),
+        403: errorResponse(403),
+        404: errorResponse(404, { message: 'Sakhi not found.' }),
+        500: errorResponse(500),
+      },
+    },
+    authenticate(signer),
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(sakhiIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.getById(req.params.sakhiId, req.user)));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/auth-service/src/sakhis/sakhi.module.ts
+++ b/apps/auth-service/src/sakhis/sakhi.module.ts
@@ -1,0 +1,12 @@
+import type { DocumentedRouter, TokenSigner } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { SakhiRepository } from './sakhi.repository';
+import { SakhiService } from './sakhi.service';
+import { createSakhiRouter } from './sakhi.controller';
+
+/** Composition root for the Sakhi-read feature: wires repository → service → router. */
+export function createSakhiModule(prisma: PrismaService, signer: TokenSigner): DocumentedRouter {
+  const repository = new SakhiRepository(prisma);
+  const service = new SakhiService(repository);
+  return createSakhiRouter(service, signer);
+}

--- a/apps/auth-service/src/sakhis/sakhi.repository.spec.ts
+++ b/apps/auth-service/src/sakhis/sakhi.repository.spec.ts
@@ -1,0 +1,58 @@
+import { SakhiRepository } from './sakhi.repository';
+
+describe('SakhiRepository', () => {
+  const findMany = jest.fn();
+  const findFirst = jest.fn();
+  const prisma = { sakhiProfile: { findMany, findFirst } } as never;
+  let repository: SakhiRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new SakhiRepository(prisma);
+  });
+
+  describe('findByProject', () => {
+    it('queries Sakhis for the given project, excluding soft-deleted, ordered by display name', async () => {
+      findMany.mockResolvedValue([
+        { id: 'sakhi-1', primaryProjectId: 'project-1', user: { displayName: 'Priya' } },
+      ]);
+
+      const result = await repository.findByProject('project-1');
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: { primaryProjectId: 'project-1', isDeleted: false },
+        include: { user: true },
+        orderBy: { user: { displayName: 'asc' } },
+      });
+      expect(result).toEqual([
+        { id: 'sakhi-1', primaryProjectId: 'project-1', user: { displayName: 'Priya' } },
+      ]);
+    });
+
+    it('returns an empty array when the project has no Sakhis', async () => {
+      findMany.mockResolvedValue([]);
+      const result = await repository.findByProject('project-with-no-sakhis');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findById', () => {
+    it('queries a single Sakhi by id, excluding soft-deleted', async () => {
+      findFirst.mockResolvedValue({ id: 'sakhi-1', user: { displayName: 'Priya' } });
+
+      const result = await repository.findById('sakhi-1');
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: { id: 'sakhi-1', isDeleted: false },
+        include: { user: true },
+      });
+      expect(result).toEqual({ id: 'sakhi-1', user: { displayName: 'Priya' } });
+    });
+
+    it('returns null when the Sakhi does not exist', async () => {
+      findFirst.mockResolvedValue(null);
+      const result = await repository.findById('missing');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/auth-service/src/sakhis/sakhi.repository.ts
+++ b/apps/auth-service/src/sakhis/sakhi.repository.ts
@@ -1,0 +1,21 @@
+import type { PrismaService } from '../prisma/prisma.service';
+
+/** Data access for Sakhi profile reads (project-scoped list, single lookup). */
+export class SakhiRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findByProject(projectId: string) {
+    return this.prisma.sakhiProfile.findMany({
+      where: { primaryProjectId: projectId, isDeleted: false },
+      include: { user: true },
+      orderBy: { user: { displayName: 'asc' } },
+    });
+  }
+
+  findById(id: string) {
+    return this.prisma.sakhiProfile.findFirst({
+      where: { id, isDeleted: false },
+      include: { user: true },
+    });
+  }
+}

--- a/apps/auth-service/src/sakhis/sakhi.service.spec.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.spec.ts
@@ -1,0 +1,122 @@
+import { SakhiService } from './sakhi.service';
+import type { SakhiRepository } from './sakhi.repository';
+
+describe('SakhiService', () => {
+  const repository = {
+    findByProject: jest.fn(),
+    findById: jest.fn(),
+  } as unknown as jest.Mocked<SakhiRepository>;
+
+  let service: SakhiService;
+
+  const unscopedCaller = { projectId: null };
+  const scopedCaller = (projectId: string) => ({ projectId });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SakhiService(repository);
+  });
+
+  const rawProfile = () => ({
+    id: 'sakhi-1',
+    employeeCode: 'EMP-00123',
+    primaryProjectId: 'project-1',
+    supervisorId: 'supervisor-1',
+    activeFrom: new Date('2026-04-01'),
+    activeTo: null,
+    panToken: Buffer.from('secret'),
+    aadhaarToken: Buffer.from('secret'),
+    bankAccountToken: Buffer.from('secret'),
+    user: {
+      displayName: 'Priya Sharma',
+      mobileNumber: '+919000000123',
+      status: 'ACTIVE',
+      passwordHash: 'hashed',
+    },
+  });
+
+  describe('listByProject', () => {
+    it('returns the projected Sakhis for a project, never leaking PII tokens or passwordHash', async () => {
+      repository.findByProject.mockResolvedValue([rawProfile()] as never);
+
+      const result = await service.listByProject('project-1', unscopedCaller);
+
+      expect(result).toEqual([
+        {
+          sakhiId: 'sakhi-1',
+          displayName: 'Priya Sharma',
+          mobileNumber: '+919000000123',
+          status: 'ACTIVE',
+          employeeCode: 'EMP-00123',
+          primaryProjectId: 'project-1',
+          supervisorId: 'supervisor-1',
+          activeFrom: new Date('2026-04-01'),
+          activeTo: null,
+        },
+      ]);
+      expect(result[0]).not.toHaveProperty('panToken');
+      expect(result[0]).not.toHaveProperty('aadhaarToken');
+      expect(result[0]).not.toHaveProperty('bankAccountToken');
+      expect(result[0]).not.toHaveProperty('passwordHash');
+    });
+
+    it('returns an empty array (not an error) when the project has no Sakhis', async () => {
+      repository.findByProject.mockResolvedValue([]);
+      await expect(
+        service.listByProject('project-with-no-sakhis', unscopedCaller),
+      ).resolves.toEqual([]);
+    });
+
+    it('allows a caller with no project scope (MANAGER/ADMIN) to list any project', async () => {
+      repository.findByProject.mockResolvedValue([]);
+      await expect(service.listByProject('project-1', unscopedCaller)).resolves.toEqual([]);
+      expect(repository.findByProject).toHaveBeenCalledWith('project-1');
+    });
+
+    it('allows a scoped caller (SUPERVISOR) to list their own project', async () => {
+      repository.findByProject.mockResolvedValue([]);
+      await expect(service.listByProject('project-1', scopedCaller('project-1'))).resolves.toEqual(
+        [],
+      );
+    });
+
+    it('rejects a scoped caller listing a different project', async () => {
+      await expect(
+        service.listByProject('project-1', scopedCaller('project-2')),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findByProject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the projected Sakhi', async () => {
+      repository.findById.mockResolvedValue(rawProfile() as never);
+
+      const result = await service.getById('sakhi-1', unscopedCaller);
+
+      expect(result).toMatchObject({ sakhiId: 'sakhi-1', displayName: 'Priya Sharma' });
+      expect(result).not.toHaveProperty('passwordHash');
+    });
+
+    it('throws 404 when the Sakhi does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(service.getById('missing', unscopedCaller)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('allows a scoped caller (SUPERVISOR) to fetch a Sakhi in their own project', async () => {
+      repository.findById.mockResolvedValue(rawProfile() as never);
+      await expect(service.getById('sakhi-1', scopedCaller('project-1'))).resolves.toMatchObject({
+        sakhiId: 'sakhi-1',
+      });
+    });
+
+    it('rejects a scoped caller fetching a Sakhi from a different project', async () => {
+      repository.findById.mockResolvedValue(rawProfile() as never);
+      await expect(service.getById('sakhi-1', scopedCaller('project-2'))).rejects.toMatchObject({
+        status: 403,
+      });
+    });
+  });
+});

--- a/apps/auth-service/src/sakhis/sakhi.service.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.ts
@@ -1,0 +1,56 @@
+import { forbidden, notFound } from '@armman/service-commons';
+import type { SakhiRepository } from './sakhi.repository';
+
+/** The calling principal's own scope, as carried on their JWT/trusted-identity headers. */
+export interface CallerScope {
+  readonly projectId: string | null;
+}
+
+/**
+ * Response is projected to a safe subset — never the encrypted PII tokens
+ * (panToken/aadhaarToken/bankAccountToken), passwordHash, or other audit
+ * columns. Combines User (identity) and SakhiProfile (program assignment)
+ * fields, since a Sakhi is 1:1 across the two tables.
+ */
+function toApiSakhi(profile: Record<string, unknown>) {
+  const user = profile.user as Record<string, unknown>;
+  return {
+    sakhiId: profile.id,
+    displayName: user.displayName,
+    mobileNumber: user.mobileNumber,
+    status: user.status,
+    employeeCode: profile.employeeCode,
+    primaryProjectId: profile.primaryProjectId,
+    supervisorId: profile.supervisorId,
+    activeFrom: profile.activeFrom,
+    activeTo: profile.activeTo,
+  };
+}
+
+/** Business logic for Sakhi profile reads. */
+export class SakhiService {
+  constructor(private readonly repository: SakhiRepository) {}
+
+  /**
+   * A caller with a project scope on their JWT (typically SUPERVISOR — one
+   * project per Supervisor per SRS) may only see that project's Sakhis. A
+   * caller with no project scope (MANAGER/ADMIN, who oversee multiple
+   * projects — HLD's dashboard "Project Selector") is unrestricted here.
+   */
+  async listByProject(projectId: string, caller: CallerScope) {
+    if (caller.projectId && caller.projectId !== projectId) {
+      throw forbidden('You do not have access to this project.');
+    }
+    const profiles = await this.repository.findByProject(projectId);
+    return profiles.map((p) => toApiSakhi(p as unknown as Record<string, unknown>));
+  }
+
+  async getById(id: string, caller: CallerScope) {
+    const profile = await this.repository.findById(id);
+    if (!profile) throw notFound('Sakhi not found.');
+    if (caller.projectId && caller.projectId !== profile.primaryProjectId) {
+      throw forbidden('You do not have access to this Sakhi.');
+    }
+    return toApiSakhi(profile as unknown as Record<string, unknown>);
+  }
+}

--- a/apps/supervisor-operations-service/.env.example
+++ b/apps/supervisor-operations-service/.env.example
@@ -8,3 +8,6 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
+# Gateway base URL used to reach auth-service's /sakhis/:id endpoint (Sakhi
+# ownership check for inventory-transaction authorization).
+AUTH_SERVICE_BASE_URL=http://localhost:3000

--- a/apps/supervisor-operations-service/src/config/app-config.ts
+++ b/apps/supervisor-operations-service/src/config/app-config.ts
@@ -16,6 +16,11 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  // Base URL of the gateway to reach auth-service's /sakhis/:id endpoint
+  // through (same naming/default as beneficiary-service's geography.client.ts)
+  // — used to verify a Sakhi's assigned supervisor before returning/writing
+  // her inventory-transaction history.
+  AUTH_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/supervisor-operations-service/src/operations/dto/create-inventory-item.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-inventory-item.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for creating an inventory item (consumables/instruments
+ * master data, ERD §4.7 inventory_items). ADMIN-only — this is centrally
+ * managed catalog data, not something recorded per-transaction.
+ * `.strict()` rejects unknown fields, matching the repo-wide convention.
+ */
+export const createInventoryItemSchema = z
+  .object({
+    itemCode: z.string().trim().min(1).max(80),
+    itemName: z.string().trim().min(1).max(160),
+    itemCategory: z.enum(['CONSUMABLE', 'INSTRUMENT']),
+    unit: z.string().trim().min(1).max(30),
+    status: z.enum(['ACTIVE', 'INACTIVE']).default('ACTIVE'),
+  })
+  .strict();
+
+export type CreateInventoryItemInput = z.infer<typeof createInventoryItemSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/create-inventory-transaction.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-inventory-transaction.dto.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for recording an inventory transaction. Per FR-SV-1.1, a
+ * Supervisor selects a Program, then a Sakhi, then one or more items, then a
+ * transaction type, date, and optional remarks in a single submission —
+ * `items` is therefore an array, and the service creates one
+ * `inventory_transactions` row per item (the schema stores one item+quantity
+ * per row; there is no multi-item row shape to match the submission 1:1).
+ * `.strict()` rejects unknown fields, matching the repo-wide convention.
+ *
+ * `supervisorId` is deliberately NOT a field here — it is always the
+ * authenticated caller's own id (see operations.service.ts), never
+ * client-supplied, so a Supervisor can never record a transaction under
+ * another Supervisor's name.
+ */
+const transactionItemSchema = z
+  .object({
+    itemId: z.string().uuid(),
+    quantity: z.number().int().positive(),
+  })
+  .strict();
+
+export const createInventoryTransactionSchema = z
+  .object({
+    projectId: z.string().uuid(),
+    sakhiId: z.string().uuid(),
+    transactionType: z.enum(['HANDOVER', 'RETURNED', 'PERMANENT_DAMAGED', 'MISPLACED', 'CONSUMED']),
+    transactionDate: z.coerce.date(),
+    remarks: z.string().trim().min(1).optional(),
+    items: z.array(transactionItemSchema).min(1),
+  })
+  .strict();
+
+export type CreateInventoryTransactionInput = z.infer<typeof createInventoryTransactionSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/update-inventory-transaction.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-inventory-transaction.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Partial update — only the fields that describe "what happened," not the
+ * transaction's identity (itemId/sakhiId/projectId/supervisorId/
+ * transactionType are immutable after creation, matching this repo's
+ * append-only-ledger convention for audit-relevant records). At least one
+ * field must be present.
+ */
+export const updateInventoryTransactionSchema = z
+  .object({
+    quantity: z.number().int().positive(),
+    transactionDate: z.coerce.date(),
+    remarks: z.string().trim().min(1).nullable(),
+  })
+  .partial()
+  .strict()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided.',
+  });
+
+export type UpdateInventoryTransactionInput = z.infer<typeof updateInventoryTransactionSchema>;

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -2,12 +2,17 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { OperationsService } from './operations.service';
 import { createSupervisorEventSchema } from './dto/create-supervisorEvent.dto';
+import { createInventoryItemSchema } from './dto/create-inventory-item.dto';
+import { createInventoryTransactionSchema } from './dto/create-inventory-transaction.dto';
+import { updateInventoryTransactionSchema } from './dto/update-inventory-transaction.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
+  validate,
   validateBody,
 } from '../app.module';
 
@@ -87,6 +92,20 @@ const callLogSchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
+const sakhiIdParamsSchema = z
+  .object({
+    sakhiId: z.string().uuid(),
+  })
+  .strict();
+
+const transactionIdParamsSchema = z
+  .object({
+    id: z.string().uuid(),
+  })
+  .strict();
+
+const createInventoryTransactionRequestSchema = createInventoryTransactionSchema;
+
 const apiErrorSchema = z.object({
   success: z.literal(false),
   message: z.string(),
@@ -164,6 +183,29 @@ export function createOperationsRouter(service: OperationsService) {
     }),
   );
 
+  doc.post(
+    '/inventory-items',
+    {
+      summary: 'Create an inventory item (consumables/instruments master data)',
+      tags: ['Supervisor Operations'],
+      responses: {
+        201: { description: 'Inventory item created', schema: envelope(inventoryItemSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        409: { description: 'itemCode already exists', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('ADMIN'),
+    validateBody(createInventoryItemSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const created = await service.createInventoryItem(req.body, req.user.id);
+      res.status(201).json(ok(created));
+    }),
+  );
+
   doc.get(
     '/inventory-transactions',
     {
@@ -182,6 +224,117 @@ export function createOperationsRouter(service: OperationsService) {
     requireRoles('SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.listInventoryTransactions()));
+    }),
+  );
+
+  doc.get(
+    '/sakhis/:sakhiId/inventory-transactions',
+    {
+      summary: "One Sakhi's inventory transaction history",
+      tags: ['Supervisor Operations'],
+      params: sakhiIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Inventory transactions for this Sakhi',
+          schema: envelope(z.array(inventoryTransactionSchema)),
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER'),
+    validate(sakhiIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      res.json(
+        ok(
+          await service.listInventoryTransactionsBySakhi(
+            req.params.sakhiId,
+            req.user,
+            authorizationHeader,
+          ),
+        ),
+      );
+    }),
+  );
+
+  doc.post(
+    '/inventory-transactions',
+    {
+      summary: 'Record an inventory transaction (one or more items)',
+      tags: ['Supervisor Operations'],
+      responses: {
+        201: {
+          description: 'Inventory transaction(s) created',
+          schema: envelope(z.array(inventoryTransactionSchema)),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        422: { description: 'Referenced item not found or inactive', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR'),
+    validateBody(createInventoryTransactionRequestSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const created = await service.createInventoryTransactions(req.body, req.user);
+      res.status(201).json(ok(created));
+    }),
+  );
+
+  doc.put(
+    '/inventory-transactions/:id',
+    {
+      summary: "Edit a transaction's quantity/date/remarks",
+      tags: ['Supervisor Operations'],
+      params: transactionIdParamsSchema,
+      responses: {
+        200: { description: 'Transaction updated', schema: envelope(inventoryTransactionSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Transaction not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR'),
+    validate(transactionIdParamsSchema, 'params'),
+    validateBody(updateInventoryTransactionSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const updated = await service.updateInventoryTransaction(req.params.id, req.body, req.user);
+      res.json(ok(updated));
+    }),
+  );
+
+  doc.delete(
+    '/inventory-transactions/:id',
+    {
+      summary: 'Delete an inventory transaction (soft delete)',
+      tags: ['Supervisor Operations'],
+      params: transactionIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Transaction deleted',
+          schema: envelope(z.object({ deleted: z.literal(true) })),
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Transaction not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR'),
+    validate(transactionIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      await service.deleteInventoryTransaction(req.params.id, req.user);
+      res.json(ok({ deleted: true }));
     }),
   );
 

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -282,7 +282,13 @@ export function createOperationsRouter(service: OperationsService) {
     validateBody(createInventoryTransactionRequestSchema),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
-      const created = await service.createInventoryTransactions(req.body, req.user);
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const created = await service.createInventoryTransactions(
+        req.body,
+        req.user,
+        authorizationHeader,
+      );
       res.status(201).json(ok(created));
     }),
   );

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -177,7 +177,7 @@ export function createOperationsRouter(service: OperationsService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SUPERVISOR', 'MANAGER'),
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.listInventoryItems()));
     }),
@@ -221,7 +221,7 @@ export function createOperationsRouter(service: OperationsService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SUPERVISOR', 'MANAGER'),
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.listInventoryTransactions()));
     }),
@@ -243,7 +243,7 @@ export function createOperationsRouter(service: OperationsService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SUPERVISOR', 'MANAGER'),
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(sakhiIdParamsSchema, 'params'),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
@@ -278,7 +278,7 @@ export function createOperationsRouter(service: OperationsService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SUPERVISOR'),
+    requireRoles('SUPERVISOR', 'ADMIN'),
     validateBody(createInventoryTransactionRequestSchema),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
@@ -308,7 +308,7 @@ export function createOperationsRouter(service: OperationsService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SUPERVISOR'),
+    requireRoles('SUPERVISOR', 'ADMIN'),
     validate(transactionIdParamsSchema, 'params'),
     validateBody(updateInventoryTransactionSchema),
     asyncHandler(async (req, res, next) => {
@@ -335,7 +335,7 @@ export function createOperationsRouter(service: OperationsService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SUPERVISOR'),
+    requireRoles('SUPERVISOR', 'ADMIN'),
     validate(transactionIdParamsSchema, 'params'),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -228,7 +228,7 @@ export function createOperationsRouter(service: OperationsService) {
   );
 
   doc.get(
-    '/sakhis/:sakhiId/inventory-transactions',
+    '/inventory-transactions/by-sakhi/:sakhiId',
     {
       summary: "One Sakhi's inventory transaction history",
       tags: ['Supervisor Operations'],

--- a/apps/supervisor-operations-service/src/operations/operations.module.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.module.ts
@@ -2,6 +2,7 @@ import type { DocumentedRouter } from '@armman/service-commons';
 import type { PrismaService } from '../prisma/prisma.service';
 import { OperationsRepository } from './operations.repository';
 import { OperationsService } from './operations.service';
+import { SakhiClient } from './sakhi.client';
 import { createOperationsRouter } from './operations.controller';
 
 /**
@@ -11,6 +12,7 @@ import { createOperationsRouter } from './operations.controller';
  */
 export function createOperationsModule(prisma: PrismaService): DocumentedRouter {
   const repository = new OperationsRepository(prisma);
-  const service = new OperationsService(repository);
+  const sakhiClient = new SakhiClient();
+  const service = new OperationsService(repository, sakhiClient);
   return createOperationsRouter(service);
 }

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -1,5 +1,8 @@
 import type { PrismaService } from '../prisma/prisma.service';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
+import type { CreateInventoryItemInput } from './dto/create-inventory-item.dto';
+import type { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.dto';
+import type { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.dto';
 
 /**
  * Data access for supervisor operations. Owns only this service's tables
@@ -29,11 +32,97 @@ export class OperationsRepository {
     });
   }
 
+  createInventoryItem(data: CreateInventoryItemInput, createdByUserId: string) {
+    return this.prisma.inventoryItem.create({
+      data: { ...data, createdByUserId, updatedByUserId: createdByUserId },
+    });
+  }
+
   findInventoryTransactions() {
     return this.prisma.inventoryTransaction.findMany({
       where: { isDeleted: false },
       orderBy: { transactionDate: 'desc' },
       take: 50,
+    });
+  }
+
+  /** One Sakhi's transaction history (FR-SV-1.5), excluding soft-deleted. */
+  findInventoryTransactionsBySakhi(sakhiId: string) {
+    return this.prisma.inventoryTransaction.findMany({
+      where: { sakhiId, isDeleted: false },
+      orderBy: { transactionDate: 'desc' },
+    });
+  }
+
+  findInventoryItemById(id: string) {
+    return this.prisma.inventoryItem.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  findInventoryTransactionById(id: string) {
+    return this.prisma.inventoryTransaction.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  /**
+   * Creates one row per item in a single submission (FR-SV-1.1: "one or more
+   * items"), atomically — either every row is created or none are, so a
+   * partial failure never leaves the ledger half-written for one submit.
+   */
+  createInventoryTransactions(
+    rows: Array<
+      Omit<CreateInventoryTransactionInput, 'items'> & {
+        supervisorId: string;
+        itemId: string;
+        quantity: number;
+      }
+    >,
+    createdByUserId: string,
+  ) {
+    return this.prisma.$transaction(
+      rows.map((row) =>
+        this.prisma.inventoryTransaction.create({
+          data: {
+            projectId: row.projectId,
+            supervisorId: row.supervisorId,
+            sakhiId: row.sakhiId,
+            itemId: row.itemId,
+            transactionType: row.transactionType,
+            quantity: row.quantity,
+            transactionDate: row.transactionDate,
+            remarks: row.remarks ?? null,
+            createdByUserId,
+            updatedByUserId: createdByUserId,
+          },
+        }),
+      ),
+    );
+  }
+
+  /**
+   * Only ever writes the fields describing "what happened" (quantity, date,
+   * remarks) — itemId/sakhiId/projectId/supervisorId/transactionType are
+   * immutable, matching this repo's append-only-ledger convention.
+   */
+  async updateInventoryTransaction(
+    id: string,
+    data: UpdateInventoryTransactionInput,
+    updatedByUserId: string,
+  ) {
+    const existing = await this.findInventoryTransactionById(id);
+    if (!existing) return null;
+
+    return this.prisma.inventoryTransaction.update({
+      where: { id },
+      data: { ...data, updatedByUserId },
+    });
+  }
+
+  async softDeleteInventoryTransaction(id: string, updatedByUserId: string) {
+    const existing = await this.findInventoryTransactionById(id);
+    if (!existing) return null;
+
+    return this.prisma.inventoryTransaction.update({
+      where: { id },
+      data: { isDeleted: true, deletedAt: new Date(), updatedByUserId },
     });
   }
 

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -324,11 +324,22 @@ describe('OperationsService', () => {
       items: [{ itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', quantity: 2 }],
     };
 
+    const sakhi = {
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      supervisorId: supervisorCaller.id,
+      primaryProjectId: '22222222-2222-2222-2222-222222222222',
+    };
+
     it('creates one row per item, using the caller’s own id as supervisorId (never client-supplied)', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
       repository.findInventoryItemById.mockResolvedValue(activeItem);
       repository.createInventoryTransactions.mockResolvedValue([inventoryTransactionRow]);
 
-      const result = await service.createInventoryTransactions(baseDto, supervisorCaller);
+      const result = await service.createInventoryTransactions(
+        baseDto,
+        supervisorCaller,
+        'Bearer token',
+      );
 
       expect(repository.findInventoryItemById).toHaveBeenCalledWith(
         'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
@@ -350,25 +361,57 @@ describe('OperationsService', () => {
       expect(result).toEqual([inventoryTransactionRow]);
     });
 
+    it('rejects a Supervisor posting for a Sakhi assigned to another Supervisor, without creating anything', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+
+      await expect(
+        service.createInventoryTransactions(baseDto, otherSupervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findInventoryItemById).not.toHaveBeenCalled();
+      expect(repository.createInventoryTransactions).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the Sakhi does not exist, without creating anything', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+
+      await expect(
+        service.createInventoryTransactions(baseDto, supervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(repository.createInventoryTransactions).not.toHaveBeenCalled();
+    });
+
+    it('allows a MANAGER regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findInventoryItemById.mockResolvedValue(activeItem);
+      repository.createInventoryTransactions.mockResolvedValue([inventoryTransactionRow]);
+
+      await service.createInventoryTransactions(baseDto, managerCaller, 'Bearer token');
+
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+      expect(repository.createInventoryTransactions).toHaveBeenCalled();
+    });
+
     it('rejects when a referenced item does not exist, without creating anything', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
       repository.findInventoryItemById.mockResolvedValue(null);
 
       await expect(
-        service.createInventoryTransactions(baseDto, supervisorCaller),
+        service.createInventoryTransactions(baseDto, supervisorCaller, 'Bearer token'),
       ).rejects.toMatchObject({ status: 422 });
       expect(repository.createInventoryTransactions).not.toHaveBeenCalled();
     });
 
     it('rejects when a referenced item is inactive, without creating anything', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
       repository.findInventoryItemById.mockResolvedValue({ ...activeItem, status: 'INACTIVE' });
 
       await expect(
-        service.createInventoryTransactions(baseDto, supervisorCaller),
+        service.createInventoryTransactions(baseDto, supervisorCaller, 'Bearer token'),
       ).rejects.toMatchObject({ status: 422 });
       expect(repository.createInventoryTransactions).not.toHaveBeenCalled();
     });
 
     it('creates multiple rows for a multi-item submission', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
       repository.findInventoryItemById.mockResolvedValue(activeItem);
       repository.createInventoryTransactions.mockResolvedValue([
         inventoryTransactionRow,
@@ -383,7 +426,7 @@ describe('OperationsService', () => {
         ],
       };
 
-      await service.createInventoryTransactions(dto, supervisorCaller);
+      await service.createInventoryTransactions(dto, supervisorCaller, 'Bearer token');
 
       expect(repository.createInventoryTransactions).toHaveBeenCalledWith(
         expect.arrayContaining([

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -1,5 +1,6 @@
 import { OperationsService } from './operations.service';
 import type { OperationsRepository } from './operations.repository';
+import type { SakhiClient } from './sakhi.client';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
 import type {
   SupervisorEvent,
@@ -13,14 +14,31 @@ describe('OperationsService', () => {
     findEvents: jest.fn(),
     createEvent: jest.fn(),
     findInventoryItems: jest.fn(),
+    createInventoryItem: jest.fn(),
     findInventoryTransactions: jest.fn(),
+    findInventoryTransactionsBySakhi: jest.fn(),
+    findInventoryItemById: jest.fn(),
+    findInventoryTransactionById: jest.fn(),
+    createInventoryTransactions: jest.fn(),
+    updateInventoryTransaction: jest.fn(),
+    softDeleteInventoryTransaction: jest.fn(),
     findCallLogs: jest.fn(),
   } as unknown as jest.Mocked<OperationsRepository>;
+  const sakhiClient = {
+    findById: jest.fn(),
+  } as unknown as jest.Mocked<SakhiClient>;
   let service: OperationsService;
+
+  const supervisorCaller = {
+    id: '33333333-3333-3333-3333-333333333333',
+    roles: ['SUPERVISOR'],
+  };
+  const otherSupervisorCaller = { id: 'other-supervisor', roles: ['SUPERVISOR'] };
+  const managerCaller = { id: 'manager-1', roles: ['MANAGER'] };
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new OperationsService(repository);
+    service = new OperationsService(repository, sakhiClient);
   });
 
   const eventRow: SupervisorEvent = {
@@ -131,6 +149,48 @@ describe('OperationsService', () => {
     await expect(service.listInventoryItems()).resolves.toBe(rows);
   });
 
+  describe('createInventoryItem', () => {
+    const dto = {
+      itemCode: 'BP-01',
+      itemName: 'BP Monitor',
+      itemCategory: 'INSTRUMENT' as const,
+      unit: 'unit',
+      status: 'ACTIVE' as const,
+    };
+    const createdRow: InventoryItem = {
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      itemCode: 'BP-01',
+      itemName: 'BP Monitor',
+      itemCategory: 'INSTRUMENT',
+      unit: 'unit',
+      status: 'ACTIVE',
+      createdAt: new Date(),
+      createdByUserId: 'admin-1',
+      updatedAt: new Date(),
+      updatedByUserId: 'admin-1',
+      isDeleted: false,
+      deletedAt: null,
+    };
+
+    it('creates an item via repository with the given data', async () => {
+      repository.createInventoryItem.mockResolvedValue(createdRow);
+      await expect(service.createInventoryItem(dto, 'admin-1')).resolves.toBe(createdRow);
+      expect(repository.createInventoryItem).toHaveBeenCalledWith(dto, 'admin-1');
+    });
+
+    it('maps a unique-constraint violation (duplicate itemCode) to 409', async () => {
+      repository.createInventoryItem.mockRejectedValue({ code: 'P2002' });
+      await expect(service.createInventoryItem(dto, 'admin-1')).rejects.toMatchObject({
+        status: 409,
+      });
+    });
+
+    it('propagates other repository errors unchanged', async () => {
+      repository.createInventoryItem.mockRejectedValue(new Error('db down'));
+      await expect(service.createInventoryItem(dto, 'admin-1')).rejects.toThrow('db down');
+    });
+  });
+
   it('lists inventory transactions via repository', async () => {
     const rows: InventoryTransaction[] = [
       {
@@ -153,6 +213,258 @@ describe('OperationsService', () => {
     ];
     repository.findInventoryTransactions.mockResolvedValue(rows);
     await expect(service.listInventoryTransactions()).resolves.toBe(rows);
+  });
+
+  const inventoryTransactionRow: InventoryTransaction = {
+    id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    projectId: '22222222-2222-2222-2222-222222222222',
+    supervisorId: '33333333-3333-3333-3333-333333333333',
+    sakhiId: '44444444-4444-4444-4444-444444444444',
+    itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    transactionType: 'HANDOVER',
+    quantity: 1,
+    transactionDate: new Date('2026-07-01'),
+    remarks: null,
+    createdAt: new Date(),
+    createdByUserId: null,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+  };
+
+  const activeItem: InventoryItem = {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    itemCode: 'BP-01',
+    itemName: 'BP Monitor',
+    itemCategory: 'INSTRUMENT',
+    unit: 'unit',
+    status: 'ACTIVE',
+    createdAt: new Date(),
+    createdByUserId: null,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+  };
+
+  describe('listInventoryTransactionsBySakhi', () => {
+    const sakhi = {
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      supervisorId: supervisorCaller.id,
+      primaryProjectId: '22222222-2222-2222-2222-222222222222',
+    };
+
+    it('lists a Sakhi’s transactions via repository when the caller is her assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findInventoryTransactionsBySakhi.mockResolvedValue([inventoryTransactionRow]);
+
+      await expect(
+        service.listInventoryTransactionsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          supervisorCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([inventoryTransactionRow]);
+      expect(repository.findInventoryTransactionsBySakhi).toHaveBeenCalledWith(
+        '44444444-4444-4444-4444-444444444444',
+      );
+    });
+
+    it('returns an empty array (not an error) when the Sakhi has no transactions', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findInventoryTransactionsBySakhi.mockResolvedValue([]);
+      await expect(
+        service.listInventoryTransactionsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          supervisorCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([]);
+    });
+
+    it('rejects a Supervisor who is not this Sakhi’s assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      await expect(
+        service.listInventoryTransactionsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          otherSupervisorCaller,
+          'Bearer token',
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findInventoryTransactionsBySakhi).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 when the Sakhi does not exist', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+      await expect(
+        service.listInventoryTransactionsBySakhi('missing', supervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('allows a MANAGER regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findInventoryTransactionsBySakhi.mockResolvedValue([inventoryTransactionRow]);
+      await expect(
+        service.listInventoryTransactionsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          managerCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([inventoryTransactionRow]);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createInventoryTransactions', () => {
+    const baseDto = {
+      projectId: '22222222-2222-2222-2222-222222222222',
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      transactionType: 'HANDOVER' as const,
+      transactionDate: new Date('2026-07-01'),
+      items: [{ itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', quantity: 2 }],
+    };
+
+    it('creates one row per item, using the caller’s own id as supervisorId (never client-supplied)', async () => {
+      repository.findInventoryItemById.mockResolvedValue(activeItem);
+      repository.createInventoryTransactions.mockResolvedValue([inventoryTransactionRow]);
+
+      const result = await service.createInventoryTransactions(baseDto, supervisorCaller);
+
+      expect(repository.findInventoryItemById).toHaveBeenCalledWith(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      );
+      expect(repository.createInventoryTransactions).toHaveBeenCalledWith(
+        [
+          {
+            projectId: baseDto.projectId,
+            supervisorId: supervisorCaller.id,
+            sakhiId: baseDto.sakhiId,
+            transactionType: baseDto.transactionType,
+            transactionDate: baseDto.transactionDate,
+            itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            quantity: 2,
+          },
+        ],
+        supervisorCaller.id,
+      );
+      expect(result).toEqual([inventoryTransactionRow]);
+    });
+
+    it('rejects when a referenced item does not exist, without creating anything', async () => {
+      repository.findInventoryItemById.mockResolvedValue(null);
+
+      await expect(
+        service.createInventoryTransactions(baseDto, supervisorCaller),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(repository.createInventoryTransactions).not.toHaveBeenCalled();
+    });
+
+    it('rejects when a referenced item is inactive, without creating anything', async () => {
+      repository.findInventoryItemById.mockResolvedValue({ ...activeItem, status: 'INACTIVE' });
+
+      await expect(
+        service.createInventoryTransactions(baseDto, supervisorCaller),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(repository.createInventoryTransactions).not.toHaveBeenCalled();
+    });
+
+    it('creates multiple rows for a multi-item submission', async () => {
+      repository.findInventoryItemById.mockResolvedValue(activeItem);
+      repository.createInventoryTransactions.mockResolvedValue([
+        inventoryTransactionRow,
+        inventoryTransactionRow,
+      ]);
+
+      const dto = {
+        ...baseDto,
+        items: [
+          { itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', quantity: 2 },
+          { itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', quantity: 5 },
+        ],
+      };
+
+      await service.createInventoryTransactions(dto, supervisorCaller);
+
+      expect(repository.createInventoryTransactions).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ quantity: 2, supervisorId: supervisorCaller.id }),
+          expect.objectContaining({ quantity: 5, supervisorId: supervisorCaller.id }),
+        ]),
+        supervisorCaller.id,
+      );
+    });
+  });
+
+  describe('updateInventoryTransaction', () => {
+    it('updates via repository and returns the updated row when the caller owns the transaction', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(inventoryTransactionRow);
+      repository.updateInventoryTransaction.mockResolvedValue(inventoryTransactionRow);
+
+      const result = await service.updateInventoryTransaction(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        { quantity: 3 },
+        supervisorCaller,
+      );
+
+      expect(repository.updateInventoryTransaction).toHaveBeenCalledWith(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        { quantity: 3 },
+        supervisorCaller.id,
+      );
+      expect(result).toBe(inventoryTransactionRow);
+    });
+
+    it('throws 404 when the transaction does not exist', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(null);
+      await expect(
+        service.updateInventoryTransaction('missing', { quantity: 3 }, supervisorCaller),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('rejects a Supervisor who does not own the transaction, without updating anything', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(inventoryTransactionRow);
+      await expect(
+        service.updateInventoryTransaction(
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          { quantity: 3 },
+          otherSupervisorCaller,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.updateInventoryTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteInventoryTransaction', () => {
+    it('soft-deletes via repository when the caller owns the transaction', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(inventoryTransactionRow);
+      repository.softDeleteInventoryTransaction.mockResolvedValue(inventoryTransactionRow);
+      await service.deleteInventoryTransaction(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        supervisorCaller,
+      );
+      expect(repository.softDeleteInventoryTransaction).toHaveBeenCalledWith(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        supervisorCaller.id,
+      );
+    });
+
+    it('throws 404 when the transaction does not exist', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(null);
+      await expect(
+        service.deleteInventoryTransaction('missing', supervisorCaller),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('rejects a Supervisor who does not own the transaction, without deleting anything', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(inventoryTransactionRow);
+      await expect(
+        service.deleteInventoryTransaction(
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          otherSupervisorCaller,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.softDeleteInventoryTransaction).not.toHaveBeenCalled();
+    });
   });
 
   it('lists call logs via repository', async () => {

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -35,6 +35,7 @@ describe('OperationsService', () => {
   };
   const otherSupervisorCaller = { id: 'other-supervisor', roles: ['SUPERVISOR'] };
   const managerCaller = { id: 'manager-1', roles: ['MANAGER'] };
+  const adminCaller = { id: 'admin-1', roles: ['ADMIN'] };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -313,6 +314,18 @@ describe('OperationsService', () => {
       ).resolves.toEqual([inventoryTransactionRow]);
       expect(sakhiClient.findById).not.toHaveBeenCalled();
     });
+
+    it('allows an ADMIN regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findInventoryTransactionsBySakhi.mockResolvedValue([inventoryTransactionRow]);
+      await expect(
+        service.listInventoryTransactionsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          adminCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([inventoryTransactionRow]);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
   });
 
   describe('createInventoryTransactions', () => {
@@ -388,6 +401,19 @@ describe('OperationsService', () => {
 
       expect(sakhiClient.findById).not.toHaveBeenCalled();
       expect(repository.createInventoryTransactions).toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN regardless of Sakhi assignment, stamping their own id as supervisorId', async () => {
+      repository.findInventoryItemById.mockResolvedValue(activeItem);
+      repository.createInventoryTransactions.mockResolvedValue([inventoryTransactionRow]);
+
+      await service.createInventoryTransactions(baseDto, adminCaller, 'Bearer token');
+
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+      expect(repository.createInventoryTransactions).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ supervisorId: adminCaller.id })]),
+        adminCaller.id,
+      );
     });
 
     it('rejects when a referenced item does not exist, without creating anything', async () => {
@@ -475,6 +501,24 @@ describe('OperationsService', () => {
       ).rejects.toMatchObject({ status: 403 });
       expect(repository.updateInventoryTransaction).not.toHaveBeenCalled();
     });
+
+    it('allows an ADMIN to update a transaction they do not own', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(inventoryTransactionRow);
+      repository.updateInventoryTransaction.mockResolvedValue(inventoryTransactionRow);
+
+      const result = await service.updateInventoryTransaction(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        { quantity: 3 },
+        adminCaller,
+      );
+
+      expect(repository.updateInventoryTransaction).toHaveBeenCalledWith(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        { quantity: 3 },
+        adminCaller.id,
+      );
+      expect(result).toBe(inventoryTransactionRow);
+    });
   });
 
   describe('deleteInventoryTransaction', () => {
@@ -507,6 +551,16 @@ describe('OperationsService', () => {
         ),
       ).rejects.toMatchObject({ status: 403 });
       expect(repository.softDeleteInventoryTransaction).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN to delete a transaction they do not own', async () => {
+      repository.findInventoryTransactionById.mockResolvedValue(inventoryTransactionRow);
+      repository.softDeleteInventoryTransaction.mockResolvedValue(inventoryTransactionRow);
+      await service.deleteInventoryTransaction('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', adminCaller);
+      expect(repository.softDeleteInventoryTransaction).toHaveBeenCalledWith(
+        'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        adminCaller.id,
+      );
     });
   });
 

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -87,15 +87,31 @@ export class OperationsService {
   }
 
   /**
-   * Validates every referenced item exists and is ACTIVE before writing
-   * anything (fails the whole submission up front rather than partway
-   * through the atomic create), then persists one row per item.
+   * A SUPERVISOR may only record a transaction against a Sakhi actually
+   * assigned to them — same ownership check as listInventoryTransactionsBySakhi,
+   * so a Supervisor can't write inventory history onto another Supervisor's
+   * Sakhi (MANAGER is exempt, matching the read path). Then validates every
+   * referenced item exists and is ACTIVE before writing anything (fails the
+   * whole submission up front rather than partway through the atomic
+   * create), then persists one row per item.
    *
    * `supervisorId` is never taken from the client-supplied body — it's
    * always the authenticated caller's own id, so a Supervisor can never
    * record a transaction under another Supervisor's name.
    */
-  async createInventoryTransactions(dto: CreateInventoryTransactionInput, caller: CallerIdentity) {
+  async createInventoryTransactions(
+    dto: CreateInventoryTransactionInput,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    if (!caller.roles.includes('MANAGER')) {
+      const sakhi = await this.sakhiClient.findById(dto.sakhiId, authorizationHeader);
+      if (!sakhi) throw unprocessable('sakhiId: Sakhi not found.');
+      if (sakhi.supervisorId !== caller.id) {
+        throw forbidden('You do not have access to this Sakhi.');
+      }
+    }
+
     for (const { itemId } of dto.items) {
       const item = await this.repository.findInventoryItemById(itemId);
       if (!item) throw unprocessable(`items: item ${itemId} not found.`);

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -25,6 +25,11 @@ export interface CallerIdentity {
   readonly roles: readonly string[];
 }
 
+/** MANAGER and ADMIN are unrestricted across all inventory ownership checks. */
+function isPrivileged(caller: CallerIdentity): boolean {
+  return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
+}
+
 /** Supervisor operations domain logic. Data access is delegated to the repository. */
 export class OperationsService {
   constructor(
@@ -68,15 +73,14 @@ export class OperationsService {
   /**
    * A SUPERVISOR may only see a Sakhi's history if that Sakhi is actually
    * assigned to them (checked via auth-service, since sakhi_profiles isn't
-   * this service's table — forklift rule). A MANAGER oversees multiple
-   * Supervisors' Sakhis, so is unrestricted here.
+   * this service's table — forklift rule). MANAGER and ADMIN are unrestricted.
    */
   async listInventoryTransactionsBySakhi(
     sakhiId: string,
     caller: CallerIdentity,
     authorizationHeader: string,
   ) {
-    if (!caller.roles.includes('MANAGER')) {
+    if (!isPrivileged(caller)) {
       const sakhi = await this.sakhiClient.findById(sakhiId, authorizationHeader);
       if (!sakhi) throw notFound('Sakhi not found.');
       if (sakhi.supervisorId !== caller.id) {
@@ -90,21 +94,24 @@ export class OperationsService {
    * A SUPERVISOR may only record a transaction against a Sakhi actually
    * assigned to them — same ownership check as listInventoryTransactionsBySakhi,
    * so a Supervisor can't write inventory history onto another Supervisor's
-   * Sakhi (MANAGER is exempt, matching the read path). Then validates every
-   * referenced item exists and is ACTIVE before writing anything (fails the
-   * whole submission up front rather than partway through the atomic
-   * create), then persists one row per item.
+   * Sakhi (MANAGER and ADMIN are exempt, matching the read path). Then
+   * validates every referenced item exists and is ACTIVE before writing
+   * anything (fails the whole submission up front rather than partway
+   * through the atomic create), then persists one row per item.
    *
    * `supervisorId` is never taken from the client-supplied body — it's
    * always the authenticated caller's own id, so a Supervisor can never
-   * record a transaction under another Supervisor's name.
+   * record a transaction under another Supervisor's name. When a MANAGER or
+   * ADMIN records one directly, the row is stamped with their own id too —
+   * they aren't a real Supervisor, but every transaction needs a recorder,
+   * and this still traces back to exactly who created it.
    */
   async createInventoryTransactions(
     dto: CreateInventoryTransactionInput,
     caller: CallerIdentity,
     authorizationHeader: string,
   ) {
-    if (!caller.roles.includes('MANAGER')) {
+    if (!isPrivileged(caller)) {
       const sakhi = await this.sakhiClient.findById(dto.sakhiId, authorizationHeader);
       if (!sakhi) throw unprocessable('sakhiId: Sakhi not found.');
       if (sakhi.supervisorId !== caller.id) {
@@ -130,6 +137,7 @@ export class OperationsService {
     return this.repository.createInventoryTransactions(rows, caller.id);
   }
 
+  /** A SUPERVISOR may only edit their own transactions. MANAGER and ADMIN are unrestricted. */
   async updateInventoryTransaction(
     id: string,
     dto: UpdateInventoryTransactionInput,
@@ -137,7 +145,7 @@ export class OperationsService {
   ) {
     const existing = await this.repository.findInventoryTransactionById(id);
     if (!existing) throw notFound('Inventory transaction not found.');
-    if (existing.supervisorId !== caller.id) {
+    if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
       throw forbidden('You do not have access to this transaction.');
     }
 
@@ -146,10 +154,11 @@ export class OperationsService {
     return updated;
   }
 
+  /** A SUPERVISOR may only delete their own transactions. MANAGER and ADMIN are unrestricted. */
   async deleteInventoryTransaction(id: string, caller: CallerIdentity) {
     const existing = await this.repository.findInventoryTransactionById(id);
     if (!existing) throw notFound('Inventory transaction not found.');
-    if (existing.supervisorId !== caller.id) {
+    if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
       throw forbidden('You do not have access to this transaction.');
     }
 

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -1,10 +1,36 @@
-import { unprocessable } from '@armman/service-commons';
+import { conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
 import type { OperationsRepository } from './operations.repository';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
+import type { CreateInventoryItemInput } from './dto/create-inventory-item.dto';
+import type { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.dto';
+import type { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.dto';
+import type { SakhiClient } from './sakhi.client';
+
+/** Prisma unique-constraint violation code (itemCode). */
+const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
+
+/** Narrows a caught Prisma error to a unique-constraint violation (P2002). */
+function isUniqueConstraintViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === PRISMA_UNIQUE_CONSTRAINT_CODE
+  );
+}
+
+/** The calling principal's own identity, as carried on their trusted-identity headers. */
+export interface CallerIdentity {
+  readonly id: string;
+  readonly roles: readonly string[];
+}
 
 /** Supervisor operations domain logic. Data access is delegated to the repository. */
 export class OperationsService {
-  constructor(private readonly repository: OperationsRepository) {}
+  constructor(
+    private readonly repository: OperationsRepository,
+    private readonly sakhiClient: SakhiClient,
+  ) {}
 
   listEvents() {
     return this.repository.findEvents();
@@ -24,8 +50,95 @@ export class OperationsService {
     return this.repository.findInventoryItems();
   }
 
+  async createInventoryItem(dto: CreateInventoryItemInput, createdByUserId: string) {
+    try {
+      return await this.repository.createInventoryItem(dto, createdByUserId);
+    } catch (err) {
+      if (isUniqueConstraintViolation(err)) {
+        throw conflict('An inventory item with this itemCode already exists.');
+      }
+      throw err;
+    }
+  }
+
   listInventoryTransactions() {
     return this.repository.findInventoryTransactions();
+  }
+
+  /**
+   * A SUPERVISOR may only see a Sakhi's history if that Sakhi is actually
+   * assigned to them (checked via auth-service, since sakhi_profiles isn't
+   * this service's table — forklift rule). A MANAGER oversees multiple
+   * Supervisors' Sakhis, so is unrestricted here.
+   */
+  async listInventoryTransactionsBySakhi(
+    sakhiId: string,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    if (!caller.roles.includes('MANAGER')) {
+      const sakhi = await this.sakhiClient.findById(sakhiId, authorizationHeader);
+      if (!sakhi) throw notFound('Sakhi not found.');
+      if (sakhi.supervisorId !== caller.id) {
+        throw forbidden('You do not have access to this Sakhi.');
+      }
+    }
+    return this.repository.findInventoryTransactionsBySakhi(sakhiId);
+  }
+
+  /**
+   * Validates every referenced item exists and is ACTIVE before writing
+   * anything (fails the whole submission up front rather than partway
+   * through the atomic create), then persists one row per item.
+   *
+   * `supervisorId` is never taken from the client-supplied body — it's
+   * always the authenticated caller's own id, so a Supervisor can never
+   * record a transaction under another Supervisor's name.
+   */
+  async createInventoryTransactions(dto: CreateInventoryTransactionInput, caller: CallerIdentity) {
+    for (const { itemId } of dto.items) {
+      const item = await this.repository.findInventoryItemById(itemId);
+      if (!item) throw unprocessable(`items: item ${itemId} not found.`);
+      if (item.status !== 'ACTIVE') {
+        throw unprocessable(`items: item ${itemId} is not active.`);
+      }
+    }
+
+    const { items, ...header } = dto;
+    const rows = items.map((item) => ({
+      ...header,
+      supervisorId: caller.id,
+      itemId: item.itemId,
+      quantity: item.quantity,
+    }));
+    return this.repository.createInventoryTransactions(rows, caller.id);
+  }
+
+  async updateInventoryTransaction(
+    id: string,
+    dto: UpdateInventoryTransactionInput,
+    caller: CallerIdentity,
+  ) {
+    const existing = await this.repository.findInventoryTransactionById(id);
+    if (!existing) throw notFound('Inventory transaction not found.');
+    if (existing.supervisorId !== caller.id) {
+      throw forbidden('You do not have access to this transaction.');
+    }
+
+    const updated = await this.repository.updateInventoryTransaction(id, dto, caller.id);
+    if (!updated) throw notFound('Inventory transaction not found.');
+    return updated;
+  }
+
+  async deleteInventoryTransaction(id: string, caller: CallerIdentity) {
+    const existing = await this.repository.findInventoryTransactionById(id);
+    if (!existing) throw notFound('Inventory transaction not found.');
+    if (existing.supervisorId !== caller.id) {
+      throw forbidden('You do not have access to this transaction.');
+    }
+
+    const deleted = await this.repository.softDeleteInventoryTransaction(id, caller.id);
+    if (!deleted) throw notFound('Inventory transaction not found.');
   }
 
   listCallLogs() {

--- a/apps/supervisor-operations-service/src/operations/sakhi.client.ts
+++ b/apps/supervisor-operations-service/src/operations/sakhi.client.ts
@@ -1,0 +1,37 @@
+import { badGateway } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+interface Sakhi {
+  sakhiId: string;
+  supervisorId: string | null;
+  primaryProjectId: string;
+}
+
+/**
+ * Fetches a Sakhi's own record from auth-service (through the gateway, so the
+ * caller's forwarded Authorization header is verified) — used to check which
+ * Supervisor a Sakhi is actually assigned to before returning or writing her
+ * inventory-transaction history. supervisor-operations-service doesn't own
+ * sakhi_profiles (forklift rule: no cross-service DB joins), so this
+ * ownership check can only happen over the API.
+ */
+export class SakhiClient {
+  async findById(sakhiId: string, authorizationHeader: string): Promise<Sakhi | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.AUTH_SERVICE_BASE_URL}/api/v1/sakhis/${sakhiId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the Sakhi — the auth service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw badGateway('Unable to resolve the Sakhi — the auth service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: Sakhi };
+    return body.data;
+  }
+}

--- a/apps/visit-form-service/prisma/seed-data/mother-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/mother-registration.json
@@ -95,11 +95,11 @@
       "question_code": "unique_id"
     },
     {
-      "label": "Registrtion date",
+      "label": "Registration date",
       "section": "Personal Info",
       "required": true,
       "input_type": "date",
-      "question_code": "registrtion_date"
+      "question_code": "registration_date"
     },
     {
       "label": "Project name",


### PR DESCRIPTION
## Summary
- Add project-scoped Sakhi read endpoints (`GET /projects/:projectId/sakhis`, `GET /sakhis/:sakhiId`) in auth-service, routed through the gateway.
- Add inventory item and inventory transaction CRUD in supervisor-operations-service (`POST /inventory-items`, `GET/POST /inventory-transactions`, `GET /inventory-transactions/by-sakhi/:sakhiId`, `PUT`/`DELETE /inventory-transactions/:id`), backed by a cross-service `SakhiClient` that verifies Sakhi-Supervisor assignment via HTTP (no cross-service DB joins, per the forklift rule).
- Harden all new endpoints against IDOR: Supervisors can only act on Sakhis assigned to them and transactions they created; MANAGER is unrestricted on reads; **ADMIN now has full, unrestricted access across every inventory-item/inventory-transaction endpoint** (role gate + ownership-check bypass), matching how MANAGER already behaved on read paths.
- Fix a real gateway routing bug: `GET /sakhis/:sakhiId/inventory-transactions` was unreachable through the gateway proxy (parameterized prefixes aren't supported by the underlying `http-proxy-middleware` rewrite) — moved to `GET /inventory-transactions/by-sakhi/:sakhiId`, which falls under the existing static `/inventory-transactions` gateway route.
- Fix a data-integrity bug: duplicate Karnataka STATE rows in `geography_units` (Postgres NULL≠NULL breaks the unique index for STATE-level rows since `parentId` is always null there) — added an explicit app-level uniqueness check.
- Fix a race condition in `GET /master-data/deltas`: `serverTime` is now captured before the delta queries run, not after, so clients no longer miss updates that land in the query window.
- Fix seed-data bugs in `mother-registration.json` (children-under-5 validation range, split combined name field into first/middle/last, corrected `beneficiary_id`/`unique_id`/`registration_date` field config to use valid `computedFrom` enum values).
- Add per-level geography tables (`states` through `padas`) alongside the existing `geography_units` table (additive-only migration, old table kept as a rollback safety net) — Phase 1 of a larger schema migration, scoped down per explicit review.

## Test plan
- [x] `npx nx test supervisor-operations-service` — 34/34 passing, including new ADMIN-bypass coverage on all 4 ownership-checked service methods
- [x] `npx nx lint supervisor-operations-service` — clean
- [x] `npx nx build supervisor-operations-service` — succeeds
- [x] Live E2E curl testing of all inventory-transaction endpoints across success/failure/IDOR scenarios (SUPERVISOR, MANAGER, ADMIN, cross-Supervisor rejection)
- [x] Verified ADMIN can now list/create/update/delete inventory transactions and inventory items regardless of Sakhi assignment or transaction ownership
- [x] Verified the `/inventory-transactions/by-sakhi/:sakhiId` route is reachable end-to-end through the gateway (previously 400'd due to the routing bug above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


Related to #74
