### PR TITLE
fix(auth-service): Scope GET /projects and GET /projects/:id/sakhis to the caller

### DIFF
--- a/apps/auth-service/prisma/schema.prisma
+++ b/apps/auth-service/prisma/schema.prisma
@@ -188,9 +188,17 @@ model Project {
 }
 
 // Column set matches ERD Appendix A.1 ("sakhi_profiles") exactly.
-// supervisorId references supervisor_profiles.supervisor_id, which is not
-// modeled anywhere yet — left as a plain scalar (no relation) rather than
-// invented.
+// supervisorId is documented in the ERD as referencing
+// supervisor_profiles.supervisor_id, but that table has no application code
+// anywhere reading or writing it (dead schema) — every real write path
+// (auth.service.ts's updateUser, via PATCH /users/:id) stores the
+// Supervisor's users.user_id here instead, matching the JWT `sub` every
+// other service treats as "the Supervisor's identity" (e.g.
+// sakhi.service.ts's listByProject SUPERVISOR-ownership filter). Kept as a
+// plain scalar (no relation) rather than inventing one, since there is
+// nothing to relate to yet — but if supervisor_profiles is ever wired up,
+// this column's actual contents (users.user_id) must be reconciled with
+// whatever id space that table ends up using.
 model SakhiProfile {
   id               String    @id @default(uuid()) @map("sakhi_id")
   userId           String    @unique @map("user_id")

--- a/apps/auth-service/src/projects/project.controller.ts
+++ b/apps/auth-service/src/projects/project.controller.ts
@@ -12,6 +12,7 @@ import {
   errorResponse,
   ok,
   requireRoles,
+  unauthorized,
   validate,
   validateBody,
 } from '../app.module';
@@ -72,8 +73,9 @@ export function createProjectRouter(service: ProjectService, signer: TokenSigner
       },
     },
     authenticate(signer),
-    asyncHandler(async (_req, res) => {
-      res.json(ok(await service.list()));
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.list(req.user)));
     }),
   );
 

--- a/apps/auth-service/src/projects/project.service.spec.ts
+++ b/apps/auth-service/src/projects/project.service.spec.ts
@@ -62,6 +62,12 @@ describe('ProjectService', () => {
       const result = await service.list({ roles: ['SUPERVISOR'], projectId: 'missing-project' });
       expect(result).toEqual([]);
     });
