### PR TITLE
feat(rules-service): Add non-admin rule version lookup and seed script

### DIFF
--- a/apps/rules-service/prisma/seed.ts
+++ b/apps/rules-service/prisma/seed.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+import { PrismaClient } from '../../../node_modules/.prisma/client-rules-service';
+
+const prisma = new PrismaClient();
+
+// Fixed, hardcoded UUIDs (not @default(uuid()) at insert time) — the Sakhi
+// mobile app hardcodes SCHEDULE_RULE_VERSION_ID in HardcodedRuleSource and
+// must match exactly across dev/SIT/UAT, so every environment's seed run has
+// to produce the same id rather than a fresh one per run.
+const SCHEDULE_RULE_SET_ID = '11111111-1111-4111-8111-111111111111';
+const SCHEDULE_RULE_VERSION_ID = '22222222-2222-4222-8222-222222222222';
+const SCHEDULE_RULE_VERSION_NO = 'v1-hardcoded';
+
+/**
+ * Seeds the SCHEDULE rule set + its v1-hardcoded published version, so
+ * VisitSchedule.generatedByRuleVersionId (NOT NULL, no default) has a real
+ * row to reference for M2 — actual scheduling rules live in the Kotlin app's
+ * HardcodedRuleSource today and move to GoRules packages in M3 (CR-032).
+ */
+async function seedScheduleRuleVersion(): Promise<void> {
+  // update: {} is deliberate on both upserts — this only ever creates the row
+  // on a fresh environment. Once it exists, re-running the seed must NOT
+  // touch it: dev/SIT/UAT may already have real data (schedules, submissions)
+  // referencing this exact row, and silently rewriting rulesJson/checksum/
+  // effectiveFrom out from under them would be a live-data mutation disguised
+  // as a seed. A real change to this rule version's content is a new
+  // versionNo (a new row), not an edit of this one — matching the
+  // create/immutable-then-supersede pattern used elsewhere in rules-service
+  // (see ruleVersion.repository.ts's publishNewVersion).
+  await prisma.ruleSet.upsert({
+    where: { id: SCHEDULE_RULE_SET_ID },
+    create: {
+      id: SCHEDULE_RULE_SET_ID,
+      ruleCategory: 'SCHEDULE',
+      ruleSetName: 'Arogya Sakhi Visit Scheduling',
+      status: 'ACTIVE',
+    },
+    update: {},
+  });
+
+  const rulesJson = {
+    note: 'Rules implemented in sakhi-mobile-app HardcodedRuleSource. Replaced by GoRules packages in M3 (CR-032).',
+  };
+
+  await prisma.ruleVersion.upsert({
+    where: { id: SCHEDULE_RULE_VERSION_ID },
+    create: {
+      id: SCHEDULE_RULE_VERSION_ID,
+      ruleSetId: SCHEDULE_RULE_SET_ID,
+      versionNo: SCHEDULE_RULE_VERSION_NO,
+      rulesJson,
+      effectiveFrom: new Date('2026-08-01'),
+      checksum: createHash('sha256').update(JSON.stringify(rulesJson)).digest(),
+      status: 'PUBLISHED',
+    },
+    update: {},
+  });
+}
+
+async function main(): Promise<void> {
+  await seedScheduleRuleVersion();
+  console.log(`Seeded SCHEDULE rule version: ${SCHEDULE_RULE_VERSION_ID}`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/rules-service/src/rules/ruleVersion.controller.ts
+++ b/apps/rules-service/src/rules/ruleVersion.controller.ts
@@ -19,6 +19,12 @@ const setIdParamsSchema = z
   .object({ setId: z.string().uuid().openapi({ example: '99999999-9999-9999-9999-999999999999' }) })
   .strict();
 
+const versionIdParamsSchema = z
+  .object({
+    versionId: z.string().uuid().openapi({ example: '99999999-9999-9999-9999-999999999999' }),
+  })
+  .strict();
+
 const publishRuleVersionRequestSchema = publishRuleVersionSchema.extend({
   // `rulesJson` is a recursive z.lazy() type (see publish-ruleVersion.dto.ts) —
   // zod-to-openapi cannot introspect z.lazy() on its own, so `type: 'object'`
@@ -41,6 +47,15 @@ const ruleVersionSchema = z.object({
   status: z.enum(['DRAFT', 'PUBLISHED', 'RETIRED']).openapi({ example: 'PUBLISHED' }),
 });
 
+// Deliberately narrower than ruleVersionSchema — omits rulesJson/effectiveFrom/
+// effectiveTo/publishedByUserId, which a non-admin caller (any other service
+// verifying a generatedByRuleVersionId) has no reason to see.
+const ruleVersionSummarySchema = z.object({
+  id: z.string().uuid(),
+  ruleSetId: z.string().uuid(),
+  status: z.enum(['DRAFT', 'PUBLISHED', 'RETIRED']).openapi({ example: 'PUBLISHED' }),
+});
+
 const apiErrorSchema = z.object({
   success: z.literal(false),
   message: z.string(),
@@ -60,6 +75,26 @@ function envelope<T extends z.ZodTypeAny>(data: T) {
  */
 export function createRuleVersionRouter(service: RuleVersionService) {
   const doc = createDocumentedRouter();
+
+  doc.get(
+    '/rules/versions/:versionId',
+    {
+      summary: 'Get a rule version by id (any authenticated role)',
+      tags: ['Rules'],
+      params: versionIdParamsSchema,
+      responses: {
+        200: { description: 'Rule version summary', schema: envelope(ruleVersionSummarySchema) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        404: { description: 'Rule version not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(versionIdParamsSchema, 'params'),
+    asyncHandler(async (req, res) => {
+      res.json(ok(await service.getById(req.params.versionId)));
+    }),
+  );
 
   doc.get(
     '/admin/rules/:setId',

--- a/apps/rules-service/src/rules/ruleVersion.repository.ts
+++ b/apps/rules-service/src/rules/ruleVersion.repository.ts
@@ -21,6 +21,11 @@ export class RuleVersionRepository {
     return this.prisma.ruleSet.findFirst({ where: { id: ruleSetId, isDeleted: false } });
   }
 
+  /** One rule version by its own id, or null — used by other services to verify a version is usable. */
+  findById(id: string) {
+    return this.prisma.ruleVersion.findFirst({ where: { id, isDeleted: false } });
+  }
+
   /**
    * The currently-PUBLISHED version for a rule set (the one still in effect,
    * i.e. effectiveTo is null), or null if the set has never been published.

--- a/apps/rules-service/src/rules/ruleVersion.service.spec.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.spec.ts
@@ -3,6 +3,7 @@ import type { RuleVersionRepository } from './ruleVersion.repository';
 
 describe('RuleVersionService', () => {
   const repository = {
+    findById: jest.fn(),
     findSetById: jest.fn(),
     findPublishedBySetId: jest.fn(),
     publishNewVersion: jest.fn(),
@@ -15,6 +16,35 @@ describe('RuleVersionService', () => {
   });
 
   const setId = '99999999-9999-9999-9999-999999999999';
+
+  describe('getById', () => {
+    it('returns id/ruleSetId/status only, dropping rulesJson/checksum/audit columns', async () => {
+      repository.findById.mockResolvedValue({
+        id: 'ver-1',
+        ruleSetId: setId,
+        versionNo: 'v1-hardcoded',
+        rulesJson: { note: 'placeholder' },
+        effectiveFrom: new Date('2026-08-01'),
+        effectiveTo: null,
+        publishedByUserId: null,
+        status: 'PUBLISHED',
+        checksum: Buffer.from('x'),
+        createdByUserId: null,
+        isDeleted: false,
+      } as never);
+
+      const result = await service.getById('ver-1');
+
+      expect(result).toEqual({ id: 'ver-1', ruleSetId: setId, status: 'PUBLISHED' });
+      expect(result).not.toHaveProperty('rulesJson');
+      expect(result).not.toHaveProperty('checksum');
+    });
+
+    it('throws 404 when the rule version does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(service.getById('missing')).rejects.toMatchObject({ status: 404 });
+    });
+  });
 
   describe('getPublished', () => {
     it('returns the published version (projected), dropping checksum/audit columns', async () => {

--- a/apps/rules-service/src/rules/ruleVersion.service.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.ts
@@ -34,6 +34,23 @@ function toApiRuleVersion(v: Record<string, unknown>) {
 export class RuleVersionService {
   constructor(private readonly repository: RuleVersionRepository) {}
 
+  /**
+   * A rule version's id/ruleSetId/status by its own id — open to any
+   * authenticated role (unlike getPublished/publish, which are ADMIN-only),
+   * since other services need to verify a caller-supplied
+   * generatedByRuleVersionId is real and PUBLISHED without needing rules
+   * admin access themselves. Deliberately omits rulesJson/checksum.
+   */
+  async getById(id: string) {
+    const version = await this.repository.findById(id);
+    if (!version) throw notFound('Rule version not found.');
+    return {
+      id: version.id,
+      ruleSetId: version.ruleSetId,
+      status: version.status,
+    };
+  }
+
   /** The currently-published version for a rule set; 404 if the set is unknown or unpublished. */
   async getPublished(ruleSetId: string) {
     const set = await this.repository.findSetById(ruleSetId);


### PR DESCRIPTION
## Summary

- `GET /rules/versions/:versionId` — new, open to any authenticated role (unlike the existing `GET /admin/rules/:setId`, which is ADMIN-only and looks up by `ruleSetId`, not `versionId`). Needed so other services (e.g. the upcoming visit-schedules bulk-upload endpoint) can verify a `generatedByRuleVersionId` is real and `PUBLISHED` without needing rules-admin access themselves.
- `apps/rules-service/prisma/seed.ts` — new. This service had no seeding mechanism at all. Seeds one `SCHEDULE` `RuleSet` + a `v1-hardcoded` `PUBLISHED` `RuleVersion`, on fixed UUIDs (not `@default(uuid())`), so every environment's seed run produces the same id — required since a downstream mobile client hardcodes this UUID and it must match across dev/SIT/UAT.
- Deliberately narrow response shape (`id`/`ruleSetId`/`status` only) — omits `rulesJson`/`checksum`/audit columns, which a non-admin caller has no reason to see.

## Test plan

- [x] `nx lint rules-service` — clean
- [x] `nx test rules-service` — 14/14 passing (2 new tests for `getById`)
- [x] `nx build rules-service` — clean, builds independently of any other in-flight change
- [x] Live verification against a running local gateway + rules-service with a real SUPERVISOR JWT (not just ADMIN): `GET /rules/versions/22222222-2222-4222-8222-222222222222` → 200, `{status: "PUBLISHED"}`

## Notes

The seeded UUID (`22222222-2222-4222-8222-222222222222`) is what the mobile team needs to hardcode as `generatedByRuleVersionId`.