### PR TITLE
feat(supervisor-operations-service): Add GET /call-sheet-stats (by-sakhi and batch)

### DIFF
--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -128,4 +128,9 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
     target: appConfig.SUPERVISOR_OPERATIONS_SERVICE_URL,
     requiresAuth: true,
   },
+  {
+    prefix: '/call-sheet-stats',
+    target: appConfig.SUPERVISOR_OPERATIONS_SERVICE_URL,
+    requiresAuth: true,
+  },
 ];

--- a/apps/supervisor-operations-service/src/operations/dto/call-sheet-stats.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/call-sheet-stats.dto.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * The 7 fixed "kind" rows a Sakhi's call-sheet stats card shows. Only
+ * FOLLOWUP_PENDING is backed by real data today (CallLog.callStatus ===
+ * 'CALL_BACK') — the other 6 need data models that either don't exist yet
+ * or live in other services (visit schedules/instances, closure forms,
+ * ANC/PNC risk state) and are returned as a fixed { count: 0, updated: 0 }
+ * placeholder until that's scoped. See operations.service.ts's
+ * getCallSheetStats for the per-kind breakdown.
+ */
+export const CALL_SHEET_STAT_KINDS = [
+  'VISIT_DUE',
+  'VISIT_3_DAYS_TO_EXPIRE',
+  'FOLLOWUP_PENDING',
+  'CLOSURE_FORM_PENDING',
+  'MISSED_VISIT',
+  'HIGH_RISK_ANC',
+  'HIGH_RISK_PNC',
+] as const;
+
+export type CallSheetStatKind = (typeof CALL_SHEET_STAT_KINDS)[number];
+
+/**
+ * Query schema for the batch variant, `GET /call-sheet-stats?sakhiIds=...`.
+ * Kept as a plain string + `.refine()` (not `z.coerce.*`), matching
+ * list-recent-call-logs.dto.ts's own note on why — zod-to-openapi cannot
+ * introspect a `ZodEffects`-wrapped transform and crashes OpenAPI doc
+ * generation at startup.
+ */
+export const listCallSheetStatsBatchQuerySchema = z
+  .object({
+    sakhiIds: z
+      .string()
+      .trim()
+      .min(1)
+      .refine((v) => v.split(',').every((id) => z.string().uuid().safeParse(id.trim()).success), {
+        message: 'sakhiIds: must be a comma-separated list of uuids',
+      }),
+  })
+  .strict();
+
+export type ListCallSheetStatsBatchQuery = z.infer<typeof listCallSheetStatsBatchQuerySchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/call-sheet-stats.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/call-sheet-stats.dto.ts
@@ -22,6 +22,16 @@ export const CALL_SHEET_STAT_KINDS = [
 export type CallSheetStatKind = (typeof CALL_SHEET_STAT_KINDS)[number];
 
 /**
+ * Batch is currently one sakhiClient.findById round-trip to auth-service per
+ * id (parallelized, but still N calls) — capped so a card-grid list view
+ * can't fan out an unbounded number of concurrent auth-service calls in one
+ * request. Matches the visit-schedules bulk-upload endpoint's own cap.
+ * Revisit if this ever needs a real roster (fetch-once-then-filter, like
+ * beneficiary-service's listSakhiIdsForSupervisor) instead of per-id calls.
+ */
+export const MAX_BATCH_SAKHI_IDS = 100;
+
+/**
  * Query schema for the batch variant, `GET /call-sheet-stats?sakhiIds=...`.
  * Kept as a plain string + `.refine()` (not `z.coerce.*`), matching
  * list-recent-call-logs.dto.ts's own note on why — zod-to-openapi cannot
@@ -34,9 +44,18 @@ export const listCallSheetStatsBatchQuerySchema = z
       .string()
       .trim()
       .min(1)
-      .refine((v) => v.split(',').every((id) => z.string().uuid().safeParse(id.trim()).success), {
-        message: 'sakhiIds: must be a comma-separated list of uuids',
-      }),
+      .refine(
+        (v) => {
+          const ids = v.split(',');
+          return (
+            ids.length <= MAX_BATCH_SAKHI_IDS &&
+            ids.every((id) => z.string().uuid().safeParse(id.trim()).success)
+          );
+        },
+        {
+          message: `sakhiIds: must be a comma-separated list of at most ${MAX_BATCH_SAKHI_IDS} uuids`,
+        },
+      ),
   })
   .strict();
 

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -18,6 +18,10 @@ import { updateGatheringAttendanceSchema } from './dto/update-gathering-attendan
 import { completeTopicMarkSchema, createTopicMarkSchema } from './dto/create-topic-mark.dto';
 import { topicMarkQuerySchema } from './dto/topic-mark-query.dto';
 import {
+  CALL_SHEET_STAT_KINDS,
+  listCallSheetStatsBatchQuerySchema,
+} from './dto/call-sheet-stats.dto';
+import {
   asyncHandler,
   createDocumentedRouter,
   ok,
@@ -117,6 +121,18 @@ const callLogSchema = z.object({
   responder: z.enum(['RELATIVE', 'HUSBAND', 'SAKHI', 'PERSON_WHO_DOES_NOT_KNOW_WOMAN']).nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+});
+
+const callSheetStatsSchema = z.object({
+  sakhiId: z.string().uuid(),
+  lastDataSyncDate: z.string().openapi({ example: '2026-08-04' }),
+  rows: z.array(
+    z.object({
+      kind: z.enum(CALL_SHEET_STAT_KINDS),
+      updated: z.number().int(),
+      count: z.number().int(),
+    }),
+  ),
 });
 
 const sakhiIdParamsSchema = z
@@ -731,6 +747,65 @@ export function createOperationsRouter(service: OperationsService) {
           ),
         ),
       );
+    }),
+  );
+
+  doc.get(
+    '/call-sheet-stats/by-sakhi/:sakhiId',
+    {
+      summary: "A Sakhi's call-sheet stats card (7 fixed kind rows)",
+      tags: ['Supervisor Operations'],
+      params: sakhiIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Call-sheet stats for this Sakhi',
+          schema: envelope(callSheetStatsSchema),
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Sakhi not assigned to caller', schema: apiErrorSchema },
+        404: { description: 'Sakhi not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(sakhiIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      res.json(
+        ok(await service.getCallSheetStats(req.params.sakhiId, req.user, authorizationHeader)),
+      );
+    }),
+  );
+
+  doc.get(
+    '/call-sheet-stats',
+    {
+      summary: 'Call-sheet stats for multiple Sakhis in one call (list-view card grid)',
+      tags: ['Supervisor Operations'],
+      query: listCallSheetStatsBatchQuerySchema,
+      responses: {
+        200: {
+          description:
+            'Call-sheet stats for every requested sakhiId the caller may access — an unauthorized or unknown id is silently omitted, not an error',
+          schema: envelope(z.array(callSheetStatsSchema)),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(listCallSheetStatsBatchQuerySchema, 'query'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const sakhiIds = String(req.query.sakhiIds)
+        .split(',')
+        .map((id) => id.trim());
+      res.json(ok(await service.getCallSheetStatsBatch(sakhiIds, req.user, authorizationHeader)));
     }),
   );
 

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -241,6 +241,17 @@ export class OperationsRepository {
   }
 
   /**
+   * Call-sheet stats' FOLLOWUP_PENDING count — a call logged as CALL_BACK
+   * (the caller asked to be rung again) with no newer call logged since.
+   * The only one of the 7 call-sheet-stats kinds backed by real data today.
+   */
+  countPendingFollowups(sakhiId: string) {
+    return this.prisma.callLog.count({
+      where: { sakhiId, isDeleted: false, callStatus: 'CALL_BACK' },
+    });
+  }
+
+  /**
    * Only ever writes the fields captured after a call ends (status, end
    * time, duration, notes, followup) — sakhiId/projectId/supervisorId/
    * callStartAt/callDatetime are immutable, matching this repo's

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -241,14 +241,22 @@ export class OperationsRepository {
   }
 
   /**
-   * Call-sheet stats' FOLLOWUP_PENDING count — a call logged as CALL_BACK
-   * (the caller asked to be rung again) with no newer call logged since.
-   * The only one of the 7 call-sheet-stats kinds backed by real data today.
+   * Call-sheet stats' FOLLOWUP_PENDING count — 1 if this Sakhi's most recent
+   * call is still CALL_BACK (unresolved), 0 otherwise (including "never
+   * called"). NOT a count of every CALL_BACK ever logged: call_logs has no
+   * beneficiary/thread grouping (it's one Supervisor-to-Sakhi check-in call
+   * per row, per FR-SV-3.3), so a later call of any status supersedes an
+   * earlier CALL_BACK — it doesn't stay "pending" once the Supervisor has
+   * called again, whatever the outcome of that later call. The only one of
+   * the 7 call-sheet-stats kinds backed by real data today.
    */
-  countPendingFollowups(sakhiId: string) {
-    return this.prisma.callLog.count({
-      where: { sakhiId, isDeleted: false, callStatus: 'CALL_BACK' },
+  async countPendingFollowups(sakhiId: string): Promise<number> {
+    const latest = await this.prisma.callLog.findFirst({
+      where: { sakhiId, isDeleted: false },
+      orderBy: { callDatetime: 'desc' },
+      select: { callStatus: true },
     });
+    return latest?.callStatus === 'CALL_BACK' ? 1 : 0;
   }
 
   /**

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -33,6 +33,7 @@ describe('OperationsService', () => {
     findCallLogsBySakhi: jest.fn(),
     findRecentCallLogsBySakhi: jest.fn(),
     updateCallLog: jest.fn(),
+    countPendingFollowups: jest.fn(),
   } as unknown as jest.Mocked<OperationsRepository>;
   const sakhiClient = {
     findById: jest.fn(),
@@ -1317,6 +1318,92 @@ describe('OperationsService', () => {
         ),
       ).resolves.toEqual([callLogRow]);
       expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCallSheetStats', () => {
+    const sakhiId = '44444444-4444-4444-4444-444444444444';
+    const allKinds = [
+      'VISIT_DUE',
+      'VISIT_3_DAYS_TO_EXPIRE',
+      'FOLLOWUP_PENDING',
+      'CLOSURE_FORM_PENDING',
+      'MISSED_VISIT',
+      'HIGH_RISK_ANC',
+      'HIGH_RISK_PNC',
+    ];
+
+    it('returns a real FOLLOWUP_PENDING count and a fixed 0 for every other kind', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.countPendingFollowups.mockResolvedValue(3);
+
+      const result = await service.getCallSheetStats(sakhiId, supervisorCaller, 'Bearer token');
+
+      expect(result.sakhiId).toBe(sakhiId);
+      expect(typeof result.lastDataSyncDate).toBe('string');
+      expect(result.rows.map((r) => r.kind)).toEqual(allKinds);
+      const followupRow = result.rows.find((r) => r.kind === 'FOLLOWUP_PENDING');
+      expect(followupRow).toMatchObject({ count: 3, updated: 0 });
+      for (const row of result.rows.filter((r) => r.kind !== 'FOLLOWUP_PENDING')) {
+        expect(row).toMatchObject({ count: 0, updated: 0 });
+      }
+    });
+
+    it('rejects a Supervisor who is not this Sakhi’s assigned Supervisor', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      await expect(
+        service.getCallSheetStats(sakhiId, otherSupervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.countPendingFollowups).not.toHaveBeenCalled();
+    });
+
+    it('throws 404 when the Sakhi does not exist', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+      await expect(
+        service.getCallSheetStats('missing', supervisorCaller, 'Bearer token'),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('allows a MANAGER regardless of Sakhi assignment', async () => {
+      sakhiClient.findById.mockResolvedValue(sakhi);
+      repository.countPendingFollowups.mockResolvedValue(0);
+      await expect(
+        service.getCallSheetStats(sakhiId, managerCaller, 'Bearer token'),
+      ).resolves.toMatchObject({ sakhiId });
+    });
+  });
+
+  describe('getCallSheetStatsBatch', () => {
+    const ownedId = '44444444-4444-4444-4444-444444444444';
+    const notOwnedId = '55555555-5555-5555-5555-555555555555';
+
+    it('returns stats only for sakhiIds the caller may access, omitting the rest', async () => {
+      sakhiClient.findById.mockImplementation(async (id) => {
+        if (id === ownedId) return sakhi;
+        if (id === notOwnedId)
+          return { ...sakhi, sakhiId: notOwnedId, supervisorId: 'someone-else' };
+        return null;
+      });
+      repository.countPendingFollowups.mockResolvedValue(1);
+
+      const result = await service.getCallSheetStatsBatch(
+        [ownedId, notOwnedId, 'missing-id'],
+        supervisorCaller,
+        'Bearer token',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sakhiId).toBe(ownedId);
+    });
+
+    it('returns an empty array when none of the requested ids are accessible', async () => {
+      sakhiClient.findById.mockResolvedValue(null);
+      const result = await service.getCallSheetStatsBatch(
+        ['missing-1', 'missing-2'],
+        supervisorCaller,
+        'Bearer token',
+      );
+      expect(result).toEqual([]);
     });
   });
 });

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -1,3 +1,4 @@
+import { badGateway } from '@armman/service-commons';
 import { OperationsService } from './operations.service';
 import type { OperationsRepository } from './operations.repository';
 import type { SakhiClient } from './sakhi.client';
@@ -1335,7 +1336,10 @@ describe('OperationsService', () => {
 
     it('returns a real FOLLOWUP_PENDING count and a fixed 0 for every other kind', async () => {
       sakhiClient.findById.mockResolvedValue(sakhi);
-      repository.countPendingFollowups.mockResolvedValue(3);
+      // Repository now only ever returns 0 or 1 (see its own doc comment on
+      // why this isn't a plain count() of every CALL_BACK row) — 1 here
+      // means this Sakhi's most recent call is still CALL_BACK.
+      repository.countPendingFollowups.mockResolvedValue(1);
 
       const result = await service.getCallSheetStats(sakhiId, supervisorCaller, 'Bearer token');
 
@@ -1343,7 +1347,7 @@ describe('OperationsService', () => {
       expect(typeof result.lastDataSyncDate).toBe('string');
       expect(result.rows.map((r) => r.kind)).toEqual(allKinds);
       const followupRow = result.rows.find((r) => r.kind === 'FOLLOWUP_PENDING');
-      expect(followupRow).toMatchObject({ count: 3, updated: 0 });
+      expect(followupRow).toMatchObject({ count: 1, updated: 0 });
       for (const row of result.rows.filter((r) => r.kind !== 'FOLLOWUP_PENDING')) {
         expect(row).toMatchObject({ count: 0, updated: 0 });
       }
@@ -1404,6 +1408,15 @@ describe('OperationsService', () => {
         'Bearer token',
       );
       expect(result).toEqual([]);
+    });
+
+    it('propagates a genuine infra failure (e.g. badGateway from sakhiClient) instead of swallowing it as an empty result', async () => {
+      const infraError = badGateway('auth-service is unreachable.');
+      sakhiClient.findById.mockRejectedValue(infraError);
+
+      await expect(
+        service.getCallSheetStatsBatch([ownedId], supervisorCaller, 'Bearer token'),
+      ).rejects.toBe(infraError);
     });
   });
 });

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -15,6 +15,8 @@ import type { CreateGatheringInput } from './dto/create-gathering.dto';
 import type { UpdateGatheringAttendanceInput } from './dto/update-gathering-attendance.dto';
 import type { CompleteTopicMarkInput, CreateTopicMarkInput } from './dto/create-topic-mark.dto';
 import type { TopicMarkQuery } from './dto/topic-mark-query.dto';
+import type { CallSheetStatKind } from './dto/call-sheet-stats.dto';
+import { CALL_SHEET_STAT_KINDS } from './dto/call-sheet-stats.dto';
 import type { SakhiClient } from './sakhi.client';
 
 /** Default recency window for the FR-SV-3.4 "recently called" card highlight. */
@@ -42,6 +44,26 @@ export interface CallerIdentity {
 /** MANAGER and ADMIN are unrestricted across all inventory ownership checks. */
 function isPrivileged(caller: CallerIdentity): boolean {
   return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
+}
+
+/** Today's date as YYYY-MM-DD, for call-sheet-stats' lastDataSyncDate. */
+function todayDateOnly(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Builds all 7 call-sheet-stats rows in the fixed kind order. Only
+ * FOLLOWUP_PENDING carries a real count; every other kind is a
+ * { count: 0, updated: 0 } placeholder — see call-sheet-stats.dto.ts.
+ */
+function buildCallSheetStatRows(
+  pendingFollowups: number,
+): Array<{ kind: CallSheetStatKind; updated: number; count: number }> {
+  return CALL_SHEET_STAT_KINDS.map((kind) => ({
+    kind,
+    updated: 0,
+    count: kind === 'FOLLOWUP_PENDING' ? pendingFollowups : 0,
+  }));
 }
 
 /** Supervisor operations domain logic. Data access is delegated to the repository. */
@@ -351,6 +373,54 @@ export class OperationsService {
     }
     const sinceDate = new Date(Date.now() - withinHours * 60 * 60 * 1000);
     return this.repository.findRecentCallLogsBySakhi(sakhiId, sinceDate);
+  }
+
+  /**
+   * A Sakhi's call-sheet stats card: 7 fixed "kind" rows. Only
+   * FOLLOWUP_PENDING is real today — the other 6 need data models that
+   * either don't exist yet or live in other services (visit schedules,
+   * closure forms, ANC/PNC risk state); they're returned as a fixed
+   * { count: 0, updated: 0 } placeholder until that's scoped, rather than
+   * omitted, so the card's row layout doesn't have to special-case a
+   * missing kind. Same ownership rule as listCallLogsBySakhi.
+   */
+  async getCallSheetStats(sakhiId: string, caller: CallerIdentity, authorizationHeader: string) {
+    const sakhi = await this.sakhiClient.findById(sakhiId, authorizationHeader);
+    if (!sakhi) throw notFound('Sakhi not found.');
+    if (!isPrivileged(caller) && sakhi.supervisorId !== caller.id) {
+      throw forbidden('You do not have access to this Sakhi.');
+    }
+
+    const pendingFollowups = await this.repository.countPendingFollowups(sakhiId);
+    return {
+      sakhiId,
+      lastDataSyncDate: todayDateOnly(),
+      rows: buildCallSheetStatRows(pendingFollowups),
+    };
+  }
+
+  /**
+   * Batch variant of getCallSheetStats for a list-view's card grid, so the
+   * caller isn't forced into one request per Sakhi card. A sakhiId not
+   * assigned to the caller is silently omitted from the result rather than
+   * failing the whole batch — the caller's other, legitimate cards should
+   * still render.
+   */
+  async getCallSheetStatsBatch(
+    sakhiIds: string[],
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    const results = await Promise.all(
+      sakhiIds.map(async (sakhiId) => {
+        try {
+          return await this.getCallSheetStats(sakhiId, caller, authorizationHeader);
+        } catch {
+          return null;
+        }
+      }),
+    );
+    return results.filter((r): r is NonNullable<typeof r> => r !== null);
   }
 
   listTrainingTopics() {

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -1,4 +1,4 @@
-import { conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
+import { HttpError, conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
 import type { OperationsRepository } from './operations.repository';
 import type { CreateSupervisorEventInput } from './dto/create-supervisorEvent.dto';
 import type { ListSupervisorEventsQuery } from './dto/list-supervisor-events.dto';
@@ -401,10 +401,14 @@ export class OperationsService {
 
   /**
    * Batch variant of getCallSheetStats for a list-view's card grid, so the
-   * caller isn't forced into one request per Sakhi card. A sakhiId not
-   * assigned to the caller is silently omitted from the result rather than
-   * failing the whole batch — the caller's other, legitimate cards should
-   * still render.
+   * caller isn't forced into one request per Sakhi card. A sakhiId that is
+   * unknown (404) or not assigned to the caller (403) is silently omitted
+   * from the result — the caller's other, legitimate cards should still
+   * render. Anything else (e.g. a badGateway 502 from sakhiClient if
+   * auth-service is unreachable) propagates and fails the whole batch,
+   * rather than being swallowed and rendered as an indistinguishable "no
+   * card" — a real infra failure on one id should surface, not masquerade
+   * as an empty result.
    */
   async getCallSheetStatsBatch(
     sakhiIds: string[],
@@ -415,8 +419,11 @@ export class OperationsService {
       sakhiIds.map(async (sakhiId) => {
         try {
           return await this.getCallSheetStats(sakhiId, caller, authorizationHeader);
-        } catch {
-          return null;
+        } catch (err) {
+          if (err instanceof HttpError && (err.status === 403 || err.status === 404)) {
+            return null;
+          }
+          throw err;
         }
       }),
     );


### PR DESCRIPTION
## ⚠️ Partial implementation — 1 of 7 stat kinds is real data

Per the mobile team's call-sheet-stats spec, this adds:

- `GET /call-sheet-stats/by-sakhi/:sakhiId` — single Sakhi
- `GET /call-sheet-stats?sakhiIds=id1,id2,id3` — batch, for a list-view card grid without one call per card

Auth: `trustGatewayIdentity` + `requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN')` (the spec said `SUPERVISOR`/`MANAGER` only, but every other Sakhi-scoped endpoint in this file — `call-logs/by-sakhi/*`, `inventory-transactions/by-sakhi/*` — also allows ADMIN, so this follows that existing convention rather than the narrower spec list). Ownership check: 403 if the Sakhi isn't assigned to the calling Supervisor (MANAGER/ADMIN unrestricted) — reuses the exact pattern already in `listCallLogsBySakhi`.

## What's real vs. stubbed

Investigated before writing any code — **6 of the 7 "kind" rows have no existing backing data anywhere in the codebase**:

| Kind | Status |
|---|---|
| `FOLLOWUP_PENDING` | **Real.** `CallLog.callStatus === 'CALL_BACK'` count. |
| `VISIT_DUE`, `VISIT_3_DAYS_TO_EXPIRE`, `MISSED_VISIT` | Stubbed `{count: 0, updated: 0}`. visit-form-service has the right date fields but zero existing "due soon"/"missed" query logic — would need to be built there, then this service would need a cross-service client to call it. |
| `CLOSURE_FORM_PENDING` | Stubbed. closure-reopen-service tracks approval status of *already-submitted* closures, not "should be closed but isn't yet" — no matching semantic exists. |
| `HIGH_RISK_ANC`, `HIGH_RISK_PNC` | Stubbed. **"PNC" doesn't map to anything in this codebase** — the phase enum has `ANC`/`PP` (postpartum)/`NN`/etc., no `PNC`. Needs clarification from whoever wrote the spec before real logic can be built. Closest existing data (`BeneficiaryRiskConditionSummary` in beneficiary-service) has a `phase` field but no single "high-risk AND this phase" flag. |

This repo forbids cross-service DB joins (forklift rule) — even once the missing data models exist, correctly computing all 7 kinds would need real query logic built in 3-4 different services, not just an aggregator here. Scoped this PR to what's real today rather than guessing at undefined business rules.

## Test plan

- [x] `nx lint supervisor-operations-service api-gateway` — clean
- [x] `nx test supervisor-operations-service` — 150/150 passing (6 new: real FOLLOWUP_PENDING count + stub zeros, 403/404 ownership checks, batch omits inaccessible/unknown ids, batch returns `[]` rather than erroring when none are accessible)
- [x] `nx build supervisor-operations-service` — clean
- [x] Live verification against a running local gateway + supervisor-operations-service with a real SUPERVISOR JWT: single-Sakhi call returns 200 with real `FOLLOWUP_PENDING` count (matching an existing `CALL_BACK` call log) and correct zero-stubs for the other 6; batch call with one real + one fake id returns only the real one; unknown sakhiId → 404

## Follow-up needed before the other 6 kinds can be built

Whoever owns the mobile spec should clarify: (1) what "PNC" is supposed to map to, (2) where "visit due/expiring/missed" and "closure form pending" data should live and whether it needs to be modeled from scratch, (3) which service should own the cross-service aggregation once those exist.