+
+    it('does not scope down a caller who holds SUPERVISOR alongside an elevated role', async () => {
+      repository.findManyActiveProjects.mockResolvedValue(projects as never);
+      const result = await service.list({ roles: ['SUPERVISOR', 'MANAGER'], projectId: 'p1' });
+      expect(result).toHaveLength(2);
+    });
   });
 
   describe('getById', () => {

--- a/apps/auth-service/src/projects/project.service.spec.ts
+++ b/apps/auth-service/src/projects/project.service.spec.ts
@@ -19,16 +19,48 @@ describe('ProjectService', () => {
   });
 
   describe('list', () => {
+    const projects = [
+      { projectId: 'p1', projectName: 'P1', createdByUserId: 'u', isDeleted: false },
+      { projectId: 'p2', projectName: 'P2', createdByUserId: 'u', isDeleted: false },
+    ];
+
     it('returns active projects projected to the documented fields (no internal columns)', async () => {
-      const projects = [
-        { projectId: 'p1', projectName: 'P1', createdByUserId: 'u', isDeleted: false },
-      ];
       repository.findManyActiveProjects.mockResolvedValue(projects as never);
 
-      const result = await service.list();
+      const result = await service.list({ roles: ['ADMIN'], projectId: null });
       expect(result[0]).toEqual(expect.objectContaining({ projectId: 'p1', projectName: 'P1' }));
       expect(result[0]).not.toHaveProperty('createdByUserId');
       expect(result[0]).not.toHaveProperty('isDeleted');
+    });
+
+    it('returns all projects unrestricted for ADMIN', async () => {
+      repository.findManyActiveProjects.mockResolvedValue(projects as never);
+      const result = await service.list({ roles: ['ADMIN'], projectId: null });
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns all projects unrestricted for MANAGER', async () => {
+      repository.findManyActiveProjects.mockResolvedValue(projects as never);
+      const result = await service.list({ roles: ['MANAGER'], projectId: null });
+      expect(result).toHaveLength(2);
+    });
+
+    it("scopes to only the caller's own project for SUPERVISOR", async () => {
+      repository.findManyActiveProjects.mockResolvedValue(projects as never);
+      const result = await service.list({ roles: ['SUPERVISOR'], projectId: 'p2' });
+      expect(result).toEqual([expect.objectContaining({ projectId: 'p2' })]);
+    });
+
+    it("scopes to only the caller's own project for SAKHI", async () => {
+      repository.findManyActiveProjects.mockResolvedValue(projects as never);
+      const result = await service.list({ roles: ['SAKHI'], projectId: 'p1' });
+      expect(result).toEqual([expect.objectContaining({ projectId: 'p1' })]);
+    });
+
+    it('returns an empty array for a SUPERVISOR whose own project is not in the active list', async () => {
+      repository.findManyActiveProjects.mockResolvedValue(projects as never);
+      const result = await service.list({ roles: ['SUPERVISOR'], projectId: 'missing-project' });
+      expect(result).toEqual([]);
     });
   });
 

--- a/apps/auth-service/src/projects/project.service.ts
+++ b/apps/auth-service/src/projects/project.service.ts
@@ -43,6 +43,19 @@ function toApiProject(p: Record<string, unknown>) {
   };
 }
 
+/**
+ * MANAGER and ADMIN are unrestricted across all project-scoping checks —
+ * checked as the absence of an elevated role, not the presence of a
+ * restrictive one (SAKHI/SUPERVISOR), since a caller can hold multiple
+ * role assignments at once (see auth.service.ts's issueTokens) and must
+ * not be scoped down just because one of their roles is restrictive.
+ * Matches the same isPrivileged() pattern in
+ * supervisor-operations-service/operations.service.ts.
+ */
+function isPrivileged(caller: CallerScope): boolean {
+  return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
+}
+
 /** Business logic for project/funder master data. */
 export class ProjectService {
   constructor(private readonly repository: ProjectRepository) {}
@@ -50,19 +63,18 @@ export class ProjectService {
   /**
    * A caller with a project scope on their JWT (SAKHI/SUPERVISOR — one
    * project per person per the SRS) only ever sees their own project. A
-   * caller with no single-project scope (MANAGER/ADMIN, who oversee
-   * multiple projects) is unrestricted. This prevents a SAKHI/SUPERVISOR
-   * client from picking a project it has no access to out of an unscoped
-   * list and then 403ing on a follow-up call (e.g. GET /projects/:id/sakhis).
+   * privileged caller (MANAGER/ADMIN, who oversee multiple projects) is
+   * unrestricted. This prevents a SAKHI/SUPERVISOR client from picking a
+   * project it has no access to out of an unscoped list and then 403ing
+   * on a follow-up call (e.g. GET /projects/:id/sakhis).
    */
   async list(caller: CallerScope) {
     const projects = await this.repository.findManyActiveProjects();
     const mapped = projects.map((p) => toApiProject(p as unknown as Record<string, unknown>));
-    const isScoped = caller.roles.includes('SAKHI') || caller.roles.includes('SUPERVISOR');
-    if (isScoped) {
-      return mapped.filter((p) => p.projectId === caller.projectId);
+    if (isPrivileged(caller)) {
+      return mapped;
     }
-    return mapped;
+    return mapped.filter((p) => p.projectId === caller.projectId);
   }
 
   async getById(id: string) {

--- a/apps/auth-service/src/projects/project.service.ts
+++ b/apps/auth-service/src/projects/project.service.ts
@@ -4,6 +4,12 @@ import type { CreateFunderInput } from './dto/create-funder.dto';
 import type { CreateProjectInput } from './dto/create-project.dto';
 import type { UpdateProjectInput } from './dto/update-project.dto';
 
+/** The calling principal's own scope, as carried on their JWT/trusted-identity headers. */
+export interface CallerScope {
+  readonly roles: string[];
+  readonly projectId: string | null;
+}
+
 /** Prisma unique-constraint violation code (projectCode/funderCode). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
 
@@ -41,9 +47,22 @@ function toApiProject(p: Record<string, unknown>) {
 export class ProjectService {
   constructor(private readonly repository: ProjectRepository) {}
 
-  async list() {
+  /**
+   * A caller with a project scope on their JWT (SAKHI/SUPERVISOR — one
+   * project per person per the SRS) only ever sees their own project. A
+   * caller with no single-project scope (MANAGER/ADMIN, who oversee
+   * multiple projects) is unrestricted. This prevents a SAKHI/SUPERVISOR
+   * client from picking a project it has no access to out of an unscoped
+   * list and then 403ing on a follow-up call (e.g. GET /projects/:id/sakhis).
+   */
+  async list(caller: CallerScope) {
     const projects = await this.repository.findManyActiveProjects();
-    return projects.map((p) => toApiProject(p as unknown as Record<string, unknown>));
+    const mapped = projects.map((p) => toApiProject(p as unknown as Record<string, unknown>));
+    const isScoped = caller.roles.includes('SAKHI') || caller.roles.includes('SUPERVISOR');
+    if (isScoped) {
+      return mapped.filter((p) => p.projectId === caller.projectId);
+    }
+    return mapped;
   }
 
   async getById(id: string) {

--- a/apps/auth-service/src/sakhis/sakhi.service.spec.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.spec.ts
@@ -9,8 +9,12 @@ describe('SakhiService', () => {
 
   let service: SakhiService;
 
-  const unscopedCaller = { projectId: null };
-  const scopedCaller = (projectId: string) => ({ projectId });
+  const unscopedCaller = { id: 'admin-1', roles: ['ADMIN'], projectId: null };
+  const scopedCaller = (projectId: string, id = 'supervisor-1') => ({
+    id,
+    roles: ['SUPERVISOR'],
+    projectId,
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -86,6 +90,34 @@ describe('SakhiService', () => {
         service.listByProject('project-1', scopedCaller('project-2')),
       ).rejects.toMatchObject({ status: 403 });
       expect(repository.findByProject).not.toHaveBeenCalled();
+    });
+
+    it('scopes a SUPERVISOR caller to only their own assigned Sakhis', async () => {
+      const ownProfile = { ...rawProfile(), supervisorId: 'supervisor-1' };
+      const otherProfile = {
+        ...rawProfile(),
+        supervisorId: 'other-supervisor',
+        user: { ...rawProfile().user, id: 'user-2', displayName: 'Other Sakhi' },
+      };
+      repository.findByProject.mockResolvedValue([ownProfile, otherProfile] as never);
+
+      const result = await service.listByProject('project-1', scopedCaller('project-1'));
+
+      expect(result).toEqual([expect.objectContaining({ supervisorId: 'supervisor-1' })]);
+    });
+
+    it('does not scope a MANAGER/ADMIN caller — sees every Sakhi in the project', async () => {
+      const profileA = { ...rawProfile(), supervisorId: 'supervisor-1' };
+      const profileB = {
+        ...rawProfile(),
+        supervisorId: 'other-supervisor',
+        user: { ...rawProfile().user, id: 'user-2', displayName: 'Other Sakhi' },
+      };
+      repository.findByProject.mockResolvedValue([profileA, profileB] as never);
+
+      const result = await service.listByProject('project-1', unscopedCaller);
+
+      expect(result).toHaveLength(2);
     });
   });
 

--- a/apps/auth-service/src/sakhis/sakhi.service.spec.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.spec.ts
@@ -119,6 +119,25 @@ describe('SakhiService', () => {
 
       expect(result).toHaveLength(2);
     });
+
+    it('does not scope down a caller who holds SUPERVISOR alongside an elevated role', async () => {
+      const profileA = { ...rawProfile(), supervisorId: 'supervisor-1' };
+      const profileB = {
+        ...rawProfile(),
+        supervisorId: 'other-supervisor',
+        user: { ...rawProfile().user, id: 'user-2', displayName: 'Other Sakhi' },
+      };
+      repository.findByProject.mockResolvedValue([profileA, profileB] as never);
+
+      const dualRoleCaller = {
+        id: 'supervisor-1',
+        roles: ['SUPERVISOR', 'ADMIN'],
+        projectId: null,
+      };
+      const result = await service.listByProject('project-1', dualRoleCaller);
+
+      expect(result).toHaveLength(2);
+    });
   });
 
   describe('getById', () => {

--- a/apps/auth-service/src/sakhis/sakhi.service.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.ts
@@ -36,6 +36,19 @@ function toApiSakhi(profile: Record<string, unknown>) {
   };
 }
 
+/**
+ * MANAGER and ADMIN are unrestricted across all Sakhi-scoping checks —
+ * checked as the absence of an elevated role, not the presence of a
+ * restrictive one (SUPERVISOR), since a caller can hold multiple role
+ * assignments at once (see auth.service.ts's issueTokens) and must not be
+ * scoped down just because one of their roles is restrictive. Matches
+ * the same isPrivileged() pattern in
+ * supervisor-operations-service/operations.service.ts.
+ */
+function isPrivileged(caller: CallerScope): boolean {
+  return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
+}
+
 /** Business logic for Sakhi profile reads. */
 export class SakhiService {
   constructor(private readonly repository: SakhiRepository) {}
@@ -43,14 +56,14 @@ export class SakhiService {
   /**
    * A caller with a project scope on their JWT (typically SUPERVISOR — one
    * project per Supervisor per SRS) may only see that project's Sakhis. A
-   * caller with no project scope (MANAGER/ADMIN, who oversee multiple
-   * projects — HLD's dashboard "Project Selector") is unrestricted here.
+   * privileged caller (MANAGER/ADMIN, who oversee multiple projects — HLD's
+   * dashboard "Project Selector") is unrestricted here.
    *
-   * A SUPERVISOR caller is further scoped to only their own assigned
-   * Sakhis (supervisorId === caller.id) — otherwise every Supervisor
-   * sharing a project sees every other Supervisor's Sakhis too, since
-   * project membership alone doesn't imply ownership. MANAGER/ADMIN see
-   * every Sakhi in the project, matching the project-level check above.
+   * A non-privileged (SUPERVISOR) caller is further scoped to only their
+   * own assigned Sakhis (supervisorId === caller.id) — otherwise every
+   * Supervisor sharing a project sees every other Supervisor's Sakhis too,
+   * since project membership alone doesn't imply ownership. MANAGER/ADMIN
+   * see every Sakhi in the project, matching the project-level check above.
    */
   async listByProject(projectId: string, caller: CallerScope) {
     if (caller.projectId && caller.projectId !== projectId) {
@@ -58,10 +71,10 @@ export class SakhiService {
     }
     const profiles = await this.repository.findByProject(projectId);
     const mapped = profiles.map((p) => toApiSakhi(p as unknown as Record<string, unknown>));
-    if (caller.roles.includes('SUPERVISOR')) {
-      return mapped.filter((s) => s.supervisorId === caller.id);
+    if (isPrivileged(caller)) {
+      return mapped;
     }
-    return mapped;
+    return mapped.filter((s) => s.supervisorId === caller.id);
   }
 
   async getById(id: string, caller: CallerScope) {

--- a/apps/auth-service/src/sakhis/sakhi.service.ts
+++ b/apps/auth-service/src/sakhis/sakhi.service.ts
@@ -3,6 +3,8 @@ import type { SakhiRepository } from './sakhi.repository';
 
 /** The calling principal's own scope, as carried on their JWT/trusted-identity headers. */
 export interface CallerScope {
+  readonly id: string;
+  readonly roles: string[];
   readonly projectId: string | null;
 }
 
@@ -43,13 +45,23 @@ export class SakhiService {
    * project per Supervisor per SRS) may only see that project's Sakhis. A
    * caller with no project scope (MANAGER/ADMIN, who oversee multiple
    * projects — HLD's dashboard "Project Selector") is unrestricted here.
+   *
+   * A SUPERVISOR caller is further scoped to only their own assigned
+   * Sakhis (supervisorId === caller.id) — otherwise every Supervisor
+   * sharing a project sees every other Supervisor's Sakhis too, since
+   * project membership alone doesn't imply ownership. MANAGER/ADMIN see
+   * every Sakhi in the project, matching the project-level check above.
    */
   async listByProject(projectId: string, caller: CallerScope) {
     if (caller.projectId && caller.projectId !== projectId) {
       throw forbidden('You do not have access to this project.');
     }
     const profiles = await this.repository.findByProject(projectId);
-    return profiles.map((p) => toApiSakhi(p as unknown as Record<string, unknown>));
+    const mapped = profiles.map((p) => toApiSakhi(p as unknown as Record<string, unknown>));
+    if (caller.roles.includes('SUPERVISOR')) {
+      return mapped.filter((s) => s.supervisorId === caller.id);
+    }
+    return mapped;
   }
 
   async getById(id: string, caller: CallerScope) {


### PR DESCRIPTION
## Summary

Both `GET /projects` and `GET /projects/:projectId/sakhis` previously returned unscoped data to any authenticated caller:

- **`GET /projects`** listed every active project in the system regardless of the caller's role or assigned project.
- **`GET /projects/:projectId/sakhis`** returned every Sakhi in a project, checking only project membership — never actual Supervisor ownership. Any Supervisor sharing a project with other Supervisors saw every other Supervisor's Sakhi roster, not just their own.

## Fix

- `apps/auth-service/src/projects/project.service.ts` — `list()` now takes the caller and scopes SAKHI/SUPERVISOR callers to only their own `projectId`; MANAGER/ADMIN remain unrestricted (they legitimately oversee multiple projects).
- `apps/auth-service/src/sakhis/sakhi.service.ts` — `listByProject()` now additionally filters to `supervisorId === caller.id` for SUPERVISOR callers, on top of the existing project-membership check. MANAGER/ADMIN remain unrestricted.

## Why this matters

A client that fetches the project list and picks one (e.g. "the first result") for a SAKHI/SUPERVISOR caller could previously land on a project it has no access to at all, and would then 403 on the follow-up Sakhi-list call. Separately, any Supervisor sharing a project with peers saw every peer's Sakhis in the "Assign Item" / Sakhi-picker flows — both reproduced live against a real deployed environment during manual verification.

## Test plan

- [x] `nx lint auth-service` — clean
- [x] `nx test auth-service` — 210/210 passing, including new coverage:
  - `project.service.spec.ts`: SUPERVISOR/SAKHI scoped to own project; MANAGER/ADMIN unrestricted; empty result when own project isn't in the active list
  - `sakhi.service.spec.ts`: SUPERVISOR scoped to own Sakhis only; MANAGER/ADMIN see every Sakhi in the project
- [x] Live verification against a running local gateway + auth-service: 5 Supervisors sharing one project each correctly see only their own Sakhis after the fix (previously all 5 saw all 10); a Supervisor's `GET /projects` correctly excludes a second project created by another party

🤖 Generated with [Claude Code](https://claude.com/claude-code)