### PR TITLE
Add call-sheet CRUD, meeting/training lifecycle APIs, and fix media upload bugs

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,195 @@
+name: CD Dev
+
+# Redeploys the dev box (self-hosted runner on the box itself) with only the
+# services whose code actually changed.
+#
+# Also callable — redeploy-dev.yml uses it for manual runs. When `services` is
+# empty the affected set is computed; "all" or a comma-separated list overrides it.
+
+on:
+  push:
+    branches: [develop]
+  workflow_call:
+    inputs:
+      services:
+        description: 'Empty = only what changed. "all", or a comma-separated list of service names.'
+        type: string
+        required: false
+        default: ''
+
+# Never cancel a deploy in flight, and never run two at once: both would race
+# `git reset --hard` in the same directory on the same box. Queue instead.
+concurrency:
+  group: cd-dev
+  cancel-in-progress: false
+
+env:
+  DEV_WORKSPACE: ${{ vars.DEV_WORKSPACE || '/opt/dev/armaan/arogyasakhi-service' }}
+  # PM2 runs the services via `nx serve` in fork mode, so a reload restarts a
+  # webpack dev server that must rebuild before it listens. Measured at 12s for
+  # auth-service on an otherwise-quiet box; the margin here is for the case where
+  # a shared-lib change has every watcher rebuilding at once and the box is
+  # contended. Too tight fails a healthy deploy; too loose only delays reporting
+  # a broken one.
+  HEALTH_TIMEOUT_SECONDS: 120
+
+defaults:
+  run:
+    # Login shell so nvm's init is sourced. node/npm/npx/pm2 live under
+    # ~/.nvm/versions/node/<v>/bin and are absent from a non-login PATH, which
+    # is what a runner step gets by default.
+    shell: bash -leo pipefail {0}
+
+jobs:
+  detect:
+    runs-on: self-hosted
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+      count: ${{ steps.resolve.outputs.count }}
+    steps:
+      # Proved first, because everything below depends on it and the failure
+      # mode ("pm2: command not found") is otherwise confusing.
+      - name: Verify toolchain is on PATH
+        run: |
+          which node npm npx pm2 git jq
+          echo "node $(node -v) · npm $(npm -v) · pm2 $(pm2 -v)"
+
+      - name: Sync workspace and resolve services to deploy
+        id: resolve
+        env:
+          SERVICES_INPUT: ${{ inputs.services }}
+        run: |
+          cd "$DEV_WORKSPACE"
+
+          # The box's current HEAD *is* what is deployed, so it is the only
+          # trustworthy base. Captured before fetching. This is deliberately not
+          # nrwl/nx-set-shas: that keys off the last *successful run*, so a single
+          # failed deploy would leave those services looking already-shipped and
+          # they would never be redeployed.
+          base=$(git rev-parse HEAD)
+
+          git fetch origin "${{ github.ref_name }}"
+          # FETCH_HEAD rather than github.sha: if runs queued behind the
+          # concurrency group, deploying the newest commit is correct, and the
+          # superseded run then sees base == target and does nothing.
+          target=$(git rev-parse FETCH_HEAD)
+          echo "base=$base target=$target"
+
+          # No `git clean` anywhere: the box legitimately holds untracked files
+          # (ecosystem.config.js — PM2's own config — create_envs.py, notes).
+          git reset --hard "$target"
+
+          if git diff --name-only "$base" "$target" | grep -qx 'package-lock.json'; then
+            echo "::warning::package-lock.json changed. Not running npm ci — the box is on $(node -v) while CI pins 20.11.0, and installing here is what causes lockfile drift. If a service fails to boot on a missing dependency, install manually."
+          fi
+
+          all_apps=$(npx nx show projects --type app --json)
+
+          requested=$(printf '%s' "${SERVICES_INPUT:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+          if [ "$requested" = 'all' ]; then
+            apps="$all_apps"
+          elif [ -n "$requested" ]; then
+            apps=$(printf '%s' "$requested" \
+              | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | unique')
+            unknown=$(jq -nc --argjson w "$apps" --argjson h "$all_apps" '$w - $h')
+            if [ "$(jq 'length' <<<"$unknown")" -gt 0 ]; then
+              echo "::error::Unknown service(s): $(jq -r 'join(", ")' <<<"$unknown")"
+              exit 1
+            fi
+          elif [ "$base" = "$target" ]; then
+            apps='[]'
+          else
+            apps=$(npx nx show projects --affected --type app --base="$base" --head="$target" --json)
+          fi
+
+          count=$(jq 'length' <<<"$apps")
+          echo "Deploying ($count): $(jq -r 'join(", ")' <<<"$apps")"
+
+          # env_secret is derived here because GitHub expressions have no
+          # upper-casing function and so cannot turn "auth-service" into
+          # ENV_AUTH_SERVICE on their own.
+          matrix=$(jq -c '{
+            include: [ .[] | {
+              service: .,
+              env_secret: ("ENV_" + (. | ascii_upcase | gsub("-"; "_")))
+            } ]
+          }' <<<"$apps")
+
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+      # `nx serve` needs these built; documented prerequisite of the box's
+      # ecosystem.config.js. Once per run, not once per service. Nx caches it,
+      # so it is near-free when the libs did not change.
+      - name: Rebuild shared libraries
+        if: steps.resolve.outputs.count != '0'
+        run: |
+          cd "$DEV_WORKSPACE"
+          npx nx run-many -t build --projects=service-commons,core
+
+  deploy:
+    needs: detect
+    if: needs.detect.outputs.count != '0'
+    runs-on: self-hosted
+    strategy:
+      # Sequential: 17 concurrent webpack cold-builds would exhaust the box
+      # (81.9% RAM at idle). fail-fast off so one bad service does not strand
+      # the rest un-deployed.
+      max-parallel: 1
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    steps:
+      - name: Write .env from GitHub secret
+        env:
+          # Passed via env, never as a shell argument — an argument is visible
+          # in `ps` to every user on the box.
+          ENV_BODY: ${{ secrets[matrix.env_secret] }}
+        run: |
+          cd "$DEV_WORKSPACE"
+          if [ -z "${ENV_BODY:-}" ]; then
+            echo "::warning::${{ matrix.service }}: secret ${{ matrix.env_secret }} is not set — reloading against the .env already on the box."
+            exit 0
+          fi
+          printf '%s\n' "$ENV_BODY" > "apps/${{ matrix.service }}/.env"
+          chmod 600 "apps/${{ matrix.service }}/.env"
+          echo "Wrote apps/${{ matrix.service }}/.env from ${{ matrix.env_secret }}"
+
+      - name: Reload and wait for readiness
+        env:
+          SVC: ${{ matrix.service }}
+        run: |
+          cd "$DEV_WORKSPACE"
+
+          # A service present in git but not in PM2 has never been bootstrapped
+          # on this box. Auto-starting it would boot it with no .env straight
+          # into its Zod fail-fast, so skip — but loudly, because a silently
+          # never-deployed service is the worst outcome here.
+          if ! pm2 describe "$SVC" >/dev/null 2>&1; then
+            echo "::warning::$SVC is not registered in PM2 — skipping. Bootstrap it once on the box with pm2 start, then it will deploy normally."
+            exit 0
+          fi
+
+          # PM2's own env is the authoritative port: it is what injects PORT
+          # into each service, so no port table is needed anywhere here.
+          port=$(pm2 jlist | jq -r --arg s "$SVC" '.[] | select(.name == $s) | .pm2_env.env.PORT // empty')
+          if [ -z "$port" ]; then
+            echo "::error::Could not determine PORT for $SVC from PM2."
+            exit 1
+          fi
+
+          pm2 reload "$SVC" --update-env
+
+          # `pm2 reload` exiting 0 only means the process was signalled, not
+          # that the app rebuilt and bound its socket. Health is mounted under
+          # the global api/v1 prefix.
+          url="http://localhost:$port/api/v1/health/ready"
+          deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+          until curl -fsS -o /dev/null "$url"; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::$SVC not ready after ${HEALTH_TIMEOUT_SECONDS}s at $url"
+              pm2 logs "$SVC" --lines 40 --nostream || true
+              exit 1
+            fi
+            sleep 3
+          done
+          echo "$SVC ready on port $port"

--- a/.github/workflows/redeploy-dev.yml
+++ b/.github/workflows/redeploy-dev.yml
@@ -1,0 +1,34 @@
+name: Redeploy Dev (manual)
+
+# Manual trigger for the dev deploy. Actions → "Redeploy Dev (manual)" → Run
+# workflow. All the logic lives in cd-dev.yml; this only supplies the input.
+#
+# What this is for:
+#   - forcing a redeploy of a service the affected-detection skipped
+#   - redeploying after creating or fixing an ENV_<SERVICE> secret
+#
+# What it is NOT: a rollback. By the time a deploy has failed the box's HEAD has
+# already advanced, so re-running deploys the same broken commit. Rolling back is
+# manual on the box:
+#   cd /opt/dev/armaan/arogyasakhi-service
+#   git reset --hard <previous-sha> && pm2 reload <service> --update-env
+#
+# NOTE: the branch you select in the Run-workflow dialog is the branch the dev
+# box gets reset to — dispatching from a feature branch deploys that branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      services:
+        description: 'Leave empty for only what changed. Or "all" (expensive — every service rebuilds), or a comma-separated list e.g. auth-service,rules-service'
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  redeploy:
+    uses: ./.github/workflows/cd-dev.yml
+    with:
+      services: ${{ inputs.services }}
+    # Required for cd-dev.yml to read the per-service ENV_* secrets.
+    secrets: inherit

--- a/apps/auth-service/prisma/seed-data.ts
+++ b/apps/auth-service/prisma/seed-data.ts
@@ -46,12 +46,13 @@ export const ROLES: { roleCode: string; roleName: string; description: string }[
  * ReferralType, ClosureReason), so each service's migration can backfill its
  * new lookup-value-id column by looking up the row with a matching code.
  *
- * PHONE_OWNER and EDUCATION_LEVEL have no confirmed source yet — the SRS
- * cites an external "Revised App Form Final (20 March 2026)" Excel document
- * as the authoritative source for these two categories' values, and that
- * document is not available in this repo. The values below are provisional
- * placeholders (common options in Indian maternal-health programs) and MUST
- * be reviewed/replaced once the real source document is available.
+ * PHONE_OWNER, EDUCATION_LEVEL, MOBILE_NETWORK_AVAILABILITY,
+ * PARTNER_OCCUPATION, MIGRATION_PATTERN, MONTHLY_INCOME_BRACKET, RELIGION,
+ * and SOCIAL_CATEGORY value sets are sourced from the "Revised App Form
+ * Final (20 March 2026)" Excel document (transcribed at
+ * docs/Revised_App_Form_Final_20.3.26.xlsx.md in beneficiary-service,
+ * Registration_PW_D sheet rows 23-32) — the SRS's authoritative source for
+ * these categories, now available in-repo.
  */
 export const LOOKUP_CATEGORIES: {
   categoryCode: string;
@@ -74,26 +75,140 @@ export const LOOKUP_CATEGORIES: {
     categoryCode: 'PHONE_OWNER',
     categoryName: 'Phone Owner',
     description:
-      'PROVISIONAL — placeholder values pending the "Revised App Form Final (20 March 2026)" source document.',
+      'Registration form "Who owns the phone?" (Revised App Form Final, Registration_PW_D row 23).',
     values: [
       { valueCode: 'SELF', valueLabel: 'Self', sortOrder: 0 },
       { valueCode: 'HUSBAND', valueLabel: 'Husband', sortOrder: 1 },
-      { valueCode: 'FATHER_IN_LAW', valueLabel: 'Father-in-law', sortOrder: 2 },
-      { valueCode: 'OTHER_FAMILY_MEMBER', valueLabel: 'Other family member', sortOrder: 3 },
+      { valueCode: 'FAMILY_MEMBER', valueLabel: 'Family member', sortOrder: 2 },
+      { valueCode: 'ASHA', valueLabel: 'ASHA', sortOrder: 3 },
+      { valueCode: 'NEIGHBOUR', valueLabel: 'Neighbour', sortOrder: 4 },
     ],
   },
   {
     categoryCode: 'EDUCATION_LEVEL',
     categoryName: 'Education Level',
     description:
-      'PROVISIONAL — placeholder values pending the "Revised App Form Final (20 March 2026)" source document.',
+      'Registration form "Highest level of education completed" — shared by beneficiary and partner education questions (Revised App Form Final, Registration_PW_D rows 25-26).',
     values: [
-      { valueCode: 'ILLITERATE', valueLabel: 'Illiterate', sortOrder: 0 },
-      { valueCode: 'PRIMARY', valueLabel: 'Primary', sortOrder: 1 },
-      { valueCode: 'SECONDARY', valueLabel: 'Secondary', sortOrder: 2 },
-      { valueCode: 'HIGHER_SECONDARY', valueLabel: 'Higher secondary', sortOrder: 3 },
-      { valueCode: 'GRADUATE', valueLabel: 'Graduate', sortOrder: 4 },
-      { valueCode: 'POST_GRADUATE', valueLabel: 'Post-graduate', sortOrder: 5 },
+      { valueCode: 'NO_FORMAL_EDUCATION', valueLabel: 'No formal education', sortOrder: 0 },
+      { valueCode: 'PRIMARY', valueLabel: 'Primary education (Class 1-5)', sortOrder: 1 },
+      {
+        valueCode: 'UPPER_PRIMARY_MIDDLE',
+        valueLabel: 'Upper primary / Middle school (Class 6-9)',
+        sortOrder: 2,
+      },
+      { valueCode: 'TENTH_PASS', valueLabel: '10th Pass', sortOrder: 3 },
+      { valueCode: 'TWELFTH_PASS', valueLabel: '12th Pass', sortOrder: 4 },
+      { valueCode: 'DIPLOMA', valueLabel: 'Diploma', sortOrder: 5 },
+      { valueCode: 'GRADUATE', valueLabel: 'Graduate (College degree)', sortOrder: 6 },
+      { valueCode: 'POST_GRADUATE', valueLabel: 'Post Graduate and above', sortOrder: 7 },
+    ],
+  },
+  {
+    categoryCode: 'MOBILE_NETWORK_AVAILABILITY',
+    categoryName: 'Mobile Network Availability',
+    description:
+      'Registration form "Availability of Mobile Network" (Revised App Form Final, Registration_PW_D row 24).',
+    values: [
+      { valueCode: 'NO_NETWORK', valueLabel: 'No Network', sortOrder: 0 },
+      {
+        valueCode: 'VERY_POOR_NETWORK',
+        valueLabel: 'Very Poor Network (Have to go height which is 10 minutes walk away)',
+        sortOrder: 1,
+      },
+      {
+        valueCode: 'AVAILABLE_OUTSIDE_HOME_SPECIFIC_TIME',
+        valueLabel: 'Network Available outside the home at some specific time',
+        sortOrder: 2,
+      },
+      {
+        valueCode: 'AVAILABLE_OUTSIDE_HOME_ALL_TIME',
+        valueLabel: 'Network available only outside home all time',
+        sortOrder: 3,
+      },
+      { valueCode: 'FULL_NETWORK_AVAILABLE', valueLabel: 'Full Network Available', sortOrder: 4 },
+    ],
+  },
+  {
+    categoryCode: 'PARTNER_OCCUPATION',
+    categoryName: 'Partner Occupation',
+    description:
+      'Registration form "Occupation of your partner" (Revised App Form Final, Registration_PW_D row 27).',
+    values: [
+      { valueCode: 'LABOUR', valueLabel: 'Labour', sortOrder: 0 },
+      { valueCode: 'PRIVATE_JOB', valueLabel: 'Private Job', sortOrder: 1 },
+      { valueCode: 'GOVERNMENT_JOB', valueLabel: 'Government Job', sortOrder: 2 },
+      { valueCode: 'BUSINESS', valueLabel: 'Business', sortOrder: 3 },
+      { valueCode: 'FARMER', valueLabel: 'Farmer', sortOrder: 4 },
+      { valueCode: 'OTHER', valueLabel: 'Other', sortOrder: 5 },
+    ],
+  },
+  {
+    categoryCode: 'MIGRATION_PATTERN',
+    categoryName: 'Migration Pattern',
+    description:
+      'Registration form "Household\'s migration pattern" (Revised App Form Final, Registration_PW_D row 29).',
+    values: [
+      { valueCode: 'PERMANENT_MIGRATION', valueLabel: 'Permanent migration', sortOrder: 0 },
+      {
+        valueCode: 'SEASONAL_MIGRATION',
+        valueLabel: 'Seasonal migration (leave for work during specific months)',
+        sortOrder: 1,
+      },
+      {
+        valueCode: 'CIRCULAR_MIGRATION',
+        valueLabel: 'Circular migration (move between two places repeatedly)',
+        sortOrder: 2,
+      },
+      {
+        valueCode: 'TEMPORARY_MIGRATION_FOR_EMPLOYMENT',
+        valueLabel: 'Temporary migration for employment',
+        sortOrder: 3,
+      },
+      {
+        valueCode: 'DISPLACEMENT_DUE_TO_CRISIS',
+        valueLabel: 'Displacement due to crisis (disaster, conflict, eviction)',
+        sortOrder: 4,
+      },
+    ],
+  },
+  {
+    categoryCode: 'MONTHLY_INCOME_BRACKET',
+    categoryName: 'Monthly Income Bracket',
+    description:
+      'Registration form "Income of the family per month" (Revised App Form Final, Registration_PW_D row 30).',
+    values: [
+      { valueCode: 'UPTO_10000', valueLabel: '<=10000', sortOrder: 0 },
+      { valueCode: 'FROM_10001_TO_15000', valueLabel: '10001-15000', sortOrder: 1 },
+      { valueCode: 'FROM_15001_TO_20000', valueLabel: '15001-20000', sortOrder: 2 },
+      { valueCode: 'FROM_20001_TO_25000', valueLabel: '20001-25000', sortOrder: 3 },
+      { valueCode: 'ABOVE_25000', valueLabel: '>25000', sortOrder: 4 },
+    ],
+  },
+  {
+    categoryCode: 'RELIGION',
+    categoryName: 'Religion',
+    description: 'Registration form "Religion" (Revised App Form Final, Registration_PW_D row 31).',
+    values: [
+      { valueCode: 'BUDDHIST', valueLabel: 'Buddhist', sortOrder: 0 },
+      { valueCode: 'CHRISTIAN', valueLabel: 'Christian', sortOrder: 1 },
+      { valueCode: 'HINDU', valueLabel: 'Hindu', sortOrder: 2 },
+      { valueCode: 'JAIN', valueLabel: 'Jain', sortOrder: 3 },
+      { valueCode: 'MUSLIM', valueLabel: 'Muslim', sortOrder: 4 },
+      { valueCode: 'SIKH', valueLabel: 'Sikh', sortOrder: 5 },
+      { valueCode: 'OTHER', valueLabel: 'Other', sortOrder: 6 },
+    ],
+  },
+  {
+    categoryCode: 'SOCIAL_CATEGORY',
+    categoryName: 'Social Category',
+    description: 'Registration form "Category" (Revised App Form Final, Registration_PW_D row 32).',
+    values: [
+      { valueCode: 'GENERAL', valueLabel: 'General', sortOrder: 0 },
+      { valueCode: 'OBC', valueLabel: 'OBC', sortOrder: 1 },
+      { valueCode: 'OTHER', valueLabel: 'Other', sortOrder: 2 },
+      { valueCode: 'SC', valueLabel: 'SC', sortOrder: 3 },
+      { valueCode: 'ST', valueLabel: 'ST', sortOrder: 4 },
     ],
   },
   {

--- a/apps/auth-service/src/sakhis/sakhi.controller.ts
+++ b/apps/auth-service/src/sakhis/sakhi.controller.ts
@@ -21,6 +21,8 @@ const projectIdParamsSchema = z
   })
   .strict();
 
+// sakhiId is the Sakhi's users.user_id (the JWT sub), not the sakhi_profiles
+// row's own PK — see sakhi.service.ts's toApiSakhi() comment.
 const sakhiIdParamsSchema = z
   .object({
     sakhiId: z.string().uuid().openapi({ example: 'c9f8e2b1-6a3d-4f0e-9b1a-2d4e5f6a7b8c' }),

--- a/apps/auth-service/src/sakhis/sakhi.repository.spec.ts
+++ b/apps/auth-service/src/sakhis/sakhi.repository.spec.ts
@@ -37,16 +37,16 @@ describe('SakhiRepository', () => {
   });
 
   describe('findById', () => {
-    it('queries a single Sakhi by id, excluding soft-deleted', async () => {
-      findFirst.mockResolvedValue({ id: 'sakhi-1', user: { displayName: 'Priya' } });
+    it('queries a single Sakhi by user id, excluding soft-deleted', async () => {
+      findFirst.mockResolvedValue({ id: 'sakhi-1', user: { id: 'user-1', displayName: 'Priya' } });
 
-      const result = await repository.findById('sakhi-1');
+      const result = await repository.findById('user-1');
 
       expect(findFirst).toHaveBeenCalledWith({
-        where: { id: 'sakhi-1', isDeleted: false },
+        where: { userId: 'user-1', isDeleted: false },
         include: { user: true },
       });
-      expect(result).toEqual({ id: 'sakhi-1', user: { displayName: 'Priya' } });
+      expect(result).toEqual({ id: 'sakhi-1', user: { id: 'user-1', displayName: 'Priya' } });
     });
 
     it('returns null when the Sakhi does not exist', async () => {

--- a/apps/auth-service/src/sakhis/sakhi.repository.ts
+++ b/apps/auth-service/src/sakhis/sakhi.repository.ts
@@ -12,9 +12,12 @@ export class SakhiRepository {
     });
   }
 
-  findById(id: string) {
+  /** `userId` here is the Sakhi's `users.user_id` — the id `GET /sakhis/:sakhiId`
+   * takes and the id `toApiSakhi()` returns as `sakhiId`, not the
+   * `sakhi_profiles` row's own PK (see sakhi.service.ts's `toApiSakhi` comment). */
+  findById(userId: string) {
     return this.prisma.sakhiProfile.findFirst({
-      where: { id, isDeleted: false },
+      where: { userId, isDeleted: false },
       include: { user: true },
     });
   }

--- a/apps/auth-service/src/sakhis/sakhi.service.spec.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.spec.ts
@@ -28,6 +28,7 @@ describe('SakhiService', () => {
     aadhaarToken: Buffer.from('secret'),
     bankAccountToken: Buffer.from('secret'),
     user: {
+      id: 'user-1',
       displayName: 'Priya Sharma',
       mobileNumber: '+919000000123',
       status: 'ACTIVE',
@@ -43,7 +44,7 @@ describe('SakhiService', () => {
 
       expect(result).toEqual([
         {
-          sakhiId: 'sakhi-1',
+          sakhiId: 'user-1',
           displayName: 'Priya Sharma',
           mobileNumber: '+919000000123',
           status: 'ACTIVE',
@@ -92,9 +93,9 @@ describe('SakhiService', () => {
     it('returns the projected Sakhi', async () => {
       repository.findById.mockResolvedValue(rawProfile() as never);
 
-      const result = await service.getById('sakhi-1', unscopedCaller);
+      const result = await service.getById('user-1', unscopedCaller);
 
-      expect(result).toMatchObject({ sakhiId: 'sakhi-1', displayName: 'Priya Sharma' });
+      expect(result).toMatchObject({ sakhiId: 'user-1', displayName: 'Priya Sharma' });
       expect(result).not.toHaveProperty('passwordHash');
     });
 
@@ -107,14 +108,14 @@ describe('SakhiService', () => {
 
     it('allows a scoped caller (SUPERVISOR) to fetch a Sakhi in their own project', async () => {
       repository.findById.mockResolvedValue(rawProfile() as never);
-      await expect(service.getById('sakhi-1', scopedCaller('project-1'))).resolves.toMatchObject({
-        sakhiId: 'sakhi-1',
+      await expect(service.getById('user-1', scopedCaller('project-1'))).resolves.toMatchObject({
+        sakhiId: 'user-1',
       });
     });
 
     it('rejects a scoped caller fetching a Sakhi from a different project', async () => {
       repository.findById.mockResolvedValue(rawProfile() as never);
-      await expect(service.getById('sakhi-1', scopedCaller('project-2'))).rejects.toMatchObject({
+      await expect(service.getById('user-1', scopedCaller('project-2'))).rejects.toMatchObject({
         status: 403,
       });
     });

--- a/apps/auth-service/src/sakhis/sakhi.service.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.ts
@@ -11,11 +11,18 @@ export interface CallerScope {
  * (panToken/aadhaarToken/bankAccountToken), passwordHash, or other audit
  * columns. Combines User (identity) and SakhiProfile (program assignment)
  * fields, since a Sakhi is 1:1 across the two tables.
+ *
+ * `sakhiId` is the Sakhi's `users.user_id` (not the `sakhi_profiles` row's
+ * own PK) — this is the id every other service treats as "the Sakhi's
+ * identity" (it's the JWT `sub`, and what `beneficiary_cases.sakhi_id` and
+ * beneficiary-service's own-case filter both key on). Returning the profile
+ * PK here instead would silently break Supervisor-scoped queries downstream,
+ * since it's a different id for the same person.
  */
 function toApiSakhi(profile: Record<string, unknown>) {
   const user = profile.user as Record<string, unknown>;
   return {
-    sakhiId: profile.id,
+    sakhiId: user.id,
     displayName: user.displayName,
     mobileNumber: user.mobileNumber,
     status: user.status,

--- a/apps/beneficiary-service/prisma/migrations/20260731000000_add_beneficiary_socio_demographics/migration.sql
+++ b/apps/beneficiary-service/prisma/migrations/20260731000000_add_beneficiary_socio_demographics/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "beneficiary_socio_demographics" (
+    "socio_demographics_id" TEXT NOT NULL,
+    "beneficiary_id" TEXT NOT NULL,
+    "phone_owner_lookup_id" TEXT,
+    "mobile_network_availability_lookup_id" TEXT,
+    "education_level_lookup_id" TEXT,
+    "partner_education_level_lookup_id" TEXT,
+    "partner_occupation_lookup_id" TEXT,
+    "years_in_village" INTEGER,
+    "migration_pattern_lookup_id" TEXT,
+    "monthly_income_lookup_id" TEXT,
+    "religion_lookup_id" TEXT,
+    "social_category_lookup_id" TEXT,
+    "family_members_count" INTEGER,
+    "children_under_5_count" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_by_user_id" TEXT,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "updated_by_user_id" TEXT,
+
+    CONSTRAINT "beneficiary_socio_demographics_pkey" PRIMARY KEY ("socio_demographics_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "beneficiary_socio_demographics_beneficiary_id_key" ON "beneficiary_socio_demographics"("beneficiary_id");
+
+-- AddForeignKey
+ALTER TABLE "beneficiary_socio_demographics" ADD CONSTRAINT "beneficiary_socio_demographics_beneficiary_id_fkey" FOREIGN KEY ("beneficiary_id") REFERENCES "beneficiary_cases"("beneficiary_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/beneficiary-service/prisma/schema.prisma
+++ b/apps/beneficiary-service/prisma/schema.prisma
@@ -16,7 +16,8 @@
 // Tables owned by this service (beneficiary_pii, beneficiary_search_tokens, beneficiary_cases,
 // mother_case_details, child_case_details, consent_records,
 // beneficiary_risk_condition_summary, beneficiary_status_history,
-// beneficiary_current_summary) DO get proper Prisma @relation edges between each other.
+// beneficiary_current_summary, beneficiary_socio_demographics) DO get proper
+// Prisma @relation edges between each other.
 
 generator client {
   provider = "prisma-client-js"
@@ -151,6 +152,46 @@ model BeneficiaryPii {
   @@map("beneficiary_pii")
 }
 
+// Registration-time socio-demographic answers per SRS v3.0 / "Revised App Form
+// Final (20 March 2026)" Registration_PW_D sheet, rows 23-34. 1:1 with
+// BeneficiaryCase (not BeneficiaryPii): these are dropdown/count answers, not
+// person-identifying data, so they don't need encryption. Address and mobile
+// number themselves already exist (encrypted) on BeneficiaryPii — this table
+// only adds the fields that had no column anywhere yet.
+model BeneficiarySocioDemographics {
+  id            String  @id @default(uuid()) @map("socio_demographics_id")
+  beneficiaryId String  @unique @map("beneficiary_id")
+  // lookup_values.lookup_value_id (category PHONE_OWNER) — owned by another service.
+  phoneOwnerLookupId                 String? @map("phone_owner_lookup_id")
+  // lookup_values.lookup_value_id (category MOBILE_NETWORK_AVAILABILITY) — owned by another service.
+  mobileNetworkAvailabilityLookupId  String? @map("mobile_network_availability_lookup_id")
+  // lookup_values.lookup_value_id (category EDUCATION_LEVEL) — owned by another service.
+  educationLevelLookupId             String? @map("education_level_lookup_id")
+  // lookup_values.lookup_value_id (category EDUCATION_LEVEL) — owned by another service.
+  partnerEducationLevelLookupId      String? @map("partner_education_level_lookup_id")
+  // lookup_values.lookup_value_id (category PARTNER_OCCUPATION) — owned by another service.
+  partnerOccupationLookupId          String? @map("partner_occupation_lookup_id")
+  yearsInVillage                     Int?    @map("years_in_village")
+  // lookup_values.lookup_value_id (category MIGRATION_PATTERN) — owned by another service.
+  migrationPatternLookupId           String? @map("migration_pattern_lookup_id")
+  // lookup_values.lookup_value_id (category MONTHLY_INCOME_BRACKET) — owned by another service.
+  monthlyIncomeLookupId              String? @map("monthly_income_lookup_id")
+  // lookup_values.lookup_value_id (category RELIGION) — owned by another service.
+  religionLookupId                   String? @map("religion_lookup_id")
+  // lookup_values.lookup_value_id (category SOCIAL_CATEGORY) — owned by another service.
+  socialCategoryLookupId             String? @map("social_category_lookup_id")
+  familyMembersCount                 Int?    @map("family_members_count")
+  childrenUnder5Count                Int?    @map("children_under_5_count")
+  createdAt                          DateTime  @default(now()) @map("created_at")
+  createdByUserId                    String?   @map("created_by_user_id")
+  updatedAt                          DateTime  @updatedAt @map("updated_at")
+  updatedByUserId                    String?   @map("updated_by_user_id")
+
+  beneficiaryCase BeneficiaryCase @relation(fields: [beneficiaryId], references: [id])
+
+  @@map("beneficiary_socio_demographics")
+}
+
 model BeneficiarySearchToken {
   id               String   @id @default(uuid()) @map("search_token_id")
   beneficiaryId    String   @map("beneficiary_id")
@@ -217,6 +258,7 @@ model BeneficiaryCase {
   riskConditionSummaries BeneficiaryRiskConditionSummary[]
   statusHistory          BeneficiaryStatusHistory[]
   currentSummary         BeneficiaryCurrentSummary?
+  socioDemographics      BeneficiarySocioDemographics?
 
   @@map("beneficiary_cases")
 }

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -190,11 +190,14 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(listBeneficiariesQuerySchema, 'query'),
-    asyncHandler(async (req, res) => {
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
       const query = req.query as unknown as z.infer<typeof listBeneficiariesQuerySchema>;
-      res.json(ok(await service.list(query)));
+      res.json(ok(await service.list(query, req.user, authorizationHeader)));
     }),
   );
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -32,6 +32,10 @@ const piiResponseSchema = z.object({
   // Decrypted server-side for display (see BeneficiaryService.list/getById) —
   // never the raw fullNameEnc/fullNameSearchHash.
   fullName: z.string().openapi({ example: 'Jane Doe' }),
+  // Decrypted server-side for display, same as fullName — never the raw
+  // phoneEnc/addressLineEnc columns.
+  mobileNumber: z.string().nullable().openapi({ example: '9876543210' }),
+  address: z.string().nullable(),
   villageId: z.string().uuid().nullable(),
   padaId: z.string().uuid().nullable(),
   healthSubCentreId: z.string().uuid().nullable(),
@@ -83,6 +87,25 @@ const childCaseDetailsSchema = z.object({
   linkedAncCase: z.boolean(),
 });
 
+// Registration-time socio-demographic answers per SRS v3.0 / "Revised App
+// Form Final (20 March 2026)" Registration_PW_D sheet, rows 23-34.
+// *LookupId fields reference lookup_values owned by another service (plain
+// scalar ids per the forklift rule) — not resolved to labels here.
+const socioDemographicsSchema = z.object({
+  phoneOwnerLookupId: z.string().uuid().nullable(),
+  mobileNetworkAvailabilityLookupId: z.string().uuid().nullable(),
+  educationLevelLookupId: z.string().uuid().nullable(),
+  partnerEducationLevelLookupId: z.string().uuid().nullable(),
+  partnerOccupationLookupId: z.string().uuid().nullable(),
+  yearsInVillage: z.number().int().nullable(),
+  migrationPatternLookupId: z.string().uuid().nullable(),
+  monthlyIncomeLookupId: z.string().uuid().nullable(),
+  religionLookupId: z.string().uuid().nullable(),
+  socialCategoryLookupId: z.string().uuid().nullable(),
+  familyMembersCount: z.number().int().nullable(),
+  childrenUnder5Count: z.number().int().nullable(),
+});
+
 const consentRecordSchema = z.object({
   consentType: z.string().openapi({ example: 'PROGRAM_ENROLLMENT' }),
   consentStatus: z.enum(API_CONSENT_STATUSES),
@@ -118,6 +141,7 @@ const beneficiaryCaseDetailSchema = beneficiaryCaseSchema.extend({
   consentRecords: z.array(consentRecordSchema),
   riskConditionSummaries: z.array(riskConditionSummarySchema),
   statusHistory: z.array(statusHistoryEntrySchema),
+  socioDemographics: socioDemographicsSchema.nullable(),
 });
 
 // List rows carry PII (decrypted name) but not the full detail-view

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.spec.ts
@@ -1,0 +1,120 @@
+import { randomBytes } from 'node:crypto';
+import { encryptPii } from '@armman/service-commons';
+import { withDecryptedName } from './beneficiary.mapper';
+
+describe('withDecryptedName', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.PII_ENCRYPTION_KEY = randomBytes(32).toString('base64');
+    process.env.PII_SEARCH_HASH_KEY = randomBytes(32).toString('base64');
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function basePii(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'pii-1',
+      fullNameEnc: encryptPii('Jane Doe'),
+      phoneEnc: null,
+      addressLineEnc: null,
+      villageId: null,
+      padaId: null,
+      healthSubCentreId: null,
+      phcId: null,
+      healthBlockId: null,
+      dateOfBirth: null,
+      sex: null,
+      stateId: null,
+      districtId: null,
+      talukaId: null,
+      ...overrides,
+    };
+  }
+
+  it('decrypts address and mobile number from pii', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii({
+        phoneEnc: encryptPii('9876543210'),
+        addressLineEnc: encryptPii('12 Main Street'),
+      }),
+    } as never);
+
+    expect(result.pii).toMatchObject({
+      mobileNumber: '9876543210',
+      address: '12 Main Street',
+    });
+  });
+
+  it('leaves address and mobile number null without attempting to decrypt', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii({ phoneEnc: null, addressLineEnc: null }),
+    } as never);
+
+    expect(result.pii).toMatchObject({ mobileNumber: null, address: null });
+  });
+
+  it('projects socioDemographics when present, allow-listing only documented fields', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii(),
+      socioDemographics: {
+        beneficiaryId: 'x',
+        phoneOwnerLookupId: 'lv-1',
+        mobileNetworkAvailabilityLookupId: 'lv-2',
+        educationLevelLookupId: 'lv-3',
+        partnerEducationLevelLookupId: 'lv-4',
+        partnerOccupationLookupId: 'lv-5',
+        yearsInVillage: 12,
+        migrationPatternLookupId: 'lv-6',
+        monthlyIncomeLookupId: 'lv-7',
+        religionLookupId: 'lv-8',
+        socialCategoryLookupId: 'lv-9',
+        familyMembersCount: 5,
+        childrenUnder5Count: 1,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+      },
+    } as never);
+
+    expect(result.socioDemographics).toEqual({
+      phoneOwnerLookupId: 'lv-1',
+      mobileNetworkAvailabilityLookupId: 'lv-2',
+      educationLevelLookupId: 'lv-3',
+      partnerEducationLevelLookupId: 'lv-4',
+      partnerOccupationLookupId: 'lv-5',
+      yearsInVillage: 12,
+      migrationPatternLookupId: 'lv-6',
+      monthlyIncomeLookupId: 'lv-7',
+      religionLookupId: 'lv-8',
+      socialCategoryLookupId: 'lv-9',
+      familyMembersCount: 5,
+      childrenUnder5Count: 1,
+    });
+    expect(result.socioDemographics).not.toHaveProperty('beneficiaryId');
+    expect(result.socioDemographics).not.toHaveProperty('createdAt');
+  });
+
+  it('returns null socioDemographics for a case with no row yet', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii(),
+      socioDemographics: null,
+    } as never);
+
+    expect(result.socioDemographics).toBeNull();
+  });
+
+  it('omits socioDemographics entirely when the relation was not queried (list view)', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii(),
+    } as never);
+
+    expect(result).not.toHaveProperty('socioDemographics');
+  });
+});

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.ts
@@ -5,6 +5,8 @@ import { decryptPii } from '@armman/service-commons';
 export interface PiiRow {
   id: string;
   fullNameEnc: Buffer;
+  phoneEnc: Buffer | null;
+  addressLineEnc: Buffer | null;
   villageId: string | null;
   padaId: string | null;
   healthSubCentreId: string | null;
@@ -20,16 +22,17 @@ export interface PiiRow {
 /**
  * Projects a raw beneficiary_case Prisma row down to EXACTLY the fields the
  * API documents (beneficiaryCaseSchema / beneficiaryCaseDetailSchema in
- * beneficiary.controller.ts), decrypting `pii.fullName` for display. Every
- * level is allow-listed — the case, `pii`, and each nested relation — so
- * internal columns (createdByUserId/updatedByUserId/isDeleted/deletedAt,
- * encrypted/hash PII columns, undocumented case fields like
- * pregnancySequenceNo/journeyEndDate, and nested audit columns) can never
- * leak into a response even as the Prisma rows gain columns.
+ * beneficiary.controller.ts), decrypting `pii.fullName`/`pii.mobileNumber`/
+ * `pii.address` for display. Every level is allow-listed — the case, `pii`,
+ * and each nested relation — so internal columns
+ * (createdByUserId/updatedByUserId/isDeleted/deletedAt, encrypted/hash PII
+ * columns, undocumented case fields like pregnancySequenceNo/journeyEndDate,
+ * and nested audit columns) can never leak into a response even as the
+ * Prisma rows gain columns.
  *
  * Nested relations are only projected when present, so this serves both the
  * list rows (case + pii only) and the detail view (case + pii + mother/child
- * details + consent + risk/status).
+ * details + consent + risk/status + socioDemographics).
  */
 export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown }>(caseRow: T) {
   const c = caseRow as Record<string, unknown>;
@@ -55,6 +58,8 @@ export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown 
     pii: {
       id: pii.id,
       fullName: decryptPii(pii.fullNameEnc),
+      mobileNumber: pii.phoneEnc ? decryptPii(pii.phoneEnc) : null,
+      address: pii.addressLineEnc ? decryptPii(pii.addressLineEnc) : null,
       villageId: pii.villageId,
       padaId: pii.padaId,
       healthSubCentreId: pii.healthSubCentreId,
@@ -128,6 +133,25 @@ export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown 
       changedAt: h.changedAt,
       notes: h.notes,
     }));
+  }
+  const socioDemographics = c.socioDemographics as Record<string, unknown> | null | undefined;
+  if (socioDemographics !== undefined) {
+    projected.socioDemographics = socioDemographics
+      ? {
+          phoneOwnerLookupId: socioDemographics.phoneOwnerLookupId,
+          mobileNetworkAvailabilityLookupId: socioDemographics.mobileNetworkAvailabilityLookupId,
+          educationLevelLookupId: socioDemographics.educationLevelLookupId,
+          partnerEducationLevelLookupId: socioDemographics.partnerEducationLevelLookupId,
+          partnerOccupationLookupId: socioDemographics.partnerOccupationLookupId,
+          yearsInVillage: socioDemographics.yearsInVillage,
+          migrationPatternLookupId: socioDemographics.migrationPatternLookupId,
+          monthlyIncomeLookupId: socioDemographics.monthlyIncomeLookupId,
+          religionLookupId: socioDemographics.religionLookupId,
+          socialCategoryLookupId: socioDemographics.socialCategoryLookupId,
+          familyMembersCount: socioDemographics.familyMembersCount,
+          childrenUnder5Count: socioDemographics.childrenUnder5Count,
+        }
+      : null;
   }
 
   return projected;

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -48,6 +48,8 @@ export class BeneficiaryRepository {
     if (filters.atRiskOnly) {
       where.riskConditionSummaries = { some: { everAtRiskFlag: true } };
     }
+    if (filters.sakhiId) where.sakhiId = filters.sakhiId;
+    if (filters.sakhiIds) where.sakhiId = { in: filters.sakhiIds };
 
     return this.prisma.beneficiaryCase.findMany({
       where,

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -70,6 +70,7 @@ export class BeneficiaryRepository {
         // status timeline, not just the case/PII/consent rows.
         riskConditionSummaries: true,
         statusHistory: { orderBy: { changedAt: 'desc' } },
+        socioDemographics: true,
       },
     });
   }

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
@@ -12,6 +12,14 @@ export interface BeneficiaryListFilters {
   nameHash?: Buffer;
   /** hashForSearch(normalizeForSearch(mobileNumber)) — exact-match only. */
   phoneHash?: Buffer;
+  /** Role-based scoping: a SAKHI caller only ever sees their own cases. */
+  sakhiId?: string;
+  /**
+   * Role-based scoping: a SUPERVISOR caller only sees cases belonging to
+   * their own Sakhis. An empty array must return no rows — it is a
+   * default-deny result (supervisor has no Sakhis), never "no filter".
+   */
+  sakhiIds?: string[];
 }
 
 export interface DuplicateSearchTokens {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -160,6 +160,35 @@ describe('BeneficiaryService', () => {
       repository.findById.mockResolvedValue(null);
       await expect(service.getById('missing')).rejects.toMatchObject({ status: 404 });
     });
+
+    it('passes through socioDemographics from the repository', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        socioDemographics: { familyMembersCount: 4, childrenUnder5Count: 1 },
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x');
+
+      expect(result.socioDemographics).toMatchObject({
+        familyMembersCount: 4,
+        childrenUnder5Count: 1,
+      });
+    });
+
+    it('returns null socioDemographics for a case with no row yet', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        socioDemographics: null,
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x');
+
+      expect(result.socioDemographics).toBeNull();
+    });
   });
 
   describe('create — idempotent replay on localCaseUuid', () => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -190,6 +190,18 @@ describe('BeneficiaryService', () => {
       expect(call.sakhiIds).toEqual([]);
     });
 
+    it('rejects a SUPERVISOR caller with no projectId instead of resolving Sakhis with an empty path', async () => {
+      await expect(
+        service.list(
+          {},
+          caller({ id: 'sup-1', roles: ['SUPERVISOR'], projectId: null }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+      expect(repository.findMany).not.toHaveBeenCalled();
+    });
+
     it('MANAGER caller sees all beneficiaries — no sakhi scoping applied', async () => {
       repository.findMany.mockResolvedValue([]);
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -1,11 +1,13 @@
 import { randomBytes } from 'node:crypto';
-import { encryptPii } from '@armman/service-commons';
+import { encryptPii, type AuthenticatedUser } from '@armman/service-commons';
 import { BeneficiaryService } from './beneficiary.service';
 import type { BeneficiaryRepository } from './beneficiary.repository';
 import type { CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
 import { resolveHealthBlockIdFromPhc } from '../geography/geography.client';
+import { listSakhiIdsForSupervisor } from '../sakhi/sakhi.client';
 
 jest.mock('../geography/geography.client');
+jest.mock('../sakhi/sakhi.client');
 
 describe('BeneficiaryService', () => {
   const originalEnv = { ...process.env };
@@ -21,6 +23,17 @@ describe('BeneficiaryService', () => {
   const CALLER_ID = '99999999-9999-9999-9999-999999999999';
   const AUTH_HEADER = 'Bearer test-token';
   const resolveHealthBlockIdFromPhcMock = jest.mocked(resolveHealthBlockIdFromPhc);
+  const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
+
+  function caller(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
+    return {
+      id: CALLER_ID,
+      roles: ['SAKHI'],
+      projectId: '11111111-1111-1111-1111-111111111111',
+      geographyUnitId: null,
+      ...overrides,
+    };
+  }
 
   // All SRS FR-S-2.1 required PII fields present (phone, dob, the 7 geography
   // levels, rchNumber). Geography ids are uuid-shaped to satisfy the type.
@@ -96,7 +109,7 @@ describe('BeneficiaryService', () => {
         { id: 'x', pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') } },
       ] as never);
 
-      const result = await service.list({});
+      const result = await service.list({}, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(result).toEqual([
         expect.objectContaining({
@@ -109,14 +122,18 @@ describe('BeneficiaryService', () => {
     it('passes query filters through to the repository as search hashes/scalars', async () => {
       repository.findMany.mockResolvedValue([]);
 
-      await service.list({
-        projectId: 'project-1',
-        status: 'ACTIVE',
-        caseType: 'MOTHER',
-        atRiskOnly: true,
-        name: 'Jane Doe',
-        mobileNumber: '9876543210',
-      });
+      await service.list(
+        {
+          projectId: 'project-1',
+          status: 'ACTIVE',
+          caseType: 'MOTHER',
+          atRiskOnly: true,
+          name: 'Jane Doe',
+          mobileNumber: '9876543210',
+        },
+        caller({ roles: ['ADMIN'] }),
+        AUTH_HEADER,
+      );
 
       const call = repository.findMany.mock.calls[0][0];
       expect(call.projectId).toBe('project-1');
@@ -125,6 +142,84 @@ describe('BeneficiaryService', () => {
       expect(call.atRiskOnly).toBe(true);
       expect(call.nameHash).toBeInstanceOf(Buffer);
       expect(call.phoneHash).toBeInstanceOf(Buffer);
+    });
+
+    it('SAKHI caller is forced to see only their own cases, regardless of query params', async () => {
+      repository.findMany.mockResolvedValue([]);
+
+      await service.list(
+        { projectId: 'some-other-project' },
+        caller({ id: 'sakhi-1', roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiId).toBe('sakhi-1');
+      expect(call.sakhiIds).toBeUndefined();
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+    });
+
+    it('SUPERVISOR caller sees only their own Sakhis, resolved via the Sakhi lookup', async () => {
+      repository.findMany.mockResolvedValue([]);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
+
+      await service.list(
+        {},
+        caller({ id: 'sup-1', roles: ['SUPERVISOR'], projectId: 'project-1' }),
+        AUTH_HEADER,
+      );
+
+      expect(listSakhiIdsForSupervisorMock).toHaveBeenCalledWith('project-1', 'sup-1', AUTH_HEADER);
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiIds).toEqual(['sakhi-a', 'sakhi-b']);
+      expect(call.sakhiId).toBeUndefined();
+    });
+
+    it('SUPERVISOR with zero Sakhis gets an empty result, not all beneficiaries', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue([]);
+      repository.findMany.mockResolvedValue([]);
+
+      const result = await service.list(
+        {},
+        caller({ id: 'sup-1', roles: ['SUPERVISOR'] }),
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual([]);
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiIds).toEqual([]);
+    });
+
+    it('MANAGER caller sees all beneficiaries — no sakhi scoping applied', async () => {
+      repository.findMany.mockResolvedValue([]);
+
+      await service.list({}, caller({ roles: ['MANAGER'] }), AUTH_HEADER);
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiId).toBeUndefined();
+      expect(call.sakhiIds).toBeUndefined();
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+    });
+
+    it('ADMIN caller sees all beneficiaries — no sakhi scoping applied', async () => {
+      repository.findMany.mockResolvedValue([]);
+
+      await service.list({}, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiId).toBeUndefined();
+      expect(call.sakhiIds).toBeUndefined();
+    });
+
+    it("propagates an auth-service failure while resolving a Supervisor's Sakhis", async () => {
+      listSakhiIdsForSupervisorMock.mockRejectedValue(
+        Object.assign(new Error('bad gateway'), { status: 502 }),
+      );
+
+      await expect(
+        service.list({}, caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 502 });
+      expect(repository.findMany).not.toHaveBeenCalled();
     });
 
     it('passes through risk condition summaries and status history from the repository', async () => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -5,6 +5,7 @@ import {
   notFound,
   normalizeForSearch,
   unprocessable,
+  type AuthenticatedUser,
 } from '@armman/service-commons';
 import type {
   BeneficiaryRiskConditionSummary,
@@ -16,6 +17,7 @@ import { computeBmi, withDecryptedName } from './beneficiary.mapper';
 import type { BeneficiaryListFilters, BeneficiaryRepository } from './beneficiary.repository';
 import { deriveFullName, type CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
 import { resolveHealthBlockIdFromPhc } from '../geography/geography.client';
+import { listSakhiIdsForSupervisor } from '../sakhi/sakhi.client';
 
 const GESTATION_DAYS = 280;
 
@@ -37,11 +39,20 @@ export class BeneficiaryService {
   constructor(private readonly repository: BeneficiaryRepository) {}
 
   /**
-   * Lists beneficiary cases per SRS FR-S-9.2 / HLD's filter set (scope
-   * enforcement added with the auth layer). Each row's name is decrypted
-   * server-side for display — the search hash itself is never returned.
+   * Lists beneficiary cases per SRS FR-S-9.2 / HLD's filter set, scoped by
+   * the caller's role: a SAKHI only ever sees their own cases (their own id
+   * always wins over anything else), a SUPERVISOR only sees cases belonging
+   * to their own Sakhis (resolved via auth-service's existing
+   * `/projects/:projectId/sakhis`, filtered by supervisorId — no new
+   * auth-service endpoint), and MANAGER/ADMIN see everything unscoped. Each
+   * row's name is decrypted server-side for display — the search hash
+   * itself is never returned.
    */
-  async list(query: ListBeneficiariesQuery) {
+  async list(
+    query: ListBeneficiariesQuery,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
     const filters: BeneficiaryListFilters = {
       projectId: query.projectId,
       villageId: query.villageId,
@@ -54,6 +65,16 @@ export class BeneficiaryService {
         ? hashForSearch(normalizeForSearch(query.mobileNumber))
         : undefined,
     };
+
+    if (caller.roles.includes('SAKHI')) {
+      filters.sakhiId = caller.id;
+    } else if (caller.roles.includes('SUPERVISOR')) {
+      filters.sakhiIds = await listSakhiIdsForSupervisor(
+        caller.projectId ?? '',
+        caller.id,
+        authorizationHeader,
+      );
+    }
 
     const cases = await this.repository.findMany(filters);
     return cases.map(withDecryptedName);

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -1,6 +1,7 @@
 import { addDays } from '@armman/core';
 import {
   encryptPii,
+  forbidden,
   hashForSearch,
   notFound,
   normalizeForSearch,
@@ -69,8 +70,14 @@ export class BeneficiaryService {
     if (caller.roles.includes('SAKHI')) {
       filters.sakhiId = caller.id;
     } else if (caller.roles.includes('SUPERVISOR')) {
+      // Per the SRS, a Supervisor has exactly one project — a caller missing
+      // this claim is an invalid/inconsistent identity, not a "no project"
+      // case to silently degrade into a malformed `/projects//sakhis` path.
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
       filters.sakhiIds = await listSakhiIdsForSupervisor(
-        caller.projectId ?? '',
+        caller.projectId,
         caller.id,
         authorizationHeader,
       );

--- a/apps/beneficiary-service/src/sakhi/sakhi.client.spec.ts
+++ b/apps/beneficiary-service/src/sakhi/sakhi.client.spec.ts
@@ -1,0 +1,72 @@
+import { listSakhiIdsForSupervisor } from './sakhi.client';
+
+function sakhisResponse(data: { sakhiId: string; supervisorId: string | null }[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ success: true, data }),
+  };
+}
+
+describe('listSakhiIdsForSupervisor', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns only the sakhiIds matching the given supervisorId', async () => {
+    fetchMock.mockResolvedValue(
+      sakhisResponse([
+        { sakhiId: 'sakhi-a', supervisorId: 'sup-1' },
+        { sakhiId: 'sakhi-b', supervisorId: 'sup-2' },
+        { sakhiId: 'sakhi-c', supervisorId: 'sup-1' },
+      ]),
+    );
+
+    const result = await listSakhiIdsForSupervisor('project-1', 'sup-1', 'Bearer test-token');
+
+    expect(result).toEqual(['sakhi-a', 'sakhi-c']);
+  });
+
+  it('returns an empty array when the supervisor has no Sakhis', async () => {
+    fetchMock.mockResolvedValue(sakhisResponse([{ sakhiId: 'sakhi-a', supervisorId: 'sup-2' }]));
+
+    const result = await listSakhiIdsForSupervisor('project-1', 'sup-1', 'Bearer test-token');
+
+    expect(result).toEqual([]);
+  });
+
+  it('throws 502 when the auth-service call rejects (network error/timeout)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      listSakhiIdsForSupervisor('project-1', 'sup-1', 'Bearer test-token'),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+
+  it('throws 502 when the auth-service call fails with a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(
+      listSakhiIdsForSupervisor('project-1', 'sup-1', 'Bearer test-token'),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+
+  it("forwards the caller's own bearer token unchanged", async () => {
+    fetchMock.mockResolvedValue(sakhisResponse([]));
+
+    await listSakhiIdsForSupervisor('project-1', 'sup-1', 'Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/projects/project-1/sakhis'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+    );
+  });
+});

--- a/apps/beneficiary-service/src/sakhi/sakhi.client.ts
+++ b/apps/beneficiary-service/src/sakhi/sakhi.client.ts
@@ -18,6 +18,12 @@ interface ApiSakhi {
  * Called through the gateway (per AUTH_SERVICE_BASE_URL) so the gateway can
  * verify `authorizationHeader` — the original Supervisor caller's own bearer
  * token, forwarded unchanged, matching geography.client.ts's convention.
+ *
+ * Reads the full response body with no pagination handling — safe today
+ * because `SakhiRepository.findByProject` (auth-service) queries with no
+ * `take`/`skip`. If that endpoint is ever paginated, this must change too,
+ * or a Supervisor with Sakhis beyond the first page would silently see an
+ * under-scoped (incomplete) beneficiary list instead of an error.
  */
 export async function listSakhiIdsForSupervisor(
   projectId: string,

--- a/apps/beneficiary-service/src/sakhi/sakhi.client.ts
+++ b/apps/beneficiary-service/src/sakhi/sakhi.client.ts
@@ -1,0 +1,42 @@
+import { badGateway } from '@armman/service-commons';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — see geography.client.ts for the same rationale.
+const AUTH_SERVICE_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+interface ApiSakhi {
+  sakhiId: string;
+  supervisorId: string | null;
+}
+
+/**
+ * Resolves the Sakhi ids reporting to a given Supervisor, via auth-service's
+ * existing `GET /projects/:projectId/sakhis` (no new auth-service endpoint —
+ * that route already returns each Sakhi's `supervisorId`). Used to scope
+ * `GET /beneficiaries` to a Supervisor's own Sakhis' cases.
+ *
+ * Called through the gateway (per AUTH_SERVICE_BASE_URL) so the gateway can
+ * verify `authorizationHeader` — the original Supervisor caller's own bearer
+ * token, forwarded unchanged, matching geography.client.ts's convention.
+ */
+export async function listSakhiIdsForSupervisor(
+  projectId: string,
+  supervisorId: string,
+  authorizationHeader: string,
+): Promise<string[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${AUTH_SERVICE_BASE_URL}/api/v1/projects/${projectId}/sakhis`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve Sakhis — the auth service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve Sakhis — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: ApiSakhi[] };
+  return body.data.filter((sakhi) => sakhi.supervisorId === supervisorId).map((s) => s.sakhiId);
+}

--- a/apps/media-service/src/media/dto/create-mediaAsset.dto.spec.ts
+++ b/apps/media-service/src/media/dto/create-mediaAsset.dto.spec.ts
@@ -1,0 +1,84 @@
+import { createMediaAssetSchema } from './create-mediaAsset.dto';
+
+describe('createMediaAssetSchema — checksum', () => {
+  const validHexChecksum = 'a'.repeat(64);
+  const basePayload = {
+    assetType: 'OTHER' as const,
+    storageUri: 's3://arogya-media/test.jpg',
+    mimeType: 'image/jpeg',
+    sizeBytes: 204800,
+    uploadedAt: '2026-07-31T00:00:00Z',
+  };
+
+  it('accepts a valid 64-char lowercase hex string and transforms it to a Buffer', () => {
+    const result = createMediaAssetSchema.safeParse({
+      ...basePayload,
+      checksum: validHexChecksum,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.checksum).toBeInstanceOf(Buffer);
+      expect(result.data.checksum).toEqual(Buffer.from(validHexChecksum, 'hex'));
+    }
+  });
+
+  it('accepts a valid 64-char uppercase/mixed-case hex string', () => {
+    const mixedCase = 'A1b2'.repeat(16);
+    const result = createMediaAssetSchema.safeParse({ ...basePayload, checksum: mixedCase });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.checksum).toEqual(Buffer.from(mixedCase, 'hex'));
+    }
+  });
+
+  it('rejects a string shorter than 64 hex chars', () => {
+    const result = createMediaAssetSchema.safeParse({
+      ...basePayload,
+      checksum: 'a'.repeat(63),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a string longer than 64 hex chars', () => {
+    const result = createMediaAssetSchema.safeParse({
+      ...basePayload,
+      checksum: 'a'.repeat(65),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a string with non-hex characters', () => {
+    const result = createMediaAssetSchema.safeParse({
+      ...basePayload,
+      checksum: 'g'.repeat(64),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    const result = createMediaAssetSchema.safeParse({ ...basePayload, checksum: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a Buffer instance passed directly (real HTTP JSON can never produce one)', () => {
+    const result = createMediaAssetSchema.safeParse({
+      ...basePayload,
+      checksum: Buffer.from(validHexChecksum, 'hex'),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses a full valid payload end-to-end', () => {
+    const result = createMediaAssetSchema.safeParse({
+      ...basePayload,
+      checksum: validHexChecksum,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.assetType).toBe('OTHER');
+      expect(result.data.storageUri).toBe(basePayload.storageUri);
+      expect(result.data.checksum).toBeInstanceOf(Buffer);
+      expect(result.data.sizeBytes).toBe(204800n);
+    }
+  });
+});

--- a/apps/media-service/src/media/dto/create-mediaAsset.dto.ts
+++ b/apps/media-service/src/media/dto/create-mediaAsset.dto.ts
@@ -16,6 +16,19 @@ const mediaAssetTypeSchema = z.enum([
 ]);
 
 /**
+ * SHA-256 checksum, sent as a 64-char hex string (the only representation a
+ * JSON request body can carry) and converted to the `Buffer` the `Bytes`
+ * Prisma column expects. `z.instanceof(Buffer)` was used here previously,
+ * but `express.json()` never produces a `Buffer` from a JSON field — that
+ * made this endpoint unreachable over real HTTP with any client.
+ */
+const checksumSchema = z
+  .string()
+  .trim()
+  .regex(/^[0-9a-f]{64}$/i, 'must be a 64-character hex-encoded SHA-256 checksum')
+  .transform((hex) => Buffer.from(hex, 'hex'));
+
+/**
  * Validation schema for creating a media asset. `.strict()` rejects unknown
  * fields, matching the previous global ValidationPipe `forbidNonWhitelisted: true`.
  */
@@ -23,7 +36,7 @@ export const createMediaAssetSchema = z
   .object({
     assetType: mediaAssetTypeSchema,
     storageUri: z.string().trim().min(1).max(512),
-    checksum: z.instanceof(Buffer),
+    checksum: checksumSchema,
     mimeType: z.string().trim().min(1).max(120),
     sizeBytes: z.coerce.bigint(),
     uploadedByUserId: z.string().uuid().optional(),

--- a/apps/media-service/src/media/mediaAsset.controller.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.ts
@@ -2,6 +2,7 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { MediaAssetService } from './mediaAsset.service';
 import { createMediaAssetSchema } from './dto/create-mediaAsset.dto';
+import type { MediaAsset } from '../../../../node_modules/.prisma/client-media-service';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -13,29 +14,38 @@ import {
 
 extendZodWithOpenApi(z);
 
-// Request DTO annotated with examples for Swagger UI; validation behavior is
-// unchanged (`.openapi()` only attaches documentation metadata).
-// checksum is z.instanceof(Buffer) (see create-mediaAsset.dto.ts) —
-// zod-to-openapi cannot introspect z.instanceof() on its own, so an explicit
-// string/binary type is required here to short-circuit its type inference.
-const createMediaAssetRequestSchema = createMediaAssetSchema.extend({
-  checksum: createMediaAssetSchema.shape.checksum.openapi({
-    type: 'string',
-    format: 'binary',
-    description: 'SHA-256 checksum of the uploaded file.',
-  }),
-});
+/**
+ * Maps a Prisma row to its wire shape: `sizeBytes` is a `BigInt` on the
+ * Prisma model (backing the `Bytes`-range `size_bytes` column), but
+ * `JSON.stringify`/`res.json()` cannot serialize a raw `BigInt` — it throws
+ * at response time, after the DB write has already succeeded. Converting to
+ * a string here matches what `mediaAssetSchema` already documents
+ * ("BigInt serialized as string").
+ */
+function toResponse(asset: MediaAsset) {
+  return { ...asset, sizeBytes: asset.sizeBytes.toString() };
+}
 
 // Documentation-only view of the request body (passed via `doc.post`'s
-// `body` option, not to `validateBody`): `sizeBytes` is `z.coerce.bigint()`
-// on the real schema, required by Prisma's BigInt column, but
-// zod-to-openapi's own `.isOptionalSchema()` check calls `.isOptional()` on
-// it, which runs the real coercion against `undefined` and throws instead of
-// failing gracefully — no `.openapi()` metadata can suppress that, since the
-// crash happens before metadata is consulted. Substituting a plain
-// `z.string()` here only changes what Swagger *displays*; `validateBody`
-// below still validates/coerces the real bigint.
-const createMediaAssetDocSchema = createMediaAssetRequestSchema.extend({
+// `body` option, not to `validateBody`):
+// - `sizeBytes` is `z.coerce.bigint()` on the real schema, required by
+//   Prisma's BigInt column, but zod-to-openapi's own `.isOptionalSchema()`
+//   check calls `.isOptional()` on it, which runs the real coercion against
+//   `undefined` and throws instead of failing gracefully — no `.openapi()`
+//   metadata can suppress that, since the crash happens before metadata is
+//   consulted.
+// - `checksum` is a hex string piped through `.transform()` on the real
+//   schema (see create-mediaAsset.dto.ts) — zod-to-openapi cannot introspect
+//   a `ZodEffects`/transform chain and crashes doc generation at startup
+//   (same class of issue as z.coerce.*/z.lazy()/z.instanceof() elsewhere in
+//   this repo).
+// Substituting plain `z.string()` schemas here only changes what Swagger
+// *displays*; `validateBody` below still runs the real coercion/transform.
+const createMediaAssetDocSchema = createMediaAssetSchema.extend({
+  checksum: z.string().openapi({
+    example: 'a'.repeat(64),
+    description: '64-character hex-encoded SHA-256 checksum of the uploaded file.',
+  }),
   sizeBytes: z.string().openapi({
     example: '204800',
     description: 'File size in bytes.',
@@ -102,7 +112,7 @@ export function createMediaAssetRouter(service: MediaAssetService) {
     trustGatewayIdentity,
     requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
-      res.json(ok(await service.list()));
+      res.json(ok((await service.list()).map(toResponse)));
     }),
   );
 
@@ -121,10 +131,10 @@ export function createMediaAssetRouter(service: MediaAssetService) {
     },
     trustGatewayIdentity,
     requireRoles('SAKHI'),
-    validateBody(createMediaAssetRequestSchema),
+    validateBody(createMediaAssetSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);
-      res.status(201).json(ok(created));
+      res.status(201).json(ok(toResponse(created)));
     }),
   );
 

--- a/apps/media-service/src/media/mediaAsset.controller.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.ts
@@ -2,6 +2,12 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { MediaAssetService } from './mediaAsset.service';
 import { createMediaAssetSchema } from './dto/create-mediaAsset.dto';
+// Same relative-path-into-generated-client import every service's own
+// prisma.service.ts uses (see e.g. apps/media-service/src/prisma/prisma.service.ts,
+// or auth-service's geography.repository.ts for another domain-file example) —
+// a repo-wide convention rather than a one-off shortcut. The path depth is
+// fixed by this file's own location (apps/media-service/src/media/), so it
+// only breaks if that directory nesting changes, not from Prisma/package-manager churn.
 import type { MediaAsset } from '../../../../node_modules/.prisma/client-media-service';
 import {
   asyncHandler,

--- a/apps/supervisor-operations-service/src/operations/dto/create-call-log.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-call-log.dto.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for logging a call (FR-SV-3.1/3.2, ERD §4.7 call_logs).
+ * `.strict()` rejects unknown fields, matching the repo-wide convention.
+ *
+ * `supervisorId` is deliberately NOT a field here — it is always the
+ * authenticated caller's own id (see operations.service.ts), never
+ * client-supplied, so a Supervisor can never log a call under another
+ * Supervisor's name.
+ *
+ * `callDurationSeconds` is optional here (unlike on update) — per
+ * FR-SV-3.2's own start/end split, duration is realistically only known
+ * once the call has ended, so it's set via PATCH, not required at creation.
+ */
+export const createCallLogSchema = z
+  .object({
+    projectId: z.string().uuid(),
+    sakhiId: z.string().uuid(),
+    callDatetime: z.coerce.date(),
+    callStatus: z.enum([
+      'CONNECTED',
+      'NOT_CONNECTED',
+      'FOLLOWUP_REQUIRED',
+      'BUSY',
+      'SWITCHED_OFF',
+      'WRONG_NUMBER',
+    ]),
+    notes: z.string().trim().min(1).optional(),
+    followupAction: z.string().trim().min(1).optional(),
+    callStartAt: z.coerce.date(),
+    callEndAt: z.coerce.date().optional(),
+    callDurationSeconds: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+export type CreateCallLogInput = z.infer<typeof createCallLogSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/list-recent-call-logs.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/list-recent-call-logs.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Query schema for `GET /sakhis/:sakhiId/call-logs/recent` (FR-SV-3.4). Kept
+ * as a plain optional string with a `.refine()` (not `.coerce.number()`),
+ * mirroring get-master-data-deltas.dto.ts — zod-to-openapi cannot introspect
+ * `z.coerce.*`/`ZodEffects` internals and crashes OpenAPI doc generation at
+ * startup.
+ */
+export const listRecentCallLogsQuerySchema = z
+  .object({
+    withinHours: z
+      .string()
+      .trim()
+      .optional()
+      .refine((v) => !v || (/^\d+$/.test(v) && Number(v) > 0), {
+        message: 'withinHours: Must be a positive integer',
+      }),
+  })
+  .strict();
+
+export type ListRecentCallLogsQuery = z.infer<typeof listRecentCallLogsQuerySchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/list-supervisor-events.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/list-supervisor-events.dto.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+/**
+ * Query schema for `GET /supervisor-events`. Plain optional strings (not
+ * `z.enum().optional()` composed with `.coerce`) — zod-to-openapi cannot
+ * introspect `ZodEffects`/`ZodPipeline` internals and crashes OpenAPI doc
+ * generation at startup, matching the convention in
+ * get-master-data-deltas.dto.ts and list-recent-call-logs.dto.ts.
+ */
+export const listSupervisorEventsQuerySchema = z
+  .object({
+    status: z.enum(['SCHEDULED', 'COMPLETED', 'CANCELLED']).optional(),
+    eventType: z.enum(['MEETING', 'TRAINING']).optional(),
+  })
+  .strict();
+
+export type ListSupervisorEventsQuery = z.infer<typeof listSupervisorEventsQuerySchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/update-attendance.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-attendance.dto.spec.ts
@@ -1,0 +1,31 @@
+import { updateAttendanceSchema } from './update-attendance.dto';
+
+describe('updateAttendanceSchema — duplicate sakhiId', () => {
+  const entry = (sakhiId: string) => ({
+    sakhiId,
+    attendanceStatus: 'PRESENT' as const,
+  });
+
+  it('accepts distinct sakhiIds', () => {
+    const result = updateAttendanceSchema.safeParse({
+      attendance: [
+        entry('11111111-1111-1111-1111-111111111111'),
+        entry('22222222-2222-2222-2222-222222222222'),
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a repeated sakhiId within the same submission', () => {
+    const result = updateAttendanceSchema.safeParse({
+      attendance: [
+        entry('11111111-1111-1111-1111-111111111111'),
+        entry('11111111-1111-1111-1111-111111111111'),
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/sakhiId must not repeat/);
+    }
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/update-attendance.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-attendance.dto.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for `PUT /supervisor-events/:id/attendance` (FR-SV-2.3,
+ * ERD §4.7 event_attendance). One entry per Sakhi marked present/absent for
+ * the event; pre/post training scores only meaningful for TRAINING events
+ * but accepted unconditionally here (the column allows it for either event
+ * type — see EventAttendance model comment). `.strict()` rejects unknown
+ * fields, matching the repo-wide convention.
+ */
+const attendanceEntrySchema = z
+  .object({
+    sakhiId: z.string().uuid(),
+    attendanceStatus: z.enum(['PRESENT', 'ABSENT', 'PARTIAL']),
+    preTrainingScore: z.number().min(0).max(100).optional(),
+    postTrainingScore: z.number().min(0).max(100).optional(),
+    remarks: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export const updateAttendanceSchema = z
+  .object({
+    attendance: z.array(attendanceEntrySchema).min(1),
+  })
+  .strict();
+
+export type UpdateAttendanceInput = z.infer<typeof updateAttendanceSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/update-attendance.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-attendance.dto.ts
@@ -22,6 +22,21 @@ export const updateAttendanceSchema = z
   .object({
     attendance: z.array(attendanceEntrySchema).min(1),
   })
-  .strict();
+  .strict()
+  .refine(
+    (data) => {
+      const ids = data.attendance.map((entry) => entry.sakhiId);
+      return new Set(ids).size === ids.length;
+    },
+    {
+      // There is no DB unique constraint on (eventId, sakhiId) — see
+      // operations.repository.ts's upsertAttendance comment — so a duplicate
+      // sakhiId here would silently create two rows for the same Sakhi
+      // instead of one, since upsertAttendance's existing-row lookup runs
+      // once before the loop and can't see a sibling entry's insert.
+      message: 'attendance: sakhiId must not repeat within one submission.',
+      path: ['attendance'],
+    },
+  );
 
 export type UpdateAttendanceInput = z.infer<typeof updateAttendanceSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/update-call-log.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-call-log.dto.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * Partial update — only the fields captured after a call ends
+ * (callEndAt/callDurationSeconds/callStatus/notes/followupAction). The
+ * call's identity (sakhiId/projectId/callStartAt/callDatetime) is immutable
+ * after creation, matching this repo's append-only-ledger convention for
+ * audit-relevant records (see update-inventory-transaction.dto.ts). At least
+ * one field must be present.
+ */
+export const updateCallLogSchema = z
+  .object({
+    callStatus: z.enum([
+      'CONNECTED',
+      'NOT_CONNECTED',
+      'FOLLOWUP_REQUIRED',
+      'BUSY',
+      'SWITCHED_OFF',
+      'WRONG_NUMBER',
+    ]),
+    notes: z.string().trim().min(1).nullable(),
+    followupAction: z.string().trim().min(1).nullable(),
+    callEndAt: z.coerce.date(),
+    callDurationSeconds: z.number().int().nonnegative(),
+  })
+  .partial()
+  .strict()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided.',
+  });
+
+export type UpdateCallLogInput = z.infer<typeof updateCallLogSchema>;

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -2,9 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { OperationsService } from './operations.service';
 import { createSupervisorEventSchema } from './dto/create-supervisorEvent.dto';
+import { listSupervisorEventsQuerySchema } from './dto/list-supervisor-events.dto';
+import { updateAttendanceSchema } from './dto/update-attendance.dto';
 import { createInventoryItemSchema } from './dto/create-inventory-item.dto';
 import { createInventoryTransactionSchema } from './dto/create-inventory-transaction.dto';
 import { updateInventoryTransactionSchema } from './dto/update-inventory-transaction.dto';
+import { createCallLogSchema } from './dto/create-call-log.dto';
+import { updateCallLogSchema } from './dto/update-call-log.dto';
+import { listRecentCallLogsQuerySchema } from './dto/list-recent-call-logs.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -69,6 +74,18 @@ const inventoryTransactionSchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
+const eventAttendanceSchema = z.object({
+  id: z.string().uuid(),
+  eventId: z.string().uuid(),
+  sakhiId: z.string().uuid(),
+  attendanceStatus: z.enum(['PRESENT', 'ABSENT', 'PARTIAL']),
+  preTrainingScore: z.number().nullable(),
+  postTrainingScore: z.number().nullable(),
+  remarks: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
 const callLogSchema = z.object({
   id: z.string().uuid(),
   projectId: z.string().uuid(),
@@ -104,6 +121,18 @@ const transactionIdParamsSchema = z
   })
   .strict();
 
+const callLogIdParamsSchema = z
+  .object({
+    callLogId: z.string().uuid(),
+  })
+  .strict();
+
+const eventIdParamsSchema = z
+  .object({
+    id: z.string().uuid(),
+  })
+  .strict();
+
 const createInventoryTransactionRequestSchema = createInventoryTransactionSchema;
 
 const apiErrorSchema = z.object({
@@ -131,16 +160,19 @@ export function createOperationsRouter(service: OperationsService) {
     {
       summary: 'List recent supervisor events (meetings/training)',
       tags: ['Supervisor Operations'],
+      query: listSupervisorEventsQuerySchema,
       responses: {
         200: { description: 'Supervisor events', schema: envelope(z.array(supervisorEventSchema)) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
         403: { description: 'Caller role not permitted', schema: apiErrorSchema },
       },
     },
     trustGatewayIdentity,
     requireRoles('SUPERVISOR', 'MANAGER'),
-    asyncHandler(async (_req, res) => {
-      res.json(ok(await service.listEvents()));
+    validate(listSupervisorEventsQuerySchema, 'query'),
+    asyncHandler(async (req, res) => {
+      res.json(ok(await service.listEvents(req.query)));
     }),
   );
 
@@ -162,6 +194,126 @@ export function createOperationsRouter(service: OperationsService) {
     asyncHandler(async (req, res) => {
       const created = await service.createEvent(req.body);
       res.status(201).json(ok(created));
+    }),
+  );
+
+  doc.get(
+    '/supervisor-events/:id',
+    {
+      summary: 'Fetch a single supervisor event',
+      tags: ['Supervisor Operations'],
+      params: eventIdParamsSchema,
+      responses: {
+        200: { description: 'Supervisor event', schema: envelope(supervisorEventSchema) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Event not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(eventIdParamsSchema, 'params'),
+    asyncHandler(async (req, res) => {
+      res.json(ok(await service.getEvent(req.params.id)));
+    }),
+  );
+
+  doc.patch(
+    '/supervisor-events/:id/cancel',
+    {
+      summary: 'Cancel a scheduled supervisor event',
+      tags: ['Supervisor Operations'],
+      params: eventIdParamsSchema,
+      responses: {
+        200: { description: 'Event cancelled', schema: envelope(supervisorEventSchema) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this event', schema: apiErrorSchema },
+        404: { description: 'Event not found', schema: apiErrorSchema },
+        409: { description: 'Event is not in SCHEDULED status', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'ADMIN'),
+    validate(eventIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.cancelEvent(req.params.id, req.user)));
+    }),
+  );
+
+  doc.patch(
+    '/supervisor-events/:id/complete',
+    {
+      summary: 'Complete a scheduled supervisor event (FR-SV-2.3)',
+      tags: ['Supervisor Operations'],
+      params: eventIdParamsSchema,
+      responses: {
+        200: { description: 'Event completed', schema: envelope(supervisorEventSchema) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this event', schema: apiErrorSchema },
+        404: { description: 'Event not found', schema: apiErrorSchema },
+        409: { description: 'Event is not in SCHEDULED status', schema: apiErrorSchema },
+        422: { description: 'Missing photo or attendance', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'ADMIN'),
+    validate(eventIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.completeEvent(req.params.id, req.user)));
+    }),
+  );
+
+  doc.get(
+    '/supervisor-events/:id/attendance',
+    {
+      summary: "An event's attendance records (FR-SV-2.1/2.4)",
+      tags: ['Supervisor Operations'],
+      params: eventIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Attendance for this event',
+          schema: envelope(z.array(eventAttendanceSchema)),
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this event', schema: apiErrorSchema },
+        404: { description: 'Event not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(eventIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.getEventAttendance(req.params.id, req.user)));
+    }),
+  );
+
+  doc.put(
+    '/supervisor-events/:id/attendance',
+    {
+      summary: 'Record attendance for an event (FR-SV-2.3)',
+      tags: ['Supervisor Operations'],
+      params: eventIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Attendance recorded',
+          schema: envelope(z.array(eventAttendanceSchema)),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this event', schema: apiErrorSchema },
+        404: { description: 'Event not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'ADMIN'),
+    validate(eventIdParamsSchema, 'params'),
+    validateBody(updateAttendanceSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.updateEventAttendance(req.params.id, req.body, req.user)));
     }),
   );
 
@@ -359,6 +511,147 @@ export function createOperationsRouter(service: OperationsService) {
     requireRoles('SUPERVISOR', 'MANAGER'),
     asyncHandler(async (_req, res) => {
       res.json(ok(await service.listCallLogs()));
+    }),
+  );
+
+  doc.post(
+    '/call-logs',
+    {
+      summary: 'Log a call (FR-SV-3.1/3.2)',
+      tags: ['Supervisor Operations'],
+      responses: {
+        201: { description: 'Call log created', schema: envelope(callLogSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: {
+          description: 'Caller role not permitted, or Sakhi not assigned to caller',
+          schema: apiErrorSchema,
+        },
+        422: { description: 'Referenced Sakhi not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'ADMIN'),
+    validateBody(createCallLogSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const created = await service.createCallLog(req.body, req.user, authorizationHeader);
+      res.status(201).json(ok(created));
+    }),
+  );
+
+  doc.get(
+    '/call-logs/:callLogId',
+    {
+      summary: "Fetch a single call log's full detail",
+      tags: ['Supervisor Operations'],
+      params: callLogIdParamsSchema,
+      responses: {
+        200: { description: 'Call log', schema: envelope(callLogSchema) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this call log', schema: apiErrorSchema },
+        404: { description: 'Call log not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(callLogIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.getCallLog(req.params.callLogId, req.user)));
+    }),
+  );
+
+  doc.patch(
+    '/call-logs/:callLogId',
+    {
+      summary: 'Update a call after it ends (FR-SV-3.2)',
+      tags: ['Supervisor Operations'],
+      params: callLogIdParamsSchema,
+      responses: {
+        200: { description: 'Call log updated', schema: envelope(callLogSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this call log', schema: apiErrorSchema },
+        404: { description: 'Call log not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'ADMIN'),
+    validate(callLogIdParamsSchema, 'params'),
+    validateBody(updateCallLogSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const updated = await service.updateCallLog(req.params.callLogId, req.body, req.user);
+      res.json(ok(updated));
+    }),
+  );
+
+  doc.get(
+    '/call-logs/by-sakhi/:sakhiId',
+    {
+      summary: 'Full call history for a Sakhi, newest first (FR-SV-3.3)',
+      tags: ['Supervisor Operations'],
+      params: sakhiIdParamsSchema,
+      responses: {
+        200: { description: 'Call logs for this Sakhi', schema: envelope(z.array(callLogSchema)) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Sakhi not assigned to caller', schema: apiErrorSchema },
+        404: { description: 'Sakhi not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(sakhiIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      res.json(
+        ok(await service.listCallLogsBySakhi(req.params.sakhiId, req.user, authorizationHeader)),
+      );
+    }),
+  );
+
+  doc.get(
+    '/call-logs/by-sakhi/:sakhiId/recent',
+    {
+      summary: 'Whether a Sakhi has been called recently (FR-SV-3.4 orange-highlight state)',
+      tags: ['Supervisor Operations'],
+      params: sakhiIdParamsSchema,
+      query: listRecentCallLogsQuerySchema,
+      responses: {
+        200: {
+          description: 'Recent call logs for this Sakhi',
+          schema: envelope(z.array(callLogSchema)),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Sakhi not assigned to caller', schema: apiErrorSchema },
+        404: { description: 'Sakhi not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(sakhiIdParamsSchema, 'params'),
+    validate(listRecentCallLogsQuerySchema, 'query'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const withinHours = req.query.withinHours ? Number(req.query.withinHours) : undefined;
+      res.json(
+        ok(
+          await service.listRecentCallLogsBySakhi(
+            req.params.sakhiId,
+            req.user,
+            authorizationHeader,
+            withinHours,
+          ),
+        ),
+      );
     }),
   );
 

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -206,15 +206,16 @@ export function createOperationsRouter(service: OperationsService) {
       responses: {
         200: { description: 'Supervisor event', schema: envelope(supervisorEventSchema) },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
-        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this event', schema: apiErrorSchema },
         404: { description: 'Event not found', schema: apiErrorSchema },
       },
     },
     trustGatewayIdentity,
     requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(eventIdParamsSchema, 'params'),
-    asyncHandler(async (req, res) => {
-      res.json(ok(await service.getEvent(req.params.id)));
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.getEvent(req.params.id, req.user)));
     }),
   );
 

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -1,8 +1,12 @@
 import type { PrismaService } from '../prisma/prisma.service';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
+import type { ListSupervisorEventsQuery } from './dto/list-supervisor-events.dto';
+import type { UpdateAttendanceInput } from './dto/update-attendance.dto';
 import type { CreateInventoryItemInput } from './dto/create-inventory-item.dto';
 import type { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.dto';
 import type { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.dto';
+import type { CreateCallLogInput } from './dto/create-call-log.dto';
+import type { UpdateCallLogInput } from './dto/update-call-log.dto';
 
 /**
  * Data access for supervisor operations. Owns only this service's tables
@@ -12,9 +16,13 @@ import type { UpdateInventoryTransactionInput } from './dto/update-inventory-tra
 export class OperationsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  findEvents() {
+  findEvents(filters: ListSupervisorEventsQuery = {}) {
     return this.prisma.supervisorEvent.findMany({
-      where: { isDeleted: false },
+      where: {
+        isDeleted: false,
+        ...(filters.status ? { status: filters.status } : {}),
+        ...(filters.eventType ? { eventType: filters.eventType } : {}),
+      },
       orderBy: { eventDate: 'desc' },
       take: 50,
     });
@@ -22,6 +30,75 @@ export class OperationsRepository {
 
   createEvent(data: CreateSupervisorEventInput) {
     return this.prisma.supervisorEvent.create({ data });
+  }
+
+  findEventById(id: string) {
+    return this.prisma.supervisorEvent.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  async updateEventStatus(id: string, status: 'COMPLETED' | 'CANCELLED', updatedByUserId: string) {
+    const existing = await this.findEventById(id);
+    if (!existing) return null;
+
+    return this.prisma.supervisorEvent.update({
+      where: { id },
+      data: { status, updatedByUserId },
+    });
+  }
+
+  /** All attendance rows for one event (FR-SV-2.1/2.3/2.4), excluding soft-deleted. */
+  findAttendanceByEvent(eventId: string) {
+    return this.prisma.eventAttendance.findMany({
+      where: { eventId, isDeleted: false },
+    });
+  }
+
+  /**
+   * Upserts one row per Sakhi in the submission, keyed by (eventId, sakhiId)
+   * — there is no DB unique constraint on that pair, so `prisma.upsert`
+   * (which requires a real unique-input shape) can't be used directly. This
+   * finds the existing row (if any) for each pair first, then updates or
+   * creates inside one transaction, so a partial failure never leaves the
+   * attendance sheet half-written for one submit, and repeated PUTs of the
+   * same event's attendance (e.g. a Supervisor re-submitting after a
+   * correction) never produce duplicate rows.
+   */
+  async upsertAttendance(
+    eventId: string,
+    entries: UpdateAttendanceInput['attendance'],
+    userId: string,
+  ) {
+    const existingRows = await this.prisma.eventAttendance.findMany({
+      where: { eventId, isDeleted: false, sakhiId: { in: entries.map((e) => e.sakhiId) } },
+    });
+    const existingBySakhiId = new Map(existingRows.map((row) => [row.sakhiId, row]));
+
+    return this.prisma.$transaction(
+      entries.map((entry) => {
+        const existing = existingBySakhiId.get(entry.sakhiId);
+        const data = {
+          attendanceStatus: entry.attendanceStatus,
+          preTrainingScore: entry.preTrainingScore ?? null,
+          postTrainingScore: entry.postTrainingScore ?? null,
+          remarks: entry.remarks ?? null,
+        };
+
+        return existing
+          ? this.prisma.eventAttendance.update({
+              where: { id: existing.id },
+              data: { ...data, updatedByUserId: userId },
+            })
+          : this.prisma.eventAttendance.create({
+              data: {
+                eventId,
+                sakhiId: entry.sakhiId,
+                ...data,
+                createdByUserId: userId,
+                updatedByUserId: userId,
+              },
+            });
+      }),
+    );
   }
 
   findInventoryItems() {
@@ -131,6 +208,48 @@ export class OperationsRepository {
       where: { isDeleted: false },
       orderBy: { callDatetime: 'desc' },
       take: 50,
+    });
+  }
+
+  createCallLog(data: CreateCallLogInput & { supervisorId: string }, createdByUserId: string) {
+    return this.prisma.callLog.create({
+      data: { ...data, createdByUserId, updatedByUserId: createdByUserId },
+    });
+  }
+
+  findCallLogById(id: string) {
+    return this.prisma.callLog.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  /** One Sakhi's full call history (FR-SV-3.3), newest first, excluding soft-deleted. */
+  findCallLogsBySakhi(sakhiId: string) {
+    return this.prisma.callLog.findMany({
+      where: { sakhiId, isDeleted: false },
+      orderBy: { callDatetime: 'desc' },
+    });
+  }
+
+  /** A Sakhi's calls within the last `sinceDate` (FR-SV-3.4 recency check), newest first. */
+  findRecentCallLogsBySakhi(sakhiId: string, sinceDate: Date) {
+    return this.prisma.callLog.findMany({
+      where: { sakhiId, isDeleted: false, callDatetime: { gte: sinceDate } },
+      orderBy: { callDatetime: 'desc' },
+    });
+  }
+
+  /**
+   * Only ever writes the fields captured after a call ends (status, end
+   * time, duration, notes, followup) — sakhiId/projectId/supervisorId/
+   * callStartAt/callDatetime are immutable, matching this repo's
+   * append-only-ledger convention.
+   */
+  async updateCallLog(id: string, data: UpdateCallLogInput, updatedByUserId: string) {
+    const existing = await this.findCallLogById(id);
+    if (!existing) return null;
+
+    return this.prisma.callLog.update({
+      where: { id },
+      data: { ...data, updatedByUserId },
     });
   }
 }

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -4,6 +4,7 @@ import type { SakhiClient } from './sakhi.client';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
 import type {
   SupervisorEvent,
+  EventAttendance,
   InventoryItem,
   InventoryTransaction,
   CallLog,
@@ -13,6 +14,10 @@ describe('OperationsService', () => {
   const repository = {
     findEvents: jest.fn(),
     createEvent: jest.fn(),
+    findEventById: jest.fn(),
+    updateEventStatus: jest.fn(),
+    findAttendanceByEvent: jest.fn(),
+    upsertAttendance: jest.fn(),
     findInventoryItems: jest.fn(),
     createInventoryItem: jest.fn(),
     findInventoryTransactions: jest.fn(),
@@ -23,6 +28,11 @@ describe('OperationsService', () => {
     updateInventoryTransaction: jest.fn(),
     softDeleteInventoryTransaction: jest.fn(),
     findCallLogs: jest.fn(),
+    createCallLog: jest.fn(),
+    findCallLogById: jest.fn(),
+    findCallLogsBySakhi: jest.fn(),
+    findRecentCallLogsBySakhi: jest.fn(),
+    updateCallLog: jest.fn(),
   } as unknown as jest.Mocked<OperationsRepository>;
   const sakhiClient = {
     findById: jest.fn(),
@@ -127,6 +137,338 @@ describe('OperationsService', () => {
     repository.createEvent.mockResolvedValue(eventRow);
     await expect(service.createEvent(dto)).resolves.toBe(eventRow);
     expect(repository.createEvent).toHaveBeenCalledWith(dto);
+  });
+
+  it('lists events with filters via repository', async () => {
+    repository.findEvents.mockResolvedValue([eventRow]);
+    await service.listEvents({ status: 'SCHEDULED', eventType: 'TRAINING' });
+    expect(repository.findEvents).toHaveBeenCalledWith({
+      status: 'SCHEDULED',
+      eventType: 'TRAINING',
+    });
+  });
+
+  describe('getEvent', () => {
+    it('returns the event when it exists', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(service.getEvent(eventRow.id)).resolves.toBe(eventRow);
+    });
+
+    it('throws 404 when the event does not exist', async () => {
+      repository.findEventById.mockResolvedValue(null);
+      await expect(service.getEvent('missing')).rejects.toMatchObject({ status: 404 });
+    });
+  });
+
+  describe('cancelEvent', () => {
+    const cancelledRow: SupervisorEvent = { ...eventRow, status: 'CANCELLED' };
+
+    it('cancels a SCHEDULED event owned by the caller', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.updateEventStatus.mockResolvedValue(cancelledRow);
+
+      const result = await service.cancelEvent(eventRow.id, supervisorCaller);
+
+      expect(repository.updateEventStatus).toHaveBeenCalledWith(
+        eventRow.id,
+        'CANCELLED',
+        supervisorCaller.id,
+      );
+      expect(result).toBe(cancelledRow);
+    });
+
+    it('throws 404 when the event does not exist', async () => {
+      repository.findEventById.mockResolvedValue(null);
+      await expect(service.cancelEvent('missing', supervisorCaller)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('rejects a Supervisor who does not own the event, without updating anything', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(service.cancelEvent(eventRow.id, otherSupervisorCaller)).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 when the event is already COMPLETED', async () => {
+      repository.findEventById.mockResolvedValue({ ...eventRow, status: 'COMPLETED' });
+      await expect(service.cancelEvent(eventRow.id, supervisorCaller)).rejects.toMatchObject({
+        status: 409,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 when the event is already CANCELLED', async () => {
+      repository.findEventById.mockResolvedValue(cancelledRow);
+      await expect(service.cancelEvent(eventRow.id, supervisorCaller)).rejects.toMatchObject({
+        status: 409,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN to cancel an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.updateEventStatus.mockResolvedValue(cancelledRow);
+      await expect(service.cancelEvent(eventRow.id, adminCaller)).resolves.toBe(cancelledRow);
+    });
+
+    it('allows a MANAGER to cancel an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.updateEventStatus.mockResolvedValue(cancelledRow);
+      await expect(service.cancelEvent(eventRow.id, managerCaller)).resolves.toBe(cancelledRow);
+    });
+  });
+
+  describe('completeEvent', () => {
+    const eventWithPhoto: SupervisorEvent = {
+      ...eventRow,
+      photoMediaId: '55555555-5555-5555-5555-555555555555',
+    };
+    const completedRow: SupervisorEvent = { ...eventWithPhoto, status: 'COMPLETED' };
+    const attendanceRow: EventAttendance = {
+      id: '66666666-6666-6666-6666-666666666666',
+      eventId: eventRow.id,
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      attendanceStatus: 'PRESENT',
+      preTrainingScore: null,
+      postTrainingScore: null,
+      remarks: null,
+      createdAt: new Date(),
+      createdByUserId: null,
+      updatedAt: new Date(),
+      updatedByUserId: null,
+      isDeleted: false,
+      deletedAt: null,
+    };
+
+    it('completes a SCHEDULED event with a photo and existing attendance', async () => {
+      repository.findEventById.mockResolvedValue(eventWithPhoto);
+      repository.findAttendanceByEvent.mockResolvedValue([attendanceRow]);
+      repository.updateEventStatus.mockResolvedValue(completedRow);
+
+      const result = await service.completeEvent(eventRow.id, supervisorCaller);
+
+      expect(repository.updateEventStatus).toHaveBeenCalledWith(
+        eventRow.id,
+        'COMPLETED',
+        supervisorCaller.id,
+      );
+      expect(result).toBe(completedRow);
+    });
+
+    it('throws 422 when photoMediaId is missing', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(service.completeEvent(eventRow.id, supervisorCaller)).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws 422 when no attendance rows exist for the event', async () => {
+      repository.findEventById.mockResolvedValue(eventWithPhoto);
+      repository.findAttendanceByEvent.mockResolvedValue([]);
+      await expect(service.completeEvent(eventRow.id, supervisorCaller)).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 when the event does not exist', async () => {
+      repository.findEventById.mockResolvedValue(null);
+      await expect(service.completeEvent('missing', supervisorCaller)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('rejects a Supervisor who does not own the event, without completing it', async () => {
+      repository.findEventById.mockResolvedValue(eventWithPhoto);
+      await expect(service.completeEvent(eventRow.id, otherSupervisorCaller)).rejects.toMatchObject(
+        { status: 403 },
+      );
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 when the event is already COMPLETED', async () => {
+      repository.findEventById.mockResolvedValue(completedRow);
+      await expect(service.completeEvent(eventRow.id, supervisorCaller)).rejects.toMatchObject({
+        status: 409,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 when the event is already CANCELLED', async () => {
+      repository.findEventById.mockResolvedValue({ ...eventWithPhoto, status: 'CANCELLED' });
+      await expect(service.completeEvent(eventRow.id, supervisorCaller)).rejects.toMatchObject({
+        status: 409,
+      });
+      expect(repository.updateEventStatus).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN to complete an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventWithPhoto);
+      repository.findAttendanceByEvent.mockResolvedValue([attendanceRow]);
+      repository.updateEventStatus.mockResolvedValue(completedRow);
+      await expect(service.completeEvent(eventRow.id, adminCaller)).resolves.toBe(completedRow);
+    });
+
+    it('allows a MANAGER to complete an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventWithPhoto);
+      repository.findAttendanceByEvent.mockResolvedValue([attendanceRow]);
+      repository.updateEventStatus.mockResolvedValue(completedRow);
+      await expect(service.completeEvent(eventRow.id, managerCaller)).resolves.toBe(completedRow);
+    });
+  });
+
+  describe('getEventAttendance', () => {
+    const attendanceRow: EventAttendance = {
+      id: '66666666-6666-6666-6666-666666666666',
+      eventId: eventRow.id,
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      attendanceStatus: 'PRESENT',
+      preTrainingScore: null,
+      postTrainingScore: null,
+      remarks: null,
+      createdAt: new Date(),
+      createdByUserId: null,
+      updatedAt: new Date(),
+      updatedByUserId: null,
+      isDeleted: false,
+      deletedAt: null,
+    };
+
+    it('returns attendance rows for an event owned by the caller', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.findAttendanceByEvent.mockResolvedValue([attendanceRow]);
+      await expect(service.getEventAttendance(eventRow.id, supervisorCaller)).resolves.toEqual([
+        attendanceRow,
+      ]);
+    });
+
+    it('throws 404 when the event does not exist', async () => {
+      repository.findEventById.mockResolvedValue(null);
+      await expect(service.getEventAttendance('missing', supervisorCaller)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('rejects a Supervisor who does not own the event', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(
+        service.getEventAttendance(eventRow.id, otherSupervisorCaller),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('returns an empty array when the event has no attendance yet', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.findAttendanceByEvent.mockResolvedValue([]);
+      await expect(service.getEventAttendance(eventRow.id, supervisorCaller)).resolves.toEqual([]);
+    });
+
+    it('allows a MANAGER to view attendance for an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.findAttendanceByEvent.mockResolvedValue([attendanceRow]);
+      await expect(service.getEventAttendance(eventRow.id, managerCaller)).resolves.toEqual([
+        attendanceRow,
+      ]);
+    });
+
+    it('allows an ADMIN to view attendance for an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.findAttendanceByEvent.mockResolvedValue([attendanceRow]);
+      await expect(service.getEventAttendance(eventRow.id, adminCaller)).resolves.toEqual([
+        attendanceRow,
+      ]);
+    });
+  });
+
+  describe('updateEventAttendance', () => {
+    const attendanceRow: EventAttendance = {
+      id: '66666666-6666-6666-6666-666666666666',
+      eventId: eventRow.id,
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      attendanceStatus: 'PRESENT',
+      preTrainingScore: null,
+      postTrainingScore: null,
+      remarks: null,
+      createdAt: new Date(),
+      createdByUserId: null,
+      updatedAt: new Date(),
+      updatedByUserId: null,
+      isDeleted: false,
+      deletedAt: null,
+    };
+    const dto = {
+      attendance: [
+        { sakhiId: '44444444-4444-4444-4444-444444444444', attendanceStatus: 'PRESENT' as const },
+      ],
+    };
+
+    it('upserts attendance via repository for an event owned by the caller', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.upsertAttendance.mockResolvedValue([attendanceRow]);
+
+      const result = await service.updateEventAttendance(eventRow.id, dto, supervisorCaller);
+
+      expect(repository.upsertAttendance).toHaveBeenCalledWith(
+        eventRow.id,
+        dto.attendance,
+        supervisorCaller.id,
+      );
+      expect(result).toEqual([attendanceRow]);
+    });
+
+    it('throws 404 when the event does not exist', async () => {
+      repository.findEventById.mockResolvedValue(null);
+      await expect(
+        service.updateEventAttendance('missing', dto, supervisorCaller),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.upsertAttendance).not.toHaveBeenCalled();
+    });
+
+    it('rejects a Supervisor who does not own the event, without writing anything', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(
+        service.updateEventAttendance(eventRow.id, dto, otherSupervisorCaller),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.upsertAttendance).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN to write attendance for an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.upsertAttendance.mockResolvedValue([attendanceRow]);
+      await expect(service.updateEventAttendance(eventRow.id, dto, adminCaller)).resolves.toEqual([
+        attendanceRow,
+      ]);
+    });
+
+    it('allows a MANAGER to write attendance for an event they do not own', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.upsertAttendance.mockResolvedValue([attendanceRow]);
+      await expect(service.updateEventAttendance(eventRow.id, dto, managerCaller)).resolves.toEqual(
+        [attendanceRow],
+      );
+    });
+
+    it('writes multiple attendance rows for a multi-Sakhi submission', async () => {
+      const multiDto = {
+        attendance: [
+          { sakhiId: '44444444-4444-4444-4444-444444444444', attendanceStatus: 'PRESENT' as const },
+          { sakhiId: '55555555-5555-5555-5555-555555555555', attendanceStatus: 'ABSENT' as const },
+        ],
+      };
+      repository.findEventById.mockResolvedValue(eventRow);
+      repository.upsertAttendance.mockResolvedValue([attendanceRow, attendanceRow]);
+
+      await service.updateEventAttendance(eventRow.id, multiDto, supervisorCaller);
+
+      expect(repository.upsertAttendance).toHaveBeenCalledWith(
+        eventRow.id,
+        multiDto.attendance,
+        supervisorCaller.id,
+      );
+    });
   });
 
   it('lists inventory items via repository', async () => {
@@ -588,5 +930,372 @@ describe('OperationsService', () => {
     ];
     repository.findCallLogs.mockResolvedValue(rows);
     await expect(service.listCallLogs()).resolves.toBe(rows);
+  });
+
+  const callLogRow: CallLog = {
+    id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    projectId: '22222222-2222-2222-2222-222222222222',
+    supervisorId: '33333333-3333-3333-3333-333333333333',
+    sakhiId: '44444444-4444-4444-4444-444444444444',
+    callDatetime: new Date('2026-07-01T10:00:00Z'),
+    callStatus: 'CONNECTED',
+    notes: null,
+    followupAction: null,
+    callStartAt: new Date('2026-07-01T10:00:00Z'),
+    callEndAt: new Date('2026-07-01T10:05:00Z'),
+    callDurationSeconds: 300,
+    createdAt: new Date(),
+    createdByUserId: null,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+  };
+
+  const sakhi = {
+    sakhiId: '44444444-4444-4444-4444-444444444444',
+    supervisorId: supervisorCaller.id,
+    primaryProjectId: '22222222-2222-2222-2222-222222222222',
+  };
+
+  describe('createCallLog', () => {
+    const baseDto = {
+      projectId: '22222222-2222-2222-2222-222222222222',
+      sakhiId: '44444444-4444-4444-4444-444444444444',
+      callDatetime: new Date('2026-07-01T10:00:00Z'),
+      callStatus: 'CONNECTED' as const,
+      callStartAt: new Date('2026-07-01T10:00:00Z'),
+    };
+
+    it('creates a call log via repository, using the caller’s own id as supervisorId', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.createCallLog.mockResolvedValue(callLogRow);
+
+      const result = await service.createCallLog(baseDto, supervisorCaller, 'Bearer token');
+
+      expect(repository.createCallLog).toHaveBeenCalledWith(
+        { ...baseDto, supervisorId: supervisorCaller.id },
+        supervisorCaller.id,
+      );
+      expect(result).toBe(callLogRow);
+    });
+
+    it('rejects a Supervisor logging a call for a Sakhi assigned to another Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      await expect(
+        service.createCallLog(baseDto, otherSupervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.createCallLog).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the Sakhi does not exist, without creating anything', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+      await expect(
+        service.createCallLog(baseDto, supervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(repository.createCallLog).not.toHaveBeenCalled();
+    });
+
+    it('allows a MANAGER regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.createCallLog.mockResolvedValue(callLogRow);
+      await service.createCallLog(baseDto, managerCaller, 'Bearer token');
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+      expect(repository.createCallLog).toHaveBeenCalledWith(
+        { ...baseDto, supervisorId: managerCaller.id },
+        managerCaller.id,
+      );
+    });
+
+    it('allows an ADMIN regardless of Sakhi assignment, stamping their own id as supervisorId', async () => {
+      repository.createCallLog.mockResolvedValue(callLogRow);
+      await service.createCallLog(baseDto, adminCaller, 'Bearer token');
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+      expect(repository.createCallLog).toHaveBeenCalledWith(
+        { ...baseDto, supervisorId: adminCaller.id },
+        adminCaller.id,
+      );
+    });
+
+    it('propagates repository errors on createCallLog', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.createCallLog.mockRejectedValue(new Error('db down'));
+      await expect(
+        service.createCallLog(baseDto, supervisorCaller, 'Bearer token'),
+      ).rejects.toThrow('db down');
+    });
+  });
+
+  describe('getCallLog', () => {
+    it('returns the call log when the caller owns it', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      await expect(
+        service.getCallLog('cccccccc-cccc-cccc-cccc-cccccccccccc', supervisorCaller),
+      ).resolves.toBe(callLogRow);
+    });
+
+    it('throws 404 when the call log does not exist', async () => {
+      repository.findCallLogById.mockResolvedValue(null);
+      await expect(service.getCallLog('missing', supervisorCaller)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('rejects a Supervisor who does not own the call log', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      await expect(
+        service.getCallLog('cccccccc-cccc-cccc-cccc-cccccccccccc', otherSupervisorCaller),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('allows a MANAGER to fetch a call log they do not own', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      await expect(
+        service.getCallLog('cccccccc-cccc-cccc-cccc-cccccccccccc', managerCaller),
+      ).resolves.toBe(callLogRow);
+    });
+
+    it('allows an ADMIN to fetch a call log they do not own', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      await expect(
+        service.getCallLog('cccccccc-cccc-cccc-cccc-cccccccccccc', adminCaller),
+      ).resolves.toBe(callLogRow);
+    });
+  });
+
+  describe('updateCallLog', () => {
+    it('updates via repository and returns the updated row when the caller owns the call log', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      repository.updateCallLog.mockResolvedValue(callLogRow);
+
+      const result = await service.updateCallLog(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callStatus: 'FOLLOWUP_REQUIRED' },
+        supervisorCaller,
+      );
+
+      expect(repository.updateCallLog).toHaveBeenCalledWith(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callStatus: 'FOLLOWUP_REQUIRED' },
+        supervisorCaller.id,
+      );
+      expect(result).toBe(callLogRow);
+    });
+
+    it('throws 404 when the call log does not exist', async () => {
+      repository.findCallLogById.mockResolvedValue(null);
+      await expect(
+        service.updateCallLog('missing', { callStatus: 'BUSY' }, supervisorCaller),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('rejects a Supervisor who does not own the call log, without updating anything', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      await expect(
+        service.updateCallLog(
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          { callStatus: 'BUSY' },
+          otherSupervisorCaller,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.updateCallLog).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN to update a call log they do not own', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      repository.updateCallLog.mockResolvedValue(callLogRow);
+
+      const result = await service.updateCallLog(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callStatus: 'BUSY' },
+        adminCaller,
+      );
+
+      expect(repository.updateCallLog).toHaveBeenCalledWith(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callStatus: 'BUSY' },
+        adminCaller.id,
+      );
+      expect(result).toBe(callLogRow);
+    });
+
+    it('allows a MANAGER to update a call log they do not own', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      repository.updateCallLog.mockResolvedValue(callLogRow);
+
+      await service.updateCallLog(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callStatus: 'BUSY' },
+        managerCaller,
+      );
+
+      expect(repository.updateCallLog).toHaveBeenCalledWith(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callStatus: 'BUSY' },
+        managerCaller.id,
+      );
+    });
+  });
+
+  describe('listCallLogsBySakhi', () => {
+    it('lists a Sakhi’s call logs via repository when the caller is her assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findCallLogsBySakhi.mockResolvedValue([callLogRow]);
+
+      await expect(
+        service.listCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          supervisorCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([callLogRow]);
+      expect(repository.findCallLogsBySakhi).toHaveBeenCalledWith(
+        '44444444-4444-4444-4444-444444444444',
+      );
+    });
+
+    it('rejects a Supervisor who is not this Sakhi’s assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      await expect(
+        service.listCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          otherSupervisorCaller,
+          'Bearer token',
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findCallLogsBySakhi).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 when the Sakhi does not exist', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+      await expect(
+        service.listCallLogsBySakhi('missing', supervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('returns an empty array (not an error) when the Sakhi has no call logs', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findCallLogsBySakhi.mockResolvedValue([]);
+      await expect(
+        service.listCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          supervisorCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([]);
+    });
+
+    it('allows a MANAGER regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findCallLogsBySakhi.mockResolvedValue([callLogRow]);
+      await expect(
+        service.listCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          managerCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([callLogRow]);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findCallLogsBySakhi.mockResolvedValue([callLogRow]);
+      await expect(
+        service.listCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          adminCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([callLogRow]);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listRecentCallLogsBySakhi', () => {
+    it('lists recent call logs using the default window when the caller is her assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findRecentCallLogsBySakhi.mockResolvedValue([callLogRow]);
+
+      await expect(
+        service.listRecentCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          supervisorCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([callLogRow]);
+      expect(repository.findRecentCallLogsBySakhi).toHaveBeenCalledWith(
+        '44444444-4444-4444-4444-444444444444',
+        expect.any(Date),
+      );
+    });
+
+    it('respects a custom withinHours window', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findRecentCallLogsBySakhi.mockResolvedValue([]);
+
+      await service.listRecentCallLogsBySakhi(
+        '44444444-4444-4444-4444-444444444444',
+        supervisorCaller,
+        'Bearer token',
+        24,
+      );
+
+      const [, sinceDate] = repository.findRecentCallLogsBySakhi.mock.calls[0];
+      const hoursAgo = (Date.now() - sinceDate.getTime()) / (60 * 60 * 1000);
+      expect(hoursAgo).toBeCloseTo(24, 0);
+    });
+
+    it('rejects a Supervisor who is not this Sakhi’s assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      await expect(
+        service.listRecentCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          otherSupervisorCaller,
+          'Bearer token',
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findRecentCallLogsBySakhi).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 when the Sakhi does not exist', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+      await expect(
+        service.listRecentCallLogsBySakhi('missing', supervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('returns an empty array when no calls fall within the window', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.findRecentCallLogsBySakhi.mockResolvedValue([]);
+      await expect(
+        service.listRecentCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          supervisorCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([]);
+    });
+
+    it('allows a MANAGER regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findRecentCallLogsBySakhi.mockResolvedValue([callLogRow]);
+      await expect(
+        service.listRecentCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          managerCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([callLogRow]);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+
+    it('allows an ADMIN regardless of Sakhi assignment, without calling the Sakhi client', async () => {
+      repository.findRecentCallLogsBySakhi.mockResolvedValue([callLogRow]);
+      await expect(
+        service.listRecentCallLogsBySakhi(
+          '44444444-4444-4444-4444-444444444444',
+          adminCaller,
+          'Bearer token',
+        ),
+      ).resolves.toEqual([callLogRow]);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -149,14 +149,33 @@ describe('OperationsService', () => {
   });
 
   describe('getEvent', () => {
-    it('returns the event when it exists', async () => {
+    it('returns the event when it exists and is owned by the caller', async () => {
       repository.findEventById.mockResolvedValue(eventRow);
-      await expect(service.getEvent(eventRow.id)).resolves.toBe(eventRow);
+      await expect(service.getEvent(eventRow.id, supervisorCaller)).resolves.toBe(eventRow);
     });
 
     it('throws 404 when the event does not exist', async () => {
       repository.findEventById.mockResolvedValue(null);
-      await expect(service.getEvent('missing')).rejects.toMatchObject({ status: 404 });
+      await expect(service.getEvent('missing', supervisorCaller)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('rejects a Supervisor who does not own the event', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(service.getEvent(eventRow.id, otherSupervisorCaller)).rejects.toMatchObject({
+        status: 403,
+      });
+    });
+
+    it('allows MANAGER to fetch any event', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(service.getEvent(eventRow.id, managerCaller)).resolves.toBe(eventRow);
+    });
+
+    it('allows ADMIN to fetch any event', async () => {
+      repository.findEventById.mockResolvedValue(eventRow);
+      await expect(service.getEvent(eventRow.id, adminCaller)).resolves.toBe(eventRow);
     });
   });
 

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -1,10 +1,17 @@
 import { conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
 import type { OperationsRepository } from './operations.repository';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
+import type { ListSupervisorEventsQuery } from './dto/list-supervisor-events.dto';
+import type { UpdateAttendanceInput } from './dto/update-attendance.dto';
 import type { CreateInventoryItemInput } from './dto/create-inventory-item.dto';
 import type { CreateInventoryTransactionInput } from './dto/create-inventory-transaction.dto';
 import type { UpdateInventoryTransactionInput } from './dto/update-inventory-transaction.dto';
+import type { CreateCallLogInput } from './dto/create-call-log.dto';
+import type { UpdateCallLogInput } from './dto/update-call-log.dto';
 import type { SakhiClient } from './sakhi.client';
+
+/** Default recency window for the FR-SV-3.4 "recently called" card highlight. */
+const DEFAULT_RECENT_CALL_WINDOW_HOURS = 72;
 
 /** Prisma unique-constraint violation code (itemCode). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
@@ -37,8 +44,8 @@ export class OperationsService {
     private readonly sakhiClient: SakhiClient,
   ) {}
 
-  listEvents() {
-    return this.repository.findEvents();
+  listEvents(filters?: ListSupervisorEventsQuery) {
+    return this.repository.findEvents(filters);
   }
 
   createEvent(dto: CreateSupervisorEventInput) {
@@ -49,6 +56,89 @@ export class OperationsService {
       throw unprocessable('photoMediaId is required when status is COMPLETED.');
     }
     return this.repository.createEvent(dto);
+  }
+
+  async getEvent(id: string) {
+    const event = await this.repository.findEventById(id);
+    if (!event) throw notFound('Event not found.');
+    return event;
+  }
+
+  /**
+   * A SUPERVISOR may only cancel their own events. MANAGER and ADMIN are
+   * unrestricted. Only a SCHEDULED event can be cancelled — SRS/ERD don't
+   * state this explicitly, but cancelling an already-COMPLETED/CANCELLED
+   * event has no meaningful effect and would silently discard history.
+   */
+  async cancelEvent(id: string, caller: CallerIdentity) {
+    const existing = await this.repository.findEventById(id);
+    if (!existing) throw notFound('Event not found.');
+    if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this event.');
+    }
+    if (existing.status !== 'SCHEDULED') {
+      throw conflict(`Cannot cancel an event with status ${existing.status}.`);
+    }
+
+    const updated = await this.repository.updateEventStatus(id, 'CANCELLED', caller.id);
+    if (!updated) throw notFound('Event not found.');
+    return updated;
+  }
+
+  /**
+   * A SUPERVISOR may only complete their own events. MANAGER and ADMIN are
+   * unrestricted. Only a SCHEDULED event can be completed. Per FR-SV-2.3
+   * ("mark attendance for each Sakhi individually, upload at least one event
+   * photo, and submit"), completion requires both a photo (existing rule,
+   * mirrored from createEvent) and at least one attendance row already
+   * recorded — a Supervisor can't submit completion before marking anyone.
+   */
+  async completeEvent(id: string, caller: CallerIdentity) {
+    const existing = await this.repository.findEventById(id);
+    if (!existing) throw notFound('Event not found.');
+    if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this event.');
+    }
+    if (existing.status !== 'SCHEDULED') {
+      throw conflict(`Cannot complete an event with status ${existing.status}.`);
+    }
+    if (!existing.photoMediaId) {
+      throw unprocessable('photoMediaId is required to complete this event.');
+    }
+
+    const attendance = await this.repository.findAttendanceByEvent(id);
+    if (attendance.length === 0) {
+      throw unprocessable('At least one attendance record is required to complete this event.');
+    }
+
+    const updated = await this.repository.updateEventStatus(id, 'COMPLETED', caller.id);
+    if (!updated) throw notFound('Event not found.');
+    return updated;
+  }
+
+  /** A SUPERVISOR may only view their own events' attendance. MANAGER and ADMIN are unrestricted. */
+  async getEventAttendance(id: string, caller: CallerIdentity) {
+    const event = await this.repository.findEventById(id);
+    if (!event) throw notFound('Event not found.');
+    if (event.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this event.');
+    }
+    return this.repository.findAttendanceByEvent(id);
+  }
+
+  /**
+   * A SUPERVISOR may only record attendance for their own events. MANAGER
+   * and ADMIN are unrestricted. Upserts by (eventId, sakhiId) so repeated
+   * submissions (e.g. corrections before completion) never create
+   * duplicate rows for the same Sakhi.
+   */
+  async updateEventAttendance(id: string, dto: UpdateAttendanceInput, caller: CallerIdentity) {
+    const event = await this.repository.findEventById(id);
+    if (!event) throw notFound('Event not found.');
+    if (event.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this event.');
+    }
+    return this.repository.upsertAttendance(id, dto.attendance, caller.id);
   }
 
   listInventoryItems() {
@@ -168,5 +258,87 @@ export class OperationsService {
 
   listCallLogs() {
     return this.repository.findCallLogs();
+  }
+
+  /**
+   * A SUPERVISOR may only log a call against a Sakhi actually assigned to
+   * them — same ownership check as createInventoryTransactions. `supervisorId`
+   * is never taken from the client-supplied body — it's always the
+   * authenticated caller's own id.
+   */
+  async createCallLog(
+    dto: CreateCallLogInput,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    if (!isPrivileged(caller)) {
+      const sakhi = await this.sakhiClient.findById(dto.sakhiId, authorizationHeader);
+      if (!sakhi) throw unprocessable('sakhiId: Sakhi not found.');
+      if (sakhi.supervisorId !== caller.id) {
+        throw forbidden('You do not have access to this Sakhi.');
+      }
+    }
+    return this.repository.createCallLog({ ...dto, supervisorId: caller.id }, caller.id);
+  }
+
+  /** A SUPERVISOR may only view their own call logs. MANAGER and ADMIN are unrestricted. */
+  async getCallLog(id: string, caller: CallerIdentity) {
+    const existing = await this.repository.findCallLogById(id);
+    if (!existing) throw notFound('Call log not found.');
+    if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this call log.');
+    }
+    return existing;
+  }
+
+  /** A SUPERVISOR may only edit their own call logs. MANAGER and ADMIN are unrestricted. */
+  async updateCallLog(id: string, dto: UpdateCallLogInput, caller: CallerIdentity) {
+    const existing = await this.repository.findCallLogById(id);
+    if (!existing) throw notFound('Call log not found.');
+    if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this call log.');
+    }
+
+    const updated = await this.repository.updateCallLog(id, dto, caller.id);
+    if (!updated) throw notFound('Call log not found.');
+    return updated;
+  }
+
+  /**
+   * A SUPERVISOR may only see a Sakhi's call history if that Sakhi is
+   * actually assigned to them (checked via auth-service, since
+   * sakhi_profiles isn't this service's table — forklift rule). MANAGER and
+   * ADMIN are unrestricted.
+   */
+  async listCallLogsBySakhi(sakhiId: string, caller: CallerIdentity, authorizationHeader: string) {
+    if (!isPrivileged(caller)) {
+      const sakhi = await this.sakhiClient.findById(sakhiId, authorizationHeader);
+      if (!sakhi) throw notFound('Sakhi not found.');
+      if (sakhi.supervisorId !== caller.id) {
+        throw forbidden('You do not have access to this Sakhi.');
+      }
+    }
+    return this.repository.findCallLogsBySakhi(sakhiId);
+  }
+
+  /**
+   * Whether a Sakhi has been called within `withinHours` (FR-SV-3.4's
+   * orange-highlight card state). Same ownership rule as listCallLogsBySakhi.
+   */
+  async listRecentCallLogsBySakhi(
+    sakhiId: string,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+    withinHours: number = DEFAULT_RECENT_CALL_WINDOW_HOURS,
+  ) {
+    if (!isPrivileged(caller)) {
+      const sakhi = await this.sakhiClient.findById(sakhiId, authorizationHeader);
+      if (!sakhi) throw notFound('Sakhi not found.');
+      if (sakhi.supervisorId !== caller.id) {
+        throw forbidden('You do not have access to this Sakhi.');
+      }
+    }
+    const sinceDate = new Date(Date.now() - withinHours * 60 * 60 * 1000);
+    return this.repository.findRecentCallLogsBySakhi(sakhiId, sinceDate);
   }
 }

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -58,9 +58,13 @@ export class OperationsService {
     return this.repository.createEvent(dto);
   }
 
-  async getEvent(id: string) {
+  /** A SUPERVISOR may only fetch their own events. MANAGER and ADMIN are unrestricted. */
+  async getEvent(id: string, caller: CallerIdentity) {
     const event = await this.repository.findEventById(id);
     if (!event) throw notFound('Event not found.');
+    if (event.supervisorId !== caller.id && !isPrivileged(caller)) {
+      throw forbidden('You do not have access to this event.');
+    }
     return event;
   }
 


### PR DESCRIPTION
Closes #93, closes #94, closes #95, closes #96, closes #97

## Summary
- **Call Sheet (FR-SV-3.1–3.4)** — closes #93: added `POST /call-logs`, `GET`/`PATCH /call-logs/:callLogId`, and `GET /call-logs/by-sakhi/:sakhiId(/recent)` — only list/no-filter existed before. Ownership mirrors the existing `inventory-transactions` pattern (`supervisorId` always server-derived, `SakhiClient`-checked, MANAGER/ADMIN unrestricted). The Sakhi-scoped routes sit under `/call-logs/by-sakhi/:sakhiId` rather than `/sakhis/:sakhiId/call-logs`, since the gateway's proxy can't rewrite a mid-path param into a different downstream service (`/sakhis` already routes to `auth-service`) — confirmed by reading `register-proxies.ts`.
- **Meeting/Training lifecycle (FR-SV-2.1–2.4)** — closes #94: added `GET /supervisor-events?status=&eventType=` (filtering), `GET /supervisor-events/:id`, `PATCH .../:id/cancel`, `PATCH .../:id/complete`, and `GET`/`PUT .../:id/attendance`. Cancel/complete are restricted to `SCHEDULED` events (409 otherwise); complete additionally requires a photo (existing rule) and at least one recorded attendance row (FR-SV-2.3's "mark attendance ... upload photo ... submit" flow). Attendance upserts by `(eventId, sakhiId)` since no DB unique constraint exists on that pair.
- **media-service fix** — closes #95: `POST /media` validated `checksum` as `z.instanceof(Buffer)`, which `express.json()` can never produce from a JSON body — the endpoint was unreachable over real HTTP with any client, always failing validation regardless of input. Now accepts a 64-char hex SHA-256 string and transforms it to a `Buffer` for the `Bytes` column.
- **media-service fix (found while testing the above)** — also part of #95: once `POST /media` could actually be reached, it 500'd — `sizeBytes` is a `BigInt` on the Prisma model, and `JSON.stringify` can't serialize it. `res.json()` was crashing after the DB write had already succeeded. Both `GET`/`POST /media` responses now stringify `sizeBytes`, matching what the response schema already documented.
- **Role-based scoping on `GET /beneficiaries` (SRS FR-S-9.2)** — closes #96: Sakhi callers now see only their own cases, Supervisor callers see only cases belonging to their own Sakhis (resolved via auth-service's existing `GET /projects/:projectId/sakhis`, filtered by `supervisorId` — no new auth-service endpoint), and Manager/Admin see everything unscoped. `ADMIN` was also missing from the route's allowed roles entirely. New `apps/beneficiary-service/src/sakhi/sakhi.client.ts` calls auth-service to resolve a Supervisor's Sakhi ids.
- **auth-service id-mismatch fix, found while verifying the above** — closes #97: `GET /projects/:projectId/sakhis` / `GET /sakhis/:sakhiId` returned `sakhiId: profile.id` (the `sakhi_profiles` row's own PK), but `beneficiary_cases.sakhi_id` is populated with the Sakhi's `users.user_id` (the JWT `sub`) — the same id beneficiary-service's own SAKHI-role filter already uses. The mismatched id spaces meant a Supervisor's `GET /beneficiaries` call always returned zero rows regardless of real Sakhi assignment. Fixed `toApiSakhi()` to return `user.id`, and `sakhi.repository.ts`'s `findById` to query by `userId`. No DB migration needed — only changes which column backs the API field.

## Test plan
- [x] `nx lint supervisor-operations-service` / `nx lint media-service` — clean
- [x] `nx test supervisor-operations-service` — 94/94 passing (29 new call-log tests, 31 new event/attendance tests)
- [x] `nx test media-service` — 12/12 passing (8 new checksum DTO tests)
- [x] `nx build` both services — clean, including OpenAPI doc generation (a real risk given `zod-to-openapi`'s inability to introspect `ZodEffects`/transform chains — caught and fixed a genuine crash-at-boot here)
- [x] Live end-to-end verification against a running gateway + both services with real JWTs (SUPERVISOR and SAKHI roles): full call-log CRUD cycle, full meeting/training lifecycle including the complete-with-photo-and-attendance happy path, and 400/403/404/409/422 error paths all confirmed with real HTTP requests, not just mocks
- [x] `nx affected -t lint test` (auth-service, beneficiary-service) — clean
- [x] Live end-to-end verification of `GET /beneficiaries` role-scoping against a running gateway with real JWTs across a 5-scenario matrix: Sakhi A sees only her own cases; Sakhi B (different Sakhi, same Supervisor as A) sees only her own; a Supervisor supervising both A and B sees the union of both; a different Supervisor (supervising neither) correctly sees zero cases (no cross-supervisor leakage); Admin sees all cases unscoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
