### PR TITLE
fix(supervisor-operations-service): Add validation gaps for events, transactions and call logs

### DIFF
--- a/apps/supervisor-operations-service/src/operations/dto/create-call-log.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-call-log.dto.spec.ts
@@ -1,0 +1,83 @@
+import { createCallLogSchema } from './create-call-log.dto';
+
+describe('createCallLogSchema', () => {
+  const baseInput = {
+    projectId: '22222222-2222-2222-2222-222222222222',
+    sakhiId: '44444444-4444-4444-4444-444444444444',
+    callDatetime: new Date('2026-07-01T09:00:00Z'),
+    callStatus: 'PICKED_UP_TALKED' as const,
+  };
+
+  it('reproduces the reported bug payload as a clean validation error, not a crash', () => {
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: new Date('2026-10-03T09:53:14Z'),
+      callEndAt: new Date('2026-10-01T09:53:14Z'),
+      callDurationSeconds: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects callEndAt before callStartAt', () => {
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: new Date(Date.now() - 60 * 60 * 1000),
+      callEndAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts callEndAt after callStartAt', () => {
+    const start = new Date(Date.now() - 60 * 60 * 1000);
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: start,
+      callEndAt: new Date(start.getTime() + 5 * 60 * 1000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a call log with no callEndAt', () => {
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a future callStartAt', () => {
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts callStartAt equal to now', () => {
+    const now = new Date();
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: now,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a future callEndAt', () => {
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: new Date(Date.now() - 60 * 60 * 1000),
+      callEndAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts callStartAt equal to callEndAt', () => {
+    const t = new Date(Date.now() - 60 * 60 * 1000);
+    const result = createCallLogSchema.safeParse({
+      ...baseInput,
+      callStartAt: t,
+      callEndAt: t,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/create-call-log.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-call-log.dto.ts
@@ -37,6 +37,18 @@ export const createCallLogSchema = z
       .enum(['RELATIVE', 'HUSBAND', 'SAKHI', 'PERSON_WHO_DOES_NOT_KNOW_WOMAN'])
       .optional(),
   })
-  .strict();
+  .strict()
+  .refine((data) => data.callStartAt.getTime() <= Date.now(), {
+    message: 'callStartAt must not be in the future.',
+    path: ['callStartAt'],
+  })
+  .refine((data) => !data.callEndAt || data.callEndAt.getTime() <= Date.now(), {
+    message: 'callEndAt must not be in the future.',
+    path: ['callEndAt'],
+  })
+  .refine((data) => !data.callEndAt || data.callEndAt.getTime() >= data.callStartAt.getTime(), {
+    message: 'callEndAt must not be before callStartAt.',
+    path: ['callEndAt'],
+  });
 
 export type CreateCallLogInput = z.infer<typeof createCallLogSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/create-inventory-transaction.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-inventory-transaction.dto.spec.ts
@@ -1,0 +1,37 @@
+import { createInventoryTransactionSchema } from './create-inventory-transaction.dto';
+
+describe('createInventoryTransactionSchema', () => {
+  const baseInput = {
+    projectId: '22222222-2222-2222-2222-222222222222',
+    sakhiId: '44444444-4444-4444-4444-444444444444',
+    transactionType: 'HANDOVER' as const,
+    items: [{ itemId: '55555555-5555-5555-5555-555555555555', quantity: 1 }],
+  };
+
+  it('rejects a future transactionDate', () => {
+    const result = createInventoryTransactionSchema.safeParse({
+      ...baseInput,
+      transactionDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['transactionDate']);
+    }
+  });
+
+  it('accepts today as transactionDate', () => {
+    const result = createInventoryTransactionSchema.safeParse({
+      ...baseInput,
+      transactionDate: new Date(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a past transactionDate', () => {
+    const result = createInventoryTransactionSchema.safeParse({
+      ...baseInput,
+      transactionDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/create-inventory-transaction.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-inventory-transaction.dto.ts
@@ -26,7 +26,9 @@ export const createInventoryTransactionSchema = z
     projectId: z.string().uuid(),
     sakhiId: z.string().uuid(),
     transactionType: z.enum(['HANDOVER', 'RETURNED', 'PERMANENT_DAMAGED', 'MISPLACED', 'CONSUMED']),
-    transactionDate: z.coerce.date(),
+    transactionDate: z.coerce.date().refine((date) => date.getTime() <= Date.now(), {
+      message: 'transactionDate must not be in the future.',
+    }),
     remarks: z.string().trim().min(1).optional(),
     items: z.array(transactionItemSchema).min(1),
   })

--- a/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.spec.ts
@@ -1,0 +1,59 @@
+import { createSupervisorEventSchema } from './create-supervisorEvent.dto';
+
+describe('createSupervisorEventSchema', () => {
+  const baseInput = {
+    projectId: '22222222-2222-2222-2222-222222222222',
+    supervisorId: '33333333-3333-3333-3333-333333333333',
+    eventType: 'MEETING' as const,
+    topicsJson: { agenda: 'review' },
+    status: 'SCHEDULED' as const,
+  };
+
+  it('rejects a past eventDate', () => {
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      eventDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['eventDate']);
+    }
+  });
+
+  it('accepts a future eventDate', () => {
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      eventDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a remark shorter than 3 characters', () => {
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      eventDate: new Date(Date.now() + 60 * 60 * 1000),
+      remarks: 'ab',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['remarks']);
+    }
+  });
+
+  it('accepts a remark of exactly 3 characters', () => {
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      eventDate: new Date(Date.now() + 60 * 60 * 1000),
+      remarks: 'abc',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an omitted remark', () => {
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      eventDate: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.spec.ts
@@ -28,6 +28,22 @@ describe('createSupervisorEventSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts today as eventDate regardless of the current time of day', () => {
+    // eventDate is @db.Date — a same-day value coerces to today's UTC
+    // midnight, which is an instant in the past for all but the first
+    // millisecond of the day. Regression test for that bug: this must pass
+    // no matter what time "now" actually is when the test runs.
+    const today = new Date();
+    const todayDateOnly = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      eventDate: todayDateOnly,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('rejects a remark shorter than 3 characters', () => {
     const result = createSupervisorEventSchema.safeParse({
       ...baseInput,

--- a/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { diffInDays, startOfUTCDay } from '@armman/core';
 
 /**
  * Recursive JSON value type usable inside the `topicsJson` payload (nulls allowed
@@ -41,7 +42,11 @@ export const createSupervisorEventSchema = z
     projectId: z.string().uuid(),
     supervisorId: z.string().uuid(),
     eventType: z.enum(['MEETING', 'TRAINING']),
-    eventDate: z.coerce.date().refine((date) => date.getTime() >= Date.now(), {
+    // eventDate is @db.Date (calendar date, no time-of-day) — comparing its
+    // coerced midnight value against the exact current instant would reject
+    // today itself for all but the first millisecond after UTC midnight, so
+    // "now" is normalized to midnight UTC before comparing whole calendar days.
+    eventDate: z.coerce.date().refine((date) => diffInDays(startOfUTCDay(new Date()), date) >= 0, {
       message: 'eventDate must not be in the past.',
     }),
     topicsJson: jsonValueSchema,

--- a/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.ts
@@ -41,9 +41,11 @@ export const createSupervisorEventSchema = z
     projectId: z.string().uuid(),
     supervisorId: z.string().uuid(),
     eventType: z.enum(['MEETING', 'TRAINING']),
-    eventDate: z.coerce.date(),
+    eventDate: z.coerce.date().refine((date) => date.getTime() >= Date.now(), {
+      message: 'eventDate must not be in the past.',
+    }),
     topicsJson: jsonValueSchema,
-    remarks: z.string().trim().min(1).optional(),
+    remarks: z.string().trim().min(3).optional(),
     status: z.enum(['SCHEDULED', 'COMPLETED', 'CANCELLED']),
     photoMediaId: z.string().uuid().optional(),
   })

--- a/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.spec.ts
@@ -15,6 +15,19 @@ describe('rescheduleEventSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts today as eventDate regardless of the current time of day', () => {
+    // eventDate is @db.Date — a same-day value coerces to today's UTC
+    // midnight, which is an instant in the past for all but the first
+    // millisecond of the day. Regression test for that bug: this must pass
+    // no matter what time "now" actually is when the test runs.
+    const today = new Date();
+    const todayDateOnly = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+    );
+    const result = rescheduleEventSchema.safeParse({ eventDate: todayDateOnly });
+    expect(result.success).toBe(true);
+  });
+
   it('rejects a remark shorter than 3 characters', () => {
     const result = rescheduleEventSchema.safeParse({
       eventDate: new Date(Date.now() + 60 * 60 * 1000),

--- a/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.spec.ts
@@ -1,0 +1,33 @@
+import { rescheduleEventSchema } from './reschedule-event.dto';
+
+describe('rescheduleEventSchema', () => {
+  it('rejects a past eventDate', () => {
+    const result = rescheduleEventSchema.safeParse({
+      eventDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a future eventDate', () => {
+    const result = rescheduleEventSchema.safeParse({
+      eventDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a remark shorter than 3 characters', () => {
+    const result = rescheduleEventSchema.safeParse({
+      eventDate: new Date(Date.now() + 60 * 60 * 1000),
+      remarks: 'x',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a valid remark', () => {
+    const result = rescheduleEventSchema.safeParse({
+      eventDate: new Date(Date.now() + 60 * 60 * 1000),
+      remarks: 'Rescheduled per Sakhi request',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.ts
@@ -8,8 +8,10 @@ import { z } from 'zod';
  */
 export const rescheduleEventSchema = z
   .object({
-    eventDate: z.coerce.date(),
-    remarks: z.string().trim().min(1).optional(),
+    eventDate: z.coerce.date().refine((date) => date.getTime() >= Date.now(), {
+      message: 'eventDate must not be in the past.',
+    }),
+    remarks: z.string().trim().min(3).optional(),
   })
   .strict();
 

--- a/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/reschedule-event.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { diffInDays, startOfUTCDay } from '@armman/core';
 
 /**
  * Validation schema for rescheduling a SCHEDULED supervisor event to a new
@@ -8,7 +9,11 @@ import { z } from 'zod';
  */
 export const rescheduleEventSchema = z
   .object({
-    eventDate: z.coerce.date().refine((date) => date.getTime() >= Date.now(), {
+    // eventDate is @db.Date (calendar date, no time-of-day) — comparing its
+    // coerced midnight value against the exact current instant would reject
+    // today itself for all but the first millisecond after UTC midnight, so
+    // "now" is normalized to midnight UTC before comparing whole calendar days.
+    eventDate: z.coerce.date().refine((date) => diffInDays(startOfUTCDay(new Date()), date) >= 0, {
       message: 'eventDate must not be in the past.',
     }),
     remarks: z.string().trim().min(3).optional(),

--- a/apps/supervisor-operations-service/src/operations/dto/update-call-log.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-call-log.dto.spec.ts
@@ -1,0 +1,22 @@
+import { updateCallLogSchema } from './update-call-log.dto';
+
+describe('updateCallLogSchema', () => {
+  it('rejects a future callEndAt', () => {
+    const result = updateCallLogSchema.safeParse({
+      callEndAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts callEndAt equal to now', () => {
+    const result = updateCallLogSchema.safeParse({
+      callEndAt: new Date(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an update with no callEndAt at all', () => {
+    const result = updateCallLogSchema.safeParse({ callStatus: 'NOT_PICKED_UP' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/update-call-log.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-call-log.dto.ts
@@ -32,6 +32,10 @@ export const updateCallLogSchema = z
   .strict()
   .refine((data) => Object.keys(data).length > 0, {
     message: 'At least one field must be provided.',
+  })
+  .refine((data) => !data.callEndAt || data.callEndAt.getTime() <= Date.now(), {
+    message: 'callEndAt must not be in the future.',
+    path: ['callEndAt'],
   });
 
 export type UpdateCallLogInput = z.infer<typeof updateCallLogSchema>;

--- a/apps/supervisor-operations-service/src/operations/dto/update-inventory-transaction.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-inventory-transaction.dto.spec.ts
@@ -1,0 +1,22 @@
+import { updateInventoryTransactionSchema } from './update-inventory-transaction.dto';
+
+describe('updateInventoryTransactionSchema', () => {
+  it('rejects a future transactionDate', () => {
+    const result = updateInventoryTransactionSchema.safeParse({
+      transactionDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a valid transactionDate', () => {
+    const result = updateInventoryTransactionSchema.safeParse({
+      transactionDate: new Date(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an update with no transactionDate at all', () => {
+    const result = updateInventoryTransactionSchema.safeParse({ quantity: 5 });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/dto/update-inventory-transaction.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/update-inventory-transaction.dto.ts
@@ -17,6 +17,10 @@ export const updateInventoryTransactionSchema = z
   .strict()
   .refine((data) => Object.keys(data).length > 0, {
     message: 'At least one field must be provided.',
+  })
+  .refine((data) => !data.transactionDate || data.transactionDate.getTime() <= Date.now(), {
+    message: 'transactionDate must not be in the future.',
+    path: ['transactionDate'],
   });
 
 export type UpdateInventoryTransactionInput = z.infer<typeof updateInventoryTransactionSchema>;

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -604,8 +604,9 @@ export function createOperationsRouter(service: OperationsService) {
     },
     trustGatewayIdentity,
     requireRoles('SUPERVISOR', 'MANAGER'),
-    asyncHandler(async (_req, res) => {
-      res.json(ok(await service.listCallLogs()));
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.listCallLogs(req.user)));
     }),
   );
 

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -35,6 +35,19 @@ export class OperationsRepository {
     return this.prisma.supervisorEvent.create({ data });
   }
 
+  /** An existing, non-cancelled event for this supervisor+project at the exact same eventDate, if any. */
+  findConflictingEvent(supervisorId: string, projectId: string, eventDate: Date) {
+    return this.prisma.supervisorEvent.findFirst({
+      where: {
+        supervisorId,
+        projectId,
+        eventDate,
+        isDeleted: false,
+        status: { not: 'CANCELLED' },
+      },
+    });
+  }
+
   findEventById(id: string) {
     return this.prisma.supervisorEvent.findFirst({ where: { id, isDeleted: false } });
   }
@@ -206,9 +219,10 @@ export class OperationsRepository {
     });
   }
 
-  findCallLogs() {
+  /** Recent call logs, scoped to one supervisor unless `supervisorId` is omitted (MANAGER/ADMIN). */
+  findCallLogs(supervisorId?: string) {
     return this.prisma.callLog.findMany({
-      where: { isDeleted: false },
+      where: { isDeleted: false, ...(supervisorId ? { supervisorId } : {}) },
       orderBy: { callDatetime: 'desc' },
       take: 50,
     });

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -15,6 +15,7 @@ describe('OperationsService', () => {
   const repository = {
     findEvents: jest.fn(),
     createEvent: jest.fn(),
+    findConflictingEvent: jest.fn(),
     findEventById: jest.fn(),
     updateEventStatus: jest.fn(),
     findAttendanceByEvent: jest.fn(),
@@ -112,8 +113,8 @@ describe('OperationsService', () => {
     ).rejects.toThrow('db down');
   });
 
-  it('rejects a COMPLETED event with no photoMediaId without hitting the repository', () => {
-    expect(() =>
+  it('rejects a COMPLETED event with no photoMediaId without hitting the repository', async () => {
+    await expect(
       service.createEvent({
         projectId: '22222222-2222-2222-2222-222222222222',
         supervisorId: '33333333-3333-3333-3333-333333333333',
@@ -122,7 +123,7 @@ describe('OperationsService', () => {
         topicsJson: ['review'],
         status: 'COMPLETED',
       }),
-    ).toThrow('photoMediaId is required when status is COMPLETED.');
+    ).rejects.toThrow('photoMediaId is required when status is COMPLETED.');
     expect(repository.createEvent).not.toHaveBeenCalled();
   });
 
@@ -137,6 +138,42 @@ describe('OperationsService', () => {
       photoMediaId: '55555555-5555-5555-5555-555555555555',
     };
     repository.createEvent.mockResolvedValue(eventRow);
+    await expect(service.createEvent(dto)).resolves.toBe(eventRow);
+    expect(repository.createEvent).toHaveBeenCalledWith(dto);
+  });
+
+  it('rejects a duplicate event for the same supervisor/project/eventDate, without creating anything', async () => {
+    const dto: CreateSupervisorEventInput = {
+      projectId: '22222222-2222-2222-2222-222222222222',
+      supervisorId: '33333333-3333-3333-3333-333333333333',
+      eventType: 'MEETING',
+      eventDate: new Date('2026-07-01T10:00:00Z'),
+      topicsJson: ['review'],
+      status: 'SCHEDULED',
+    };
+    repository.findConflictingEvent.mockResolvedValue(eventRow);
+
+    await expect(service.createEvent(dto)).rejects.toMatchObject({ status: 409 });
+    expect(repository.findConflictingEvent).toHaveBeenCalledWith(
+      dto.supervisorId,
+      dto.projectId,
+      dto.eventDate,
+    );
+    expect(repository.createEvent).not.toHaveBeenCalled();
+  });
+
+  it('allows creating an event when no conflicting event exists', async () => {
+    const dto: CreateSupervisorEventInput = {
+      projectId: '22222222-2222-2222-2222-222222222222',
+      supervisorId: '33333333-3333-3333-3333-333333333333',
+      eventType: 'MEETING',
+      eventDate: new Date('2026-07-01T10:00:00Z'),
+      topicsJson: ['review'],
+      status: 'SCHEDULED',
+    };
+    repository.findConflictingEvent.mockResolvedValue(null);
+    repository.createEvent.mockResolvedValue(eventRow);
+
     await expect(service.createEvent(dto)).resolves.toBe(eventRow);
     expect(repository.createEvent).toHaveBeenCalledWith(dto);
   });
@@ -951,7 +988,15 @@ describe('OperationsService', () => {
       },
     ];
     repository.findCallLogs.mockResolvedValue(rows);
-    await expect(service.listCallLogs()).resolves.toBe(rows);
+    await expect(service.listCallLogs(supervisorCaller)).resolves.toBe(rows);
+    expect(repository.findCallLogs).toHaveBeenCalledWith(supervisorCaller.id);
+  });
+
+  it('lists all call logs unscoped for a MANAGER', async () => {
+    const rows: CallLog[] = [];
+    repository.findCallLogs.mockResolvedValue(rows);
+    await expect(service.listCallLogs(managerCaller)).resolves.toBe(rows);
+    expect(repository.findCallLogs).toHaveBeenCalledWith(undefined);
   });
 
   const callLogRow: CallLog = {
@@ -1121,6 +1166,36 @@ describe('OperationsService', () => {
         ),
       ).rejects.toMatchObject({ status: 403 });
       expect(repository.updateCallLog).not.toHaveBeenCalled();
+    });
+
+    it('rejects a callEndAt earlier than the record’s own callStartAt, without updating anything', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      await expect(
+        service.updateCallLog(
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          { callEndAt: new Date(callLogRow.callStartAt.getTime() - 60 * 60 * 1000) },
+          supervisorCaller,
+        ),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(repository.updateCallLog).not.toHaveBeenCalled();
+    });
+
+    it('accepts a callEndAt at or after the record’s own callStartAt', async () => {
+      repository.findCallLogById.mockResolvedValue(callLogRow);
+      repository.updateCallLog.mockResolvedValue(callLogRow);
+
+      const callEndAt = new Date(callLogRow.callStartAt.getTime() + 60 * 1000);
+      await service.updateCallLog(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callEndAt },
+        supervisorCaller,
+      );
+
+      expect(repository.updateCallLog).toHaveBeenCalledWith(
+        'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        { callEndAt },
+        supervisorCaller.id,
+      );
     });
 
     it('allows an ADMIN to update a call log they do not own', async () => {

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -77,12 +77,23 @@ export class OperationsService {
     return this.repository.findEvents(filters);
   }
 
-  createEvent(dto: CreateSupervisorEventInput) {
+  async createEvent(dto: CreateSupervisorEventInput) {
     // The DTO's photoMediaId is application-mandatory when status = COMPLETED
     // (ERD §4.7) — the schema keeps it optional so SCHEDULED/CANCELLED events
     // can be created without a photo, so this rule is enforced here instead.
     if (dto.status === 'COMPLETED' && !dto.photoMediaId) {
       throw unprocessable('photoMediaId is required when status is COMPLETED.');
+    }
+    // A supervisor can't have two events at the same exact instant for the
+    // same project — almost certainly a duplicate submission, not two real
+    // meetings. Cancelled events don't block a re-create at that slot.
+    const existingConflict = await this.repository.findConflictingEvent(
+      dto.supervisorId,
+      dto.projectId,
+      dto.eventDate,
+    );
+    if (existingConflict) {
+      throw conflict('An event for this supervisor and project already exists at this date/time.');
     }
     return this.repository.createEvent(dto);
   }
@@ -289,8 +300,9 @@ export class OperationsService {
     if (!deleted) throw notFound('Inventory transaction not found.');
   }
 
-  listCallLogs() {
-    return this.repository.findCallLogs();
+  /** A SUPERVISOR may only see their own call logs. MANAGER and ADMIN are unrestricted. */
+  listCallLogs(caller: CallerIdentity) {
+    return this.repository.findCallLogs(isPrivileged(caller) ? undefined : caller.id);
   }
 
   /**
@@ -330,6 +342,11 @@ export class OperationsService {
     if (!existing) throw notFound('Call log not found.');
     if (existing.supervisorId !== caller.id && !isPrivileged(caller)) {
       throw forbidden('You do not have access to this call log.');
+    }
+    // callStartAt is immutable (see updateCallLogSchema), so this is the only
+    // place the ordering can be checked against the record's actual start time.
+    if (dto.callEndAt && dto.callEndAt.getTime() < existing.callStartAt.getTime()) {
+      throw unprocessable('callEndAt must not be before callStartAt.');
     }
 
     const updated = await this.repository.updateCallLog(id, dto, caller.id);

--- a/libs/core/src/date.util.spec.ts
+++ b/libs/core/src/date.util.spec.ts
@@ -1,10 +1,32 @@
-import { addDays, diffInDays } from './date.util';
+import { addDays, diffInDays, startOfUTCDay } from './date.util';
 
 describe('date.util', () => {
   it('addDays adds whole days', () => {
-    expect(addDays(new Date('2026-01-01T00:00:00Z'), 5).toISOString()).toBe('2026-01-06T00:00:00.000Z');
+    expect(addDays(new Date('2026-01-01T00:00:00Z'), 5).toISOString()).toBe(
+      '2026-01-06T00:00:00.000Z',
+    );
   });
   it('diffInDays computes whole-day difference', () => {
     expect(diffInDays(new Date('2026-01-01T00:00:00Z'), new Date('2026-01-06T00:00:00Z'))).toBe(5);
+  });
+
+  describe('startOfUTCDay', () => {
+    it('returns midnight UTC of the same calendar day', () => {
+      expect(startOfUTCDay(new Date('2026-08-07T23:59:00Z')).toISOString()).toBe(
+        '2026-08-07T00:00:00.000Z',
+      );
+    });
+
+    it('is a no-op when already at midnight UTC', () => {
+      expect(startOfUTCDay(new Date('2026-08-07T00:00:00Z')).toISOString()).toBe(
+        '2026-08-07T00:00:00.000Z',
+      );
+    });
+
+    it('lets a same-day @db.Date value compare as "today" late in the day', () => {
+      const now = new Date('2026-08-07T23:59:00Z');
+      const eventDateToday = new Date('2026-08-07T00:00:00Z');
+      expect(diffInDays(startOfUTCDay(now), eventDateToday)).toBe(0);
+    });
   });
 });

--- a/libs/core/src/date.util.ts
+++ b/libs/core/src/date.util.ts
@@ -11,3 +11,13 @@ export function addDays(date: Date, days: number): Date {
 export function diffInDays(a: Date, b: Date): number {
   return Math.floor((b.getTime() - a.getTime()) / MS_PER_DAY);
 }
+
+/**
+ * Midnight UTC of the given date's calendar day — the instant a `@db.Date`
+ * column's coerced value represents. Normalizing "now" to this before a
+ * diffInDays comparison avoids the bug where a same-day @db.Date value reads
+ * as "in the past" for every instant after UTC midnight.
+ */
+export function startOfUTCDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}


### PR DESCRIPTION
## Summary
Fixes 7 backend defects reported in API testing (`Arogya Sakhi API Observation.docx.md`), scoped to `supervisor-operations-service`:

- **Supervisor events**: reject a past `eventDate` on create/reschedule; reject `remarks` shorter than 3 characters; reject a duplicate event for the same supervisor/project at the exact same `eventDate` (409)
- **Inventory transactions**: reject a future `transactionDate` on both create and update
- **Call logs**: `GET /call-logs` now scopes results to the caller's own logs (MANAGER/ADMIN remain unrestricted) — previously returned every supervisor's logs
- **Call logs**: reject a future `callStartAt`/`callEndAt`, and reject `callEndAt` earlier than `callStartAt` on both create and update — this is the root cause of the reported `502`/`INTERNAL_ERROR` on `POST /call-logs`, which now returns a clean `400 VALIDATION_ERROR` for that payload

Items reported as `403 FORBIDDEN` on events/transactions/call-logs the tester "should have access to" were investigated and confirmed **working as intended** (SUPERVISOR-scoped ownership checks by design) — not changed here.

## Test plan
- [x] `nx test supervisor-operations-service` — 182/182 passing (30 new tests added across 6 new DTO spec files + service-layer additions)
- [x] `nx lint supervisor-operations-service` — clean
- [x] `nx build supervisor-operations-service` — compiles with no type errors
- [x] Regression-tested the exact reported `POST /call-logs` payload (`callEndAt` before `callStartAt`) — confirmed it now returns `400`, not `502`