### PR TITLE
fix(supervisor-operations-service): Annotate gt parameter type in upsertTopicMark

### DIFF
--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -530,7 +530,9 @@ export class OperationsService {
     }
 
     const gatheringTopics = await this.repository.findGatheringTopics(dto.gatheringId);
-    const belongsToGathering = gatheringTopics.some((gt) => gt.topicId === topicId);
+    const belongsToGathering = gatheringTopics.some(
+      (gt: (typeof gatheringTopics)[number]) => gt.topicId === topicId,
+    );
     if (!belongsToGathering) {
       throw unprocessable('topicId: this topic is not part of the referenced gathering.');
     }


### PR DESCRIPTION
## Summary

- `upsertTopicMark`'s `gatheringTopics.some((gt) => gt.topicId === topicId)` had no type annotation on `gt`, which failed `noImplicitAny` (`TS7006`) on the dev box's stricter build config — this was blocking dev deploys of `supervisor-operations-service` after PR #99 merged.
- `gt` now takes an explicit type derived from `findGatheringTopics`'s own return type (`(typeof gatheringTopics)[number]`), so it can't drift from the repository's actual return shape.

This fix was originally pushed to the `feature/call-sheet-and-supervisor-events` branch, but landed *after* PR #99 was already merged, so it never made it into `develop`. Cherry-picked onto a fresh branch here.

## Test plan

- [x] `nx build supervisor-operations-service` — clean, no TS errors
- [x] `nx lint supervisor-operations-service` — clean
- [x] `nx test supervisor-operations-service` — 144/144 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)