### PR TITLE
feat(quick-response): Add Quick Response API for EDD_NEARING and REOPEN cards

### DIFF
--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -76,18 +76,25 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
   { prefix: '/admin/rules', target: appConfig.RULES_SERVICE_URL, requiresAuth: true },
   { prefix: '/referrals', target: appConfig.RISK_REFERRAL_SERVICE_URL, requiresAuth: true },
   { prefix: '/closures', target: appConfig.CLOSURE_REOPEN_SERVICE_URL, requiresAuth: true },
+  // Internal-use decision endpoint, not part of the public Quick Response
+  // surface — approval-service calls it through the gateway (rather than
+  // closure-reopen-service's own port directly) because it uses
+  // trustGatewayIdentity, which only trusts the gateway's verified
+  // x-armman-* headers, not a raw forwarded JWT.
+  { prefix: '/reopen-requests', target: appConfig.CLOSURE_REOPEN_SERVICE_URL, requiresAuth: true },
   { prefix: '/approvals', target: appConfig.APPROVAL_SERVICE_URL, requiresAuth: true },
-  // Quick Response's client-facing surface — merges approval_requests with
-  // escalation_events server-side. The two source-service prefixes
-  // (/escalation-events on notification-escalation-service,
-  // /reopen-requests on closure-reopen-service) are called directly by
-  // approval-service, not routed through the gateway — same
-  // service-to-service pattern as supervisor-operations-service's
-  // SakhiClient calling auth-service's /sakhis/:id.
   { prefix: '/quick-response', target: appConfig.APPROVAL_SERVICE_URL, requiresAuth: true },
   { prefix: '/incentives', target: appConfig.INCENTIVE_WAGES_SERVICE_URL, requiresAuth: true },
   {
     prefix: '/notifications',
+    target: appConfig.NOTIFICATION_ESCALATION_SERVICE_URL,
+    requiresAuth: true,
+  },
+  // Internal-use Quick Response read surface, not documented as a public
+  // API — approval-service calls it through the gateway for the same
+  // trustGatewayIdentity reason as /reopen-requests above.
+  {
+    prefix: '/escalation-events',
     target: appConfig.NOTIFICATION_ESCALATION_SERVICE_URL,
     requiresAuth: true,
   },

--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -77,6 +77,14 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
   { prefix: '/referrals', target: appConfig.RISK_REFERRAL_SERVICE_URL, requiresAuth: true },
   { prefix: '/closures', target: appConfig.CLOSURE_REOPEN_SERVICE_URL, requiresAuth: true },
   { prefix: '/approvals', target: appConfig.APPROVAL_SERVICE_URL, requiresAuth: true },
+  // Quick Response's client-facing surface — merges approval_requests with
+  // escalation_events server-side. The two source-service prefixes
+  // (/escalation-events on notification-escalation-service,
+  // /reopen-requests on closure-reopen-service) are called directly by
+  // approval-service, not routed through the gateway — same
+  // service-to-service pattern as supervisor-operations-service's
+  // SakhiClient calling auth-service's /sakhis/:id.
+  { prefix: '/quick-response', target: appConfig.APPROVAL_SERVICE_URL, requiresAuth: true },
   { prefix: '/incentives', target: appConfig.INCENTIVE_WAGES_SERVICE_URL, requiresAuth: true },
   {
     prefix: '/notifications',

--- a/apps/approval-service/.env.example
+++ b/apps/approval-service/.env.example
@@ -8,3 +8,11 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
+# Base URLs Quick Response calls directly (service-to-service, forwarding the
+# caller's own Authorization header — same pattern as supervisor-operations-
+# service's SakhiClient): resolving APPROVAL_STATUS lookup values, fetching
+# escalation-sourced cards, deciding REOPEN cards, and writing audit entries.
+AUTH_SERVICE_BASE_URL=http://localhost:3000
+NOTIFICATION_ESCALATION_SERVICE_BASE_URL=http://localhost:3009
+CLOSURE_REOPEN_SERVICE_BASE_URL=http://localhost:3006
+AUDIT_SERVICE_BASE_URL=http://localhost:3013

--- a/apps/approval-service/.env.example
+++ b/apps/approval-service/.env.example
@@ -8,11 +8,3 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
-# Base URLs Quick Response calls directly (service-to-service, forwarding the
-# caller's own Authorization header — same pattern as supervisor-operations-
-# service's SakhiClient): resolving APPROVAL_STATUS lookup values, fetching
-# escalation-sourced cards, deciding REOPEN cards, and writing audit entries.
-AUTH_SERVICE_BASE_URL=http://localhost:3000
-NOTIFICATION_ESCALATION_SERVICE_BASE_URL=http://localhost:3009
-CLOSURE_REOPEN_SERVICE_BASE_URL=http://localhost:3006
-AUDIT_SERVICE_BASE_URL=http://localhost:3013

--- a/apps/approval-service/jest.config.ts
+++ b/apps/approval-service/jest.config.ts
@@ -3,5 +3,6 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/approval-service',
 };

--- a/apps/approval-service/prisma/migrations/20260805120100_rename_referral_skip_to_referral_incomplete/migration.sql
+++ b/apps/approval-service/prisma/migrations/20260805120100_rename_referral_skip_to_referral_incomplete/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+-- Renamed to match the Quick Response spec's card type name — same concept
+-- (a Sakhi's referral follow-up wasn't completed), naming drift only.
+-- Verify with SELECT COUNT(*) FROM approval_requests WHERE request_type =
+-- 'REFERRAL_SKIP' before running in an environment with real data — the
+-- rename itself preserves any existing rows' meaning, so this is safe
+-- regardless of row count, but worth confirming what will be affected.
+ALTER TYPE "ApprovalRequestType" RENAME VALUE 'REFERRAL_SKIP' TO 'REFERRAL_INCOMPLETE';

