### PR TITLE
Add standalone lookup-category seed script

### DIFF
--- a/apps/auth-service/prisma/seed-lookups-only.ts
+++ b/apps/auth-service/prisma/seed-lookups-only.ts
@@ -1,0 +1,56 @@
+import { PrismaClient } from '../../../node_modules/.prisma/client-auth-service';
+import { LOOKUP_CATEGORIES } from './seed-data';
+
+const prisma = new PrismaClient();
+
+/**
+ * Standalone runner for just the lookup-category seed step (extracted from
+ * seed.ts's seedLookups()). Skips any category that already exists by
+ * categoryCode, so it's safe to run against an environment (e.g. dev) that
+ * already has some categories seeded — it only creates what's missing, never
+ * touches existing categories/values, and never runs the rest of seed.ts's
+ * roles/users/geography/project steps.
+ */
+async function main(): Promise<void> {
+  let createdCategories = 0;
+  let createdValues = 0;
+  const createdCodes: string[] = [];
+  const skippedCodes: string[] = [];
+
+  for (const category of LOOKUP_CATEGORIES) {
+    const existing = await prisma.lookupCategory.findUnique({
+      where: { categoryCode: category.categoryCode },
+    });
+    if (existing) {
+      skippedCodes.push(category.categoryCode);
+      continue;
+    }
+
+    await prisma.lookupCategory.create({
+      data: {
+        categoryCode: category.categoryCode,
+        categoryName: category.categoryName,
+        description: category.description,
+        values: { createMany: { data: category.values } },
+      },
+    });
+    createdCategories += 1;
+    createdValues += category.values.length;
+    createdCodes.push(category.categoryCode);
+  }
+
+  console.log('\nLookup seed summary:');
+  console.log(
+    `  Created ${createdCategories} categor${createdCategories === 1 ? 'y' : 'ies'} (${createdValues} values): ${createdCodes.join(', ') || 'none'}`,
+  );
+  console.log(`  Skipped (already existed): ${skippedCodes.join(', ') || 'none'}`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- Adds `apps/auth-service/prisma/seed-lookups-only.ts`, extracted from `seed.ts`'s `seedLookups()` step.
- Some environments are missing lookup categories that exist locally (e.g. `MOBILE_NETWORK_AVAILABILITY`, `PARTNER_OCCUPATION`, `MIGRATION_PATTERN`, `MONTHLY_INCOME_BRACKET`, `RELIGION`, `SOCIAL_CATEGORY`), which causes beneficiary-service's socio-demographics resolution to return `null` for those fields even when a Sakhi answers them, since the underlying master data was never seeded.
- Skips any category that already exists by `categoryCode` — safe to run against a partially-seeded environment. Touches nothing else (no roles/users/geography/project seeding), unlike running the full `seed.ts`.

## Test plan
- [x] Type-checks cleanly (`tsc --noEmit`)
- [x] Lints cleanly (`nx run auth-service:lint`)
- [x] Ran against local's dev DB (Supabase, `auth_service` schema) — correctly reported all 16 categories already present, 0 created (idempotent, no-op when nothing missing)
- [ ] Run against the environment actually missing the 6 categories (RDS-hosted dev, `api.armman.org`) to confirm it creates them — network access to that host wasn't available from this session; to be run separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)