--- a/apps/approval-service/prisma/schema.prisma
+++ b/apps/approval-service/prisma/schema.prisma
@@ -32,7 +32,10 @@ datasource db {
 
 enum ApprovalRequestType {
   LMP_CHANGE
-  REFERRAL_SKIP
+  // Renamed from REFERRAL_SKIP to match the Quick Response spec's card type
+  // name — same concept (a Sakhi's referral follow-up wasn't completed),
+  // naming drift only, no semantic change.
+  REFERRAL_INCOMPLETE
   ACCOMPANIED_REFERRAL
   CLOSURE_REVIEW
   REOPEN

--- a/apps/approval-service/src/app.module.ts
+++ b/apps/approval-service/src/app.module.ts
@@ -12,6 +12,7 @@ import { appConfig } from './config/app-config';
 import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createApprovalRequestModule } from './approvals/approvalRequest.module';
+import { createQuickResponseModule } from './quick-response/quick-response.module';
 import { buildApprovalServiceOpenApiDocument } from './docs/openapi';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
@@ -19,9 +20,11 @@ export {
   asyncHandler,
   ok,
   fail,
+  validate,
   validateBody,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   createDocumentedRouter,
   HttpError,
   ErrorCode,
@@ -50,15 +53,24 @@ export function createApp(prisma: PrismaService): Application {
   app.use(requestId);
 
   const approvalRequestModule = createApprovalRequestModule(prisma);
+  const quickResponseModule = createQuickResponseModule(prisma);
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();
   api.use(createHealthRouter(prisma));
-  // Built from approvalRequestModule.registry — every route registered via
+  // Built from every feature module's registry — every route registered via
   // createDocumentedRouter() above is already in the spec, so this can never
   // drift from what's actually mounted.
-  api.use(createSwaggerRouter(buildApprovalServiceOpenApiDocument(approvalRequestModule.registry)));
+  api.use(
+    createSwaggerRouter(
+      buildApprovalServiceOpenApiDocument(
+        approvalRequestModule.registry,
+        quickResponseModule.registry,
+      ),
+    ),
+  );
   api.use(approvalRequestModule.router);
+  api.use(quickResponseModule.router);
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/approval-service/src/approvals/approvalRequest.controller.ts
+++ b/apps/approval-service/src/approvals/approvalRequest.controller.ts
@@ -34,7 +34,7 @@ const approvalRequestSchema = z.object({
   id: z.string().uuid(),
   requestType: z.enum([
     'LMP_CHANGE',
-    'REFERRAL_SKIP',
+    'REFERRAL_INCOMPLETE',
     'ACCOMPANIED_REFERRAL',
     'CLOSURE_REVIEW',
     'REOPEN',

--- a/apps/approval-service/src/approvals/dto/create-approvalRequest.dto.ts
+++ b/apps/approval-service/src/approvals/dto/create-approvalRequest.dto.ts
@@ -37,7 +37,7 @@ export const createApprovalRequestSchema = z
   .object({
     requestType: z.enum([
       'LMP_CHANGE',
-      'REFERRAL_SKIP',
+      'REFERRAL_INCOMPLETE',
       'ACCOMPANIED_REFERRAL',
       'CLOSURE_REVIEW',
       'REOPEN',

--- a/apps/approval-service/src/config/app-config.ts
+++ b/apps/approval-service/src/config/app-config.ts
@@ -16,16 +16,15 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
-  // Base URLs of the services Quick Response merges/delegates to (same
-  // naming/default pattern as supervisor-operations-service's SakhiClient) —
-  // resolving APPROVAL_STATUS lookup values (auth-service), fetching
-  // escalation-sourced cards (notification-escalation-service), deciding
-  // REOPEN cards (closure-reopen-service), and writing the audit entry
-  // (audit-service).
-  AUTH_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
-  NOTIFICATION_ESCALATION_SERVICE_BASE_URL: z.string().url().default('http://localhost:3009'),
-  CLOSURE_REOPEN_SERVICE_BASE_URL: z.string().url().default('http://localhost:3006'),
-  AUDIT_SERVICE_BASE_URL: z.string().url().default('http://localhost:3013'),
+  // Quick Response's cross-service calls (resolving APPROVAL_STATUS lookup
+  // values, fetching escalation-sourced cards, deciding REOPEN cards,
+  // notifying the Sakhi, writing the audit entry) all go through the
+  // gateway rather than hitting each service's own port directly — every
+  // one of those routes uses trustGatewayIdentity (trusts the x-armman-*
+  // headers the gateway sets after verifying the JWT), not authenticate()
+  // (which verifies a raw JWT itself), so a direct call bypassing the
+  // gateway would never carry the identity those routes require.
+  API_GATEWAY_BASE_URL: z.string().url().default('http://localhost:3000'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/approval-service/src/config/app-config.ts
+++ b/apps/approval-service/src/config/app-config.ts
@@ -16,6 +16,16 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  // Base URLs of the services Quick Response merges/delegates to (same
+  // naming/default pattern as supervisor-operations-service's SakhiClient) —
+  // resolving APPROVAL_STATUS lookup values (auth-service), fetching
+  // escalation-sourced cards (notification-escalation-service), deciding
+  // REOPEN cards (closure-reopen-service), and writing the audit entry
+  // (audit-service).
+  AUTH_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
+  NOTIFICATION_ESCALATION_SERVICE_BASE_URL: z.string().url().default('http://localhost:3009'),
+  CLOSURE_REOPEN_SERVICE_BASE_URL: z.string().url().default('http://localhost:3006'),
+  AUDIT_SERVICE_BASE_URL: z.string().url().default('http://localhost:3013'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/approval-service/src/docs/openapi.ts
+++ b/apps/approval-service/src/docs/openapi.ts
@@ -1,15 +1,16 @@
-import type { OpenAPIRegistry } from '@armman/service-commons';
-import { buildServiceOpenApiDocument } from '@armman/service-commons';
+import { OpenAPIRegistry, buildServiceOpenApiDocument } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Builds the approval-service OpenAPI document from the registry that
- * `createApprovalRequestRouter` (via `createDocumentedRouter()`) already
- * populated as each route was defined — there is no separate,
- * hand-maintained route list to keep in sync here.
+ * Builds the approval-service OpenAPI document from every feature router's
+ * registry — each `createDocumentedRouter()` call creates its own registry,
+ * merged here (via the registry's `parents` constructor param) so
+ * approvals/quick-response routes never overwrite each other in the
+ * combined doc.
  */
-export function buildApprovalServiceOpenApiDocument(registry: OpenAPIRegistry) {
-  return buildServiceOpenApiDocument(registry, {
+export function buildApprovalServiceOpenApiDocument(...registries: OpenAPIRegistry[]) {
+  const merged = new OpenAPIRegistry(registries);
+  return buildServiceOpenApiDocument(merged, {
     title: 'Arogya Sakhi — Approval Service API',
     description: 'Generic supervisor approval requests and decisions.',
     port: appConfig.PORT,

--- a/apps/approval-service/src/quick-response/audit.client.ts
+++ b/apps/approval-service/src/quick-response/audit.client.ts
@@ -1,0 +1,34 @@
+import { badGateway } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+/**
+ * Writes an audit_log entry after a Quick Response decision, calling
+ * audit-service's POST /audit directly (not through the gateway),
+ * forwarding the caller's own Authorization header — same pattern
+ * supervisor-operations-service's SakhiClient uses.
+ */
+export class AuditClient {
+  async log(
+    actorUserId: string,
+    action: string,
+    entityType: string,
+    entityId: string,
+    afterJson: Record<string, unknown>,
+    authorizationHeader: string,
+  ): Promise<void> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.AUDIT_SERVICE_BASE_URL}/api/v1/audit`, {
+        method: 'POST',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ actorUserId, action, entityType, entityId, afterJson }),
+      });
+    } catch {
+      throw badGateway('Unable to write the audit log entry — audit-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      throw badGateway('Unable to write the audit log entry — audit-service returned an error.');
+    }
+  }
+}

--- a/apps/approval-service/src/quick-response/audit.client.ts
+++ b/apps/approval-service/src/quick-response/audit.client.ts
@@ -18,7 +18,7 @@ export class AuditClient {
   ): Promise<void> {
     let res: Response;
     try {
-      res = await fetch(`${appConfig.AUDIT_SERVICE_BASE_URL}/api/v1/audit`, {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/audit`, {
         method: 'POST',
         headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
         body: JSON.stringify({ actorUserId, action, entityType, entityId, afterJson }),

--- a/apps/approval-service/src/quick-response/dto/decide-quick-response.dto.ts
+++ b/apps/approval-service/src/quick-response/dto/decide-quick-response.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for POST /quick-response/:cardId/decision. `decision`
+ * is a plain string (not a fixed enum) since valid values differ per card
+ * type (APPROVE/REJECT for most, OKAY for EDD_NEARING, TRANSFER/CLOSE for
+ * MISSED_VISIT) — the service layer validates the value against the
+ * specific card type it resolves to.
+ */
+export const decideQuickResponseSchema = z
+  .object({
+    cardSource: z.enum(['approval_requests', 'escalation_events']),
+    decision: z.string().trim().min(1),
+    decisionReasonCodeLookupId: z.string().uuid().optional(),
+    decisionNotes: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export type DecideQuickResponseInput = z.infer<typeof decideQuickResponseSchema>;

--- a/apps/approval-service/src/quick-response/dto/list-quick-response.dto.ts
+++ b/apps/approval-service/src/quick-response/dto/list-quick-response.dto.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for GET /quick-response query params. `status` defaults
+ * to PENDING per the Quick Response spec — resolved against APPROVAL_STATUS
+ * lookup values for approval_requests, and mapped to escalation_events'
+ * OPEN status for escalation-sourced cards (escalation_events has no
+ * PENDING value of its own).
+ */
+export const listQuickResponseSchema = z
+  .object({
+    status: z.string().trim().min(1).default('PENDING'),
+    cursor: z.string().trim().min(1).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  })
+  .strict();
+
+export type ListQuickResponseInput = z.infer<typeof listQuickResponseSchema>;

--- a/apps/approval-service/src/quick-response/escalation.client.ts
+++ b/apps/approval-service/src/quick-response/escalation.client.ts
@@ -1,0 +1,58 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface EscalationCard {
+  cardId: string;
+  cardType: 'MISSED_VISIT' | 'EDD_NEARING';
+  cardSource: 'escalation_events';
+  beneficiaryId: string;
+  visitId: string | null;
+  referralId: string | null;
+  escalationType: string;
+  status: string;
+  raisedAt: string;
+}
+
+interface EscalationEventsResponse {
+  cards: EscalationCard[];
+  nextCursor: string | null;
+}
+
+/**
+ * Fetches escalation-sourced Quick Response cards from
+ * notification-escalation-service — called directly (not through the
+ * gateway), forwarding the caller's own Authorization header, same pattern
+ * supervisor-operations-service's SakhiClient uses.
+ */
+export class EscalationClient {
+  async list(
+    status: string,
+    cursor: string | undefined,
+    limit: number,
+    authorizationHeader: string,
+  ): Promise<EscalationEventsResponse> {
+    const params = new URLSearchParams({ status, limit: String(limit) });
+    if (cursor) params.set('cursor', cursor);
+
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.NOTIFICATION_ESCALATION_SERVICE_BASE_URL}/api/v1/escalation-events?${params.toString()}`,
+        { headers: { Authorization: authorizationHeader } },
+      );
+    } catch {
+      throw badGateway('Unable to fetch escalation events — the service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to fetch escalation events.');
+      }
+      throw badGateway('Unable to fetch escalation events — the service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: EscalationEventsResponse };
+    return body.data;
+  }
+}

--- a/apps/approval-service/src/quick-response/escalation.client.ts
+++ b/apps/approval-service/src/quick-response/escalation.client.ts
@@ -20,9 +20,9 @@ interface EscalationEventsResponse {
 
 /**
  * Fetches escalation-sourced Quick Response cards from
- * notification-escalation-service — called directly (not through the
- * gateway), forwarding the caller's own Authorization header, same pattern
- * supervisor-operations-service's SakhiClient uses.
+ * notification-escalation-service — called through the gateway, forwarding
+ * the caller's own Authorization header, same pattern supervisor-operations-
+ * service's SakhiClient uses.
  */
 export class EscalationClient {
   async list(
@@ -53,6 +53,30 @@ export class EscalationClient {
     }
 
     const body = (await res.json()) as { data: EscalationEventsResponse };
+    return body.data;
+  }
+
+  /** Fetches a single escalation-sourced card, or null if it doesn't exist. */
+  async findById(id: string, authorizationHeader: string): Promise<EscalationCard | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/escalation-events/${id}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to fetch the escalation event — the service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to fetch the escalation event.');
+      }
+      throw badGateway('Unable to fetch the escalation event — the service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: EscalationCard };
     return body.data;
   }
 }

--- a/apps/approval-service/src/quick-response/escalation.client.ts
+++ b/apps/approval-service/src/quick-response/escalation.client.ts
@@ -37,7 +37,7 @@ export class EscalationClient {
     let res: Response;
     try {
       res = await fetch(
-        `${appConfig.NOTIFICATION_ESCALATION_SERVICE_BASE_URL}/api/v1/escalation-events?${params.toString()}`,
+        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/escalation-events?${params.toString()}`,
         { headers: { Authorization: authorizationHeader } },
       );
     } catch {

--- a/apps/approval-service/src/quick-response/lookup.client.ts
+++ b/apps/approval-service/src/quick-response/lookup.client.ts
@@ -24,7 +24,7 @@ export class LookupClient {
   ): Promise<string | null> {
     let res: Response;
     try {
-      res = await fetch(`${appConfig.AUTH_SERVICE_BASE_URL}/api/v1/lookups/APPROVAL_STATUS`, {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/lookups/APPROVAL_STATUS`, {
         headers: { Authorization: authorizationHeader },
       });
     } catch {

--- a/apps/approval-service/src/quick-response/lookup.client.ts
+++ b/apps/approval-service/src/quick-response/lookup.client.ts
@@ -1,0 +1,46 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+interface LookupValue {
+  id: string;
+  valueCode: string;
+}
+
+interface LookupCategory {
+  categoryCode: string;
+  values: LookupValue[];
+}
+
+/**
+ * Resolves an APPROVAL_STATUS value code (e.g. "PENDING") to its
+ * lookup_value_id for the current environment, since
+ * approval_requests.decision_status_lookup_id is an environment-specific FK,
+ * not a stable literal (unlike rules-service's hardcoded rule-version seed).
+ */
+export class LookupClient {
+  async resolveApprovalStatusId(
+    valueCode: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.AUTH_SERVICE_BASE_URL}/api/v1/lookups/APPROVAL_STATUS`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve APPROVAL_STATUS — auth-service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve APPROVAL_STATUS.');
+      }
+      throw badGateway('Unable to resolve APPROVAL_STATUS — auth-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: LookupCategory };
+    return body.data.values.find((v) => v.valueCode === valueCode)?.id ?? null;
+  }
+}

--- a/apps/approval-service/src/quick-response/notification.client.ts
+++ b/apps/approval-service/src/quick-response/notification.client.ts
@@ -17,20 +17,17 @@ export class NotificationClient {
   ): Promise<void> {
     let res: Response;
     try {
-      res = await fetch(
-        `${appConfig.NOTIFICATION_ESCALATION_SERVICE_BASE_URL}/api/v1/notifications`,
-        {
-          method: 'POST',
-          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            recipientUserId,
-            notificationType,
-            title,
-            body,
-            status: 'UNREAD',
-          }),
-        },
-      );
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/notifications`, {
+        method: 'POST',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recipientUserId,
+          notificationType,
+          title,
+          body,
+          status: 'UNREAD',
+        }),
+      });
     } catch {
       throw badGateway(
         'Unable to notify the Sakhi — notification-escalation-service is unreachable.',

--- a/apps/approval-service/src/quick-response/notification.client.ts
+++ b/apps/approval-service/src/quick-response/notification.client.ts
@@ -1,0 +1,46 @@
+import { badGateway } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+/**
+ * Notifies a Sakhi after a Quick Response decision, calling
+ * notification-escalation-service's POST /notifications directly (not
+ * through the gateway), forwarding the caller's own Authorization header —
+ * same pattern supervisor-operations-service's SakhiClient uses.
+ */
+export class NotificationClient {
+  async notify(
+    recipientUserId: string,
+    notificationType: string,
+    title: string,
+    body: string,
+    authorizationHeader: string,
+  ): Promise<void> {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.NOTIFICATION_ESCALATION_SERVICE_BASE_URL}/api/v1/notifications`,
+        {
+          method: 'POST',
+          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            recipientUserId,
+            notificationType,
+            title,
+            body,
+            status: 'UNREAD',
+          }),
+        },
+      );
+    } catch {
+      throw badGateway(
+        'Unable to notify the Sakhi — notification-escalation-service is unreachable.',
+      );
+    }
+
+    if (!res.ok) {
+      throw badGateway(
+        'Unable to notify the Sakhi — notification-escalation-service returned an error.',
+      );
+    }
+  }
+}

--- a/apps/approval-service/src/quick-response/quick-response.controller.ts
+++ b/apps/approval-service/src/quick-response/quick-response.controller.ts
@@ -1,0 +1,134 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { QuickResponseService } from './quick-response.service';
+import { listQuickResponseSchema } from './dto/list-quick-response.dto';
+import { decideQuickResponseSchema } from './dto/decide-quick-response.dto';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  unauthorized,
+  validate,
+  validateBody,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const cardIdParamsSchema = z
+  .object({
+    cardId: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }),
+  })
+  .strict();
+
+const decideQuickResponseRequestSchema = decideQuickResponseSchema.extend({
+  cardSource: decideQuickResponseSchema.shape.cardSource.openapi({ example: 'approval_requests' }),
+  decision: decideQuickResponseSchema.shape.decision.openapi({ example: 'APPROVE' }),
+});
+
+const quickResponseCardSchema = z
+  .object({
+    cardId: z.string().uuid(),
+    cardType: z.string().openapi({ example: 'REOPEN' }),
+    cardSource: z.enum(['approval_requests', 'escalation_events']),
+    beneficiaryId: z.string().uuid().nullable(),
+    raisedAt: z.string().datetime(),
+  })
+  .passthrough();
+
+const listQuickResponseResponseSchema = z.object({
+  cards: z.array(quickResponseCardSchema),
+  nextCursor: z.string().nullable(),
+});
+
+const decideQuickResponseResponseSchema = z.object({
+  cardId: z.string().uuid(),
+  cardSource: z.enum(['approval_requests', 'escalation_events']),
+  decision: z.string(),
+});
+
+const apiErrorSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+  errorCode: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+  details: z.record(z.unknown()).optional(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Quick Response HTTP routes. Mounted under the global `api/v1` prefix.
+ * GET merges approval_requests + escalation_events (SUPERVISOR/MANAGER);
+ * POST decides a card (SUPERVISOR only, per spec).
+ */
+export function createQuickResponseRouter(service: QuickResponseService) {
+  const doc = createDocumentedRouter();
+
+  doc.get(
+    '/quick-response',
+    {
+      summary: 'List Quick Response cards, merged from approval_requests and escalation_events',
+      tags: ['Quick Response'],
+      responses: {
+        200: {
+          description: 'Merged Quick Response cards',
+          schema: envelope(listQuickResponseResponseSchema),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER'),
+    validate(listQuickResponseSchema, 'query'),
+    asyncHandler(async (req, res, next) => {
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const query = req.query as unknown as z.infer<typeof listQuickResponseSchema>;
+      res.json(ok(await service.list(query, authorizationHeader)));
+    }),
+  );
+
+  doc.post(
+    '/quick-response/:cardId/decision',
+    {
+      summary: 'Decide a Quick Response card',
+      tags: ['Quick Response'],
+      params: cardIdParamsSchema,
+      responses: {
+        200: { description: 'Card decided', schema: envelope(decideQuickResponseResponseSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Card not found', schema: apiErrorSchema },
+        409: { description: 'Card already decided', schema: apiErrorSchema },
+        501: {
+          description: 'Decision not yet implemented for this card type',
+          schema: apiErrorSchema,
+        },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR'),
+    validate(cardIdParamsSchema, 'params'),
+    validateBody(decideQuickResponseRequestSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const result = await service.decide(
+        req.params.cardId,
+        req.user,
+        req.body,
+        authorizationHeader,
+      );
+      res.json(ok(result));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/approval-service/src/quick-response/quick-response.controller.ts
+++ b/apps/approval-service/src/quick-response/quick-response.controller.ts
@@ -120,12 +120,7 @@ export function createQuickResponseRouter(service: QuickResponseService) {
       if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');
       if (!authorizationHeader) return next(unauthorized());
-      const result = await service.decide(
-        req.params.cardId,
-        req.user,
-        req.body,
-        authorizationHeader,
-      );
+      const result = await service.decide(req.params.cardId, req.body, authorizationHeader);
       res.json(ok(result));
     }),
   );

--- a/apps/approval-service/src/quick-response/quick-response.module.ts
+++ b/apps/approval-service/src/quick-response/quick-response.module.ts
@@ -6,8 +6,6 @@ import { createQuickResponseRouter } from './quick-response.controller';
 import { LookupClient } from './lookup.client';
 import { EscalationClient } from './escalation.client';
 import { ReopenRequestClient } from './reopen-request.client';
-import { NotificationClient } from './notification.client';
-import { AuditClient } from './audit.client';
 
 /**
  * Composition root for the Quick Response feature: wires repository +
@@ -20,8 +18,6 @@ export function createQuickResponseModule(prisma: PrismaService): DocumentedRout
     new LookupClient(),
     new EscalationClient(),
     new ReopenRequestClient(),
-    new NotificationClient(),
-    new AuditClient(),
   );
   return createQuickResponseRouter(service);
 }

--- a/apps/approval-service/src/quick-response/quick-response.module.ts
+++ b/apps/approval-service/src/quick-response/quick-response.module.ts
@@ -1,0 +1,27 @@
+import type { DocumentedRouter } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { QuickResponseRepository } from './quick-response.repository';
+import { QuickResponseService } from './quick-response.service';
+import { createQuickResponseRouter } from './quick-response.controller';
+import { LookupClient } from './lookup.client';
+import { EscalationClient } from './escalation.client';
+import { ReopenRequestClient } from './reopen-request.client';
+import { NotificationClient } from './notification.client';
+import { AuditClient } from './audit.client';
+
+/**
+ * Composition root for the Quick Response feature: wires repository +
+ * cross-service clients → service → router.
+ */
+export function createQuickResponseModule(prisma: PrismaService): DocumentedRouter {
+  const repository = new QuickResponseRepository(prisma);
+  const service = new QuickResponseService(
+    repository,
+    new LookupClient(),
+    new EscalationClient(),
+    new ReopenRequestClient(),
+    new NotificationClient(),
+    new AuditClient(),
+  );
+  return createQuickResponseRouter(service);
+}

--- a/apps/approval-service/src/quick-response/quick-response.repository.ts
+++ b/apps/approval-service/src/quick-response/quick-response.repository.ts
@@ -1,0 +1,38 @@
+import type { PrismaService } from '../prisma/prisma.service';
+
+/** Data access for the approval_requests half of Quick Response's merged feed. */
+export class QuickResponseRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Cursor-paginated by `(createdAt, id)` DESC, same scheme as
+   * notification-escalation-service's escalation.repository.ts — `id`
+   * breaks ties within the same millisecond.
+   */
+  findMany(
+    decisionStatusLookupId: string,
+    limit: number,
+    cursor: { createdAt: Date; id: string } | null,
+  ) {
+    return this.prisma.approvalRequest.findMany({
+      where: {
+        decisionStatusLookupId,
+        isDeleted: false,
+        ...(cursor
+          ? {
+              OR: [
+                { createdAt: { lt: cursor.createdAt } },
+                { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: limit + 1,
+    });
+  }
+
+  findById(id: string) {
+    return this.prisma.approvalRequest.findFirst({ where: { id, isDeleted: false } });
+  }
+}

--- a/apps/approval-service/src/quick-response/quick-response.service.spec.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.spec.ts
@@ -3,8 +3,6 @@ import type { QuickResponseRepository } from './quick-response.repository';
 import type { LookupClient } from './lookup.client';
 import type { EscalationClient } from './escalation.client';
 import type { ReopenRequestClient } from './reopen-request.client';
-import type { NotificationClient } from './notification.client';
-import type { AuditClient } from './audit.client';
 
 function approvalRequest(overrides: Partial<Record<string, unknown>> = {}) {
   return {
@@ -37,6 +35,21 @@ function approvalRequest(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+function escalationCard(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    cardId: '66666666-6666-6666-6666-666666666666',
+    cardType: 'EDD_NEARING' as const,
+    cardSource: 'escalation_events' as const,
+    beneficiaryId: '77777777-7777-7777-7777-777777777777',
+    visitId: null,
+    referralId: null,
+    escalationType: 'EDD_NEARING',
+    status: 'OPEN',
+    raisedAt: '2026-08-05T11:00:00.000Z',
+    ...overrides,
+  };
+}
+
 describe('QuickResponseService', () => {
   const repository = {
     findMany: jest.fn(),
@@ -45,24 +58,17 @@ describe('QuickResponseService', () => {
   const lookupClient = {
     resolveApprovalStatusId: jest.fn(),
   } as unknown as jest.Mocked<LookupClient>;
-  const escalationClient = { list: jest.fn() } as unknown as jest.Mocked<EscalationClient>;
+  const escalationClient = {
+    list: jest.fn(),
+    findById: jest.fn(),
+  } as unknown as jest.Mocked<EscalationClient>;
   const reopenRequestClient = { decide: jest.fn() } as unknown as jest.Mocked<ReopenRequestClient>;
-  const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
-  const auditClient = { log: jest.fn() } as unknown as jest.Mocked<AuditClient>;
   let service: QuickResponseService;
   const authHeader = 'Bearer token';
-  const supervisor = { id: '55555555-5555-5555-5555-555555555555' };
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new QuickResponseService(
-      repository,
-      lookupClient,
-      escalationClient,
-      reopenRequestClient,
-      notificationClient,
-      auditClient,
-    );
+    service = new QuickResponseService(repository, lookupClient, escalationClient, reopenRequestClient);
   });
 
   describe('list', () => {
@@ -74,19 +80,7 @@ describe('QuickResponseService', () => {
         approvalRequest({ createdAt: new Date('2026-08-05T09:00:00.000Z') }),
       ]);
       escalationClient.list.mockResolvedValue({
-        cards: [
-          {
-            cardId: '66666666-6666-6666-6666-666666666666',
-            cardType: 'EDD_NEARING',
-            cardSource: 'escalation_events',
-            beneficiaryId: '77777777-7777-7777-7777-777777777777',
-            visitId: null,
-            referralId: null,
-            escalationType: 'EDD_NEARING',
-            status: 'OPEN',
-            raisedAt: '2026-08-05T11:00:00.000Z',
-          },
-        ],
+        cards: [escalationCard()],
         nextCursor: null,
       });
 
@@ -136,22 +130,34 @@ describe('QuickResponseService', () => {
 
   describe('decide — EDD_NEARING (escalation_events)', () => {
     it('acknowledges OKAY with no audit/notify side effects', async () => {
+      escalationClient.findById.mockResolvedValue(escalationCard());
+
       const result = await service.decide(
         '66666666-6666-6666-6666-666666666666',
-        supervisor,
         { cardSource: 'escalation_events', decision: 'OKAY' },
         authHeader,
       );
       expect(result).toMatchObject({ decision: 'OKAY', acknowledged: true });
-      expect(auditClient.log).not.toHaveBeenCalled();
-      expect(notificationClient.notify).not.toHaveBeenCalled();
     });
 
-    it('501s a non-OKAY decision on an escalation card', async () => {
+    it('404s when the escalation card does not exist', async () => {
+      escalationClient.findById.mockResolvedValue(null);
+
       await expect(
         service.decide(
           '66666666-6666-6666-6666-666666666666',
-          supervisor,
+          { cardSource: 'escalation_events', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('501s a non-OKAY decision on an escalation card', async () => {
+      escalationClient.findById.mockResolvedValue(escalationCard());
+
+      await expect(
+        service.decide(
+          '66666666-6666-6666-6666-666666666666',
           { cardSource: 'escalation_events', decision: 'APPROVE' },
           authHeader,
         ),
@@ -160,7 +166,7 @@ describe('QuickResponseService', () => {
   });
 
   describe('decide — REOPEN (approval_requests)', () => {
-    it('approves: decides via ReopenRequestClient, audits, and notifies the Sakhi', async () => {
+    it('approves: decides via ReopenRequestClient', async () => {
       repository.findById.mockResolvedValue(approvalRequest());
       reopenRequestClient.decide.mockResolvedValue({
         id: '33333333-3333-3333-3333-333333333333',
@@ -170,7 +176,6 @@ describe('QuickResponseService', () => {
 
       const result = await service.decide(
         '11111111-1111-1111-1111-111111111111',
-        supervisor,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
         authHeader,
       );
@@ -182,18 +187,10 @@ describe('QuickResponseService', () => {
         undefined,
         authHeader,
       );
-      expect(auditClient.log).toHaveBeenCalledTimes(1);
-      expect(notificationClient.notify).toHaveBeenCalledWith(
-        '44444444-4444-4444-4444-444444444444',
-        'REOPEN_UPDATE',
-        expect.any(String),
-        expect.any(String),
-        authHeader,
-      );
       expect(result.decision).toBe('APPROVE');
     });
 
-    it('rejects: persisted as REJECTED — "Cannot re-open" per product decision, audit/notify still fire', async () => {
+    it('rejects: persisted as REJECTED — "Cannot re-open" per product decision', async () => {
       repository.findById.mockResolvedValue(approvalRequest());
       reopenRequestClient.decide.mockResolvedValue({
         id: '33333333-3333-3333-3333-333333333333',
@@ -201,14 +198,12 @@ describe('QuickResponseService', () => {
         supervisorStatus: 'REJECTED',
       });
 
-      await service.decide(
+      const result = await service.decide(
         '11111111-1111-1111-1111-111111111111',
-        supervisor,
         { cardSource: 'approval_requests', decision: 'REJECT' },
         authHeader,
       );
-      expect(auditClient.log).toHaveBeenCalledTimes(1);
-      expect(notificationClient.notify).toHaveBeenCalledTimes(1);
+      expect(result.decision).toBe('REJECT');
     });
 
     it('404s on an unknown cardId', async () => {
@@ -216,7 +211,6 @@ describe('QuickResponseService', () => {
       await expect(
         service.decide(
           'unknown-id',
-          supervisor,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
           authHeader,
         ),
@@ -231,13 +225,10 @@ describe('QuickResponseService', () => {
       await expect(
         service.decide(
           '11111111-1111-1111-1111-111111111111',
-          supervisor,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 409 });
-      expect(auditClient.log).not.toHaveBeenCalled();
-      expect(notificationClient.notify).not.toHaveBeenCalled();
     });
 
     it('rejects an invalid decision value for a REOPEN card', async () => {
@@ -245,7 +236,6 @@ describe('QuickResponseService', () => {
       await expect(
         service.decide(
           '11111111-1111-1111-1111-111111111111',
-          supervisor,
           { cardSource: 'approval_requests', decision: 'OKAY' },
           authHeader,
         ),
@@ -265,7 +255,6 @@ describe('QuickResponseService', () => {
       await expect(
         service.decide(
           '11111111-1111-1111-1111-111111111111',
-          supervisor,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
           authHeader,
         ),

--- a/apps/approval-service/src/quick-response/quick-response.service.spec.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.spec.ts
@@ -107,6 +107,17 @@ describe('QuickResponseService', () => {
       expect(escalationClient.list).toHaveBeenCalledWith('OPEN', undefined, 50, authHeader);
     });
 
+    it('skips the escalation-events call entirely for a non-PENDING status', async () => {
+      lookupClient.resolveApprovalStatusId.mockResolvedValue(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      );
+      repository.findMany.mockResolvedValue([]);
+
+      const result = await service.list({ status: 'APPROVED', limit: 50 }, authHeader);
+      expect(escalationClient.list).not.toHaveBeenCalled();
+      expect(result.cards).toHaveLength(0);
+    });
+
     it('returns an empty list when the APPROVAL_STATUS lookup value is unknown', async () => {
       lookupClient.resolveApprovalStatusId.mockResolvedValue(null);
       escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });

--- a/apps/approval-service/src/quick-response/quick-response.service.spec.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.spec.ts
@@ -1,0 +1,264 @@
+import { QuickResponseService } from './quick-response.service';
+import type { QuickResponseRepository } from './quick-response.repository';
+import type { LookupClient } from './lookup.client';
+import type { EscalationClient } from './escalation.client';
+import type { ReopenRequestClient } from './reopen-request.client';
+import type { NotificationClient } from './notification.client';
+import type { AuditClient } from './audit.client';
+
+function approvalRequest(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    requestType: 'REOPEN' as const,
+    beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    sourceEntityType: 'BeneficiaryCase',
+    sourceEntityId: '22222222-2222-2222-2222-222222222222',
+    sourceSubmissionId: null,
+    decisionReasonCodeLookupId: null,
+    decisionNotes: null,
+    decidedByUserId: null,
+    sourceAnswerId: null,
+    referralId: null,
+    closureId: null,
+    reopenRequestId: '33333333-3333-3333-3333-333333333333',
+    requestedByUserId: '44444444-4444-4444-4444-444444444444',
+    approverUserId: null,
+    requestPayloadJson: null,
+    decisionStatusLookupId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    decisionPayloadJson: null,
+    decidedAt: null,
+    createdAt: new Date('2026-08-05T10:00:00.000Z'),
+    createdByUserId: null,
+    updatedAt: new Date('2026-08-05T10:00:00.000Z'),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('QuickResponseService', () => {
+  const repository = {
+    findMany: jest.fn(),
+    findById: jest.fn(),
+  } as unknown as jest.Mocked<QuickResponseRepository>;
+  const lookupClient = {
+    resolveApprovalStatusId: jest.fn(),
+  } as unknown as jest.Mocked<LookupClient>;
+  const escalationClient = { list: jest.fn() } as unknown as jest.Mocked<EscalationClient>;
+  const reopenRequestClient = { decide: jest.fn() } as unknown as jest.Mocked<ReopenRequestClient>;
+  const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
+  const auditClient = { log: jest.fn() } as unknown as jest.Mocked<AuditClient>;
+  let service: QuickResponseService;
+  const authHeader = 'Bearer token';
+  const supervisor = { id: '55555555-5555-5555-5555-555555555555' };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new QuickResponseService(
+      repository,
+      lookupClient,
+      escalationClient,
+      reopenRequestClient,
+      notificationClient,
+      auditClient,
+    );
+  });
+
+  describe('list', () => {
+    it('merges approval_requests and escalation_events sorted by raisedAt DESC', async () => {
+      lookupClient.resolveApprovalStatusId.mockResolvedValue(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      );
+      repository.findMany.mockResolvedValue([
+        approvalRequest({ createdAt: new Date('2026-08-05T09:00:00.000Z') }),
+      ]);
+      escalationClient.list.mockResolvedValue({
+        cards: [
+          {
+            cardId: '66666666-6666-6666-6666-666666666666',
+            cardType: 'EDD_NEARING',
+            cardSource: 'escalation_events',
+            beneficiaryId: '77777777-7777-7777-7777-777777777777',
+            visitId: null,
+            referralId: null,
+            escalationType: 'EDD_NEARING',
+            status: 'OPEN',
+            raisedAt: '2026-08-05T11:00:00.000Z',
+          },
+        ],
+        nextCursor: null,
+      });
+
+      const result = await service.list({ status: 'PENDING', limit: 50 }, authHeader);
+      expect(result.cards).toHaveLength(2);
+      expect(result.cards[0].cardId).toBe('66666666-6666-6666-6666-666666666666');
+      expect(result.cards[1].cardId).toBe('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('maps status=PENDING to OPEN for the escalation-events call', async () => {
+      lookupClient.resolveApprovalStatusId.mockResolvedValue(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      );
+      repository.findMany.mockResolvedValue([]);
+      escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
+
+      await service.list({ status: 'PENDING', limit: 50 }, authHeader);
+      expect(escalationClient.list).toHaveBeenCalledWith('OPEN', undefined, 50, authHeader);
+    });
+
+    it('returns an empty list when the APPROVAL_STATUS lookup value is unknown', async () => {
+      lookupClient.resolveApprovalStatusId.mockResolvedValue(null);
+      escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
+
+      const result = await service.list({ status: 'BOGUS', limit: 50 }, authHeader);
+      expect(result.cards).toHaveLength(0);
+      expect(repository.findMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed cursor with a 400', async () => {
+      await expect(
+        service.list({ status: 'PENDING', cursor: 'not-valid!!', limit: 50 }, authHeader),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+  });
+
+  describe('decide — EDD_NEARING (escalation_events)', () => {
+    it('acknowledges OKAY with no audit/notify side effects', async () => {
+      const result = await service.decide(
+        '66666666-6666-6666-6666-666666666666',
+        supervisor,
+        { cardSource: 'escalation_events', decision: 'OKAY' },
+        authHeader,
+      );
+      expect(result).toMatchObject({ decision: 'OKAY', acknowledged: true });
+      expect(auditClient.log).not.toHaveBeenCalled();
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('501s a non-OKAY decision on an escalation card', async () => {
+      await expect(
+        service.decide(
+          '66666666-6666-6666-6666-666666666666',
+          supervisor,
+          { cardSource: 'escalation_events', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 501 });
+    });
+  });
+
+  describe('decide — REOPEN (approval_requests)', () => {
+    it('approves: decides via ReopenRequestClient, audits, and notifies the Sakhi', async () => {
+      repository.findById.mockResolvedValue(approvalRequest());
+      reopenRequestClient.decide.mockResolvedValue({
+        id: '33333333-3333-3333-3333-333333333333',
+        beneficiaryId: '22222222-2222-2222-2222-222222222222',
+        supervisorStatus: 'APPROVED',
+      });
+
+      const result = await service.decide(
+        '11111111-1111-1111-1111-111111111111',
+        supervisor,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+
+      expect(reopenRequestClient.decide).toHaveBeenCalledWith(
+        '33333333-3333-3333-3333-333333333333',
+        'APPROVED',
+        undefined,
+        undefined,
+        authHeader,
+      );
+      expect(auditClient.log).toHaveBeenCalledTimes(1);
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        '44444444-4444-4444-4444-444444444444',
+        'REOPEN_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+    });
+
+    it('rejects: persisted as REJECTED — "Cannot re-open" per product decision, audit/notify still fire', async () => {
+      repository.findById.mockResolvedValue(approvalRequest());
+      reopenRequestClient.decide.mockResolvedValue({
+        id: '33333333-3333-3333-3333-333333333333',
+        beneficiaryId: '22222222-2222-2222-2222-222222222222',
+        supervisorStatus: 'REJECTED',
+      });
+
+      await service.decide(
+        '11111111-1111-1111-1111-111111111111',
+        supervisor,
+        { cardSource: 'approval_requests', decision: 'REJECT' },
+        authHeader,
+      );
+      expect(auditClient.log).toHaveBeenCalledTimes(1);
+      expect(notificationClient.notify).toHaveBeenCalledTimes(1);
+    });
+
+    it('404s on an unknown cardId', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(
+        service.decide(
+          'unknown-id',
+          supervisor,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('propagates a 409 from closure-reopen-service (already-decided reopen request)', async () => {
+      repository.findById.mockResolvedValue(approvalRequest());
+      const conflictError = Object.assign(new Error('Already decided'), { status: 409 });
+      reopenRequestClient.decide.mockRejectedValue(conflictError);
+
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          supervisor,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(auditClient.log).not.toHaveBeenCalled();
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid decision value for a REOPEN card', async () => {
+      repository.findById.mockResolvedValue(approvalRequest());
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          supervisor,
+          { cardSource: 'approval_requests', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+  });
+
+  describe('decide — the other 6 stubbed card types', () => {
+    it.each([
+      'LMP_CHANGE',
+      'ACCOMPANIED_REFERRAL',
+      'CLOSURE_REVIEW',
+      'REFERRAL_INCOMPLETE',
+      'DATA_RESTORE',
+    ])('501s a decision on a %s card', async (requestType) => {
+      repository.findById.mockResolvedValue(approvalRequest({ requestType }));
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          supervisor,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 501 });
+    });
+  });
+});

--- a/apps/approval-service/src/quick-response/quick-response.service.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.ts
@@ -3,8 +3,6 @@ import type { QuickResponseRepository } from './quick-response.repository';
 import type { LookupClient } from './lookup.client';
 import type { EscalationClient, EscalationCard } from './escalation.client';
 import type { ReopenRequestClient } from './reopen-request.client';
-import type { NotificationClient } from './notification.client';
-import type { AuditClient } from './audit.client';
 import type { ListQuickResponseInput } from './dto/list-quick-response.dto';
 import type { DecideQuickResponseInput } from './dto/decide-quick-response.dto';
 
@@ -68,8 +66,6 @@ export class QuickResponseService {
     private readonly lookupClient: LookupClient,
     private readonly escalationClient: EscalationClient,
     private readonly reopenRequestClient: ReopenRequestClient,
-    private readonly notificationClient: NotificationClient,
-    private readonly auditClient: AuditClient,
   ) {}
 
   /**
@@ -132,19 +128,21 @@ export class QuickResponseService {
    * write endpoint in a service that doesn't have one yet, so they respond
    * 501 rather than silently no-op or guess at undefined behavior.
    */
-  async decide(
+  async decide(cardId: string, dto: DecideQuickResponseInput, authorizationHeader: string) {
+    if (dto.cardSource === 'escalation_events') {
+      return this.decideEscalationCard(cardId, dto, authorizationHeader);
+    }
+    return this.decideApprovalRequestCard(cardId, dto, authorizationHeader);
+  }
+
+  private async decideEscalationCard(
     cardId: string,
-    caller: { id: string },
     dto: DecideQuickResponseInput,
     authorizationHeader: string,
   ) {
-    if (dto.cardSource === 'escalation_events') {
-      return this.decideEscalationCard(cardId, dto);
-    }
-    return this.decideApprovalRequestCard(cardId, caller, dto, authorizationHeader);
-  }
+    const existing = await this.escalationClient.findById(cardId, authorizationHeader);
+    if (!existing) throw notFound('Quick Response card not found.');
 
-  private async decideEscalationCard(cardId: string, dto: DecideQuickResponseInput) {
     // Only EDD_NEARING is wired this phase; MISSED_VISIT's TRANSFER/CLOSE
     // actions need write paths in services that don't have them yet.
     if (dto.decision !== 'OKAY') {
@@ -165,7 +163,6 @@ export class QuickResponseService {
 
   private async decideApprovalRequestCard(
     cardId: string,
-    caller: { id: string },
     dto: DecideQuickResponseInput,
     authorizationHeader: string,
   ) {
@@ -187,6 +184,11 @@ export class QuickResponseService {
       throw new HttpError(500, 'This REOPEN card has no linked reopen request.');
     }
 
+    // The audit_log entry and Sakhi notification are written by
+    // closure-reopen-service's own decide flow, not here — that's the only
+    // place a reopen decision is actually persisted, so the audit trail
+    // can't be bypassed by calling that endpoint directly instead of through
+    // Quick Response.
     const decided = await this.reopenRequestClient.decide(
       existing.reopenRequestId,
       dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED',
@@ -194,27 +196,6 @@ export class QuickResponseService {
       dto.decisionNotes,
       authorizationHeader,
     );
-
-    await this.auditClient.log(
-      caller.id,
-      `QUICK_RESPONSE_${dto.decision}`,
-      'ReopenRequest',
-      decided.id,
-      { decision: dto.decision, decisionNotes: dto.decisionNotes ?? null },
-      authorizationHeader,
-    );
-
-    if (existing.requestedByUserId) {
-      await this.notificationClient.notify(
-        existing.requestedByUserId,
-        'REOPEN_UPDATE',
-        'Reopen request decided',
-        dto.decision === 'APPROVE'
-          ? 'Your reopen request was approved.'
-          : 'Your reopen request was rejected.',
-        authorizationHeader,
-      );
-    }
 
     return {
       cardId,

--- a/apps/approval-service/src/quick-response/quick-response.service.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.ts
@@ -47,9 +47,17 @@ function encodeCursor(row: { createdAt: Date; id: string }): string {
   return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, 'utf8').toString('base64url');
 }
 
-/** escalation_events has no PENDING status — OPEN is its "not yet acted on" equivalent. */
-function mapStatusForEscalations(status: string): string {
-  return status === 'PENDING' ? 'OPEN' : status;
+/**
+ * Maps an APPROVAL_STATUS value code onto escalation_events.status, or
+ * returns null when there's no meaningful equivalent. Only PENDING
+ * (escalation_events' "not yet acted on" state is OPEN) has one —
+ * APPROVED/REJECTED/AUTO_LAPSED/CANCELLED are approval-specific decision
+ * outcomes that don't exist in EscalationStatus's vocabulary, so those
+ * statuses skip the escalation-events call entirely rather than forwarding
+ * a value that call would reject.
+ */
+function mapStatusForEscalations(status: string): string | null {
+  return status === 'PENDING' ? 'OPEN' : null;
 }
 
 /** Quick Response's domain logic: merges approval_requests + escalation_events
@@ -91,12 +99,15 @@ export class QuickResponseService {
         raisedAt: row.createdAt.toISOString(),
       }));
 
-    const escalationResult = await this.escalationClient.list(
-      mapStatusForEscalations(query.status),
-      query.cursor,
-      query.limit,
-      authorizationHeader,
-    );
+    const escalationStatus = mapStatusForEscalations(query.status);
+    const escalationResult = escalationStatus
+      ? await this.escalationClient.list(
+          escalationStatus,
+          query.cursor,
+          query.limit,
+          authorizationHeader,
+        )
+      : { cards: [], nextCursor: null };
 
     const merged: QuickResponseCard[] = [...approvalCards, ...escalationResult.cards].sort(
       (a, b) => new Date(b.raisedAt).getTime() - new Date(a.raisedAt).getTime(),

--- a/apps/approval-service/src/quick-response/quick-response.service.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.ts
@@ -1,0 +1,215 @@
+import { badRequest, notFound, HttpError } from '@armman/service-commons';
+import type { QuickResponseRepository } from './quick-response.repository';
+import type { LookupClient } from './lookup.client';
+import type { EscalationClient, EscalationCard } from './escalation.client';
+import type { ReopenRequestClient } from './reopen-request.client';
+import type { NotificationClient } from './notification.client';
+import type { AuditClient } from './audit.client';
+import type { ListQuickResponseInput } from './dto/list-quick-response.dto';
+import type { DecideQuickResponseInput } from './dto/decide-quick-response.dto';
+
+/** Every ApprovalRequestType maps 1:1 to a Quick Response card type — same name. */
+const APPROVAL_REQUEST_CARD_TYPES = new Set([
+  'LMP_CHANGE',
+  'REFERRAL_INCOMPLETE',
+  'ACCOMPANIED_REFERRAL',
+  'CLOSURE_REVIEW',
+  'REOPEN',
+  'DATA_RESTORE',
+]);
+
+interface ApprovalRequestCard {
+  cardId: string;
+  cardType: string;
+  cardSource: 'approval_requests';
+  beneficiaryId: string | null;
+  raisedAt: string;
+}
+
+type QuickResponseCard = ApprovalRequestCard | EscalationCard;
+
+function decodeCursor(cursor: string): { createdAt: Date; id: string } {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+  } catch {
+    throw badRequest('cursor: Invalid cursor.');
+  }
+  const [createdAtIso, id] = decoded.split('|');
+  const createdAt = createdAtIso ? new Date(createdAtIso) : null;
+  if (!createdAt || Number.isNaN(createdAt.getTime()) || !id) {
+    throw badRequest('cursor: Invalid cursor.');
+  }
+  return { createdAt, id };
+}
+
+function encodeCursor(row: { createdAt: Date; id: string }): string {
+  return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, 'utf8').toString('base64url');
+}
+
+/** escalation_events has no PENDING status — OPEN is its "not yet acted on" equivalent. */
+function mapStatusForEscalations(status: string): string {
+  return status === 'PENDING' ? 'OPEN' : status;
+}
+
+/** Quick Response's domain logic: merges approval_requests + escalation_events
+ * into one feed, and dispatches decisions per card type. */
+export class QuickResponseService {
+  constructor(
+    private readonly repository: QuickResponseRepository,
+    private readonly lookupClient: LookupClient,
+    private readonly escalationClient: EscalationClient,
+    private readonly reopenRequestClient: ReopenRequestClient,
+    private readonly notificationClient: NotificationClient,
+    private readonly auditClient: AuditClient,
+  ) {}
+
+  /**
+   * Merges both sources in memory (no cross-service DB join, per the
+   * forklift rule) and re-paginates over the combined set. Cursor pagination
+   * across two independently-paginated remote sources is approximate under
+   * concurrent writes between page fetches — an accepted trade-off at this
+   * scale, not solved further here.
+   */
+  async list(query: ListQuickResponseInput, authorizationHeader: string) {
+    const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+
+    const approvalStatusId = await this.lookupClient.resolveApprovalStatusId(
+      query.status,
+      authorizationHeader,
+    );
+    const approvalRows = approvalStatusId
+      ? await this.repository.findMany(approvalStatusId, query.limit, cursor)
+      : [];
+    const approvalCards: ApprovalRequestCard[] = approvalRows
+      .filter((row) => APPROVAL_REQUEST_CARD_TYPES.has(row.requestType))
+      .map((row) => ({
+        cardId: row.id,
+        cardType: row.requestType,
+        cardSource: 'approval_requests' as const,
+        beneficiaryId: row.beneficiaryId,
+        raisedAt: row.createdAt.toISOString(),
+      }));
+
+    const escalationResult = await this.escalationClient.list(
+      mapStatusForEscalations(query.status),
+      query.cursor,
+      query.limit,
+      authorizationHeader,
+    );
+
+    const merged: QuickResponseCard[] = [...approvalCards, ...escalationResult.cards].sort(
+      (a, b) => new Date(b.raisedAt).getTime() - new Date(a.raisedAt).getTime(),
+    );
+
+    const hasMore = merged.length > query.limit;
+    const page = hasMore ? merged.slice(0, query.limit) : merged;
+    const nextCursor = hasMore
+      ? encodeCursor({
+          createdAt: new Date(page[page.length - 1].raisedAt),
+          id: page[page.length - 1].cardId,
+        })
+      : null;
+
+    return { cards: page, nextCursor };
+  }
+
+  /**
+   * Dispatches a decision by card type. Only EDD_NEARING and REOPEN are
+   * fully wired in this phase — every other card type's real side effect
+   * (ANC regen, incentive trigger, closure/referral status writes) needs a
+   * write endpoint in a service that doesn't have one yet, so they respond
+   * 501 rather than silently no-op or guess at undefined behavior.
+   */
+  async decide(
+    cardId: string,
+    caller: { id: string },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    if (dto.cardSource === 'escalation_events') {
+      return this.decideEscalationCard(cardId, dto);
+    }
+    return this.decideApprovalRequestCard(cardId, caller, dto, authorizationHeader);
+  }
+
+  private async decideEscalationCard(cardId: string, dto: DecideQuickResponseInput) {
+    // Only EDD_NEARING is wired this phase; MISSED_VISIT's TRANSFER/CLOSE
+    // actions need write paths in services that don't have them yet.
+    if (dto.decision !== 'OKAY') {
+      throw new HttpError(501, `Decision "${dto.decision}" is not yet implemented for this card.`);
+    }
+    // Acknowledge-only: no audit_log, no notify (spec's explicit exemption).
+    // The actual PENDING->OPEN->DISMISSED status write happens via a future
+    // escalation-decision endpoint in notification-escalation-service —
+    // out of scope for this phase's EDD_NEARING vertical slice beyond
+    // proving the read+dispatch path; tracked as a follow-up.
+    return {
+      cardId,
+      cardSource: 'escalation_events' as const,
+      decision: 'OKAY',
+      acknowledged: true,
+    };
+  }
+
+  private async decideApprovalRequestCard(
+    cardId: string,
+    caller: { id: string },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(cardId);
+    if (!existing) throw notFound('Quick Response card not found.');
+
+    if (existing.requestType !== 'REOPEN') {
+      throw new HttpError(
+        501,
+        `Decisions on "${existing.requestType}" cards are not yet implemented.`,
+      );
+    }
+    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+      throw badRequest('decision: Must be APPROVE or REJECT for a REOPEN card.');
+    }
+    if (!existing.reopenRequestId) {
+      // Data integrity issue, not a client error — a REOPEN approval_requests
+      // row must always carry the reopen_requests id it originated from.
+      throw new HttpError(500, 'This REOPEN card has no linked reopen request.');
+    }
+
+    const decided = await this.reopenRequestClient.decide(
+      existing.reopenRequestId,
+      dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED',
+      dto.decisionReasonCodeLookupId,
+      dto.decisionNotes,
+      authorizationHeader,
+    );
+
+    await this.auditClient.log(
+      caller.id,
+      `QUICK_RESPONSE_${dto.decision}`,
+      'ReopenRequest',
+      decided.id,
+      { decision: dto.decision, decisionNotes: dto.decisionNotes ?? null },
+      authorizationHeader,
+    );
+
+    if (existing.requestedByUserId) {
+      await this.notificationClient.notify(
+        existing.requestedByUserId,
+        'REOPEN_UPDATE',
+        'Reopen request decided',
+        dto.decision === 'APPROVE'
+          ? 'Your reopen request was approved.'
+          : 'Your reopen request was rejected.',
+        authorizationHeader,
+      );
+    }
+
+    return {
+      cardId,
+      cardSource: 'approval_requests' as const,
+      decision: dto.decision,
+      reopenRequest: decided,
+    };
+  }
+}

--- a/apps/approval-service/src/quick-response/reopen-request.client.ts
+++ b/apps/approval-service/src/quick-response/reopen-request.client.ts
@@ -1,0 +1,53 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface ReopenRequestRecord {
+  id: string;
+  beneficiaryId: string;
+  supervisorStatus: 'PENDING' | 'APPROVED' | 'REJECTED';
+}
+
+/**
+ * Decides a REOPEN card by calling closure-reopen-service's
+ * PATCH /reopen-requests/:id/decision directly (not through the gateway),
+ * forwarding the caller's own Authorization header — same pattern
+ * supervisor-operations-service's SakhiClient uses.
+ */
+export class ReopenRequestClient {
+  async decide(
+    id: string,
+    decision: 'APPROVED' | 'REJECTED',
+    decisionReasonCodeLookupId: string | undefined,
+    decisionNotes: string | undefined,
+    authorizationHeader: string,
+  ): Promise<ReopenRequestRecord> {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.CLOSURE_REOPEN_SERVICE_BASE_URL}/api/v1/reopen-requests/${id}/decision`,
+        {
+          method: 'PATCH',
+          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ decision, decisionReasonCodeLookupId, decisionNotes }),
+        },
+      );
+    } catch {
+      throw badGateway(
+        'Unable to decide the reopen request — closure-reopen-service is unreachable.',
+      );
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to decide the reopen request.');
+      }
+      throw badGateway(
+        'Unable to decide the reopen request — closure-reopen-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: ReopenRequestRecord };
+    return body.data;
+  }
+}

--- a/apps/approval-service/src/quick-response/reopen-request.client.ts
+++ b/apps/approval-service/src/quick-response/reopen-request.client.ts
@@ -9,9 +9,9 @@ export interface ReopenRequestRecord {
 
 /**
  * Decides a REOPEN card by calling closure-reopen-service's
- * PATCH /reopen-requests/:id/decision directly (not through the gateway),
- * forwarding the caller's own Authorization header — same pattern
- * supervisor-operations-service's SakhiClient uses.
+ * PATCH /reopen-requests/:id/decision through the gateway, forwarding the
+ * caller's own Authorization header — same pattern supervisor-operations-
+ * service's SakhiClient uses.
  */
 export class ReopenRequestClient {
   async decide(

--- a/apps/approval-service/src/quick-response/reopen-request.client.ts
+++ b/apps/approval-service/src/quick-response/reopen-request.client.ts
@@ -23,14 +23,11 @@ export class ReopenRequestClient {
   ): Promise<ReopenRequestRecord> {
     let res: Response;
     try {
-      res = await fetch(
-        `${appConfig.CLOSURE_REOPEN_SERVICE_BASE_URL}/api/v1/reopen-requests/${id}/decision`,
-        {
-          method: 'PATCH',
-          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
-          body: JSON.stringify({ decision, decisionReasonCodeLookupId, decisionNotes }),
-        },
-      );
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/reopen-requests/${id}/decision`, {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision, decisionReasonCodeLookupId, decisionNotes }),
+      });
     } catch {
       throw badGateway(
         'Unable to decide the reopen request — closure-reopen-service is unreachable.',

--- a/apps/audit-service/jest.config.ts
+++ b/apps/audit-service/jest.config.ts
@@ -3,5 +3,6 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/audit-service',
 };

--- a/apps/audit-service/src/app.module.ts
+++ b/apps/audit-service/src/app.module.ts
@@ -22,6 +22,7 @@ export {
   validateBody,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/audit-service/src/audit/auditLog.controller.ts
+++ b/apps/audit-service/src/audit/auditLog.controller.ts
@@ -8,6 +8,7 @@ import {
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   validateBody,
 } from '../app.module';
 
@@ -93,10 +94,21 @@ export function createAuditLogRouter(service: AuditLogService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('ADMIN'),
+    // ADMIN direct use, plus SUPERVISOR so approval-service can log a Quick
+    // Response decision's audit entry on the caller's behalf (it forwards
+    // the deciding Supervisor's own Authorization header, same pattern
+    // supervisor-operations-service's SakhiClient uses — no separate
+    // service-to-service credential scheme in this codebase yet).
+    // service.create() constrains a non-ADMIN caller to their own
+    // actorUserId and to the QUICK_RESPONSE_* action namespace, so this
+    // widened role can only ever log the caller's own decisions — never
+    // forge an entry attributed to someone else or write an arbitrary
+    // action/entityType.
+    requireRoles('ADMIN', 'SUPERVISOR'),
     validateBody(createAuditLogRequestSchema),
-    asyncHandler(async (req, res) => {
-      const created = await service.create(req.body);
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const created = await service.create(req.body, req.user);
       res.status(201).json(ok(created));
     }),
   );

--- a/apps/audit-service/src/audit/auditLog.service.spec.ts
+++ b/apps/audit-service/src/audit/auditLog.service.spec.ts
@@ -8,6 +8,8 @@ describe('AuditLogService', () => {
     create: jest.fn(),
   } as unknown as jest.Mocked<AuditLogRepository>;
   let service: AuditLogService;
+  const admin = { id: 'admin-1', roles: ['ADMIN'] };
+  const supervisor = { id: 'supervisor-1', roles: ['SUPERVISOR'] };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -39,16 +41,12 @@ describe('AuditLogService', () => {
     await expect(service.list()).resolves.toBe(rows);
   });
 
-  it('creates via repository with the given data', async () => {
+  it('ADMIN creates any entry as-is', async () => {
     const dto: CreateAuditLogInput = {
       actorUserId: 'user-1',
       action: 'CREATE',
       entityType: 'Beneficiary',
       entityId: 'entity-1',
-      beforeJson: { status: 'inactive' },
-      afterJson: { status: 'active' },
-      ipAddress: '127.0.0.1',
-      deviceId: 'device-1',
     };
     const created = {
       id: '1',
@@ -56,21 +54,42 @@ describe('AuditLogService', () => {
       action: dto.action,
       entityType: dto.entityType,
       entityId: dto.entityId ?? null,
-      beforeJson: dto.beforeJson ?? null,
-      afterJson: dto.afterJson ?? null,
-      ipAddress: dto.ipAddress ?? null,
-      deviceId: dto.deviceId ?? null,
+      beforeJson: null,
+      afterJson: null,
+      ipAddress: null,
+      deviceId: null,
       createdAt: new Date(),
     };
     repository.create.mockResolvedValue(created);
-    await expect(service.create(dto)).resolves.toBe(created);
+    await expect(service.create(dto, admin)).resolves.toBe(created);
     expect(repository.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('SUPERVISOR logging a QUICK_RESPONSE_ action has actorUserId forced to their own id', async () => {
+    const dto: CreateAuditLogInput = {
+      actorUserId: 'someone-else',
+      action: 'QUICK_RESPONSE_APPROVE',
+      entityType: 'ReopenRequest',
+      entityId: 'reopen-1',
+    };
+    repository.create.mockResolvedValue({ id: '1' } as never);
+    await service.create(dto, supervisor);
+    expect(repository.create).toHaveBeenCalledWith({ ...dto, actorUserId: 'supervisor-1' });
+  });
+
+  it('SUPERVISOR logging a non-QUICK_RESPONSE_ action is forbidden', () => {
+    const dto: CreateAuditLogInput = {
+      action: 'DELETE_EVERYTHING',
+      entityType: 'Beneficiary',
+    };
+    expect(() => service.create(dto, supervisor)).toThrow(expect.objectContaining({ status: 403 }));
+    expect(repository.create).not.toHaveBeenCalled();
   });
 
   it('propagates repository errors on create', async () => {
     repository.create.mockRejectedValue(new Error('db down'));
-    await expect(service.create({ action: 'CREATE', entityType: 'Beneficiary' })).rejects.toThrow(
-      'db down',
-    );
+    await expect(
+      service.create({ action: 'CREATE', entityType: 'Beneficiary' }, admin),
+    ).rejects.toThrow('db down');
   });
 });

--- a/apps/audit-service/src/audit/auditLog.service.ts
+++ b/apps/audit-service/src/audit/auditLog.service.ts
@@ -1,5 +1,11 @@
+import { forbidden } from '@armman/service-commons';
 import type { AuditLogRepository } from './auditLog.repository';
 import type { CreateAuditLogInput } from './dto/create-auditLog.dto';
+
+export interface CallerIdentity {
+  id: string;
+  roles: string[];
+}
 
 /** Audit log domain logic. Data access is delegated to the repository. */
 export class AuditLogService {
@@ -9,7 +15,21 @@ export class AuditLogService {
     return this.repository.findMany();
   }
 
-  create(dto: CreateAuditLogInput) {
+  /**
+   * ADMIN may log any entry as-is. A SUPERVISOR (the role widened for
+   * approval-service's Quick Response decisions to forward through) may
+   * only log their own QUICK_RESPONSE_* actions — actorUserId is forced to
+   * the caller's own id (never the client-supplied value) and action must
+   * be in that namespace, so the widened role can never forge an entry
+   * attributed to someone else or write an arbitrary action/entityType.
+   */
+  create(dto: CreateAuditLogInput, caller: CallerIdentity) {
+    if (!caller.roles.includes('ADMIN')) {
+      if (!dto.action.startsWith('QUICK_RESPONSE_')) {
+        throw forbidden('SUPERVISOR may only log QUICK_RESPONSE_* actions.');
+      }
+      return this.repository.create({ ...dto, actorUserId: caller.id });
+    }
     return this.repository.create(dto);
   }
 }

--- a/apps/closure-reopen-service/.env.example
+++ b/apps/closure-reopen-service/.env.example
@@ -8,3 +8,7 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
+# Reopen request decisions call audit-service and notification-escalation-
+# service through the gateway (forwarding the deciding Supervisor's own
+# JWT) to write the audit entry and notify the Sakhi.
+API_GATEWAY_BASE_URL=http://localhost:3000

--- a/apps/closure-reopen-service/jest.config.ts
+++ b/apps/closure-reopen-service/jest.config.ts
@@ -3,5 +3,6 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/closure-reopen-service',
 };

--- a/apps/closure-reopen-service/src/app.module.ts
+++ b/apps/closure-reopen-service/src/app.module.ts
@@ -12,6 +12,7 @@ import { appConfig } from './config/app-config';
 import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createClosureModule } from './closures/closure.module';
+import { createReopenRequestModule } from './reopen-requests/reopen-request.module';
 import { buildClosureReopenServiceOpenApiDocument } from './docs/openapi';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
@@ -19,9 +20,11 @@ export {
   asyncHandler,
   ok,
   fail,
+  validate,
   validateBody,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   createDocumentedRouter,
   HttpError,
   ErrorCode,
@@ -50,15 +53,24 @@ export function createApp(prisma: PrismaService): Application {
   app.use(requestId);
 
   const closureModule = createClosureModule(prisma);
+  const reopenRequestModule = createReopenRequestModule(prisma);
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();
   api.use(createHealthRouter(prisma));
-  // Built from closureModule.registry — every route registered via
+  // Built from every feature module's registry — every route registered via
   // createDocumentedRouter() above is already in the spec, so this can never
   // drift from what's actually mounted.
-  api.use(createSwaggerRouter(buildClosureReopenServiceOpenApiDocument(closureModule.registry)));
+  api.use(
+    createSwaggerRouter(
+      buildClosureReopenServiceOpenApiDocument(
+        closureModule.registry,
+        reopenRequestModule.registry,
+      ),
+    ),
+  );
   api.use(closureModule.router);
+  api.use(reopenRequestModule.router);
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/closure-reopen-service/src/config/app-config.ts
+++ b/apps/closure-reopen-service/src/config/app-config.ts
@@ -16,6 +16,11 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  // Reopen request decisions write an audit_log entry and notify the Sakhi
+  // through audit-service and notification-escalation-service respectively —
+  // via the gateway, forwarding the deciding Supervisor's own JWT, same
+  // pattern as approval-service's Quick Response clients.
+  API_GATEWAY_BASE_URL: z.string().url().default('http://localhost:3000'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/closure-reopen-service/src/docs/openapi.ts
+++ b/apps/closure-reopen-service/src/docs/openapi.ts
@@ -1,15 +1,15 @@
-import type { OpenAPIRegistry } from '@armman/service-commons';
-import { buildServiceOpenApiDocument } from '@armman/service-commons';
+import { OpenAPIRegistry, buildServiceOpenApiDocument } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Builds the closure-reopen-service OpenAPI document from the registry that
- * `createClosureRouter` (via `createDocumentedRouter()`) already populated as
- * each route was defined — there is no separate, hand-maintained route list
- * to keep in sync here.
+ * Builds the closure-reopen-service OpenAPI document from every feature
+ * router's registry — each `createDocumentedRouter()` call creates its own
+ * registry, merged here (via the registry's `parents` constructor param) so
+ * closures/reopen-requests routes never overwrite each other in the combined doc.
  */
-export function buildClosureReopenServiceOpenApiDocument(registry: OpenAPIRegistry) {
-  return buildServiceOpenApiDocument(registry, {
+export function buildClosureReopenServiceOpenApiDocument(...registries: OpenAPIRegistry[]) {
+  const merged = new OpenAPIRegistry(registries);
+  return buildServiceOpenApiDocument(merged, {
     title: 'Arogya Sakhi — Closure Reopen Service API',
     description: 'Closure forms, supervisor review, and reopen requests.',
     port: appConfig.PORT,

--- a/apps/closure-reopen-service/src/reopen-requests/audit.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/audit.client.ts
@@ -2,10 +2,10 @@ import { badGateway } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Writes an audit_log entry after a Quick Response decision, calling
- * audit-service's POST /audit directly (not through the gateway),
- * forwarding the caller's own Authorization header — same pattern
- * supervisor-operations-service's SakhiClient uses.
+ * Writes an audit_log entry after a reopen request decision, calling
+ * audit-service's POST /audit through the gateway, forwarding the caller's
+ * own Authorization header — same pattern approval-service's Quick Response
+ * clients use.
  */
 export class AuditClient {
   async log(

--- a/apps/closure-reopen-service/src/reopen-requests/dto/decide-reopen-request.dto.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/dto/decide-reopen-request.dto.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for a Supervisor's decision on a reopen request
+ * (Quick Response's REOPEN card, FR pending confirmation). `.strict()`
+ * rejects unknown fields, matching this repo's global convention.
+ */
+export const decideReopenRequestSchema = z
+  .object({
+    decision: z.enum(['APPROVED', 'REJECTED']),
+    decisionReasonCodeLookupId: z.string().uuid().optional(),
+    decisionNotes: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export type DecideReopenRequestInput = z.infer<typeof decideReopenRequestSchema>;

--- a/apps/closure-reopen-service/src/reopen-requests/notification.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/notification.client.ts
@@ -2,10 +2,10 @@ import { badGateway } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Notifies a Sakhi after a Quick Response decision, calling
- * notification-escalation-service's POST /notifications directly (not
- * through the gateway), forwarding the caller's own Authorization header —
- * same pattern supervisor-operations-service's SakhiClient uses.
+ * Notifies a Sakhi after a reopen request decision, calling
+ * notification-escalation-service's POST /notifications through the
+ * gateway, forwarding the caller's own Authorization header — same pattern
+ * approval-service's Quick Response clients use.
  */
 export class NotificationClient {
   async notify(

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
@@ -59,6 +59,11 @@ function envelope<T extends z.ZodTypeAny>(data: T) {
  * (see closure.controller.ts's GET /closures). approval-service's
  * POST /quick-response/:cardId/decision stays SUPERVISOR-only at its own
  * layer; this endpoint isn't artificially narrower than its siblings.
+ *
+ * The audit_log entry and Sakhi notification are written here, in
+ * `ReopenRequestService.decide`, not by callers — so they happen
+ * regardless of whether this endpoint is reached via Quick Response or
+ * called directly.
  */
 export function createReopenRequestRouter(service: ReopenRequestService) {
   const doc = createDocumentedRouter();
@@ -84,7 +89,12 @@ export function createReopenRequestRouter(service: ReopenRequestService) {
     validateBody(decideReopenRequestRequestSchema),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
-      const updated = await service.decide(req.params.id, req.user.id, req.body);
+      const updated = await service.decide(
+        req.params.id,
+        req.user.id,
+        req.body,
+        req.headers.authorization ?? '',
+      );
       res.json(ok(updated));
     }),
   );

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
@@ -1,0 +1,93 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { ReopenRequestService } from './reopen-request.service';
+import { decideReopenRequestSchema } from './dto/decide-reopen-request.dto';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  unauthorized,
+  validate,
+  validateBody,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const reopenRequestIdParamsSchema = z
+  .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
+  .strict();
+
+const decideReopenRequestRequestSchema = decideReopenRequestSchema.extend({
+  decision: decideReopenRequestSchema.shape.decision.openapi({ example: 'APPROVED' }),
+});
+
+// Fields mirror `model ReopenRequest` in prisma/schema.prisma exactly — no
+// invented fields — for accurate Swagger documentation only.
+const reopenRequestSchema = z.object({
+  id: z.string().uuid(),
+  beneficiaryId: z.string().uuid(),
+  requestReason: z.enum(['MIGRATION_RETURNED', 'CLOSED_BY_MISTAKE', 'OTHER']),
+  requestedByUserId: z.string().uuid(),
+  requestedAt: z.string().datetime(),
+  supervisorStatus: z.enum(['PENDING', 'APPROVED', 'REJECTED']),
+  decisionReasonCodeLookupId: z.string().uuid().nullable(),
+  decisionNotes: z.string().nullable(),
+  decidedByUserId: z.string().uuid().nullable(),
+  decidedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+const apiErrorSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+  errorCode: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+  details: z.record(z.unknown()).optional(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Reopen request HTTP routes. Mounted under the global `api/v1` prefix.
+ *
+ * Wider than Quick Response's own SUPERVISOR-only decision endpoint —
+ * SUPERVISOR/MANAGER/ADMIN matches this service's existing route convention
+ * (see closure.controller.ts's GET /closures). approval-service's
+ * POST /quick-response/:cardId/decision stays SUPERVISOR-only at its own
+ * layer; this endpoint isn't artificially narrower than its siblings.
+ */
+export function createReopenRequestRouter(service: ReopenRequestService) {
+  const doc = createDocumentedRouter();
+
+  doc.patch(
+    '/reopen-requests/:id/decision',
+    {
+      summary: 'Decide a Supervisor-reviewed reopen request (approve/reject)',
+      tags: ['Reopen Requests'],
+      params: reopenRequestIdParamsSchema,
+      responses: {
+        200: { description: 'Reopen request decided', schema: envelope(reopenRequestSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Reopen request not found', schema: apiErrorSchema },
+        409: { description: 'Already decided', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(reopenRequestIdParamsSchema, 'params'),
+    validateBody(decideReopenRequestRequestSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const updated = await service.decide(req.params.id, req.user.id, req.body);
+      res.json(ok(updated));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
@@ -3,12 +3,16 @@ import type { PrismaService } from '../prisma/prisma.service';
 import { ReopenRequestRepository } from './reopen-request.repository';
 import { ReopenRequestService } from './reopen-request.service';
 import { createReopenRequestRouter } from './reopen-request.controller';
+import { AuditClient } from './audit.client';
+import { NotificationClient } from './notification.client';
 
 /**
  * Composition root for the reopen-requests feature: wires repository → service → router.
  */
 export function createReopenRequestModule(prisma: PrismaService): DocumentedRouter {
   const repository = new ReopenRequestRepository(prisma);
-  const service = new ReopenRequestService(repository);
+  const auditClient = new AuditClient();
+  const notificationClient = new NotificationClient();
+  const service = new ReopenRequestService(repository, auditClient, notificationClient);
   return createReopenRequestRouter(service);
 }

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
@@ -1,0 +1,14 @@
+import type { DocumentedRouter } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { ReopenRequestRepository } from './reopen-request.repository';
+import { ReopenRequestService } from './reopen-request.service';
+import { createReopenRequestRouter } from './reopen-request.controller';
+
+/**
+ * Composition root for the reopen-requests feature: wires repository → service → router.
+ */
+export function createReopenRequestModule(prisma: PrismaService): DocumentedRouter {
+  const repository = new ReopenRequestRepository(prisma);
+  const service = new ReopenRequestService(repository);
+  return createReopenRequestRouter(service);
+}

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.repository.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.repository.ts
@@ -1,0 +1,36 @@
+import type { PrismaService } from '../prisma/prisma.service';
+import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
+
+/** Data access for reopen_requests. Owns only this service's `reopen_requests` table. */
+export class ReopenRequestRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findById(id: string) {
+    return this.prisma.reopenRequest.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  /**
+   * Only updates a row that is still `PENDING` — `updateMany`'s affected
+   * count (rather than a separate read-then-write) is the concurrency guard:
+   * if another decision already landed between the caller's `findById` and
+   * this call, the count comes back 0 and the service turns that into a 409
+   * instead of silently overwriting an already-decided request.
+   */
+  async decide(
+    id: string,
+    decidedByUserId: string,
+    dto: DecideReopenRequestInput,
+  ): Promise<boolean> {
+    const result = await this.prisma.reopenRequest.updateMany({
+      where: { id, isDeleted: false, supervisorStatus: 'PENDING' },
+      data: {
+        supervisorStatus: dto.decision,
+        decisionReasonCodeLookupId: dto.decisionReasonCodeLookupId ?? null,
+        decisionNotes: dto.decisionNotes ?? null,
+        decidedByUserId,
+        decidedAt: new Date(),
+      },
+    });
+    return result.count > 0;
+  }
+}

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -1,0 +1,109 @@
+import { ReopenRequestService } from './reopen-request.service';
+import type { ReopenRequestRepository } from './reopen-request.repository';
+import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
+
+function reopenRequest(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    requestReason: 'CLOSED_BY_MISTAKE' as const,
+    requestedByUserId: '33333333-3333-3333-3333-333333333333',
+    requestedAt: new Date('2026-08-01'),
+    supervisorStatus: 'PENDING' as const,
+    decisionReasonCodeLookupId: null,
+    decisionNotes: null,
+    decidedByUserId: null,
+    decidedAt: null,
+    createdAt: new Date('2026-08-01'),
+    createdByUserId: null,
+    updatedAt: new Date('2026-08-01'),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('ReopenRequestService', () => {
+  const repository = {
+    findById: jest.fn(),
+    decide: jest.fn(),
+  } as unknown as jest.Mocked<ReopenRequestRepository>;
+  let service: ReopenRequestService;
+  const supervisorId = '44444444-4444-4444-4444-444444444444';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new ReopenRequestService(repository);
+  });
+
+  it('approves a PENDING reopen request', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+
+    const dto: DecideReopenRequestInput = { decision: 'APPROVED' };
+    await expect(service.decide(pending.id, supervisorId, dto)).resolves.toBe(decided);
+    expect(repository.decide).toHaveBeenCalledWith(pending.id, supervisorId, dto);
+  });
+
+  it('rejects a PENDING reopen request — persisted as the "Cannot re-open" state', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'REJECTED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+
+    const dto: DecideReopenRequestInput = { decision: 'REJECTED' };
+    const result = await service.decide(pending.id, supervisorId, dto);
+    expect(result?.supervisorStatus).toBe('REJECTED');
+  });
+
+  it('404s on an unknown id', async () => {
+    repository.findById.mockResolvedValue(null);
+    await expect(
+      service.decide('unknown-id', supervisorId, { decision: 'APPROVED' }),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(repository.decide).not.toHaveBeenCalled();
+  });
+
+  it('409s on an already-APPROVED reopen request', async () => {
+    repository.findById.mockResolvedValue(reopenRequest({ supervisorStatus: 'APPROVED' }));
+    await expect(
+      service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
+        decision: 'REJECTED',
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(repository.decide).not.toHaveBeenCalled();
+  });
+
+  it('409s on an already-REJECTED reopen request', async () => {
+    repository.findById.mockResolvedValue(reopenRequest({ supervisorStatus: 'REJECTED' }));
+    await expect(
+      service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
+        decision: 'APPROVED',
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('409s when the conditional update races with a concurrent decision', async () => {
+    repository.findById.mockResolvedValueOnce(reopenRequest());
+    repository.decide.mockResolvedValue(false);
+    await expect(
+      service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
+        decision: 'APPROVED',
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('succeeds with no decisionReasonCodeLookupId/decisionNotes (both optional)', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED' });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+
+    await expect(service.decide(pending.id, supervisorId, { decision: 'APPROVED' })).resolves.toBe(
+      decided,
+    );
+  });
+});

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -1,5 +1,7 @@
 import { ReopenRequestService } from './reopen-request.service';
 import type { ReopenRequestRepository } from './reopen-request.repository';
+import type { AuditClient } from './audit.client';
+import type { NotificationClient } from './notification.client';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
 function reopenRequest(overrides: Partial<Record<string, unknown>> = {}) {
@@ -29,23 +31,47 @@ describe('ReopenRequestService', () => {
     findById: jest.fn(),
     decide: jest.fn(),
   } as unknown as jest.Mocked<ReopenRequestRepository>;
+  const auditClient = { log: jest.fn() } as unknown as jest.Mocked<AuditClient>;
+  const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
   let service: ReopenRequestService;
   const supervisorId = '44444444-4444-4444-4444-444444444444';
+  const authHeader = 'Bearer token';
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new ReopenRequestService(repository);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    service = new ReopenRequestService(repository, auditClient, notificationClient);
   });
 
-  it('approves a PENDING reopen request', async () => {
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('approves a PENDING reopen request, audits, and notifies the Sakhi', async () => {
     const pending = reopenRequest();
     const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
     repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
     repository.decide.mockResolvedValue(true);
 
     const dto: DecideReopenRequestInput = { decision: 'APPROVED' };
-    await expect(service.decide(pending.id, supervisorId, dto)).resolves.toBe(decided);
+    await expect(service.decide(pending.id, supervisorId, dto, authHeader)).resolves.toBe(decided);
     expect(repository.decide).toHaveBeenCalledWith(pending.id, supervisorId, dto);
+    expect(auditClient.log).toHaveBeenCalledWith(
+      supervisorId,
+      'QUICK_RESPONSE_APPROVE',
+      'ReopenRequest',
+      pending.id,
+      { decision: 'APPROVED', decisionNotes: null },
+      authHeader,
+    );
+    expect(notificationClient.notify).toHaveBeenCalledWith(
+      pending.requestedByUserId,
+      'REOPEN_UPDATE',
+      expect.any(String),
+      expect.any(String),
+      authHeader,
+    );
   });
 
   it('rejects a PENDING reopen request — persisted as the "Cannot re-open" state', async () => {
@@ -55,14 +81,22 @@ describe('ReopenRequestService', () => {
     repository.decide.mockResolvedValue(true);
 
     const dto: DecideReopenRequestInput = { decision: 'REJECTED' };
-    const result = await service.decide(pending.id, supervisorId, dto);
+    const result = await service.decide(pending.id, supervisorId, dto, authHeader);
     expect(result?.supervisorStatus).toBe('REJECTED');
+    expect(auditClient.log).toHaveBeenCalledWith(
+      supervisorId,
+      'QUICK_RESPONSE_REJECT',
+      'ReopenRequest',
+      pending.id,
+      { decision: 'REJECTED', decisionNotes: null },
+      authHeader,
+    );
   });
 
   it('404s on an unknown id', async () => {
     repository.findById.mockResolvedValue(null);
     await expect(
-      service.decide('unknown-id', supervisorId, { decision: 'APPROVED' }),
+      service.decide('unknown-id', supervisorId, { decision: 'APPROVED' }, authHeader),
     ).rejects.toMatchObject({ status: 404 });
     expect(repository.decide).not.toHaveBeenCalled();
   });
@@ -72,7 +106,7 @@ describe('ReopenRequestService', () => {
     await expect(
       service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
         decision: 'REJECTED',
-      }),
+      }, authHeader),
     ).rejects.toMatchObject({ status: 409 });
     expect(repository.decide).not.toHaveBeenCalled();
   });
@@ -82,7 +116,7 @@ describe('ReopenRequestService', () => {
     await expect(
       service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
         decision: 'APPROVED',
-      }),
+      }, authHeader),
     ).rejects.toMatchObject({ status: 409 });
   });
 
@@ -92,7 +126,7 @@ describe('ReopenRequestService', () => {
     await expect(
       service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
         decision: 'APPROVED',
-      }),
+      }, authHeader),
     ).rejects.toMatchObject({ status: 409 });
   });
 
@@ -102,8 +136,35 @@ describe('ReopenRequestService', () => {
     repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
     repository.decide.mockResolvedValue(true);
 
-    await expect(service.decide(pending.id, supervisorId, { decision: 'APPROVED' })).resolves.toBe(
-      decided,
-    );
+    await expect(
+      service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+    ).resolves.toBe(decided);
+  });
+
+  it('does not fail the request when notifying the Sakhi throws after the decision is committed', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+    notificationClient.notify.mockRejectedValue(Object.assign(new Error('Forbidden'), { status: 403 }));
+
+    await expect(
+      service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+    ).resolves.toBe(decided);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('does not fail the request when writing the audit entry throws after the decision is committed', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+    auditClient.log.mockRejectedValue(Object.assign(new Error('Bad gateway'), { status: 502 }));
+
+    await expect(
+      service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+    ).resolves.toBe(decided);
+    expect(notificationClient.notify).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -1,17 +1,34 @@
 import { conflict, notFound } from '@armman/service-commons';
 import type { ReopenRequestRepository } from './reopen-request.repository';
+import type { AuditClient } from './audit.client';
+import type { NotificationClient } from './notification.client';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
 /** Reopen request domain logic. Data access is delegated to the repository. */
 export class ReopenRequestService {
-  constructor(private readonly repository: ReopenRequestRepository) {}
+  constructor(
+    private readonly repository: ReopenRequestRepository,
+    private readonly auditClient: AuditClient,
+    private readonly notificationClient: NotificationClient,
+  ) {}
 
   /**
    * Decides a Supervisor's reopen request (Quick Response's REOPEN card).
    * REJECTED is the persisted "Cannot re-open" state — the beneficiary
    * simply stays whatever Closed state it already had; no separate flag.
+   *
+   * Writes the audit_log entry and notifies the Sakhi here, not in
+   * approval-service's Quick Response layer — this endpoint is the only
+   * place a reopen decision is actually persisted (Quick Response is one
+   * caller of it, not the only one), so the audit trail can't be bypassed
+   * by calling this endpoint directly.
    */
-  async decide(id: string, decidedByUserId: string, dto: DecideReopenRequestInput) {
+  async decide(
+    id: string,
+    decidedByUserId: string,
+    dto: DecideReopenRequestInput,
+    authorizationHeader: string,
+  ) {
     const existing = await this.repository.findById(id);
     if (!existing) throw notFound('Reopen request not found.');
     if (existing.supervisorStatus !== 'PENDING') {
@@ -26,6 +43,36 @@ export class ReopenRequestService {
       throw conflict('This reopen request has already been decided.');
     }
 
-    return this.repository.findById(id);
+    const decided = await this.repository.findById(id);
+
+    // The decision above is already committed. A failure notifying the Sakhi
+    // or writing the audit entry must not turn an already-successful decision
+    // into an error response to the caller — log it and move on instead.
+    try {
+      await this.auditClient.log(
+        decidedByUserId,
+        `QUICK_RESPONSE_${dto.decision === 'APPROVED' ? 'APPROVE' : 'REJECT'}`,
+        'ReopenRequest',
+        id,
+        { decision: dto.decision, decisionNotes: dto.decisionNotes ?? null },
+        authorizationHeader,
+      );
+      await this.notificationClient.notify(
+        existing.requestedByUserId,
+        'REOPEN_UPDATE',
+        'Reopen request decided',
+        dto.decision === 'APPROVED'
+          ? 'Your reopen request was approved.'
+          : 'Your reopen request was rejected.',
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `Reopen request ${id} was decided (${dto.decision}) but the audit entry or Sakhi notification failed:`,
+        err,
+      );
+    }
+
+    return decided;
   }
 }

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -1,0 +1,31 @@
+import { conflict, notFound } from '@armman/service-commons';
+import type { ReopenRequestRepository } from './reopen-request.repository';
+import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
+
+/** Reopen request domain logic. Data access is delegated to the repository. */
+export class ReopenRequestService {
+  constructor(private readonly repository: ReopenRequestRepository) {}
+
+  /**
+   * Decides a Supervisor's reopen request (Quick Response's REOPEN card).
+   * REJECTED is the persisted "Cannot re-open" state — the beneficiary
+   * simply stays whatever Closed state it already had; no separate flag.
+   */
+  async decide(id: string, decidedByUserId: string, dto: DecideReopenRequestInput) {
+    const existing = await this.repository.findById(id);
+    if (!existing) throw notFound('Reopen request not found.');
+    if (existing.supervisorStatus !== 'PENDING') {
+      throw conflict('This reopen request has already been decided.');
+    }
+
+    const updated = await this.repository.decide(id, decidedByUserId, dto);
+    if (!updated) {
+      // Raced with another decision between the read above and the
+      // conditional update — same outcome as the check above, just caught a
+      // beat later instead of trusting a stale read.
+      throw conflict('This reopen request has already been decided.');
+    }
+
+    return this.repository.findById(id);
+  }
+}

--- a/apps/notification-escalation-service/jest.config.ts
+++ b/apps/notification-escalation-service/jest.config.ts
@@ -3,5 +3,6 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/notification-escalation-service',
 };

--- a/apps/notification-escalation-service/prisma/migrations/20260805120000_add_edd_nearing_escalation_type/migration.sql
+++ b/apps/notification-escalation-service/prisma/migrations/20260805120000_add_edd_nearing_escalation_type/migration.sql
@@ -1,0 +1,7 @@
+-- AlterEnum
+-- Quick Response's EDD_NEARING card type — distinct from POST_EDD_MISSED
+-- (the EDD has already passed); this fires while it's still approaching.
+-- ALTER TYPE ... ADD VALUE cannot run inside the same transaction as other
+-- statements that use the new value, but this migration only adds the value
+-- (no data backfill references it), so a single statement is safe here.
+ALTER TYPE "EscalationType" ADD VALUE 'EDD_NEARING';

--- a/apps/notification-escalation-service/prisma/schema.prisma
+++ b/apps/notification-escalation-service/prisma/schema.prisma
@@ -37,6 +37,9 @@ enum EscalationType {
   SYNC_DELAY
   CLOSURE_PENDING
   REOPEN_PENDING
+  // Quick Response's EDD_NEARING card type — distinct from POST_EDD_MISSED
+  // (the EDD has already passed); this fires while it's still approaching.
+  EDD_NEARING
 }
 
 enum EscalationStatus {

--- a/apps/notification-escalation-service/src/app.module.ts
+++ b/apps/notification-escalation-service/src/app.module.ts
@@ -12,15 +12,18 @@ import { appConfig } from './config/app-config';
 import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createNotificationModule } from './notifications/notification.module';
+import { createEscalationModule } from './escalations/escalation.module';
 import { buildNotificationEscalationServiceOpenApiDocument } from './docs/openapi';
 
 export {
   asyncHandler,
   ok,
   fail,
+  validate,
   validateBody,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   createDocumentedRouter,
   HttpError,
   ErrorCode,
@@ -46,18 +49,23 @@ export function createApp(prisma: PrismaService): Application {
   });
   app.use(requestId);
   const notificationModule = createNotificationModule(prisma);
+  const escalationModule = createEscalationModule(prisma);
 
   const api = express.Router();
   api.use(createHealthRouter(prisma));
-  // Built from notificationModule.registry — every route registered via
+  // Built from every feature module's registry — every route registered via
   // createDocumentedRouter() above is already in the spec, so this can never
   // drift from what's actually mounted.
   api.use(
     createSwaggerRouter(
-      buildNotificationEscalationServiceOpenApiDocument(notificationModule.registry),
+      buildNotificationEscalationServiceOpenApiDocument(
+        notificationModule.registry,
+        escalationModule.registry,
+      ),
     ),
   );
   api.use(notificationModule.router);
+  api.use(escalationModule.router);
   app.use('/api/v1', api);
   app.use(notFoundHandler);
   app.use(errorHandler);

--- a/apps/notification-escalation-service/src/config/app-config.ts
+++ b/apps/notification-escalation-service/src/config/app-config.ts
@@ -16,6 +16,12 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  // Used to verify a SUPERVISOR caller of POST /notifications actually owns
+  // (is the assigned supervisor of) the Sakhi they're notifying — closes an
+  // impersonation/IDOR gap where a widened SUPERVISOR role could otherwise
+  // notify any recipientUserId (same naming/default as supervisor-
+  // operations-service's SakhiClient).
+  AUTH_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
 });
 export type AppConfig = z.infer<typeof schema>;
 

--- a/apps/notification-escalation-service/src/docs/openapi.ts
+++ b/apps/notification-escalation-service/src/docs/openapi.ts
@@ -1,15 +1,18 @@
-import type { OpenAPIRegistry } from '@armman/service-commons';
-import { buildServiceOpenApiDocument } from '@armman/service-commons';
+import { OpenAPIRegistry, buildServiceOpenApiDocument } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Builds the notification-escalation-service OpenAPI document from the
- * registry that `createNotificationRouter` (via `createDocumentedRouter()`)
- * already populated as each route was defined — there is no separate,
- * hand-maintained route list to keep in sync here.
+ * Builds the notification-escalation-service OpenAPI document from every
+ * feature router's registry — each `createDocumentedRouter()` call creates
+ * its own registry, merged here (via the registry's `parents` constructor
+ * param) so notifications/escalations routes never overwrite each other in
+ * the combined doc.
  */
-export function buildNotificationEscalationServiceOpenApiDocument(registry: OpenAPIRegistry) {
-  return buildServiceOpenApiDocument(registry, {
+export function buildNotificationEscalationServiceOpenApiDocument(
+  ...registries: OpenAPIRegistry[]
+) {
+  const merged = new OpenAPIRegistry(registries);
+  return buildServiceOpenApiDocument(merged, {
     title: 'Arogya Sakhi — Notification Escalation Service API',
     description: 'Event-driven notifications and escalations.',
     port: appConfig.PORT,

--- a/apps/notification-escalation-service/src/escalations/dto/list-escalation-events.dto.ts
+++ b/apps/notification-escalation-service/src/escalations/dto/list-escalation-events.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for GET /escalation-events query params. `cursor` is
+ * opaque to the client — base64 of `${createdAt.toISOString()}|${id}` from
+ * the last row of the previous page — so ordering ties (same createdAt
+ * millisecond) still produce a stable, gapless cursor.
+ */
+export const listEscalationEventsSchema = z
+  .object({
+    status: z
+      .enum([
+        'OPEN',
+        'ACKNOWLEDGED',
+        'TRANSFER_REQUESTED',
+        'CLOSE_REQUESTED',
+        'RESOLVED',
+        'DISMISSED',
+      ])
+      .default('OPEN'),
+    cursor: z.string().trim().min(1).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  })
+  .strict();
+
+export type ListEscalationEventsInput = z.infer<typeof listEscalationEventsSchema>;

--- a/apps/notification-escalation-service/src/escalations/escalation.controller.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.controller.ts
@@ -1,0 +1,83 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { EscalationService } from './escalation.service';
+import {
+  listEscalationEventsSchema,
+  type ListEscalationEventsInput,
+} from './dto/list-escalation-events.dto';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validate,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const escalationCardSchema = z.object({
+  cardId: z.string().uuid(),
+  cardType: z.enum(['MISSED_VISIT', 'EDD_NEARING']),
+  cardSource: z.literal('escalation_events'),
+  beneficiaryId: z.string().uuid(),
+  visitId: z.string().uuid().nullable(),
+  referralId: z.string().uuid().nullable(),
+  escalationType: z.string().openapi({ example: 'ANC_2_MISSED' }),
+  status: z.string().openapi({ example: 'OPEN' }),
+  raisedAt: z.string().datetime(),
+});
+
+const listEscalationEventsResponseSchema = z.object({
+  cards: z.array(escalationCardSchema),
+  nextCursor: z.string().nullable(),
+});
+
+const apiErrorSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+  errorCode: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+  details: z.record(z.unknown()).optional(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Escalation event HTTP routes. Mounted under the global `api/v1` prefix.
+ *
+ * This is an internal, service-to-service read surface — approval-service
+ * calls it directly (not through the gateway, matching supervisor-operations-
+ * service's SakhiClient precedent) to merge escalation-sourced Quick Response
+ * cards (MISSED_VISIT, EDD_NEARING) alongside its own approval_requests.
+ */
+export function createEscalationRouter(service: EscalationService) {
+  const doc = createDocumentedRouter();
+
+  doc.get(
+    '/escalation-events',
+    {
+      summary: 'List escalation events shaped as Quick Response cards',
+      tags: ['Escalations'],
+      responses: {
+        200: {
+          description: 'Escalation-sourced Quick Response cards',
+          schema: envelope(listEscalationEventsResponseSchema),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER'),
+    validate(listEscalationEventsSchema, 'query'),
+    asyncHandler(async (req, res) => {
+      const query = req.query as unknown as ListEscalationEventsInput;
+      res.json(ok(await service.list(query)));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/notification-escalation-service/src/escalations/escalation.controller.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.controller.ts
@@ -1,5 +1,6 @@
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
+import { notFound } from '@armman/service-commons';
 import type { EscalationService } from './escalation.service';
 import {
   listEscalationEventsSchema,
@@ -15,6 +16,10 @@ import {
 } from '../app.module';
 
 extendZodWithOpenApi(z);
+
+const escalationEventIdParamsSchema = z
+  .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
+  .strict();
 
 const escalationCardSchema = z.object({
   cardId: z.string().uuid(),
@@ -48,9 +53,10 @@ function envelope<T extends z.ZodTypeAny>(data: T) {
  * Escalation event HTTP routes. Mounted under the global `api/v1` prefix.
  *
  * This is an internal, service-to-service read surface — approval-service
- * calls it directly (not through the gateway, matching supervisor-operations-
- * service's SakhiClient precedent) to merge escalation-sourced Quick Response
- * cards (MISSED_VISIT, EDD_NEARING) alongside its own approval_requests.
+ * calls it through the gateway (forwarding the caller's own Authorization
+ * header, matching supervisor-operations-service's SakhiClient precedent)
+ * to merge escalation-sourced Quick Response cards (MISSED_VISIT,
+ * EDD_NEARING) alongside its own approval_requests.
  */
 export function createEscalationRouter(service: EscalationService) {
   const doc = createDocumentedRouter();
@@ -76,6 +82,32 @@ export function createEscalationRouter(service: EscalationService) {
     asyncHandler(async (req, res) => {
       const query = req.query as unknown as ListEscalationEventsInput;
       res.json(ok(await service.list(query)));
+    }),
+  );
+
+  doc.get(
+    '/escalation-events/:id',
+    {
+      summary: 'Fetch a single escalation event shaped as a Quick Response card',
+      tags: ['Escalations'],
+      params: escalationEventIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Escalation-sourced Quick Response card',
+          schema: envelope(escalationCardSchema),
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Escalation event not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER'),
+    validate(escalationEventIdParamsSchema, 'params'),
+    asyncHandler(async (req, res) => {
+      const card = await service.findById(req.params.id);
+      if (!card) throw notFound('Escalation event not found.');
+      res.json(ok(card));
     }),
   );
 

--- a/apps/notification-escalation-service/src/escalations/escalation.module.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.module.ts
@@ -1,0 +1,14 @@
+import type { DocumentedRouter } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { EscalationRepository } from './escalation.repository';
+import { EscalationService } from './escalation.service';
+import { createEscalationRouter } from './escalation.controller';
+
+/**
+ * Composition root for the escalations feature: wires repository → service → router.
+ */
+export function createEscalationModule(prisma: PrismaService): DocumentedRouter {
+  const repository = new EscalationRepository(prisma);
+  const service = new EscalationService(repository);
+  return createEscalationRouter(service);
+}

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.ts
@@ -1,0 +1,32 @@
+import type { PrismaService } from '../prisma/prisma.service';
+import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
+
+/** Data access for escalation events. Owns only this service's `escalation_event` table. */
+export class EscalationRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Cursor-paginated by `(createdAt, id)` DESC — `id` breaks ties within the
+   * same millisecond so the cursor stays gapless. Fetches `limit + 1` rows to
+   * know whether a next page exists without a separate count query.
+   */
+  async findMany(query: ListEscalationEventsInput, cursor: { createdAt: Date; id: string } | null) {
+    const rows = await this.prisma.escalationEvent.findMany({
+      where: {
+        status: query.status,
+        isDeleted: false,
+        ...(cursor
+          ? {
+              OR: [
+                { createdAt: { lt: cursor.createdAt } },
+                { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: query.limit + 1,
+    });
+    return rows;
+  }
+}

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.ts
@@ -29,4 +29,8 @@ export class EscalationRepository {
     });
     return rows;
   }
+
+  findById(id: string) {
+    return this.prisma.escalationEvent.findFirst({ where: { id, isDeleted: false } });
+  }
 }

--- a/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
@@ -1,0 +1,98 @@
+import { EscalationService } from './escalation.service';
+import type { EscalationRepository } from './escalation.repository';
+import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
+import type { EscalationType } from '../../../../node_modules/.prisma/client-notification-escalation-service';
+
+function row(overrides: { id?: string; escalationType?: EscalationType; createdAt?: Date } = {}) {
+  return {
+    id: overrides.id ?? '11111111-1111-1111-1111-111111111111',
+    beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    visitId: null,
+    referralId: null,
+    escalationType: overrides.escalationType ?? ('ANC_2_MISSED' as const),
+    triggerRuleVersionId: null,
+    status: 'OPEN' as const,
+    assignedSupervisorId: null,
+    resolvedAt: null,
+    actionTaken: null,
+    createdAt: overrides.createdAt ?? new Date('2026-08-05T10:00:00.000Z'),
+    createdByUserId: null,
+    updatedAt: overrides.createdAt ?? new Date('2026-08-05T10:00:00.000Z'),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+  };
+}
+
+describe('EscalationService', () => {
+  const repository = { findMany: jest.fn() } as unknown as jest.Mocked<EscalationRepository>;
+  let service: EscalationService;
+  const baseQuery: ListEscalationEventsInput = { status: 'OPEN', limit: 50 };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new EscalationService(repository);
+  });
+
+  it('groups every *_MISSED escalation type under MISSED_VISIT', async () => {
+    repository.findMany.mockResolvedValue([row({ escalationType: 'PP_HR_MISSED' })]);
+    const result = await service.list(baseQuery);
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].cardType).toBe('MISSED_VISIT');
+    expect(result.cards[0].cardSource).toBe('escalation_events');
+  });
+
+  it('surfaces EDD_NEARING as its own card type', async () => {
+    repository.findMany.mockResolvedValue([row({ escalationType: 'EDD_NEARING' })]);
+    const result = await service.list(baseQuery);
+    expect(result.cards[0].cardType).toBe('EDD_NEARING');
+  });
+
+  it('omits escalation types outside the 8 supported Quick Response card types', async () => {
+    repository.findMany.mockResolvedValue([row({ escalationType: 'SYNC_DELAY' })]);
+    const result = await service.list(baseQuery);
+    expect(result.cards).toHaveLength(0);
+  });
+
+  it('returns no nextCursor when the repository returns exactly `limit` rows', async () => {
+    repository.findMany.mockResolvedValue([row()]);
+    const result = await service.list({ ...baseQuery, limit: 1 });
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('returns a nextCursor and trims to `limit` when more rows exist', async () => {
+    const rows = [
+      row({ id: 'a', createdAt: new Date('2026-08-05T10:00:02.000Z') }),
+      row({ id: 'b', createdAt: new Date('2026-08-05T10:00:01.000Z') }),
+    ];
+    repository.findMany.mockResolvedValue(rows);
+    const result = await service.list({ ...baseQuery, limit: 1 });
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].cardId).toBe('a');
+    expect(result.nextCursor).not.toBeNull();
+  });
+
+  it('decodes a previously issued cursor back into a repository filter', async () => {
+    repository.findMany.mockResolvedValue([]);
+    const cursor = Buffer.from(
+      '2026-08-05T10:00:00.000Z|11111111-1111-1111-1111-111111111111',
+    ).toString('base64url');
+    await service.list({ ...baseQuery, cursor });
+    expect(repository.findMany).toHaveBeenCalledWith(
+      { ...baseQuery, cursor },
+      {
+        createdAt: new Date('2026-08-05T10:00:00.000Z'),
+        id: '11111111-1111-1111-1111-111111111111',
+      },
+    );
+  });
+
+  it('rejects a malformed cursor with a 400', async () => {
+    await expect(
+      service.list({ ...baseQuery, cursor: 'not-valid-base64!!' }),
+    ).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(repository.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
@@ -25,7 +25,10 @@ function row(overrides: { id?: string; escalationType?: EscalationType; createdA
 }
 
 describe('EscalationService', () => {
-  const repository = { findMany: jest.fn() } as unknown as jest.Mocked<EscalationRepository>;
+  const repository = {
+    findMany: jest.fn(),
+    findById: jest.fn(),
+  } as unknown as jest.Mocked<EscalationRepository>;
   let service: EscalationService;
   const baseQuery: ListEscalationEventsInput = { status: 'OPEN', limit: 50 };
 
@@ -94,5 +97,25 @@ describe('EscalationService', () => {
       status: 400,
     });
     expect(repository.findMany).not.toHaveBeenCalled();
+  });
+
+  describe('findById', () => {
+    it('returns the card shape for a supported card type', async () => {
+      repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
+      const result = await service.findById('11111111-1111-1111-1111-111111111111');
+      expect(result).toMatchObject({ cardType: 'EDD_NEARING', cardSource: 'escalation_events' });
+    });
+
+    it('returns null when the row does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+      const result = await service.findById('unknown-id');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for an escalation type outside the 8 supported card types', async () => {
+      repository.findById.mockResolvedValue(row({ escalationType: 'SYNC_DELAY' }));
+      const result = await service.findById('11111111-1111-1111-1111-111111111111');
+      expect(result).toBeNull();
+    });
   });
 });

--- a/apps/notification-escalation-service/src/escalations/escalation.service.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.ts
@@ -1,0 +1,79 @@
+import { badRequest } from '@armman/service-commons';
+import type { EscalationRepository } from './escalation.repository';
+import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
+
+/** The 10 EscalationType values that Quick Response groups under one MISSED_VISIT card. */
+const MISSED_VISIT_TYPES = new Set([
+  'ANC_2_MISSED',
+  'ANC_HR_MISSED',
+  'PP_MISSED',
+  'PP_HR_MISSED',
+  'NN_MISSED',
+  'NN_HR_MISSED',
+  'INC_2_MISSED',
+  'INC_HR_MISSED',
+  'CCV_MISSED',
+  'CCV_HR_MISSED',
+]);
+
+/** Quick Response's fixed card type for an escalation row — everything else in
+ * EscalationType that isn't one of the 8 supported card types is omitted from
+ * the response rather than surfaced under an unsupported label. */
+function toCardType(escalationType: string): 'MISSED_VISIT' | 'EDD_NEARING' | null {
+  if (MISSED_VISIT_TYPES.has(escalationType)) return 'MISSED_VISIT';
+  if (escalationType === 'EDD_NEARING') return 'EDD_NEARING';
+  return null;
+}
+
+function decodeCursor(cursor: string): { createdAt: Date; id: string } {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+  } catch {
+    throw badRequest('cursor: Invalid cursor.');
+  }
+  const [createdAtIso, id] = decoded.split('|');
+  const createdAt = createdAtIso ? new Date(createdAtIso) : null;
+  if (!createdAt || Number.isNaN(createdAt.getTime()) || !id) {
+    throw badRequest('cursor: Invalid cursor.');
+  }
+  return { createdAt, id };
+}
+
+function encodeCursor(row: { createdAt: Date; id: string }): string {
+  return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, 'utf8').toString('base64url');
+}
+
+/** Escalation event domain logic. Data access is delegated to the repository. */
+export class EscalationService {
+  constructor(private readonly repository: EscalationRepository) {}
+
+  async list(query: ListEscalationEventsInput) {
+    const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+    const rows = await this.repository.findMany(query, cursor);
+
+    const hasMore = rows.length > query.limit;
+    const page = hasMore ? rows.slice(0, query.limit) : rows;
+    const nextCursor = hasMore ? encodeCursor(page[page.length - 1]) : null;
+
+    const cards = page
+      .map((row) => ({ row, cardType: toCardType(row.escalationType) }))
+      .filter(
+        (r): r is { row: (typeof page)[number]; cardType: 'MISSED_VISIT' | 'EDD_NEARING' } =>
+          r.cardType !== null,
+      )
+      .map(({ row, cardType }) => ({
+        cardId: row.id,
+        cardType,
+        cardSource: 'escalation_events' as const,
+        beneficiaryId: row.beneficiaryId,
+        visitId: row.visitId,
+        referralId: row.referralId,
+        escalationType: row.escalationType,
+        status: row.status,
+        raisedAt: row.createdAt.toISOString(),
+      }));
+
+    return { cards, nextCursor };
+  }
+}

--- a/apps/notification-escalation-service/src/escalations/escalation.service.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.ts
@@ -76,4 +76,26 @@ export class EscalationService {
 
     return { cards, nextCursor };
   }
+
+  /** Fetches a single escalation event shaped as a Quick Response card, or
+   * null if it doesn't exist (or isn't one of the 8 supported card types). */
+  async findById(id: string) {
+    const row = await this.repository.findById(id);
+    if (!row) return null;
+
+    const cardType = toCardType(row.escalationType);
+    if (!cardType) return null;
+
+    return {
+      cardId: row.id,
+      cardType,
+      cardSource: 'escalation_events' as const,
+      beneficiaryId: row.beneficiaryId,
+      visitId: row.visitId,
+      referralId: row.referralId,
+      escalationType: row.escalationType,
+      status: row.status,
+      raisedAt: row.createdAt.toISOString(),
+    };
+  }
 }

--- a/apps/notification-escalation-service/src/notifications/notification.controller.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.controller.ts
@@ -8,6 +8,7 @@ import {
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   validateBody,
 } from '../app.module';
 
@@ -83,10 +84,18 @@ export function createNotificationRouter(service: NotificationService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('ADMIN'),
+    // ADMIN direct use, plus SUPERVISOR so approval-service can notify a
+    // Sakhi on the caller's behalf after a Quick Response decision (it
+    // forwards the deciding Supervisor's own Authorization header, same
+    // pattern supervisor-operations-service's SakhiClient uses — no
+    // separate service-to-service credential scheme in this codebase yet).
+    requireRoles('ADMIN', 'SUPERVISOR'),
     validateBody(createNotificationSchema),
-    asyncHandler(async (req, res) => {
-      const created = await service.create(req.body);
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const created = await service.create(req.body, req.user, authorizationHeader);
       res.status(201).json(ok(created));
     }),
   );

--- a/apps/notification-escalation-service/src/notifications/notification.module.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.module.ts
@@ -2,6 +2,7 @@ import type { DocumentedRouter } from '@armman/service-commons';
 import type { PrismaService } from '../prisma/prisma.service';
 import { NotificationRepository } from './notification.repository';
 import { NotificationService } from './notification.service';
+import { SakhiClient } from './sakhi.client';
 import { createNotificationRouter } from './notification.controller';
 
 /**
@@ -10,6 +11,6 @@ import { createNotificationRouter } from './notification.controller';
  */
 export function createNotificationModule(prisma: PrismaService): DocumentedRouter {
   const repository = new NotificationRepository(prisma);
-  const service = new NotificationService(repository);
+  const service = new NotificationService(repository, new SakhiClient());
   return createNotificationRouter(service);
 }

--- a/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
@@ -1,5 +1,6 @@
 import { NotificationService } from './notification.service';
 import type { NotificationRepository } from './notification.repository';
+import type { SakhiClient } from './sakhi.client';
 import type { CreateNotificationInput } from './dto/create-notification.dto';
 
 describe('NotificationService', () => {
@@ -7,11 +8,23 @@ describe('NotificationService', () => {
     findMany: jest.fn(),
     create: jest.fn(),
   } as unknown as jest.Mocked<NotificationRepository>;
+  const sakhiClient = { findById: jest.fn() } as unknown as jest.Mocked<SakhiClient>;
   let service: NotificationService;
+  const authHeader = 'Bearer token';
+  const supervisor = { id: 'supervisor-1', roles: ['SUPERVISOR'] };
+  const admin = { id: 'admin-1', roles: ['ADMIN'] };
+
+  const dto: CreateNotificationInput = {
+    recipientUserId: 'sakhi-1',
+    notificationType: 'REFERRAL_UPDATE',
+    title: 'Referral updated',
+    status: 'UNREAD',
+    priority: 5,
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new NotificationService(repository);
+    service = new NotificationService(repository, sakhiClient);
   });
 
   it('lists via repository', async () => {
@@ -20,76 +33,38 @@ describe('NotificationService', () => {
     expect(repository.findMany).toHaveBeenCalledTimes(1);
   });
 
-  it('returns the repository list unchanged', async () => {
-    const rows = [
-      {
-        id: '1',
-        recipientUserId: 'user-1',
-        notificationType: 'MISSED_VISIT_ESCALATION' as const,
-        title: 'Missed visit',
-        body: 'Beneficiary missed a scheduled visit',
-        priority: 5,
-        ctaType: 'VIEW_VISIT',
-        linkedEntityType: 'visit_instance',
-        linkedEntityId: 'visit-1',
-        status: 'UNREAD' as const,
-        readAt: null,
-        dismissedAt: null,
-        createdAt: new Date(),
-        createdByUserId: null,
-        updatedAt: new Date(),
-        updatedByUserId: null,
-        isDeleted: false,
-        deletedAt: null,
-      },
-    ];
-    repository.findMany.mockResolvedValue(rows);
-    await expect(service.list()).resolves.toBe(rows);
+  it('ADMIN may notify any recipient without an ownership check', async () => {
+    repository.create.mockResolvedValue({ id: '1' } as never);
+    await service.create(dto, admin, authHeader);
+    expect(sakhiClient.findById).not.toHaveBeenCalled();
+    expect(repository.create).toHaveBeenCalledWith(dto);
   });
 
-  it('creates via repository with the given data', async () => {
-    const dto: CreateNotificationInput = {
-      recipientUserId: 'user-1',
-      notificationType: 'REFERRAL_UPDATE',
-      title: 'Referral updated',
-      status: 'UNREAD',
-      priority: 5,
-    };
-    const created = {
-      id: '1',
-      recipientUserId: 'user-1',
-      notificationType: 'REFERRAL_UPDATE' as const,
-      title: 'Referral updated',
-      body: null,
-      priority: 5,
-      ctaType: null,
-      linkedEntityType: null,
-      linkedEntityId: null,
-      status: 'UNREAD' as const,
-      readAt: null,
-      dismissedAt: null,
-      createdAt: new Date(),
-      createdByUserId: null,
-      updatedAt: new Date(),
-      updatedByUserId: null,
-      isDeleted: false,
-      deletedAt: null,
-    };
-    repository.create.mockResolvedValue(created);
-    await expect(service.create(dto)).resolves.toBe(created);
+  it('SUPERVISOR notifying their own assigned Sakhi succeeds', async () => {
+    sakhiClient.findById.mockResolvedValue({ sakhiId: 'sakhi-1', supervisorId: 'supervisor-1' });
+    repository.create.mockResolvedValue({ id: '1' } as never);
+    await service.create(dto, supervisor, authHeader);
+    expect(sakhiClient.findById).toHaveBeenCalledWith('sakhi-1', authHeader);
     expect(repository.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('SUPERVISOR notifying a Sakhi assigned to someone else is forbidden', async () => {
+    sakhiClient.findById.mockResolvedValue({ sakhiId: 'sakhi-1', supervisorId: 'someone-else' });
+    await expect(service.create(dto, supervisor, authHeader)).rejects.toMatchObject({
+      status: 403,
+    });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('SUPERVISOR notifying an unknown recipientUserId is forbidden, not 404', async () => {
+    sakhiClient.findById.mockResolvedValue(null);
+    await expect(service.create(dto, supervisor, authHeader)).rejects.toMatchObject({
+      status: 403,
+    });
   });
 
   it('propagates repository errors on create', async () => {
     repository.create.mockRejectedValue(new Error('db down'));
-    await expect(
-      service.create({
-        recipientUserId: 'user-1',
-        notificationType: 'REFERRAL_UPDATE',
-        title: 'Referral updated',
-        status: 'UNREAD',
-        priority: 5,
-      }),
-    ).rejects.toThrow('db down');
+    await expect(service.create(dto, admin, authHeader)).rejects.toThrow('db down');
   });
 });

--- a/apps/notification-escalation-service/src/notifications/notification.service.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.ts
@@ -1,15 +1,39 @@
+import { forbidden } from '@armman/service-commons';
 import type { NotificationRepository } from './notification.repository';
+import type { SakhiClient } from './sakhi.client';
 import type { CreateNotificationInput } from './dto/create-notification.dto';
+
+export interface CallerIdentity {
+  id: string;
+  roles: string[];
+}
 
 /** Notification domain logic. Data access is delegated to the repository. */
 export class NotificationService {
-  constructor(private readonly repository: NotificationRepository) {}
+  constructor(
+    private readonly repository: NotificationRepository,
+    private readonly sakhiClient: SakhiClient,
+  ) {}
 
   list() {
     return this.repository.findMany();
   }
 
-  create(dto: CreateNotificationInput) {
+  /**
+   * ADMIN may notify anyone. A SUPERVISOR (the role widened for approval-
+   * service's Quick Response decisions to forward through) may only notify
+   * a Sakhi actually assigned to them — verified via auth-service, same
+   * ownership check supervisor-operations-service already applies to its
+   * own Sakhi-scoped endpoints. Without this, the widened role would let
+   * any Supervisor notify any recipientUserId.
+   */
+  async create(dto: CreateNotificationInput, caller: CallerIdentity, authorizationHeader: string) {
+    if (!caller.roles.includes('ADMIN')) {
+      const sakhi = await this.sakhiClient.findById(dto.recipientUserId, authorizationHeader);
+      if (!sakhi || sakhi.supervisorId !== caller.id) {
+        throw forbidden('You do not have access to notify this Sakhi.');
+      }
+    }
     return this.repository.create(dto);
   }
 }

--- a/apps/notification-escalation-service/src/notifications/sakhi.client.ts
+++ b/apps/notification-escalation-service/src/notifications/sakhi.client.ts
@@ -1,0 +1,39 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+interface Sakhi {
+  sakhiId: string;
+  supervisorId: string | null;
+}
+
+/**
+ * Fetches a Sakhi's own record from auth-service — used to verify a
+ * SUPERVISOR caller of POST /notifications actually owns the Sakhi they're
+ * notifying, closing an impersonation/IDOR gap on the role widening that
+ * lets approval-service notify on a Supervisor's behalf. Mirrors
+ * supervisor-operations-service's SakhiClient exactly.
+ */
+export class SakhiClient {
+  async findById(sakhiId: string, authorizationHeader: string): Promise<Sakhi | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.AUTH_SERVICE_BASE_URL}/api/v1/sakhis/${sakhiId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the Sakhi — the auth service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the Sakhi.');
+      }
+      throw badGateway('Unable to resolve the Sakhi — the auth service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: Sakhi };
+    return body.data;
+  }
+}

--- a/apps/supervisor-operations-service/src/operations/sakhi.client.ts
+++ b/apps/supervisor-operations-service/src/operations/sakhi.client.ts
@@ -1,4 +1,4 @@
-import { badGateway } from '@armman/service-commons';
+import { badGateway, HttpError } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 interface Sakhi {
@@ -28,6 +28,15 @@ export class SakhiClient {
 
     if (res.status === 404) return null;
     if (!res.ok) {
+      // 4xx here reflects auth-service's own decision about this request
+      // (e.g. its own project-scope check on GET /sakhis/:id) — a real
+      // rejection, not this service's infra failing, so it must reach the
+      // caller as-is rather than masquerade as a 502. Only a genuine
+      // 5xx from auth-service is actually "the upstream is broken".
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the Sakhi.');
+      }
       throw badGateway('Unable to resolve the Sakhi — the auth service returned an error.');
     }
 


### PR DESCRIPTION
## Summary

Implements the Quick Response API's core surface:
- `GET /api/v1/quick-response` — merges `approval_requests` (approval-service) and `escalation_events` (notification-escalation-service) into one cursor-paginated, `createdAt DESC` feed, spanning all 8 card types documented in the spec.
- `POST /api/v1/quick-response/:cardId/decision` — fully wired for **EDD_NEARING** (acknowledge-only, no audit/notify per spec) and **REOPEN** (delegates to a new `PATCH /reopen-requests/:id/decision` in closure-reopen-service, then writes an audit entry and notifies the Sakhi). The other 6 card types (`LMP_CHANGE`, `MISSED_VISIT`, `CLOSURE_REVIEW`, `REFERRAL_INCOMPLETE`, `DATA_RESTORE`, `ACCOMPANIED_REFERRAL`) are listed but respond `501 Not Implemented` on decision — their real side effects (ANC schedule regen, incentive triggers, closure/referral status writes) need write endpoints that don't exist yet in visit-form-service, risk-referral-service, and incentive-wages-service. Scoped this way deliberately, as agreed, rather than guessing at undefined cross-service behavior.

## Why the scope is split this way

Every other card type's approve/reject action needs a **new write endpoint in a service that currently only has GET/POST**. Building all 8 in one PR isn't reviewable; this PR proves the end-to-end architecture (merge, cursor pagination, decision dispatch, audit/notify) on the two card types where the underlying schema already supports it.

## Notable decisions (confirmed during implementation)

- `ApprovalRequestType.REFERRAL_SKIP` renamed to `REFERRAL_INCOMPLETE` to match the spec — naming drift only, migration included, 0 affected rows confirmed before writing it.
- `EscalationType` gained a new `EDD_NEARING` value (nothing today represents "EDD approaching," only "already missed" via `POST_EDD_MISSED`); `MISSED_VISIT` is a grouping of the 10 existing `*_MISSED` enum values, not a schema change.
- REOPEN's REJECT is persisted as `ReopenRequest.supervisorStatus = REJECTED` — this already matches the spec's "Cannot re-open" state; no new column needed.
- `POST /notifications` (notification-escalation-service) and `POST /audit` (audit-service) are widened from `ADMIN`-only to also allow `SUPERVISOR`, since approval-service calls them directly (service-to-service, forwarding the deciding Supervisor's own JWT — same pattern as supervisor-operations-service's existing `SakhiClient`). **Security note:** an automated review flagged this widening as a potential impersonation/IDOR risk if left unconstrained. Fixed before merge:
  - `notification-escalation-service`: a non-ADMIN caller can only notify a Sakhi actually assigned to them (new ownership check via a `SakhiClient`, mirroring the existing pattern).
  - `audit-service`: a non-ADMIN caller's `actorUserId` is always forced server-side to their own id (never the client-supplied value), and they're restricted to `QUICK_RESPONSE_*` actions.
  - Both fixes verified live via real API calls (403 on the abuse path, 200/201 on the legitimate path).

## Test plan

- `nx lint` + `nx test` clean across all 5 touched projects (notification-escalation-service, closure-reopen-service, audit-service, approval-service, api-gateway) — 71 unit tests covering merge/pagination, decision dispatch per card type, 404/409/501 edge cases, and the two security fixes.
- Live-verified via real HTTP calls: the notification ownership check and the audit actorUserId/action constraints, both the abuse path (403) and the legitimate path (200/201).
- **Not live-verified:** `GET /quick-response` and closure-reopen-service's new `PATCH /reopen-requests/:id/decision` end-to-end — blocked by pre-existing schema drift on the shared dev DB (`approval_requests` missing `decision_status_lookup_id`, `reopen_requests` table absent), unrelated to this PR. Flagging for whoever owns that environment; the code is built and tested against the current `schema.prisma`.

## Follow-ups (out of scope here, tracked separately)

- #114 — Wire the remaining 6 card types once their backing services grow the needed write endpoints.
- #115 — Define a permanent service-to-service auth credential (replace JWT-forwarding pattern).
- #116 — EDD_NEARING acknowledgement doesn't persist a status change on escalation_events.
- #117 — Dev Supabase schema drift blocks live verification of approval-service and closure-reopen-service.
