### PR TITLE
fix(visit-form-service): Close validation gaps on CHILD_REGISTRATION/ANC_VISIT, fix met-beneficiary skip logic

### DIFF
--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -87,6 +87,11 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
   { prefix: '/quick-response', target: appConfig.APPROVAL_SERVICE_URL, requiresAuth: true },
   { prefix: '/incentives', target: appConfig.INCENTIVE_WAGES_SERVICE_URL, requiresAuth: true },
   {
+    prefix: '/incentive-rates',
+    target: appConfig.INCENTIVE_WAGES_SERVICE_URL,
+    requiresAuth: true,
+  },
+  {
     prefix: '/notifications',
     target: appConfig.NOTIFICATION_ESCALATION_SERVICE_URL,
     requiresAuth: true,

--- a/apps/approval-service/src/quick-response/beneficiary.client.ts
+++ b/apps/approval-service/src/quick-response/beneficiary.client.ts
@@ -1,0 +1,83 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface BeneficiaryCaseRecord {
+  id: string;
+}
+
+export interface BeneficiaryCaseDetail {
+  id: string;
+  sakhiId: string;
+}
+
+/**
+ * Applies an approved LMP change by calling beneficiary-service's
+ * PATCH /beneficiaries/:id/lmp through the gateway, forwarding the caller's
+ * own Authorization header — same pattern this service's ReopenRequestClient
+ * uses.
+ */
+export class BeneficiaryClient {
+  /**
+   * Fetches a beneficiary's own record — used to resolve the assigned
+   * Sakhi's id for an ACCOMPANIED_REFERRAL incentive trigger (FR-SV-4.9),
+   * since neither approval_requests nor referrals carries a sakhiId column.
+   */
+  async getById(
+    beneficiaryId: string,
+    authorizationHeader: string,
+  ): Promise<BeneficiaryCaseDetail | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the beneficiary — beneficiary-service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the beneficiary.');
+      }
+      throw badGateway(
+        'Unable to resolve the beneficiary — beneficiary-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: BeneficiaryCaseDetail };
+    return body.data;
+  }
+
+  async applyLmpChange(
+    beneficiaryId: string,
+    lmpDate: string,
+    authorizationHeader: string,
+  ): Promise<BeneficiaryCaseRecord> {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/lmp`,
+        {
+          method: 'PATCH',
+          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ lmpDate }),
+        },
+      );
+    } catch {
+      throw badGateway('Unable to apply the LMP change — beneficiary-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to apply the LMP change.');
+      }
+      throw badGateway('Unable to apply the LMP change — beneficiary-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: BeneficiaryCaseRecord };
+    return body.data;
+  }
+}

--- a/apps/approval-service/src/quick-response/closure.client.ts
+++ b/apps/approval-service/src/quick-response/closure.client.ts
@@ -1,0 +1,47 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface ClosureRecord {
+  id: string;
+  beneficiaryId: string;
+  supervisorStatus: 'PENDING' | 'APPROVED' | 'REJECTED' | null;
+}
+
+/**
+ * Decides a CLOSURE_REVIEW card by calling closure-reopen-service's
+ * PATCH /closures/:id/decision through the gateway, forwarding the caller's
+ * own Authorization header — same pattern this service's ReopenRequestClient
+ * uses. The Sakhi notification for this decision is sent by
+ * closure-reopen-service's own decide flow, not here — see that service's
+ * ClosureService.decide.
+ */
+export class ClosureClient {
+  async decide(
+    id: string,
+    decision: 'APPROVED' | 'REJECTED',
+    supervisorNotes: string | undefined,
+    authorizationHeader: string,
+  ): Promise<ClosureRecord> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/closures/${id}/decision`, {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision, supervisorNotes }),
+      });
+    } catch {
+      throw badGateway('Unable to decide the closure — closure-reopen-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to decide the closure.');
+      }
+      throw badGateway('Unable to decide the closure — closure-reopen-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: ClosureRecord };
+    return body.data;
+  }
+}

--- a/apps/approval-service/src/quick-response/incentive.client.ts
+++ b/apps/approval-service/src/quick-response/incentive.client.ts
@@ -1,0 +1,99 @@
+import { badGateway, HttpError, notFound } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+interface IncentiveRateRecord {
+  id: string;
+}
+
+/**
+ * Resolves the active incentive rate and creates an incentive event by
+ * calling incentive-wages-service's GET /incentive-rates/active and
+ * POST /incentives through the gateway, forwarding the caller's own
+ * Authorization header — same pattern this service's other clients use.
+ * Used for the ACCOMPANIED_REFERRAL incentive trigger (FR-SV-4.9).
+ */
+export class IncentiveClient {
+  private async findActiveRate(
+    referralType: 'ACCOMPANIED',
+    authorizationHeader: string,
+  ): Promise<IncentiveRateRecord | null> {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/incentive-rates/active?rateType=REFERRAL&referralType=${referralType}`,
+        { headers: { Authorization: authorizationHeader } },
+      );
+    } catch {
+      throw badGateway(
+        'Unable to resolve the incentive rate — incentive-wages-service is unreachable.',
+      );
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the incentive rate.');
+      }
+      throw badGateway(
+        'Unable to resolve the incentive rate — incentive-wages-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: IncentiveRateRecord };
+    return body.data;
+  }
+
+  /**
+   * Triggers an ACCOMPANIED_REFERRAL incentive for the given Sakhi. Throws
+   * (not tolerated) if no active rate is configured — the Supervisor needs
+   * to know the incentive couldn't be triggered, not have it silently
+   * skipped as if it succeeded.
+   */
+  async triggerAccompaniedReferral(
+    sakhiId: string,
+    referralId: string,
+    authorizationHeader: string,
+  ): Promise<void> {
+    const rate = await this.findActiveRate('ACCOMPANIED', authorizationHeader);
+    if (!rate) {
+      throw notFound('No active incentive rate configured for accompanied referrals.');
+    }
+
+    const now = new Date();
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/incentives`, {
+        method: 'POST',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sakhiId,
+          sourceEntityType: 'REFERRAL',
+          sourceEntityId: referralId,
+          eventMonth: now.toISOString(),
+          rateId: rate.id,
+          quantity: 1,
+          // amountInr is deliberately omitted — incentive-wages-service
+          // re-derives it from rateId server-side (see
+          // createIncentiveEventSchema's doc comment); trusting a
+          // client-supplied amount here would be exactly the privilege
+          // escalation that field's removal closes.
+          eligibilityStatus: 'ELIGIBLE',
+          calculatedAt: now.toISOString(),
+        }),
+      });
+    } catch {
+      throw badGateway('Unable to trigger the incentive — incentive-wages-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to trigger the incentive.');
+      }
+      throw badGateway(
+        'Unable to trigger the incentive — incentive-wages-service returned an error.',
+      );
+    }
+  }
+}

--- a/apps/approval-service/src/quick-response/notification.client.ts
+++ b/apps/approval-service/src/quick-response/notification.client.ts
@@ -1,0 +1,43 @@
+import { badGateway } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+/**
+ * Notifies a Sakhi after a Quick Response card decision, calling
+ * notification-escalation-service's POST /notifications through the
+ * gateway, forwarding the caller's own Authorization header — same pattern
+ * closure-reopen-service's NotificationClient uses.
+ */
+export class NotificationClient {
+  async notify(
+    recipientUserId: string,
+    notificationType: string,
+    title: string,
+    body: string,
+    authorizationHeader: string,
+  ): Promise<void> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/notifications`, {
+        method: 'POST',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recipientUserId,
+          notificationType,
+          title,
+          body,
+          status: 'UNREAD',
+        }),
+      });
+    } catch {
+      throw badGateway(
+        'Unable to notify the Sakhi — notification-escalation-service is unreachable.',
+      );
+    }
+
+    if (!res.ok) {
+      throw badGateway(
+        'Unable to notify the Sakhi — notification-escalation-service returned an error.',
+      );
+    }
+  }
+}

--- a/apps/approval-service/src/quick-response/quick-response.controller.ts
+++ b/apps/approval-service/src/quick-response/quick-response.controller.ts
@@ -120,7 +120,12 @@ export function createQuickResponseRouter(service: QuickResponseService) {
       if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');
       if (!authorizationHeader) return next(unauthorized());
-      const result = await service.decide(req.params.cardId, req.body, authorizationHeader);
+      const result = await service.decide(
+        req.params.cardId,
+        req.body,
+        req.user.id,
+        authorizationHeader,
+      );
       res.json(ok(result));
     }),
   );

--- a/apps/approval-service/src/quick-response/quick-response.module.ts
+++ b/apps/approval-service/src/quick-response/quick-response.module.ts
@@ -6,6 +6,12 @@ import { createQuickResponseRouter } from './quick-response.controller';
 import { LookupClient } from './lookup.client';
 import { EscalationClient } from './escalation.client';
 import { ReopenRequestClient } from './reopen-request.client';
+import { BeneficiaryClient } from './beneficiary.client';
+import { NotificationClient } from './notification.client';
+import { ClosureClient } from './closure.client';
+import { ReferralClient } from './referral.client';
+import { IncentiveClient } from './incentive.client';
+import { UserClient } from './user.client';
 
 /**
  * Composition root for the Quick Response feature: wires repository +
@@ -18,6 +24,12 @@ export function createQuickResponseModule(prisma: PrismaService): DocumentedRout
     new LookupClient(),
     new EscalationClient(),
     new ReopenRequestClient(),
+    new BeneficiaryClient(),
+    new NotificationClient(),
+    new ClosureClient(),
+    new ReferralClient(),
+    new IncentiveClient(),
+    new UserClient(),
   );
   return createQuickResponseRouter(service);
 }

--- a/apps/approval-service/src/quick-response/quick-response.repository.ts
+++ b/apps/approval-service/src/quick-response/quick-response.repository.ts
@@ -35,4 +35,37 @@ export class QuickResponseRepository {
   findById(id: string) {
     return this.prisma.approvalRequest.findFirst({ where: { id, isDeleted: false } });
   }
+
+  /**
+   * Marks an approval_requests card decided — conditional on `decidedAt`
+   * still being null, so a race between two concurrent decisions on the
+   * same card only ever wins once. Returns false (not an error) when the
+   * conditional update matches nothing, so the caller can turn that into a
+   * 409 the same way every other decide() flow in this codebase does.
+   *
+   * Every APPROVAL_REQUEST_CARD_TYPES card type needs this — without it, a
+   * card's real side effect (LMP write, referral/closure/reopen status
+   * change) can be re-triggered by re-approving the same card, since
+   * nothing on the approval_requests row itself ever recorded that it was
+   * already decided.
+   */
+  async markDecided(
+    id: string,
+    decisionStatusLookupId: string,
+    decidedByUserId: string,
+    decisionNotes: string | undefined,
+    decisionReasonCodeLookupId: string | undefined,
+  ): Promise<boolean> {
+    const result = await this.prisma.approvalRequest.updateMany({
+      where: { id, isDeleted: false, decidedAt: null },
+      data: {
+        decisionStatusLookupId,
+        decidedByUserId,
+        decidedAt: new Date(),
+        decisionNotes: decisionNotes ?? null,
+        decisionReasonCodeLookupId: decisionReasonCodeLookupId ?? null,
+      },
+    });
+    return result.count > 0;
+  }
 }

--- a/apps/approval-service/src/quick-response/quick-response.service.spec.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.spec.ts
@@ -3,6 +3,12 @@ import type { QuickResponseRepository } from './quick-response.repository';
 import type { LookupClient } from './lookup.client';
 import type { EscalationClient } from './escalation.client';
 import type { ReopenRequestClient } from './reopen-request.client';
+import type { BeneficiaryClient } from './beneficiary.client';
+import type { NotificationClient } from './notification.client';
+import type { ClosureClient } from './closure.client';
+import type { ReferralClient } from './referral.client';
+import type { IncentiveClient } from './incentive.client';
+import type { UserClient } from './user.client';
 
 function approvalRequest(overrides: Partial<Record<string, unknown>> = {}) {
   return {
@@ -63,12 +69,40 @@ describe('QuickResponseService', () => {
     findById: jest.fn(),
   } as unknown as jest.Mocked<EscalationClient>;
   const reopenRequestClient = { decide: jest.fn() } as unknown as jest.Mocked<ReopenRequestClient>;
+  const beneficiaryClient = {
+    applyLmpChange: jest.fn(),
+    getById: jest.fn(),
+  } as unknown as jest.Mocked<BeneficiaryClient>;
+  const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
+  const closureClient = { decide: jest.fn() } as unknown as jest.Mocked<ClosureClient>;
+  const referralClient = { decide: jest.fn() } as unknown as jest.Mocked<ReferralClient>;
+  const incentiveClient = {
+    triggerAccompaniedReferral: jest.fn(),
+  } as unknown as jest.Mocked<IncentiveClient>;
+  const userClient = { reactivateUser: jest.fn() } as unknown as jest.Mocked<UserClient>;
   let service: QuickResponseService;
   const authHeader = 'Bearer token';
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new QuickResponseService(repository, lookupClient, escalationClient, reopenRequestClient);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    service = new QuickResponseService(
+      repository,
+      lookupClient,
+      escalationClient,
+      reopenRequestClient,
+      beneficiaryClient,
+      notificationClient,
+      closureClient,
+      referralClient,
+      incentiveClient,
+      userClient,
+    );
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('list', () => {
@@ -243,22 +277,656 @@ describe('QuickResponseService', () => {
     });
   });
 
-  describe('decide — the other 6 stubbed card types', () => {
-    it.each([
-      'LMP_CHANGE',
-      'ACCOMPANIED_REFERRAL',
-      'CLOSURE_REVIEW',
-      'REFERRAL_INCOMPLETE',
-      'DATA_RESTORE',
-    ])('501s a decision on a %s card', async (requestType) => {
-      repository.findById.mockResolvedValue(approvalRequest({ requestType }));
+  describe("decide — DATA_RESTORE (reactivates the requesting Sakhi's account)", () => {
+    function dataRestoreRequest(overrides: Partial<Record<string, unknown>> = {}) {
+      return approvalRequest({
+        requestType: 'DATA_RESTORE',
+        reopenRequestId: null,
+        beneficiaryId: null,
+        requestedByUserId: '99999999-9999-9999-9999-999999999999',
+        ...overrides,
+      });
+    }
+
+    it('approves: reactivates the requesting Sakhi via UserClient and notifies', async () => {
+      const card = dataRestoreRequest();
+      repository.findById.mockResolvedValue(card);
+      userClient.reactivateUser.mockResolvedValue({
+        id: card.requestedByUserId as string,
+        status: 'ACTIVE',
+      });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+
+      expect(userClient.reactivateUser).toHaveBeenCalledWith(card.requestedByUserId, authHeader);
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        card.requestedByUserId,
+        'DATA_RESTORE_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+    });
+
+    it('rejects: makes no reactivation call, still notifies', async () => {
+      const card = dataRestoreRequest();
+      repository.findById.mockResolvedValue(card);
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'REJECT' },
+        authHeader,
+      );
+
+      expect(userClient.reactivateUser).not.toHaveBeenCalled();
+      expect(notificationClient.notify).toHaveBeenCalled();
+      expect(result.decision).toBe('REJECT');
+    });
+
+    it('rejects an invalid decision value', async () => {
+      const card = dataRestoreRequest();
+      repository.findById.mockResolvedValue(card);
+
       await expect(
         service.decide(
-          '11111111-1111-1111-1111-111111111111',
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(userClient.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('propagates a reactivation failure — NOT tolerated like the notification', async () => {
+      const card = dataRestoreRequest();
+      repository.findById.mockResolvedValue(card);
+      userClient.reactivateUser.mockRejectedValue(
+        Object.assign(new Error('This user is already ACTIVE.'), { status: 409 }),
+      );
+
+      await expect(
+        service.decide(
+          card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
           authHeader,
         ),
-      ).rejects.toMatchObject({ status: 501 });
+      ).rejects.toMatchObject({ status: 409 });
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the request when notifying the Sakhi throws after reactivation succeeds', async () => {
+      const card = dataRestoreRequest();
+      repository.findById.mockResolvedValue(card);
+      userClient.reactivateUser.mockResolvedValue({
+        id: card.requestedByUserId as string,
+        status: 'ACTIVE',
+      });
+      notificationClient.notify.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { status: 403 }),
+      );
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('list — DATA_RESTORE is visible even though it has no decision path yet', () => {
+    it('returns DATA_RESTORE alongside every other card type', async () => {
+      lookupClient.resolveApprovalStatusId.mockResolvedValue(
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      );
+      repository.findMany.mockResolvedValue([
+        approvalRequest({ id: 'card-restore', requestType: 'DATA_RESTORE' }),
+        approvalRequest({ id: 'card-reopen', requestType: 'REOPEN' }),
+        approvalRequest({ id: 'card-lmp', requestType: 'LMP_CHANGE' }),
+        approvalRequest({ id: 'card-closure', requestType: 'CLOSURE_REVIEW' }),
+        approvalRequest({ id: 'card-ref-inc', requestType: 'REFERRAL_INCOMPLETE' }),
+        approvalRequest({ id: 'card-acc-ref', requestType: 'ACCOMPANIED_REFERRAL' }),
+      ]);
+      escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
+
+      const result = await service.list({ status: 'PENDING', limit: 50 }, authHeader);
+      const types = result.cards.map((c) => c.cardType);
+
+      expect(types).toEqual(
+        expect.arrayContaining([
+          'DATA_RESTORE',
+          'REOPEN',
+          'LMP_CHANGE',
+          'CLOSURE_REVIEW',
+          'REFERRAL_INCOMPLETE',
+          'ACCOMPANIED_REFERRAL',
+        ]),
+      );
+      expect(result.cards).toHaveLength(6);
+    });
+  });
+
+  describe('decide — CLOSURE_REVIEW (approval_requests)', () => {
+    function closureReviewRequest(overrides: Partial<Record<string, unknown>> = {}) {
+      return approvalRequest({
+        requestType: 'CLOSURE_REVIEW',
+        reopenRequestId: null,
+        closureId: '55555555-5555-5555-5555-555555555555',
+        ...overrides,
+      });
+    }
+
+    it('approves: decides via ClosureClient', async () => {
+      const card = closureReviewRequest();
+      repository.findById.mockResolvedValue(card);
+      closureClient.decide.mockResolvedValue({
+        id: card.closureId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        supervisorStatus: 'APPROVED',
+      });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+
+      expect(closureClient.decide).toHaveBeenCalledWith(
+        card.closureId,
+        'APPROVED',
+        undefined,
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+    });
+
+    it('rejects: decides via ClosureClient with REJECTED', async () => {
+      const card = closureReviewRequest();
+      repository.findById.mockResolvedValue(card);
+      closureClient.decide.mockResolvedValue({
+        id: card.closureId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        supervisorStatus: 'REJECTED',
+      });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'REJECT' },
+        authHeader,
+      );
+      expect(closureClient.decide).toHaveBeenCalledWith(
+        card.closureId,
+        'REJECTED',
+        undefined,
+        authHeader,
+      );
+      expect(result.decision).toBe('REJECT');
+    });
+
+    it('500s when the card has no linked closure', async () => {
+      const card = closureReviewRequest({ closureId: null });
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 500 });
+      expect(closureClient.decide).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid decision value for a CLOSURE_REVIEW card', async () => {
+      const card = closureReviewRequest();
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(closureClient.decide).not.toHaveBeenCalled();
+    });
+
+    it('propagates a 409 from closure-reopen-service (already-decided closure)', async () => {
+      const card = closureReviewRequest();
+      repository.findById.mockResolvedValue(card);
+      closureClient.decide.mockRejectedValue(
+        Object.assign(new Error('Already decided'), { status: 409 }),
+      );
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+  });
+
+  describe('decide — REFERRAL_INCOMPLETE (approval_requests)', () => {
+    function referralIncompleteRequest(overrides: Partial<Record<string, unknown>> = {}) {
+      return approvalRequest({
+        requestType: 'REFERRAL_INCOMPLETE',
+        reopenRequestId: null,
+        referralId: '66666666-6666-6666-6666-666666666666',
+        ...overrides,
+      });
+    }
+
+    it('approves: decides via ReferralClient with LAPSE and notifies the Sakhi', async () => {
+      const card = referralIncompleteRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'LAPSED',
+      });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+
+      expect(referralClient.decide).toHaveBeenCalledWith(card.referralId, 'LAPSE', authHeader);
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        card.requestedByUserId,
+        'REFERRAL_INCOMPLETE_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+    });
+
+    it('rejects: decides via ReferralClient with REFILL', async () => {
+      const card = referralIncompleteRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'PENDING_FOLLOWUP',
+      });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'REJECT' },
+        authHeader,
+      );
+      expect(referralClient.decide).toHaveBeenCalledWith(card.referralId, 'REFILL', authHeader);
+      expect(result.decision).toBe('REJECT');
+    });
+
+    it('500s when the card has no linked referral', async () => {
+      const card = referralIncompleteRequest({ referralId: null });
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 500 });
+      expect(referralClient.decide).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid decision value for a REFERRAL_INCOMPLETE card', async () => {
+      const card = referralIncompleteRequest();
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(referralClient.decide).not.toHaveBeenCalled();
+    });
+
+    it('propagates a 409 from risk-referral-service (referral not PENDING_FOLLOWUP)', async () => {
+      const card = referralIncompleteRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockRejectedValue(
+        Object.assign(new Error('Cannot decide'), { status: 409 }),
+      );
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('does not fail the request when notifying the Sakhi throws after the decision is applied', async () => {
+      const card = referralIncompleteRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'LAPSED',
+      });
+      notificationClient.notify.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { status: 403 }),
+      );
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('decide — ACCOMPANIED_REFERRAL (approval_requests)', () => {
+    function accompaniedReferralRequest(overrides: Partial<Record<string, unknown>> = {}) {
+      return approvalRequest({
+        requestType: 'ACCOMPANIED_REFERRAL',
+        reopenRequestId: null,
+        referralId: '77777777-7777-7777-7777-777777777777',
+        ...overrides,
+      });
+    }
+
+    it('approves: completes the referral, resolves the Sakhi, triggers the incentive, notifies', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'COMPLETED',
+      });
+      beneficiaryClient.getById.mockResolvedValue({
+        id: card.beneficiaryId as string,
+        sakhiId: '88888888-8888-8888-8888-888888888888',
+      });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+
+      expect(referralClient.decide).toHaveBeenCalledWith(card.referralId, 'COMPLETE', authHeader);
+      expect(beneficiaryClient.getById).toHaveBeenCalledWith(card.beneficiaryId, authHeader);
+      expect(incentiveClient.triggerAccompaniedReferral).toHaveBeenCalledWith(
+        '88888888-8888-8888-8888-888888888888',
+        card.referralId,
+        authHeader,
+      );
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        card.requestedByUserId,
+        'ACCOMPANIED_REFERRAL_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+    });
+
+    it('rejects: makes no referral-side call, no incentive, still notifies', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'REJECT' },
+        authHeader,
+      );
+
+      expect(referralClient.decide).not.toHaveBeenCalled();
+      expect(incentiveClient.triggerAccompaniedReferral).not.toHaveBeenCalled();
+      expect(notificationClient.notify).toHaveBeenCalled();
+      expect(result.decision).toBe('REJECT');
+    });
+
+    it('500s when the card has no linked referral', async () => {
+      const card = accompaniedReferralRequest({ referralId: null });
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 500 });
+      expect(referralClient.decide).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid decision value', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('propagates a referral decision failure without notifying or triggering an incentive', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockRejectedValue(
+        Object.assign(new Error('Cannot decide'), { status: 409 }),
+      );
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(beneficiaryClient.getById).not.toHaveBeenCalled();
+      expect(incentiveClient.triggerAccompaniedReferral).not.toHaveBeenCalled();
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('propagates a "no active rate" failure from the incentive trigger (not tolerated)', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'COMPLETED',
+      });
+      beneficiaryClient.getById.mockResolvedValue({
+        id: card.beneficiaryId as string,
+        sakhiId: '88888888-8888-8888-8888-888888888888',
+      });
+      incentiveClient.triggerAccompaniedReferral.mockRejectedValue(
+        Object.assign(new Error('No active incentive rate'), { status: 404 }),
+      );
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('404s when the linked beneficiary cannot be found', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'COMPLETED',
+      });
+      beneficiaryClient.getById.mockResolvedValue(null);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(incentiveClient.triggerAccompaniedReferral).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the request when notifying the Sakhi throws after approval is applied', async () => {
+      const card = accompaniedReferralRequest();
+      repository.findById.mockResolvedValue(card);
+      referralClient.decide.mockResolvedValue({
+        id: card.referralId as unknown as string,
+        beneficiaryId: card.beneficiaryId as string,
+        status: 'COMPLETED',
+      });
+      beneficiaryClient.getById.mockResolvedValue({
+        id: card.beneficiaryId as string,
+        sakhiId: '88888888-8888-8888-8888-888888888888',
+      });
+      notificationClient.notify.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { status: 403 }),
+      );
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('decide — LMP_CHANGE (approval_requests)', () => {
+    function lmpChangeRequest(overrides: Partial<Record<string, unknown>> = {}) {
+      return approvalRequest({
+        requestType: 'LMP_CHANGE',
+        reopenRequestId: null,
+        requestPayloadJson: {
+          newLmpDate: '2026-06-15',
+          sonographyImageUrl: 'https://example.com/sonography-proof.jpg',
+        },
+        ...overrides,
+      });
+    }
+
+    it('approves: applies the LMP change via BeneficiaryClient and notifies the Sakhi', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+      beneficiaryClient.applyLmpChange.mockResolvedValue({ id: card.beneficiaryId as string });
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+
+      expect(beneficiaryClient.applyLmpChange).toHaveBeenCalledWith(
+        card.beneficiaryId,
+        '2026-06-15',
+        authHeader,
+      );
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        card.requestedByUserId,
+        'LMP_CHANGE_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+    });
+
+    it('rejects: does not call BeneficiaryClient, still notifies the Sakhi', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'REJECT' },
+        authHeader,
+      );
+
+      expect(beneficiaryClient.applyLmpChange).not.toHaveBeenCalled();
+      expect(notificationClient.notify).toHaveBeenCalled();
+      expect(result.decision).toBe('REJECT');
+    });
+
+    it('422s on approve when requestPayloadJson has no valid newLmpDate', async () => {
+      const card = lmpChangeRequest({ requestPayloadJson: { sonographyImageUrl: 'x' } });
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(beneficiaryClient.applyLmpChange).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid decision value for an LMP_CHANGE card', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'OKAY' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('propagates a BeneficiaryClient failure on approve (not tolerated)', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+      beneficiaryClient.applyLmpChange.mockRejectedValue(
+        Object.assign(new Error('Bad gateway'), { status: 502 }),
+      );
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 502 });
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the request when notifying the Sakhi throws after approval is applied', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+      beneficiaryClient.applyLmpChange.mockResolvedValue({ id: card.beneficiaryId as string });
+      notificationClient.notify.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { status: 403 }),
+      );
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        authHeader,
+      );
+      expect(result.decision).toBe('APPROVE');
+      expect(consoleErrorSpy).toHaveBeenCalled();
     });
   });
 });

--- a/apps/approval-service/src/quick-response/quick-response.service.spec.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.spec.ts
@@ -60,6 +60,7 @@ describe('QuickResponseService', () => {
   const repository = {
     findMany: jest.fn(),
     findById: jest.fn(),
+    markDecided: jest.fn(),
   } as unknown as jest.Mocked<QuickResponseRepository>;
   const lookupClient = {
     resolveApprovalStatusId: jest.fn(),
@@ -84,9 +85,17 @@ describe('QuickResponseService', () => {
   const authHeader = 'Bearer token';
   let consoleErrorSpy: jest.SpyInstance;
 
+  const DECIDED_BY_USER_ID = '55555555-5555-5555-5555-555555555555';
+
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    // Default so every decide() test's post-side-effect markDecided call
+    // resolves a real lookup id rather than hitting the "no lookup value
+    // found" log branch — tests asserting list()'s own filtering override
+    // this per-call as needed.
+    lookupClient.resolveApprovalStatusId.mockResolvedValue('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+    repository.markDecided.mockResolvedValue(true);
     service = new QuickResponseService(
       repository,
       lookupClient,
@@ -169,6 +178,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         '66666666-6666-6666-6666-666666666666',
         { cardSource: 'escalation_events', decision: 'OKAY' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(result).toMatchObject({ decision: 'OKAY', acknowledged: true });
@@ -181,6 +191,7 @@ describe('QuickResponseService', () => {
         service.decide(
           '66666666-6666-6666-6666-666666666666',
           { cardSource: 'escalation_events', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 404 });
@@ -193,6 +204,7 @@ describe('QuickResponseService', () => {
         service.decide(
           '66666666-6666-6666-6666-666666666666',
           { cardSource: 'escalation_events', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 501 });
@@ -211,6 +223,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         '11111111-1111-1111-1111-111111111111',
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -235,6 +248,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         '11111111-1111-1111-1111-111111111111',
         { cardSource: 'approval_requests', decision: 'REJECT' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(result.decision).toBe('REJECT');
@@ -246,6 +260,7 @@ describe('QuickResponseService', () => {
         service.decide(
           'unknown-id',
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 404 });
@@ -260,6 +275,7 @@ describe('QuickResponseService', () => {
         service.decide(
           '11111111-1111-1111-1111-111111111111',
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 409 });
@@ -271,6 +287,7 @@ describe('QuickResponseService', () => {
         service.decide(
           '11111111-1111-1111-1111-111111111111',
           { cardSource: 'approval_requests', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 400 });
@@ -299,6 +316,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -320,6 +338,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'REJECT' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -336,6 +355,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 400 });
@@ -353,6 +373,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 409 });
@@ -373,6 +394,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(result.decision).toBe('APPROVE');
@@ -434,6 +456,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -458,6 +481,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'REJECT' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(closureClient.decide).toHaveBeenCalledWith(
@@ -477,6 +501,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 500 });
@@ -491,6 +516,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 400 });
@@ -508,6 +534,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 409 });
@@ -536,6 +563,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -562,6 +590,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'REJECT' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(referralClient.decide).toHaveBeenCalledWith(card.referralId, 'REFILL', authHeader);
@@ -576,6 +605,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 500 });
@@ -590,6 +620,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 400 });
@@ -607,6 +638,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 409 });
@@ -627,6 +659,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(result.decision).toBe('APPROVE');
@@ -660,6 +693,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -687,6 +721,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'REJECT' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -704,6 +739,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 500 });
@@ -718,6 +754,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 400 });
@@ -734,6 +771,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 409 });
@@ -742,7 +780,7 @@ describe('QuickResponseService', () => {
       expect(notificationClient.notify).not.toHaveBeenCalled();
     });
 
-    it('propagates a "no active rate" failure from the incentive trigger (not tolerated)', async () => {
+    it('does not fail the request when the incentive trigger fails after the referral is already COMPLETED', async () => {
       const card = accompaniedReferralRequest();
       repository.findById.mockResolvedValue(card);
       referralClient.decide.mockResolvedValue({
@@ -758,14 +796,18 @@ describe('QuickResponseService', () => {
         Object.assign(new Error('No active incentive rate'), { status: 404 }),
       );
 
-      await expect(
-        service.decide(
-          card.id as string,
-          { cardSource: 'approval_requests', decision: 'APPROVE' },
-          authHeader,
-        ),
-      ).rejects.toMatchObject({ status: 404 });
-      expect(notificationClient.notify).not.toHaveBeenCalled();
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
+        authHeader,
+      );
+
+      // The referral decision (already committed, unretryable) must not be
+      // undone by a downstream incentive failure — the request still
+      // succeeds and the Sakhi is still notified.
+      expect(result.decision).toBe('APPROVE');
+      expect(notificationClient.notify).toHaveBeenCalled();
     });
 
     it('404s when the linked beneficiary cannot be found', async () => {
@@ -782,6 +824,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 404 });
@@ -807,6 +850,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(result.decision).toBe('APPROVE');
@@ -835,6 +879,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -860,6 +905,7 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'REJECT' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
 
@@ -876,6 +922,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 422 });
@@ -890,6 +937,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'OKAY' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 400 });
@@ -906,6 +954,7 @@ describe('QuickResponseService', () => {
         service.decide(
           card.id as string,
           { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
           authHeader,
         ),
       ).rejects.toMatchObject({ status: 502 });
@@ -923,10 +972,86 @@ describe('QuickResponseService', () => {
       const result = await service.decide(
         card.id as string,
         { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
         authHeader,
       );
       expect(result.decision).toBe('APPROVE');
       expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('marks the card decided (decisionStatusLookupId, decidedByUserId) after a successful approve', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+      beneficiaryClient.applyLmpChange.mockResolvedValue({ id: card.beneficiaryId as string });
+
+      await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE', decisionNotes: 'Looks right' },
+        DECIDED_BY_USER_ID,
+        authHeader,
+      );
+
+      expect(repository.markDecided).toHaveBeenCalledWith(
+        card.id,
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        DECIDED_BY_USER_ID,
+        'Looks right',
+        undefined,
+      );
+    });
+
+    it('409s on re-approving an already-decided LMP_CHANGE card — the core bug this guard closes', async () => {
+      const card = lmpChangeRequest({ decidedAt: new Date('2026-08-05T12:00:00.000Z') });
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      // The LMP write and Sakhi notification must never re-run on a re-approve.
+      expect(beneficiaryClient.applyLmpChange).not.toHaveBeenCalled();
+      expect(notificationClient.notify).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the request when markDecided fails after the LMP change already applied', async () => {
+      const card = lmpChangeRequest();
+      repository.findById.mockResolvedValue(card);
+      beneficiaryClient.applyLmpChange.mockResolvedValue({ id: card.beneficiaryId as string });
+      repository.markDecided.mockRejectedValue(new Error('db down'));
+
+      const result = await service.decide(
+        card.id as string,
+        { cardSource: 'approval_requests', decision: 'APPROVE' },
+        DECIDED_BY_USER_ID,
+        authHeader,
+      );
+
+      expect(result.decision).toBe('APPROVE');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('decide — already-decided guard applies to every approval_requests card type', () => {
+    it('409s on a REOPEN card that was already decided', async () => {
+      const card = approvalRequest({
+        requestType: 'REOPEN',
+        decidedAt: new Date('2026-08-05T12:00:00.000Z'),
+      });
+      repository.findById.mockResolvedValue(card);
+
+      await expect(
+        service.decide(
+          card.id as string,
+          { cardSource: 'approval_requests', decision: 'APPROVE' },
+          DECIDED_BY_USER_ID,
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(reopenRequestClient.decide).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/approval-service/src/quick-response/quick-response.service.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.ts
@@ -1,4 +1,4 @@
-import { badRequest, notFound, unprocessable, HttpError } from '@armman/service-commons';
+import { badRequest, conflict, notFound, unprocessable, HttpError } from '@armman/service-commons';
 import type { QuickResponseRepository } from './quick-response.repository';
 import type { LookupClient } from './lookup.client';
 import type { EscalationClient, EscalationCard } from './escalation.client';
@@ -150,11 +150,16 @@ export class QuickResponseService {
    * write endpoint in a service that doesn't have one yet, so they respond
    * 501 rather than silently no-op or guess at undefined behavior.
    */
-  async decide(cardId: string, dto: DecideQuickResponseInput, authorizationHeader: string) {
+  async decide(
+    cardId: string,
+    dto: DecideQuickResponseInput,
+    decidedByUserId: string,
+    authorizationHeader: string,
+  ) {
     if (dto.cardSource === 'escalation_events') {
       return this.decideEscalationCard(cardId, dto, authorizationHeader);
     }
-    return this.decideApprovalRequestCard(cardId, dto, authorizationHeader);
+    return this.decideApprovalRequestCard(cardId, dto, decidedByUserId, authorizationHeader);
   }
 
   private async decideEscalationCard(
@@ -186,65 +191,109 @@ export class QuickResponseService {
   private async decideApprovalRequestCard(
     cardId: string,
     dto: DecideQuickResponseInput,
+    decidedByUserId: string,
     authorizationHeader: string,
   ) {
     const existing = await this.repository.findById(cardId);
     if (!existing) throw notFound('Quick Response card not found.');
 
+    // Only LMP_CHANGE has no downstream state of its own to lean on for
+    // idempotency (unlike CLOSURE_REVIEW/REFERRAL_INCOMPLETE/ACCOMPANIED_
+    // REFERRAL/REOPEN, each guarded by the target service's own
+    // PENDING-only status check) — so re-approving an already-decided
+    // LMP_CHANGE card silently re-applied the LMP/EDD write and re-notified
+    // the Sakhi, contradicting this endpoint's documented "409: Card
+    // already decided" contract. Checked here, once, for every card type
+    // rather than duplicated per handler.
+    if (existing.decidedAt) {
+      throw conflict('This Quick Response card has already been decided.');
+    }
+
+    let result: Record<string, unknown>;
     if (existing.requestType === 'LMP_CHANGE') {
-      return this.decideLmpChangeCard(cardId, existing, dto, authorizationHeader);
-    }
+      result = await this.decideLmpChangeCard(cardId, existing, dto, authorizationHeader);
+    } else if (existing.requestType === 'CLOSURE_REVIEW') {
+      result = await this.decideClosureReviewCard(cardId, existing, dto, authorizationHeader);
+    } else if (existing.requestType === 'REFERRAL_INCOMPLETE') {
+      result = await this.decideReferralIncompleteCard(cardId, existing, dto, authorizationHeader);
+    } else if (existing.requestType === 'ACCOMPANIED_REFERRAL') {
+      result = await this.decideAccompaniedReferralCard(cardId, existing, dto, authorizationHeader);
+    } else if (existing.requestType === 'DATA_RESTORE') {
+      result = await this.decideDataRestoreCard(cardId, existing, dto, authorizationHeader);
+    } else if (existing.requestType === 'REOPEN') {
+      if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+        throw badRequest('decision: Must be APPROVE or REJECT for a REOPEN card.');
+      }
+      if (!existing.reopenRequestId) {
+        // Data integrity issue, not a client error — a REOPEN
+        // approval_requests row must always carry the reopen_requests id it
+        // originated from.
+        throw new HttpError(500, 'This REOPEN card has no linked reopen request.');
+      }
 
-    if (existing.requestType === 'CLOSURE_REVIEW') {
-      return this.decideClosureReviewCard(cardId, existing, dto, authorizationHeader);
-    }
+      // The audit_log entry and Sakhi notification are written by
+      // closure-reopen-service's own decide flow, not here — that's the only
+      // place a reopen decision is actually persisted, so the audit trail
+      // can't be bypassed by calling that endpoint directly instead of through
+      // Quick Response.
+      const decided = await this.reopenRequestClient.decide(
+        existing.reopenRequestId,
+        dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED',
+        dto.decisionReasonCodeLookupId,
+        dto.decisionNotes,
+        authorizationHeader,
+      );
 
-    if (existing.requestType === 'REFERRAL_INCOMPLETE') {
-      return this.decideReferralIncompleteCard(cardId, existing, dto, authorizationHeader);
-    }
-
-    if (existing.requestType === 'ACCOMPANIED_REFERRAL') {
-      return this.decideAccompaniedReferralCard(cardId, existing, dto, authorizationHeader);
-    }
-
-    if (existing.requestType === 'DATA_RESTORE') {
-      return this.decideDataRestoreCard(cardId, existing, dto, authorizationHeader);
-    }
-
-    if (existing.requestType !== 'REOPEN') {
+      result = {
+        cardId,
+        cardSource: 'approval_requests' as const,
+        decision: dto.decision,
+        reopenRequest: decided,
+      };
+    } else {
       throw new HttpError(
         501,
         `Decisions on "${existing.requestType}" cards are not yet implemented.`,
       );
     }
-    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
-      throw badRequest('decision: Must be APPROVE or REJECT for a REOPEN card.');
-    }
-    if (!existing.reopenRequestId) {
-      // Data integrity issue, not a client error — a REOPEN approval_requests
-      // row must always carry the reopen_requests id it originated from.
-      throw new HttpError(500, 'This REOPEN card has no linked reopen request.');
+
+    // Marked decided only after the real side effect above has already
+    // succeeded — a failure to persist this marker must not be reported as
+    // if the decision itself failed (log-and-continue, like every other
+    // post-commit call in this method), but it also must never run before
+    // the side effect, or a card could be marked decided while its actual
+    // effect never happened.
+    try {
+      // Every approval_requests decision reaching this point is APPROVE or
+      // REJECT — the OKAY decision only exists on the escalation_events
+      // branch, which returns earlier in decide() and never reaches here.
+      const decisionStatusLookupId = await this.lookupClient.resolveApprovalStatusId(
+        dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED',
+        authorizationHeader,
+      );
+      if (decisionStatusLookupId) {
+        await this.repository.markDecided(
+          cardId,
+          decisionStatusLookupId,
+          decidedByUserId,
+          dto.decisionNotes,
+          dto.decisionReasonCodeLookupId,
+        );
+      } else {
+        console.error(
+          `Quick Response card ${cardId} was decided (${dto.decision}) but no ` +
+            `${dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED'} APPROVAL_STATUS lookup ` +
+            'value was found — the card cannot be marked decided and remains re-decidable.',
+        );
+      }
+    } catch (err) {
+      console.error(
+        `Quick Response card ${cardId} was decided (${dto.decision}) but marking it decided failed:`,
+        err,
+      );
     }
 
-    // The audit_log entry and Sakhi notification are written by
-    // closure-reopen-service's own decide flow, not here — that's the only
-    // place a reopen decision is actually persisted, so the audit trail
-    // can't be bypassed by calling that endpoint directly instead of through
-    // Quick Response.
-    const decided = await this.reopenRequestClient.decide(
-      existing.reopenRequestId,
-      dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED',
-      dto.decisionReasonCodeLookupId,
-      dto.decisionNotes,
-      authorizationHeader,
-    );
-
-    return {
-      cardId,
-      cardSource: 'approval_requests' as const,
-      decision: dto.decision,
-      reopenRequest: decided,
-    };
+    return result;
   }
 
   /**
@@ -411,11 +460,22 @@ export class QuickResponseService {
    * Decides an ACCOMPANIED_REFERRAL card (FR-SV-4.9). Approve marks the
    * referral Completed, then resolves the assigned Sakhi (via the referral's
    * beneficiary — neither approval_requests nor referrals carries a sakhiId
-   * column) and triggers the incentive. The referral decision and incentive
-   * trigger are NOT tolerated — a Supervisor approving this card needs both
-   * to actually happen, not silently fail while looking successful. Reject
-   * makes no referral-side call at all (the referral stays Pending, per
-   * spec) and grants no incentive. Either way the Sakhi is notified,
+   * column) and triggers the incentive. The referral decision itself is NOT
+   * tolerated — a Supervisor approving this card needs the referral to
+   * actually complete, not silently fail while looking successful.
+   *
+   * The incentive trigger, unlike the referral decision, IS best-effort: by
+   * the time it runs, risk-referral-service has already committed the
+   * referral to COMPLETED — a one-shot, PENDING_FOLLOWUP-only transition
+   * with no way back. If the incentive call were allowed to fail the whole
+   * request, there would be no way to retry just this step (any retry
+   * immediately 409s on the already-terminal referral), permanently
+   * dropping a payout instead of just needing a manual follow-up. Logged,
+   * not thrown — same log-and-continue shape as the Sakhi notification
+   * below, not a "this must succeed" call like the referral decision above.
+   *
+   * Reject makes no referral-side call at all (the referral stays Pending,
+   * per spec) and grants no incentive. Either way the Sakhi is notified,
    * best-effort.
    */
   private async decideAccompaniedReferralCard(
@@ -451,11 +511,20 @@ export class QuickResponseService {
       if (!beneficiary) {
         throw notFound('The beneficiary linked to this referral was not found.');
       }
-      await this.incentiveClient.triggerAccompaniedReferral(
-        beneficiary.sakhiId,
-        existing.referralId,
-        authorizationHeader,
-      );
+      try {
+        await this.incentiveClient.triggerAccompaniedReferral(
+          beneficiary.sakhiId,
+          existing.referralId,
+          authorizationHeader,
+        );
+      } catch (err) {
+        console.error(
+          `ACCOMPANIED_REFERRAL card ${cardId} was approved and the referral marked COMPLETED, ` +
+            `but the incentive trigger failed (referral cannot be re-decided to retry — ` +
+            `needs manual follow-up):`,
+          err,
+        );
+      }
     }
 
     try {

--- a/apps/approval-service/src/quick-response/quick-response.service.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.ts
@@ -1,12 +1,28 @@
-import { badRequest, notFound, HttpError } from '@armman/service-commons';
+import { badRequest, notFound, unprocessable, HttpError } from '@armman/service-commons';
 import type { QuickResponseRepository } from './quick-response.repository';
 import type { LookupClient } from './lookup.client';
 import type { EscalationClient, EscalationCard } from './escalation.client';
 import type { ReopenRequestClient } from './reopen-request.client';
+import type { BeneficiaryClient } from './beneficiary.client';
+import type { NotificationClient } from './notification.client';
+import type { ClosureClient } from './closure.client';
+import type { ReferralClient } from './referral.client';
+import type { IncentiveClient } from './incentive.client';
+import type { UserClient } from './user.client';
 import type { ListQuickResponseInput } from './dto/list-quick-response.dto';
 import type { DecideQuickResponseInput } from './dto/decide-quick-response.dto';
 
-/** Every ApprovalRequestType maps 1:1 to a Quick Response card type — same name. */
+/**
+ * ApprovalRequestTypes surfaced as Quick Response cards — each maps 1:1 to a
+ * card type of the same name.
+ *
+ * DATA_RESTORE is included for visibility even though it has no decision
+ * path yet (see decideApprovalRequestCard) — per SRS FR-SV-4.6 its restore
+ * flow and backend behaviour must be confirmed with ARMMAN before the module
+ * is built. A Supervisor can see the card was raised; attempting to decide
+ * it correctly 501s with a message naming the blocker rather than silently
+ * hiding a request that exists.
+ */
 const APPROVAL_REQUEST_CARD_TYPES = new Set([
   'LMP_CHANGE',
   'REFERRAL_INCOMPLETE',
@@ -66,6 +82,12 @@ export class QuickResponseService {
     private readonly lookupClient: LookupClient,
     private readonly escalationClient: EscalationClient,
     private readonly reopenRequestClient: ReopenRequestClient,
+    private readonly beneficiaryClient: BeneficiaryClient,
+    private readonly notificationClient: NotificationClient,
+    private readonly closureClient: ClosureClient,
+    private readonly referralClient: ReferralClient,
+    private readonly incentiveClient: IncentiveClient,
+    private readonly userClient: UserClient,
   ) {}
 
   /**
@@ -169,6 +191,26 @@ export class QuickResponseService {
     const existing = await this.repository.findById(cardId);
     if (!existing) throw notFound('Quick Response card not found.');
 
+    if (existing.requestType === 'LMP_CHANGE') {
+      return this.decideLmpChangeCard(cardId, existing, dto, authorizationHeader);
+    }
+
+    if (existing.requestType === 'CLOSURE_REVIEW') {
+      return this.decideClosureReviewCard(cardId, existing, dto, authorizationHeader);
+    }
+
+    if (existing.requestType === 'REFERRAL_INCOMPLETE') {
+      return this.decideReferralIncompleteCard(cardId, existing, dto, authorizationHeader);
+    }
+
+    if (existing.requestType === 'ACCOMPANIED_REFERRAL') {
+      return this.decideAccompaniedReferralCard(cardId, existing, dto, authorizationHeader);
+    }
+
+    if (existing.requestType === 'DATA_RESTORE') {
+      return this.decideDataRestoreCard(cardId, existing, dto, authorizationHeader);
+    }
+
     if (existing.requestType !== 'REOPEN') {
       throw new HttpError(
         501,
@@ -202,6 +244,293 @@ export class QuickResponseService {
       cardSource: 'approval_requests' as const,
       decision: dto.decision,
       reopenRequest: decided,
+    };
+  }
+
+  /**
+   * Decides an LMP_CHANGE card (FR-SV-4.2). On APPROVE, applies the new
+   * lmpDate via beneficiary-service's PATCH /beneficiaries/:id/lmp — that
+   * call's failure is NOT tolerated (unlike the Sakhi notification below):
+   * an LMP write failing must surface to the Supervisor as a real error to
+   * retry, not be silently swallowed as if the decision succeeded. On
+   * REJECT, nothing is applied. Either way the Sakhi is notified, best-effort
+   * (a notification failure must not undo an already-applied/rejected
+   * decision).
+   *
+   * Does not regenerate the ANC visit schedule — see
+   * BeneficiaryService.applyLmpChange's doc comment for why (schedules are
+   * device-generated, not server-side).
+   */
+  private async decideLmpChangeCard(
+    cardId: string,
+    existing: {
+      beneficiaryId: string | null;
+      requestPayloadJson: unknown;
+      requestedByUserId: string;
+    },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+      throw badRequest('decision: Must be APPROVE or REJECT for an LMP_CHANGE card.');
+    }
+
+    if (dto.decision === 'APPROVE') {
+      if (!existing.beneficiaryId) {
+        throw new HttpError(500, 'This LMP_CHANGE card has no linked beneficiary.');
+      }
+      const payload = existing.requestPayloadJson as { newLmpDate?: unknown } | null;
+      if (!payload || typeof payload.newLmpDate !== 'string') {
+        throw unprocessable('This LMP_CHANGE card has no valid newLmpDate to apply.');
+      }
+      await this.beneficiaryClient.applyLmpChange(
+        existing.beneficiaryId,
+        payload.newLmpDate,
+        authorizationHeader,
+      );
+    }
+
+    try {
+      await this.notificationClient.notify(
+        existing.requestedByUserId,
+        'LMP_CHANGE_UPDATE',
+        'LMP change request decided',
+        dto.decision === 'APPROVE'
+          ? 'Your LMP change request was approved.'
+          : 'Your LMP change request was rejected.',
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `LMP_CHANGE card ${cardId} was decided (${dto.decision}) but the Sakhi notification failed:`,
+        err,
+      );
+    }
+
+    return {
+      cardId,
+      cardSource: 'approval_requests' as const,
+      decision: dto.decision,
+    };
+  }
+
+  /**
+   * Decides a CLOSURE_REVIEW card (FR-SV-4.4). Forwards the decision to
+   * closure-reopen-service's PATCH /closures/:id/decision, which is the only
+   * place a closure decision is actually persisted — the "beneficiary
+   * moves to Closed/Open list" consequence lives there too. That endpoint
+   * already sends the Sakhi notification itself, so unlike LMP_CHANGE this
+   * method does not notify a second time.
+   */
+  private async decideClosureReviewCard(
+    cardId: string,
+    existing: { closureId: string | null },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+      throw badRequest('decision: Must be APPROVE or REJECT for a CLOSURE_REVIEW card.');
+    }
+    if (!existing.closureId) {
+      // Data integrity issue, not a client error — a CLOSURE_REVIEW
+      // approval_requests row must always carry the closures id it
+      // originated from.
+      throw new HttpError(500, 'This CLOSURE_REVIEW card has no linked closure.');
+    }
+
+    const decided = await this.closureClient.decide(
+      existing.closureId,
+      dto.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED',
+      dto.decisionNotes,
+      authorizationHeader,
+    );
+
+    return {
+      cardId,
+      cardSource: 'approval_requests' as const,
+      decision: dto.decision,
+      closure: decided,
+    };
+  }
+
+  /**
+   * Decides a REFERRAL_INCOMPLETE card (FR-SV-4.5). Approve marks the
+   * referral Lapsed and grants no incentive (per spec). Reject makes no
+   * referral-side state change — the Sakhi must refill the follow-up form —
+   * but still round-trips through risk-referral-service's decide endpoint so
+   * a REFILL on a referral that isn't actually PENDING_FOLLOWUP still 409s,
+   * same as the approve path. Either way the Sakhi is notified, best-effort.
+   */
+  private async decideReferralIncompleteCard(
+    cardId: string,
+    existing: { referralId: string | null; requestedByUserId: string },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+      throw badRequest('decision: Must be APPROVE or REJECT for a REFERRAL_INCOMPLETE card.');
+    }
+    if (!existing.referralId) {
+      // Data integrity issue, not a client error — a REFERRAL_INCOMPLETE
+      // approval_requests row must always carry the referrals id it
+      // originated from.
+      throw new HttpError(500, 'This REFERRAL_INCOMPLETE card has no linked referral.');
+    }
+
+    await this.referralClient.decide(
+      existing.referralId,
+      dto.decision === 'APPROVE' ? 'LAPSE' : 'REFILL',
+      authorizationHeader,
+    );
+
+    try {
+      await this.notificationClient.notify(
+        existing.requestedByUserId,
+        'REFERRAL_INCOMPLETE_UPDATE',
+        'Referral follow-up decided',
+        dto.decision === 'APPROVE'
+          ? 'Your referral follow-up was marked Lapsed by your Supervisor.'
+          : 'Please refill the referral follow-up form.',
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `REFERRAL_INCOMPLETE card ${cardId} was decided (${dto.decision}) but the Sakhi notification failed:`,
+        err,
+      );
+    }
+
+    return {
+      cardId,
+      cardSource: 'approval_requests' as const,
+      decision: dto.decision,
+    };
+  }
+
+  /**
+   * Decides an ACCOMPANIED_REFERRAL card (FR-SV-4.9). Approve marks the
+   * referral Completed, then resolves the assigned Sakhi (via the referral's
+   * beneficiary — neither approval_requests nor referrals carries a sakhiId
+   * column) and triggers the incentive. The referral decision and incentive
+   * trigger are NOT tolerated — a Supervisor approving this card needs both
+   * to actually happen, not silently fail while looking successful. Reject
+   * makes no referral-side call at all (the referral stays Pending, per
+   * spec) and grants no incentive. Either way the Sakhi is notified,
+   * best-effort.
+   */
+  private async decideAccompaniedReferralCard(
+    cardId: string,
+    existing: {
+      referralId: string | null;
+      beneficiaryId: string | null;
+      requestedByUserId: string;
+    },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+      throw badRequest('decision: Must be APPROVE or REJECT for an ACCOMPANIED_REFERRAL card.');
+    }
+    if (!existing.referralId) {
+      // Data integrity issue, not a client error — an ACCOMPANIED_REFERRAL
+      // approval_requests row must always carry the referrals id it
+      // originated from.
+      throw new HttpError(500, 'This ACCOMPANIED_REFERRAL card has no linked referral.');
+    }
+
+    if (dto.decision === 'APPROVE') {
+      await this.referralClient.decide(existing.referralId, 'COMPLETE', authorizationHeader);
+
+      if (!existing.beneficiaryId) {
+        throw new HttpError(500, 'This ACCOMPANIED_REFERRAL card has no linked beneficiary.');
+      }
+      const beneficiary = await this.beneficiaryClient.getById(
+        existing.beneficiaryId,
+        authorizationHeader,
+      );
+      if (!beneficiary) {
+        throw notFound('The beneficiary linked to this referral was not found.');
+      }
+      await this.incentiveClient.triggerAccompaniedReferral(
+        beneficiary.sakhiId,
+        existing.referralId,
+        authorizationHeader,
+      );
+    }
+
+    try {
+      await this.notificationClient.notify(
+        existing.requestedByUserId,
+        'ACCOMPANIED_REFERRAL_UPDATE',
+        'Accompanied referral decided',
+        dto.decision === 'APPROVE'
+          ? 'Your accompanied referral was approved and completed.'
+          : 'Your accompanied referral was rejected.',
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `ACCOMPANIED_REFERRAL card ${cardId} was decided (${dto.decision}) but the Sakhi notification failed:`,
+        err,
+      );
+    }
+
+    return {
+      cardId,
+      cardSource: 'approval_requests' as const,
+      decision: dto.decision,
+    };
+  }
+
+  /**
+   * Decides a DATA_RESTORE card. Note this does NOT implement the SRS's
+   * literal FR-SV-4.6 wording ("data restore is initiated for that Sakhi's
+   * device") — that flow remains unconfirmed with ARMMAN and unbuilt. This
+   * implements a specifically-approved narrower behavior instead: on
+   * APPROVE, reactivates the requesting Sakhi's own user account
+   * (requestedByUserId) via auth-service's PATCH /users/:id/reactivate.
+   * Not tolerated — same rule as every other reactivation this service
+   * performs (LMP change, reopen, referral/closure decisions): a Supervisor
+   * who approved this needs to know if the reactivation didn't actually
+   * happen, not receive a false "success". REJECT makes no auth-service
+   * call and grants no account changes. Either way the Sakhi is notified,
+   * best-effort.
+   */
+  private async decideDataRestoreCard(
+    cardId: string,
+    existing: { requestedByUserId: string },
+    dto: DecideQuickResponseInput,
+    authorizationHeader: string,
+  ) {
+    if (dto.decision !== 'APPROVE' && dto.decision !== 'REJECT') {
+      throw badRequest('decision: Must be APPROVE or REJECT for a DATA_RESTORE card.');
+    }
+
+    if (dto.decision === 'APPROVE') {
+      await this.userClient.reactivateUser(existing.requestedByUserId, authorizationHeader);
+    }
+
+    try {
+      await this.notificationClient.notify(
+        existing.requestedByUserId,
+        'DATA_RESTORE_UPDATE',
+        'Data restore request decided',
+        dto.decision === 'APPROVE'
+          ? 'Your account has been reactivated.'
+          : 'Your data restore request was rejected.',
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `DATA_RESTORE card ${cardId} was decided (${dto.decision}) but the Sakhi notification failed:`,
+        err,
+      );
+    }
+
+    return {
+      cardId,
+      cardSource: 'approval_requests' as const,
+      decision: dto.decision,
     };
   }
 }

--- a/apps/approval-service/src/quick-response/referral.client.ts
+++ b/apps/approval-service/src/quick-response/referral.client.ts
@@ -1,0 +1,44 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface ReferralRecord {
+  id: string;
+  beneficiaryId: string;
+  status: string;
+}
+
+/**
+ * Decides a REFERRAL_INCOMPLETE or ACCOMPANIED_REFERRAL card by calling
+ * risk-referral-service's PATCH /referrals/:id/decision through the gateway,
+ * forwarding the caller's own Authorization header — same pattern this
+ * service's ReopenRequestClient/ClosureClient use.
+ */
+export class ReferralClient {
+  async decide(
+    id: string,
+    decision: 'LAPSE' | 'REFILL' | 'COMPLETE',
+    authorizationHeader: string,
+  ): Promise<ReferralRecord> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/referrals/${id}/decision`, {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision }),
+      });
+    } catch {
+      throw badGateway('Unable to decide the referral — risk-referral-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to decide the referral.');
+      }
+      throw badGateway('Unable to decide the referral — risk-referral-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: ReferralRecord };
+    return body.data;
+  }
+}

--- a/apps/approval-service/src/quick-response/user.client.ts
+++ b/apps/approval-service/src/quick-response/user.client.ts
@@ -1,0 +1,40 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface UserProfileRecord {
+  id: string;
+  status: string;
+}
+
+/**
+ * Reactivates a Sakhi's user account by calling auth-service's
+ * PATCH /users/:id/reactivate through the gateway, forwarding the caller's
+ * own Authorization header — same pattern this service's other clients use.
+ * Used for the DATA_RESTORE card's approved-decision path — narrow scope,
+ * not a general user-management call (see auth-service's own
+ * AuthService.reactivateUser doc comment).
+ */
+export class UserClient {
+  async reactivateUser(userId: string, authorizationHeader: string): Promise<UserProfileRecord> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/users/${userId}/reactivate`, {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to reactivate the user — auth-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to reactivate the user.');
+      }
+      throw badGateway('Unable to reactivate the user — auth-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: UserProfileRecord };
+    return body.data;
+  }
+}

--- a/apps/auth-service/src/auth/auth.controller.ts
+++ b/apps/auth-service/src/auth/auth.controller.ts
@@ -244,6 +244,36 @@ export function createAuthRouter(service: AuthService, signer: TokenSigner) {
     }),
   );
 
+  doc.patch(
+    '/users/:id/reactivate',
+    {
+      summary:
+        "Reactivate a deactivated user's account (Quick Response DATA_RESTORE card, approved) — " +
+        'a narrow status-only operation, unlike the general PATCH /users/:id',
+      tags: ['Users'],
+      params: userIdParamsSchema,
+      responses: {
+        200: { description: 'User reactivated', schema: envelope(userProfileSchema) },
+        401: errorResponse(401),
+        403: errorResponse(403, {
+          message: 'Only Sakhi accounts can be reactivated via this endpoint.',
+        }),
+        404: errorResponse(404, { message: 'User not found.' }),
+        409: errorResponse(409, { message: 'This user is already ACTIVE.' }),
+        500: errorResponse(500),
+      },
+    },
+    authenticate(signer),
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(userIdParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      // authenticate(signer) runs first and calls next(unauthorized()) if it
+      // fails, so req.user is always populated by the time this handler runs.
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.reactivateUser(req.params.id, req.user)));
+    }),
+  );
+
   doc.get(
     '/me',
     {

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -182,6 +182,25 @@ export class AuthRepository {
   }
 
   /**
+   * Reactivates a deactivated user's account (Quick Response's DATA_RESTORE
+   * card, approved) — flips status back to ACTIVE. Only updates a row whose
+   * status is currently one of the deactivated states; a DELETED account is
+   * deliberately excluded — that's a distinct, more serious state a bare
+   * reactivation must never silently reverse. updateMany's affected count
+   * (rather than a separate read-then-write) is the concurrency guard: if
+   * status already changed between the caller's findUserById and this call,
+   * the count comes back 0 and the service turns that into a 409 instead of
+   * silently overwriting a since-changed account.
+   */
+  async reactivateUser(userId: string): Promise<boolean> {
+    const result = await this.prisma.user.updateMany({
+      where: { id: userId, isDeleted: false, status: { in: ['INACTIVE', 'LOCKED', 'PAUSED'] } },
+      data: { status: 'ACTIVE' },
+    });
+    return result.count > 0;
+  }
+
+  /**
    * Applies the `users`/`user_roles`/`sakhi_profiles` portions of an update,
    * and — when `revokeSessions` is set — the session revocation that must
    * accompany a username/password change, all in one transaction: either

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -905,55 +905,111 @@ describe('AuthService', () => {
   });
 
   describe('reactivateUser', () => {
-    it('reactivates an INACTIVE user and returns the full profile', async () => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'INACTIVE' } as never);
-      repository.reactivateUser.mockResolvedValue(true);
-      repository.findUserByIdWithProfile.mockResolvedValue(updatedUserRow() as never);
+    const ADMIN_CALLER = { id: 'admin-1', roles: ['ADMIN'] };
+    const SUPERVISOR_CALLER = { id: 'supervisor-1', roles: ['SUPERVISOR'] };
 
-      const result = await service.reactivateUser('user-1');
+    function sakhiRow(overrides: Record<string, unknown> = {}) {
+      return {
+        ...ACTIVE_USER,
+        status: 'INACTIVE',
+        sakhiProfile: { id: 'sakhi-profile-1', supervisorId: 'supervisor-1' },
+        ...overrides,
+      };
+    }
+
+    it('reactivates an INACTIVE Sakhi and returns the full profile', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValueOnce(sakhiRow() as never);
+      repository.reactivateUser.mockResolvedValue(true);
+      repository.findUserByIdWithProfile.mockResolvedValueOnce(updatedUserRow() as never);
+
+      const result = await service.reactivateUser('user-1', ADMIN_CALLER);
 
       expect(repository.reactivateUser).toHaveBeenCalledWith('user-1');
       expect(result.status).toBe('ACTIVE');
     });
 
-    it.each(['INACTIVE', 'LOCKED', 'PAUSED'])('reactivates a %s user', async (status) => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status } as never);
+    it.each(['INACTIVE', 'LOCKED', 'PAUSED'])('reactivates a %s Sakhi', async (status) => {
+      repository.findUserByIdWithProfile.mockResolvedValueOnce(sakhiRow({ status }) as never);
       repository.reactivateUser.mockResolvedValue(true);
-      repository.findUserByIdWithProfile.mockResolvedValue(updatedUserRow() as never);
+      repository.findUserByIdWithProfile.mockResolvedValueOnce(updatedUserRow() as never);
 
-      await expect(service.reactivateUser('user-1')).resolves.toMatchObject({
+      await expect(service.reactivateUser('user-1', ADMIN_CALLER)).resolves.toMatchObject({
         status: 'ACTIVE',
       });
     });
 
     it('404s when the user does not exist', async () => {
-      repository.findUserById.mockResolvedValue(null);
-      await expect(service.reactivateUser('missing')).rejects.toMatchObject({ status: 404 });
+      repository.findUserByIdWithProfile.mockResolvedValue(null);
+      await expect(service.reactivateUser('missing', ADMIN_CALLER)).rejects.toMatchObject({
+        status: 404,
+      });
       expect(repository.reactivateUser).not.toHaveBeenCalled();
     });
 
     it('404s for a soft-deleted user', async () => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, isDeleted: true } as never);
-      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 404 });
+      repository.findUserByIdWithProfile.mockResolvedValue(sakhiRow({ isDeleted: true }) as never);
+      await expect(service.reactivateUser('user-1', ADMIN_CALLER)).rejects.toMatchObject({
+        status: 404,
+      });
       expect(repository.reactivateUser).not.toHaveBeenCalled();
     });
 
+    it('403s when the target is not a Sakhi account', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValue(
+        sakhiRow({ userRoles: [{ role: { roleCode: 'SUPERVISOR' } }] }) as never,
+      );
+      await expect(service.reactivateUser('user-1', ADMIN_CALLER)).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(repository.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('403s when a SUPERVISOR targets a Sakhi outside their own roster', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValue(
+        sakhiRow({
+          sakhiProfile: { id: 'sakhi-profile-1', supervisorId: 'some-other-supervisor' },
+        }) as never,
+      );
+      await expect(service.reactivateUser('user-1', SUPERVISOR_CALLER)).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(repository.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('allows a SUPERVISOR to reactivate a Sakhi in their own roster', async () => {
+      repository.findUserByIdWithProfile.mockResolvedValueOnce(sakhiRow() as never);
+      repository.reactivateUser.mockResolvedValue(true);
+      repository.findUserByIdWithProfile.mockResolvedValueOnce(updatedUserRow() as never);
+
+      await expect(service.reactivateUser('user-1', SUPERVISOR_CALLER)).resolves.toMatchObject({
+        status: 'ACTIVE',
+      });
+    });
+
     it('409s when the user is already ACTIVE', async () => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'ACTIVE' } as never);
-      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 409 });
+      repository.findUserByIdWithProfile.mockResolvedValue(sakhiRow({ status: 'ACTIVE' }) as never);
+      await expect(service.reactivateUser('user-1', ADMIN_CALLER)).rejects.toMatchObject({
+        status: 409,
+      });
       expect(repository.reactivateUser).not.toHaveBeenCalled();
     });
 
     it('409s for a DELETED account — never silently reactivated', async () => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'DELETED' } as never);
-      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 409 });
+      repository.findUserByIdWithProfile.mockResolvedValue(
+        sakhiRow({ status: 'DELETED' }) as never,
+      );
+      await expect(service.reactivateUser('user-1', ADMIN_CALLER)).rejects.toMatchObject({
+        status: 409,
+      });
       expect(repository.reactivateUser).not.toHaveBeenCalled();
     });
 
     it('409s when the conditional update races with a concurrent status change', async () => {
-      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'INACTIVE' } as never);
+      repository.findUserByIdWithProfile.mockResolvedValue(sakhiRow() as never);
       repository.reactivateUser.mockResolvedValue(false);
-      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 409 });
+      await expect(service.reactivateUser('user-1', ADMIN_CALLER)).rejects.toMatchObject({
+        status: 409,
+      });
     });
   });
 });

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -74,6 +74,7 @@ describe('AuthService', () => {
     findActiveUserRole: jest.fn(),
     findSakhiProfileByUserId: jest.fn(),
     updateUserTransaction: jest.fn(),
+    reactivateUser: jest.fn(),
   } as unknown as jest.Mocked<AuthRepository>;
 
   const signer = {
@@ -900,6 +901,59 @@ describe('AuthService', () => {
         sakhiProfile: { id: 'sakhi-profile-1', data: { employeeCode: 'EMP-00999' } },
         revokeSessions: true,
       });
+    });
+  });
+
+  describe('reactivateUser', () => {
+    it('reactivates an INACTIVE user and returns the full profile', async () => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'INACTIVE' } as never);
+      repository.reactivateUser.mockResolvedValue(true);
+      repository.findUserByIdWithProfile.mockResolvedValue(updatedUserRow() as never);
+
+      const result = await service.reactivateUser('user-1');
+
+      expect(repository.reactivateUser).toHaveBeenCalledWith('user-1');
+      expect(result.status).toBe('ACTIVE');
+    });
+
+    it.each(['INACTIVE', 'LOCKED', 'PAUSED'])('reactivates a %s user', async (status) => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status } as never);
+      repository.reactivateUser.mockResolvedValue(true);
+      repository.findUserByIdWithProfile.mockResolvedValue(updatedUserRow() as never);
+
+      await expect(service.reactivateUser('user-1')).resolves.toMatchObject({
+        status: 'ACTIVE',
+      });
+    });
+
+    it('404s when the user does not exist', async () => {
+      repository.findUserById.mockResolvedValue(null);
+      await expect(service.reactivateUser('missing')).rejects.toMatchObject({ status: 404 });
+      expect(repository.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('404s for a soft-deleted user', async () => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, isDeleted: true } as never);
+      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 404 });
+      expect(repository.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('409s when the user is already ACTIVE', async () => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'ACTIVE' } as never);
+      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 409 });
+      expect(repository.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('409s for a DELETED account — never silently reactivated', async () => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'DELETED' } as never);
+      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 409 });
+      expect(repository.reactivateUser).not.toHaveBeenCalled();
+    });
+
+    it('409s when the conditional update races with a concurrent status change', async () => {
+      repository.findUserById.mockResolvedValue({ ...ACTIVE_USER, status: 'INACTIVE' } as never);
+      repository.reactivateUser.mockResolvedValue(false);
+      await expect(service.reactivateUser('user-1')).rejects.toMatchObject({ status: 409 });
     });
   });
 });

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -20,6 +20,12 @@ import type { UpdateUserInput } from './dto/update-user.dto';
 // their definitions live in auth.mapper.ts.
 export type { AuthTokens, CreatedUser, UserProfile } from './auth.mapper';
 
+/** The calling principal's own scope, as carried on their JWT/trusted-identity headers. */
+export interface CallerScope {
+  readonly id: string;
+  readonly roles: string[];
+}
+
 /** Prisma unique-constraint violation code (mobileNumber/email/roleCode etc). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
 
@@ -254,6 +260,59 @@ export class AuthService {
       }
       throw err;
     }
+  }
+
+  /**
+   * Reactivates a deactivated Sakhi's account after an approved DATA_RESTORE
+   * Quick Response card. Deliberately a narrow, single-purpose operation —
+   * unlike the general `PATCH /users/:id` (ADMIN-only, can change anything
+   * about a user), this only ever flips status back to ACTIVE, so it can
+   * safely be opened to SUPERVISOR/MANAGER without widening what they can
+   * otherwise do to a user record.
+   *
+   * Restricted to SAKHI targets only — the route's role check
+   * (SUPERVISOR/MANAGER/ADMIN can call it) says nothing about who can be
+   * reactivated, so without this a SUPERVISOR could otherwise flip any
+   * deactivated account back to ACTIVE, including another SUPERVISOR's or
+   * an ADMIN's. A SUPERVISOR caller is further scoped to their own Sakhi
+   * roster (sakhiProfile.supervisorId), the same ownership check
+   * SakhiService.listByProject applies to reads.
+   */
+  async reactivateUser(userId: string, caller: CallerScope): Promise<UserProfile> {
+    const existing = await this.repository.findUserByIdWithProfile(userId);
+    if (!existing || existing.isDeleted) throw notFound('User not found.');
+
+    const targetRoleCodes = existing.userRoles.map((ur) => ur.role.roleCode);
+    if (!targetRoleCodes.includes('SAKHI')) {
+      throw forbidden('Only Sakhi accounts can be reactivated via this endpoint.');
+    }
+    if (
+      caller.roles.includes('SUPERVISOR') &&
+      !caller.roles.includes('MANAGER') &&
+      !caller.roles.includes('ADMIN') &&
+      existing.sakhiProfile?.supervisorId !== caller.id
+    ) {
+      throw forbidden('This Sakhi is not in your roster.');
+    }
+
+    if (existing.status === 'ACTIVE') {
+      throw conflict('This user is already ACTIVE.');
+    }
+    if (existing.status === 'DELETED') {
+      throw conflict('A DELETED account cannot be reactivated this way.');
+    }
+
+    const reactivated = await this.repository.reactivateUser(userId);
+    if (!reactivated) {
+      // Raced with another status change between the read above and the
+      // conditional update — same outcome as the checks above, just caught a
+      // beat later instead of trusting a stale read.
+      throw conflict('This user is no longer eligible for reactivation.');
+    }
+
+    const user = await this.repository.findUserByIdWithProfile(userId);
+    if (!user) throw notFound('User not found.');
+    return toUserProfile(user);
   }
 
   async getProfile(userId: string): Promise<UserProfile | null> {

--- a/apps/auth-service/src/lookups/dto/bulk-upsert-lookup-values.dto.ts
+++ b/apps/auth-service/src/lookups/dto/bulk-upsert-lookup-values.dto.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+const bulkUpsertLookupValueItemSchema = z
+  .object({
+    valueCode: z.string().trim().min(1).max(80),
+    valueLabel: z.string().trim().min(1).max(160),
+    sortOrder: z.number().int().min(0).optional(),
+    // Omitted = leave the existing parent alone (create path: no parent);
+    // null = explicitly clear an existing value's parent — same
+    // omitted-vs-null distinction as update-lookup-value.dto.ts, needed here
+    // too since "this value should no longer be a child of anything" is a
+    // legitimate reconciliation case.
+    parentLookupValueId: z.string().uuid().nullable().optional(),
+  })
+  .strict();
+
+/**
+ * Validation schema for reconciling a whole category's values in one call —
+ * e.g. an environment whose lookup master data has drifted from the current
+ * form schema. Creates any valueCode not already in the category, updates
+ * valueLabel/sortOrder/parentLookupValueId on any that exist and differ, and
+ * leaves every value not mentioned in the payload untouched (additive/
+ * updating only — this endpoint never deletes or deactivates a value).
+ */
+export const bulkUpsertLookupValuesSchema = z
+  .object({
+    values: z.array(bulkUpsertLookupValueItemSchema).min(1),
+  })
+  .strict()
+  .refine((data) => new Set(data.values.map((v) => v.valueCode)).size === data.values.length, {
+    message: 'valueCode must be unique within the payload.',
+    path: ['values'],
+  });
+
+export type BulkUpsertLookupValuesInput = z.infer<typeof bulkUpsertLookupValuesSchema>;

--- a/apps/auth-service/src/lookups/lookup.controller.ts
+++ b/apps/auth-service/src/lookups/lookup.controller.ts
@@ -4,6 +4,7 @@ import type { TokenSigner } from '@armman/service-commons';
 import type { LookupService } from './lookup.service';
 import { createLookupValueSchema } from './dto/create-lookup-value.dto';
 import { updateLookupValueSchema } from './dto/update-lookup-value.dto';
+import { bulkUpsertLookupValuesSchema } from './dto/bulk-upsert-lookup-values.dto';
 import {
   asyncHandler,
   authenticate,
@@ -48,6 +49,12 @@ const lookupCategorySchema = z.object({
 function envelope<T extends z.ZodTypeAny>(data: T) {
   return z.object({ success: z.literal(true), message: z.string(), data });
 }
+
+const bulkUpsertResultSchema = z.object({
+  created: z.array(z.string()).openapi({ example: ['TENTH_PASS'] }),
+  updated: z.array(z.string()).openapi({ example: ['PRIMARY'] }),
+  unchanged: z.array(z.string()).openapi({ example: ['GRADUATE'] }),
+});
 
 /**
  * Lookup category/value master-data HTTP routes. Mounted under the global
@@ -156,6 +163,37 @@ export function createLookupRouter(service: LookupService, signer: TokenSigner) 
     validateBody(updateLookupValueSchema),
     asyncHandler(async (req, res) => {
       res.json(ok(await service.updateValue(req.params.id, req.body)));
+    }),
+  );
+
+  doc.patch(
+    '/lookups/:categoryCode/values/bulk-upsert',
+    {
+      summary: "Reconcile a category's values against a target list",
+      tags: ['Lookups'],
+      params: categoryCodeParamsSchema,
+      responses: {
+        200: {
+          description: 'Values created/updated as needed; a summary of what changed',
+          schema: envelope(bulkUpsertResultSchema),
+        },
+        400: errorResponse(400, { message: 'values: Array must contain at least 1 element(s)' }),
+        401: errorResponse(401),
+        403: errorResponse(403),
+        404: errorResponse(404, { message: 'Lookup category not found.' }),
+        422: errorResponse(422, {
+          message: 'parentLookupValueId must belong to the same lookup category.',
+          description: 'Unprocessable — parentLookupValueId belongs to a different category',
+        }),
+        500: errorResponse(500),
+      },
+    },
+    authenticate(signer),
+    requireRoles('ADMIN'),
+    validate(categoryCodeParamsSchema, 'params'),
+    validateBody(bulkUpsertLookupValuesSchema),
+    asyncHandler(async (req, res) => {
+      res.json(ok(await service.bulkUpsertValues(req.params.categoryCode, req.body)));
     }),
   );
 

--- a/apps/auth-service/src/lookups/lookup.repository.ts
+++ b/apps/auth-service/src/lookups/lookup.repository.ts
@@ -1,6 +1,7 @@
 import type { PrismaService } from '../prisma/prisma.service';
 import type { CreateLookupValueInput } from './dto/create-lookup-value.dto';
 import type { UpdateLookupValueInput } from './dto/update-lookup-value.dto';
+import type { BulkUpsertLookupValuesInput } from './dto/bulk-upsert-lookup-values.dto';
 
 /** Data access for lookup categories/values master data. */
 export class LookupRepository {
@@ -42,5 +43,48 @@ export class LookupRepository {
     if (!existing) return null;
 
     return this.prisma.lookupValue.update({ where: { id }, data });
+  }
+
+  findValuesByCategoryId(lookupCategoryId: string) {
+    return this.prisma.lookupValue.findMany({ where: { lookupCategoryId } });
+  }
+
+  /**
+   * Creates/updates a category's values in one transaction — all-or-nothing,
+   * so a failure partway through never leaves a half-reconciled category.
+   * `toCreate`/`toUpdate` are pre-split by the caller (bulkUpsertValues in
+   * lookup.service.ts) since deciding new-vs-existing needs a case-
+   * insensitive-by-valueCode lookup the repository shouldn't own.
+   */
+  bulkUpsertValues(
+    lookupCategoryId: string,
+    toCreate: BulkUpsertLookupValuesInput['values'],
+    toUpdate: { id: string; data: BulkUpsertLookupValuesInput['values'][number] }[],
+  ) {
+    return this.prisma.$transaction([
+      ...toCreate.map((data) =>
+        this.prisma.lookupValue.create({
+          data: {
+            lookupCategoryId,
+            valueCode: data.valueCode,
+            valueLabel: data.valueLabel,
+            sortOrder: data.sortOrder ?? 0,
+            parentLookupValueId: data.parentLookupValueId ?? null,
+          },
+        }),
+      ),
+      ...toUpdate.map(({ id, data }) =>
+        this.prisma.lookupValue.update({
+          where: { id },
+          data: {
+            valueLabel: data.valueLabel,
+            ...(data.sortOrder !== undefined && { sortOrder: data.sortOrder }),
+            ...(data.parentLookupValueId !== undefined && {
+              parentLookupValueId: data.parentLookupValueId,
+            }),
+          },
+        }),
+      ),
+    ]);
   }
 }

--- a/apps/auth-service/src/lookups/lookup.service.spec.ts
+++ b/apps/auth-service/src/lookups/lookup.service.spec.ts
@@ -8,6 +8,8 @@ describe('LookupService', () => {
     findValueById: jest.fn(),
     createValue: jest.fn(),
     updateValue: jest.fn(),
+    findValuesByCategoryId: jest.fn(),
+    bulkUpsertValues: jest.fn(),
   } as unknown as jest.Mocked<LookupRepository>;
 
   let service: LookupService;
@@ -156,6 +158,275 @@ describe('LookupService', () => {
         service.updateValue('val-1', { parentLookupValueId: 'parent-1' }),
       ).rejects.toMatchObject({ status: 422 });
       expect(repository.updateValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bulkUpsertValues', () => {
+    const category = { id: 'cat-1', categoryCode: 'EDUCATION_LEVEL' };
+
+    it('creates every valueCode not already present in the category', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([] as never);
+
+      const input = { values: [{ valueCode: 'TENTH_PASS', valueLabel: '10th Pass' }] };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result).toEqual({ created: ['TENTH_PASS'], updated: [], unchanged: [] });
+      expect(repository.bulkUpsertValues).toHaveBeenCalledWith('cat-1', input.values, []);
+    });
+
+    it('reports no-op writes as unchanged when valueLabel/sortOrder already match', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'GRADUATE',
+          valueLabel: 'Graduate',
+          sortOrder: 4,
+          parentLookupValueId: null,
+        },
+      ] as never);
+
+      const input = { values: [{ valueCode: 'GRADUATE', valueLabel: 'Graduate', sortOrder: 4 }] };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result).toEqual({ created: [], updated: [], unchanged: ['GRADUATE'] });
+      expect(repository.bulkUpsertValues).not.toHaveBeenCalled();
+    });
+
+    it('updates only valueCodes whose valueLabel or sortOrder differ', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'PRIMARY',
+          valueLabel: 'Primary',
+          sortOrder: 1,
+          parentLookupValueId: null,
+        },
+      ] as never);
+
+      const input = {
+        values: [
+          { valueCode: 'PRIMARY', valueLabel: 'Primary education (Class 1-5)', sortOrder: 1 },
+        ],
+      };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result).toEqual({ created: [], updated: ['PRIMARY'], unchanged: [] });
+      expect(repository.bulkUpsertValues).toHaveBeenCalledWith(
+        'cat-1',
+        [],
+        [{ id: 'val-1', data: input.values[0] }],
+      );
+    });
+
+    it('splits a mixed payload into created/updated/unchanged in one call', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'PRIMARY',
+          valueLabel: 'Primary',
+          sortOrder: 1,
+          parentLookupValueId: null,
+        },
+        {
+          id: 'val-2',
+          valueCode: 'GRADUATE',
+          valueLabel: 'Graduate',
+          sortOrder: 4,
+          parentLookupValueId: null,
+        },
+      ] as never);
+
+      const input = {
+        values: [
+          { valueCode: 'PRIMARY', valueLabel: 'Primary education (Class 1-5)', sortOrder: 1 },
+          { valueCode: 'GRADUATE', valueLabel: 'Graduate', sortOrder: 4 },
+          { valueCode: 'TENTH_PASS', valueLabel: '10th Pass', sortOrder: 8 },
+        ],
+      };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result).toEqual({
+        created: ['TENTH_PASS'],
+        updated: ['PRIMARY'],
+        unchanged: ['GRADUATE'],
+      });
+    });
+
+    it('creates a value with parentLookupValueId when it belongs to the same category', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([] as never);
+      repository.findValueById.mockResolvedValue({
+        id: 'parent-1',
+        lookupCategoryId: 'cat-1',
+      } as never);
+
+      const input = {
+        values: [{ valueCode: 'SUB', valueLabel: 'Sub', parentLookupValueId: 'parent-1' }],
+      };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result.created).toEqual(['SUB']);
+    });
+
+    it('never touches an existing value absent from the payload', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'ILLITERATE',
+          valueLabel: 'Illiterate',
+          sortOrder: 0,
+          parentLookupValueId: null,
+        },
+      ] as never);
+
+      const input = { values: [{ valueCode: 'TENTH_PASS', valueLabel: '10th Pass' }] };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result.unchanged).not.toContain('ILLITERATE');
+      expect(result.updated).not.toContain('ILLITERATE');
+      expect(repository.bulkUpsertValues).toHaveBeenCalledWith(
+        'cat-1',
+        [{ valueCode: 'TENTH_PASS', valueLabel: '10th Pass' }],
+        [],
+      );
+    });
+
+    it('is idempotent: running the same payload twice reports everything unchanged the second time', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      const input = {
+        values: [{ valueCode: 'TENTH_PASS', valueLabel: '10th Pass', sortOrder: 3 }],
+      };
+
+      repository.findValuesByCategoryId.mockResolvedValueOnce([] as never);
+      const first = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+      expect(first.created).toEqual(['TENTH_PASS']);
+
+      repository.findValuesByCategoryId.mockResolvedValueOnce([
+        {
+          id: 'val-1',
+          valueCode: 'TENTH_PASS',
+          valueLabel: '10th Pass',
+          sortOrder: 3,
+          parentLookupValueId: null,
+        },
+      ] as never);
+      const second = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+      expect(second).toEqual({ created: [], updated: [], unchanged: ['TENTH_PASS'] });
+    });
+
+    it('throws 404 for an unknown category code', async () => {
+      repository.findCategoryByCode.mockResolvedValue(null);
+
+      await expect(
+        service.bulkUpsertValues('NOPE', { values: [{ valueCode: 'X', valueLabel: 'X' }] }),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.bulkUpsertValues).not.toHaveBeenCalled();
+    });
+
+    it("throws 422 when a new value's parentLookupValueId belongs to a different category", async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([] as never);
+      repository.findValueById.mockResolvedValue({
+        id: 'parent-1',
+        lookupCategoryId: 'other-cat',
+      } as never);
+
+      const input = {
+        values: [{ valueCode: 'SUB', valueLabel: 'Sub', parentLookupValueId: 'parent-1' }],
+      };
+      await expect(service.bulkUpsertValues('EDUCATION_LEVEL', input)).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(repository.bulkUpsertValues).not.toHaveBeenCalled();
+    });
+
+    it("throws 422 when an updated value's parentLookupValueId belongs to a different category", async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'PRIMARY',
+          valueLabel: 'Primary',
+          sortOrder: 1,
+          parentLookupValueId: null,
+        },
+      ] as never);
+      repository.findValueById.mockResolvedValue({
+        id: 'parent-1',
+        lookupCategoryId: 'other-cat',
+      } as never);
+
+      const input = {
+        values: [{ valueCode: 'PRIMARY', valueLabel: 'Primary', parentLookupValueId: 'parent-1' }],
+      };
+      await expect(service.bulkUpsertValues('EDUCATION_LEVEL', input)).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(repository.bulkUpsertValues).not.toHaveBeenCalled();
+    });
+
+    it('clears an existing parentLookupValueId when the payload sends null', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'SUB',
+          valueLabel: 'Sub',
+          sortOrder: 0,
+          parentLookupValueId: 'parent-1',
+        },
+      ] as never);
+
+      const input = {
+        values: [{ valueCode: 'SUB', valueLabel: 'Sub', parentLookupValueId: null }],
+      };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result).toEqual({ created: [], updated: ['SUB'], unchanged: [] });
+      expect(repository.bulkUpsertValues).toHaveBeenCalledWith(
+        'cat-1',
+        [],
+        [{ id: 'val-1', data: input.values[0] }],
+      );
+      // No same-category check needed when clearing/omitting a parent.
+      expect(repository.findValueById).not.toHaveBeenCalled();
+    });
+
+    it('treats an already-parentless value with parentLookupValueId: null as unchanged', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([
+        {
+          id: 'val-1',
+          valueCode: 'GRADUATE',
+          valueLabel: 'Graduate',
+          sortOrder: 4,
+          parentLookupValueId: null,
+        },
+      ] as never);
+
+      const input = {
+        values: [{ valueCode: 'GRADUATE', valueLabel: 'Graduate', parentLookupValueId: null }],
+      };
+      const result = await service.bulkUpsertValues('EDUCATION_LEVEL', input);
+
+      expect(result).toEqual({ created: [], updated: [], unchanged: ['GRADUATE'] });
+    });
+
+    it('throws 409 when a concurrent create wins the race on a duplicate valueCode', async () => {
+      repository.findCategoryByCode.mockResolvedValue(category as never);
+      repository.findValuesByCategoryId.mockResolvedValue([] as never);
+      repository.bulkUpsertValues.mockRejectedValue({ code: 'P2002' });
+
+      const input = { values: [{ valueCode: 'TENTH_PASS', valueLabel: '10th Pass' }] };
+
+      await expect(service.bulkUpsertValues('EDUCATION_LEVEL', input)).rejects.toMatchObject({
+        status: 409,
+      });
     });
   });
 });

--- a/apps/auth-service/src/lookups/lookup.service.ts
+++ b/apps/auth-service/src/lookups/lookup.service.ts
@@ -2,6 +2,7 @@ import { conflict, notFound, unprocessable } from '@armman/service-commons';
 import type { LookupRepository } from './lookup.repository';
 import type { CreateLookupValueInput } from './dto/create-lookup-value.dto';
 import type { UpdateLookupValueInput } from './dto/update-lookup-value.dto';
+import type { BulkUpsertLookupValuesInput } from './dto/bulk-upsert-lookup-values.dto';
 
 /** Prisma unique-constraint violation code (valueCode within a category). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
@@ -86,6 +87,78 @@ export class LookupService {
     const updated = await this.repository.updateValue(id, input);
     if (!updated) throw notFound('Lookup value not found.');
     return toApiLookupValue(updated as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Reconciles a category's values against a target list in one call —
+   * e.g. an environment whose lookup master data has drifted from the
+   * current form schema. Additive/updating only: a valueCode absent from
+   * the category is created, one present with a different valueLabel/
+   * sortOrder/parentLookupValueId is updated, and a valueCode already
+   * matching exactly is left as a no-op write. Existing values not
+   * mentioned in the payload are never touched or removed.
+   */
+  async bulkUpsertValues(categoryCode: string, input: BulkUpsertLookupValuesInput) {
+    const category = await this.repository.findCategoryByCode(categoryCode);
+    if (!category) throw notFound('Lookup category not found.');
+
+    const existingValues = await this.repository.findValuesByCategoryId(category.id);
+    const existingByCode = new Map(
+      existingValues.map((v) => [(v as { valueCode: string }).valueCode, v]),
+    );
+
+    for (const item of input.values) {
+      if (item.parentLookupValueId) {
+        const parent = await this.repository.findValueById(item.parentLookupValueId);
+        if (!parent || parent.lookupCategoryId !== category.id) {
+          throw unprocessable('parentLookupValueId must belong to the same lookup category.');
+        }
+      }
+    }
+
+    const toCreate: BulkUpsertLookupValuesInput['values'] = [];
+    const toUpdate: { id: string; data: BulkUpsertLookupValuesInput['values'][number] }[] = [];
+    const unchanged: string[] = [];
+
+    for (const item of input.values) {
+      const existing = existingByCode.get(item.valueCode) as
+        | { id: string; valueLabel: string; sortOrder: number; parentLookupValueId: string | null }
+        | undefined;
+
+      if (!existing) {
+        toCreate.push(item);
+        continue;
+      }
+
+      const isUnchanged =
+        existing.valueLabel === item.valueLabel &&
+        (item.sortOrder === undefined || existing.sortOrder === item.sortOrder) &&
+        (item.parentLookupValueId === undefined ||
+          existing.parentLookupValueId === item.parentLookupValueId);
+
+      if (isUnchanged) {
+        unchanged.push(item.valueCode);
+      } else {
+        toUpdate.push({ id: existing.id, data: item });
+      }
+    }
+
+    if (toCreate.length > 0 || toUpdate.length > 0) {
+      try {
+        await this.repository.bulkUpsertValues(category.id, toCreate, toUpdate);
+      } catch (err) {
+        if (isUniqueConstraintViolation(err)) {
+          throw conflict('A value with this code already exists in this category.');
+        }
+        throw err;
+      }
+    }
+
+    return {
+      created: toCreate.map((v) => v.valueCode),
+      updated: toUpdate.map((v) => v.data.valueCode),
+      unchanged,
+    };
   }
 }
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -176,10 +176,20 @@ const beneficiaryCaseDetailSchema = beneficiaryCaseSchema.extend({
 // BMI, or birthdate) — the Supervisor app's list UI needs these without a
 // follow-up detail call — but not the full detail-view's consent/risk/status
 // history, which only the single-case detail endpoint returns.
+//
+// sakhiName/projectName/villageName are resolved server-side from
+// auth-service (see BeneficiaryService.list's enrichListPage) since
+// beneficiary_cases/pii stores only the bare ids — the Supervisor
+// monitoring / Manager listing UI needs display names without a per-row
+// follow-up call. Nullable: a stale/deleted Sakhi, project, or village
+// resolves to null rather than failing the whole list response.
 const beneficiaryListItemSchema = beneficiaryCaseSchema.extend({
   pii: piiResponseSchema,
   motherCaseDetails: motherCaseDetailsSchema.nullable(),
   childCaseDetails: childCaseDetailsSchema.nullable(),
+  sakhiName: z.string().nullable().openapi({ example: 'Priya Sharma' }),
+  projectName: z.string().nullable().openapi({ example: 'GEP 2026-27' }),
+  villageName: z.string().nullable().openapi({ example: 'Sample Village' }),
 });
 
 const beneficiaryListPageSchema = z.object({
@@ -220,7 +230,9 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
         'nextCursor back as `cursor` to fetch the next page. A SAKHI caller is always scoped ' +
         'to their own cases regardless of sakhiId; a SUPERVISOR is scoped to their own Sakhi ' +
         'roster and may narrow further to one sakhiId within it (403 if not in their roster); ' +
-        'MANAGER/ADMIN are unscoped.',
+        'MANAGER/ADMIN are unscoped. Each row includes sakhiName/projectName/villageName, ' +
+        'resolved server-side for display (null if the referenced Sakhi/project/village is ' +
+        'stale or unresolvable).',
       tags: ['Beneficiaries'],
       responses: {
         200: {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -37,6 +37,11 @@ const piiResponseSchema = z.object({
   // phoneEnc/addressLineEnc columns.
   mobileNumber: z.string().nullable().openapi({ example: '9876543210' }),
   address: z.string().nullable(),
+  // Decrypted server-side for display, same as fullName/mobileNumber/address
+  // — never the raw rchNumberEnc column. Null when the Sakhi left RCH
+  // enrollment unanswered or had no card available (see
+  // create-beneficiary.dto.ts's rchNumber note).
+  rchNumber: z.string().nullable().openapi({ example: 'KA201900042' }),
   villageId: z.string().uuid().nullable(),
   padaId: z.string().uuid().nullable(),
   healthSubCentreId: z.string().uuid().nullable(),

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -12,6 +12,7 @@ import {
 import { createBeneficiarySchema } from './dto/create-beneficiary.dto';
 import { listBeneficiariesQuerySchema } from './dto/list-beneficiaries.dto';
 import { upsertSocioDemographicsSchema } from './dto/upsert-socio-demographics.dto';
+import { applyLmpChangeSchema } from './dto/apply-lmp-change.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -171,12 +172,21 @@ const beneficiaryCaseDetailSchema = beneficiaryCaseSchema.extend({
   socioDemographics: socioDemographicsSchema.nullable(),
 });
 
-// List rows carry PII (decrypted name) but not the full detail-view
-// includes (risk/status history/mother-or-child details/consent) — per
-// SRS FR-S-9.2 / HLD's filter table, the list only needs to support
-// search/filter and a compact display row.
+// List rows carry PII (decrypted name) and mother-or-child details (EDD/LMP/
+// BMI, or birthdate) — the Supervisor app's list UI needs these without a
+// follow-up detail call — but not the full detail-view's consent/risk/status
+// history, which only the single-case detail endpoint returns.
 const beneficiaryListItemSchema = beneficiaryCaseSchema.extend({
   pii: piiResponseSchema,
+  motherCaseDetails: motherCaseDetailsSchema.nullable(),
+  childCaseDetails: childCaseDetailsSchema.nullable(),
+});
+
+const beneficiaryListPageSchema = z.object({
+  items: z.array(beneficiaryListItemSchema),
+  nextCursor: z.string().nullable().openapi({
+    description: 'Pass back as `cursor` to fetch the next page; null when this is the last page.',
+  }),
 });
 
 function envelope<T extends z.ZodTypeAny>(data: T) {
@@ -203,16 +213,23 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
   doc.get(
     '/beneficiaries',
     {
-      summary: 'List beneficiary cases',
+      summary:
+        'List beneficiary cases. Filters: projectId, villageId, padaId, sakhiId, caseType, ' +
+        'status, atRiskOnly, name, mobileNumber, fromDate/toDate (registrationDate range). ' +
+        "Cursor-paginated via cursor/limit (default 50, max 100) — pass the response's " +
+        'nextCursor back as `cursor` to fetch the next page. A SAKHI caller is always scoped ' +
+        'to their own cases regardless of sakhiId; a SUPERVISOR is scoped to their own Sakhi ' +
+        'roster and may narrow further to one sakhiId within it (403 if not in their roster); ' +
+        'MANAGER/ADMIN are unscoped.',
       tags: ['Beneficiaries'],
       responses: {
         200: {
           description: 'Beneficiary cases retrieved',
-          schema: envelope(z.array(beneficiaryListItemSchema)),
+          schema: envelope(beneficiaryListPageSchema),
         },
         400: errorResponse(400, { message: 'atRiskOnly: Expected boolean, received string' }),
         401: errorResponse(401),
-        403: errorResponse(403),
+        403: errorResponse(403, { message: "sakhiId is not in this Supervisor's roster." }),
         500: errorResponse(500),
       },
     },
@@ -321,6 +338,81 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
       const updated = await service.upsertSocioDemographics(
         req.params.id,
         req.body,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
+    }),
+  );
+
+  doc.patch(
+    '/beneficiaries/:id/lmp',
+    {
+      summary: 'Apply an approved LMP change (FR-SV-4.2) — server-to-server only',
+      tags: ['Beneficiaries'],
+      params: idParamsSchema,
+      responses: {
+        200: {
+          description: 'LMP/EDD updated; the updated case is returned',
+          schema: envelope(beneficiaryCaseDetailSchema),
+        },
+        400: errorResponse(400, { message: 'lmpDate: Required' }),
+        401: errorResponse(401),
+        403: errorResponse(403, {
+          message: "This beneficiary case is outside this Supervisor's roster.",
+        }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(idParamsSchema, 'params'),
+    validateBody(applyLmpChangeSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.applyLmpChange(
+        req.params.id,
+        req.body.lmpDate,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
+    }),
+  );
+
+  doc.patch(
+    '/beneficiaries/:id/reactivate',
+    {
+      summary: 'Reactivate a CLOSED beneficiary case (FR-SV-4.7) — server-to-server only',
+      tags: ['Beneficiaries'],
+      params: idParamsSchema,
+      responses: {
+        200: {
+          description: 'Case reactivated; the updated case is returned',
+          schema: envelope(beneficiaryCaseDetailSchema),
+        },
+        401: errorResponse(401),
+        403: errorResponse(403, {
+          message: "This beneficiary case is outside this Supervisor's roster.",
+        }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        409: errorResponse(409, { message: 'Cannot reactivate a case with status ACTIVE.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(idParamsSchema, 'params'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.reactivateCase(
+        req.params.id,
+        req.user.id,
+        req.user,
         authorizationHeader,
       );
       res.json(ok(updated));

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.spec.ts
@@ -58,6 +58,24 @@ describe('withDecryptedName', () => {
     expect(result.pii).toMatchObject({ mobileNumber: null, address: null });
   });
 
+  it('decrypts rchNumber from pii', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii({ rchNumberEnc: encryptPii('KA201900042') }),
+    } as never);
+
+    expect(result.pii).toMatchObject({ rchNumber: 'KA201900042' });
+  });
+
+  it('leaves rchNumber null without attempting to decrypt', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii({ rchNumberEnc: null }),
+    } as never);
+
+    expect(result.pii).toMatchObject({ rchNumber: null });
+  });
+
   it('projects socioDemographics when present, allow-listing only documented fields', () => {
     const result = withDecryptedName({
       id: 'x',

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.ts
@@ -7,6 +7,7 @@ export interface PiiRow {
   fullNameEnc: Buffer;
   phoneEnc: Buffer | null;
   addressLineEnc: Buffer | null;
+  rchNumberEnc: Buffer | null;
   villageId: string | null;
   padaId: string | null;
   healthSubCentreId: string | null;
@@ -60,6 +61,7 @@ export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown 
       fullName: decryptPii(pii.fullNameEnc),
       mobileNumber: pii.phoneEnc ? decryptPii(pii.phoneEnc) : null,
       address: pii.addressLineEnc ? decryptPii(pii.addressLineEnc) : null,
+      rchNumber: pii.rchNumberEnc ? decryptPii(pii.rchNumberEnc) : null,
       villageId: pii.villageId,
       padaId: pii.padaId,
       healthSubCentreId: pii.healthSubCentreId,

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -9,6 +9,7 @@ import type {
 // the interface definitions live in beneficiary.repository.types.ts.
 export type {
   BeneficiaryListFilters,
+  BeneficiaryListPage,
   CaseCreateData,
   ChildDetailsCreateData,
   CreateEnrollmentInput,
@@ -16,6 +17,30 @@ export type {
   MotherDetailsCreateData,
   PiiCreateData,
 } from './beneficiary.repository.types';
+
+interface ListCursor {
+  createdAt: string;
+  id: string;
+}
+
+/** Encodes a row's sort key as an opaque pagination cursor. */
+function encodeCursor(row: { createdAt: Date; id: string }): string {
+  const cursor: ListCursor = { createdAt: row.createdAt.toISOString(), id: row.id };
+  return Buffer.from(JSON.stringify(cursor)).toString('base64url');
+}
+
+/** Decodes a cursor produced by encodeCursor; returns null on any malformed input. */
+function decodeCursor(cursor: string): ListCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+    if (typeof parsed?.createdAt === 'string' && typeof parsed?.id === 'string') {
+      return parsed as ListCursor;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /** Data-access layer for beneficiary cases. Only this domain touches these tables. */
 export class BeneficiaryRepository {
@@ -28,8 +53,16 @@ export class BeneficiaryRepository {
    * (no plaintext column to filter on), so search matches the same
    * non-reversible hash used for duplicate detection — exact match on the
    * normalized value, not a partial/fuzzy match.
+   *
+   * Cursor pagination sorts by (createdAt desc, id desc) — createdAt alone
+   * isn't guaranteed unique, so the id tiebreaks it into a stable order. A
+   * page fetches `limit + 1` rows to detect whether a next page exists
+   * without a separate count query; the extra row is trimmed before
+   * returning. An unparseable `filters.cursor` is treated as "start from the
+   * beginning" — a stale/corrupted cursor value degrades to a fresh first
+   * page rather than a hard failure.
    */
-  findMany(filters: BeneficiaryListFilters) {
+  async findMany(filters: BeneficiaryListFilters) {
     const where: NonNullable<Parameters<typeof this.prisma.beneficiaryCase.findMany>[0]>['where'] =
       {
         isDeleted: false,
@@ -50,13 +83,34 @@ export class BeneficiaryRepository {
     }
     if (filters.sakhiId) where.sakhiId = filters.sakhiId;
     if (filters.sakhiIds) where.sakhiId = { in: filters.sakhiIds };
+    if (filters.fromDate || filters.toDate) {
+      where.registrationDate = {
+        ...(filters.fromDate ? { gte: new Date(`${filters.fromDate}T00:00:00.000Z`) } : {}),
+        ...(filters.toDate ? { lte: new Date(`${filters.toDate}T23:59:59.999Z`) } : {}),
+      };
+    }
 
-    return this.prisma.beneficiaryCase.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      take: 50,
-      include: { pii: true },
+    const decodedCursor = filters.cursor ? decodeCursor(filters.cursor) : null;
+
+    const rows = await this.prisma.beneficiaryCase.findMany({
+      where: decodedCursor
+        ? {
+            ...where,
+            OR: [
+              { createdAt: { lt: new Date(decodedCursor.createdAt) } },
+              { createdAt: new Date(decodedCursor.createdAt), id: { lt: decodedCursor.id } },
+            ],
+          }
+        : where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      take: filters.limit + 1,
+      include: { pii: true, motherCaseDetails: true, childCaseDetails: true },
     });
+
+    const hasMore = rows.length > filters.limit;
+    const items = hasMore ? rows.slice(0, filters.limit) : rows;
+    const lastItem = items[items.length - 1];
+    return { items, nextCursor: hasMore && lastItem ? encodeCursor(lastItem) : null };
   }
 
   findById(id: string) {
@@ -216,6 +270,53 @@ export class BeneficiaryRepository {
       where: { beneficiaryId },
       create: { beneficiaryId, ...data },
       update: data,
+    });
+  }
+
+  /**
+   * Updates an existing mother case's LMP/EDD after an approved LMP_CHANGE
+   * (FR-SV-4.2). Returns null if no `mother_case_details` row exists for this
+   * beneficiary — the service turns that into a 404, since there is nothing
+   * to update (a CHILD case, or a MOTHER case with no details row yet).
+   */
+  async updateMotherLmp(beneficiaryId: string, lmpDate: Date, eddDate: Date) {
+    const result = await this.prisma.motherCaseDetails.updateMany({
+      where: { beneficiaryId },
+      data: { lmpDate, eddDate },
+    });
+    return result.count > 0;
+  }
+
+  /**
+   * Reactivates a CLOSED beneficiary case after an approved reopen request
+   * (FR-SV-4.7/FR-S-10.3) — flips currentStatus back to ACTIVE and records
+   * the transition in beneficiary_status_history for audit, in one
+   * transaction. Only updates a row that is still CLOSED — updateMany's
+   * affected count (rather than a separate read-then-write) is the
+   * concurrency guard: if the case's status already changed between the
+   * caller's findById and this call, the count comes back 0 and the service
+   * turns that into a 409 instead of silently overwriting a since-changed
+   * case. Same pattern as closures/reopen-requests/referrals.
+   */
+  async reactivateCase(beneficiaryId: string, reactivatedByUserId: string): Promise<boolean> {
+    return this.prisma.$transaction(async (tx) => {
+      const result = await tx.beneficiaryCase.updateMany({
+        where: { id: beneficiaryId, isDeleted: false, currentStatus: 'CLOSED' },
+        data: { currentStatus: 'ACTIVE' },
+      });
+      if (result.count === 0) return false;
+
+      await tx.beneficiaryStatusHistory.create({
+        data: {
+          beneficiaryId,
+          fromStatus: 'CLOSED',
+          toStatus: 'ACTIVE',
+          reasonCode: 'REOPEN_APPROVED',
+          changedByUserId: reactivatedByUserId,
+          changedAt: new Date(),
+        },
+      });
+      return true;
     });
   }
 }

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
@@ -20,6 +20,17 @@ export interface BeneficiaryListFilters {
    * default-deny result (supervisor has no Sakhis), never "no filter".
    */
   sakhiIds?: string[];
+  /** Registration date range, inclusive on both ends. */
+  fromDate?: string;
+  toDate?: string;
+  /** Opaque cursor from a prior page's `nextCursor` — see findMany's doc comment. */
+  cursor?: string;
+  limit: number;
+}
+
+export interface BeneficiaryListPage<T> {
+  items: T[];
+  nextCursor: string | null;
 }
 
 export interface DuplicateSearchTokens {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -561,6 +561,76 @@ describe('BeneficiaryService', () => {
       // 60 / (1.6*1.6) = 23.4375
       expect(call.motherDetails?.bmiAtRegistration).toBeCloseTo(23.44, 1);
     });
+
+    it('attributes the case to the authenticated caller when case.sakhiId is omitted', async () => {
+      const dto: CreateBeneficiaryInput = {
+        ...baseMotherInput,
+        case: { ...baseMotherInput.case, sakhiId: undefined },
+      };
+      repository.findDuplicateCandidate.mockResolvedValue(null);
+      repository.createEnrollment.mockImplementation((input) =>
+        Promise.resolve({ ...input } as never),
+      );
+
+      await service.create(dto, CALLER_ID, AUTH_HEADER);
+
+      const call = repository.createEnrollment.mock.calls[0][0];
+      expect(call.case.sakhiId).toBe(CALLER_ID);
+    });
+
+    it('ignores a client-supplied case.sakhiId and always uses the authenticated caller’s id', async () => {
+      // baseMotherInput.case.sakhiId ('33333333-...') deliberately differs
+      // from CALLER_ID ('99999999-...') to prove the client value is never trusted.
+      expect(baseMotherInput.case.sakhiId).not.toBe(CALLER_ID);
+      repository.findDuplicateCandidate.mockResolvedValue(null);
+      repository.createEnrollment.mockImplementation((input) =>
+        Promise.resolve({ ...input } as never),
+      );
+
+      await service.create(baseMotherInput, CALLER_ID, AUTH_HEADER);
+
+      const call = repository.createEnrollment.mock.calls[0][0];
+      expect(call.case.sakhiId).toBe(CALLER_ID);
+      expect(call.case.sakhiId).not.toBe(baseMotherInput.case.sakhiId);
+    });
+
+    it('attributes each case to its own caller when two different Sakhis enroll with the same body shape', async () => {
+      const CALLER_A = CALLER_ID;
+      const CALLER_B = '88888888-8888-8888-8888-888888888888';
+      repository.findDuplicateCandidate.mockResolvedValue(null);
+      repository.createEnrollment.mockImplementation((input) =>
+        Promise.resolve({ ...input } as never),
+      );
+
+      const dtoA: CreateBeneficiaryInput = {
+        ...baseMotherInput,
+        case: { ...baseMotherInput.case, localCaseUuid: 'local-case-uuid-caller-a' },
+      };
+      const dtoB: CreateBeneficiaryInput = {
+        ...baseMotherInput,
+        case: { ...baseMotherInput.case, localCaseUuid: 'local-case-uuid-caller-b' },
+      };
+
+      await service.create(dtoA, CALLER_A, AUTH_HEADER);
+      await service.create(dtoB, CALLER_B, AUTH_HEADER);
+
+      const [callA, callB] = repository.createEnrollment.mock.calls;
+      expect(callA[0].case.sakhiId).toBe(CALLER_A);
+      expect(callB[0].case.sakhiId).toBe(CALLER_B);
+    });
+
+    it('attributes a child enrollment to the authenticated caller, ignoring case.sakhiId', async () => {
+      expect(baseChildInput.case.sakhiId).not.toBe(CALLER_ID);
+      repository.findDuplicateCandidate.mockResolvedValue(null);
+      repository.createEnrollment.mockImplementation((input) =>
+        Promise.resolve({ ...input } as never),
+      );
+
+      await service.create(baseChildInput, CALLER_ID, AUTH_HEADER);
+
+      const call = repository.createEnrollment.mock.calls[0][0];
+      expect(call.case.sakhiId).toBe(CALLER_ID);
+    });
   });
 
   describe('create — mother enrollment (M1)', () => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -3,13 +3,19 @@ import { encryptPii, type AuthenticatedUser } from '@armman/service-commons';
 import { BeneficiaryService } from './beneficiary.service';
 import type { BeneficiaryRepository } from './beneficiary.repository';
 import type { CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
-import { resolveHealthBlockIdFromPhc } from '../geography/geography.client';
+import { resolveHealthBlockIdFromPhc, resolveVillageNames } from '../geography/geography.client';
 import { resolveLookupValues } from '../lookups/lookup.client';
-import { listSakhiIdsForSupervisor } from '../sakhi/sakhi.client';
+import {
+  getSakhiName,
+  listSakhiIdsForSupervisor,
+  listSakhiNamesForSupervisor,
+} from '../sakhi/sakhi.client';
+import { resolveProjectNames } from '../projects/project.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../lookups/lookup.client');
 jest.mock('../sakhi/sakhi.client');
+jest.mock('../projects/project.client');
 
 describe('BeneficiaryService', () => {
   const originalEnv = { ...process.env };
@@ -29,6 +35,10 @@ describe('BeneficiaryService', () => {
   const resolveHealthBlockIdFromPhcMock = jest.mocked(resolveHealthBlockIdFromPhc);
   const resolveLookupValuesMock = jest.mocked(resolveLookupValues);
   const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
+  const listSakhiNamesForSupervisorMock = jest.mocked(listSakhiNamesForSupervisor);
+  const getSakhiNameMock = jest.mocked(getSakhiName);
+  const resolveVillageNamesMock = jest.mocked(resolveVillageNames);
+  const resolveProjectNamesMock = jest.mocked(resolveProjectNames);
 
   function caller(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
     return {
@@ -100,6 +110,10 @@ describe('BeneficiaryService', () => {
     process.env.PII_SEARCH_HASH_KEY = randomBytes(32).toString('base64');
     resolveHealthBlockIdFromPhcMock.mockResolvedValue('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
     resolveLookupValuesMock.mockResolvedValue({});
+    resolveProjectNamesMock.mockResolvedValue(new Map());
+    resolveVillageNamesMock.mockResolvedValue(new Map());
+    getSakhiNameMock.mockResolvedValue(null);
+    listSakhiNamesForSupervisorMock.mockResolvedValue(new Map());
     service = new BeneficiaryService(repository);
   });
 
@@ -511,6 +525,173 @@ describe('BeneficiaryService', () => {
         service.list({ limit: 50 }, caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER),
       ).rejects.toMatchObject({ status: 502 });
       expect(repository.findMany).not.toHaveBeenCalled();
+    });
+
+    it('enriches rows with sakhiName/projectName/villageName, resolved server-side', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: 'village-1' },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+      resolveProjectNamesMock.mockResolvedValue(new Map([['project-1', 'GEP 2026-27']]));
+      resolveVillageNamesMock.mockResolvedValue(new Map([['village-1', 'Sample Village']]));
+      getSakhiNameMock.mockResolvedValue('Priya Sharma');
+
+      const result = await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.items[0]).toMatchObject({
+        sakhiName: 'Priya Sharma',
+        projectName: 'GEP 2026-27',
+        villageName: 'Sample Village',
+      });
+    });
+
+    it('resolves sakhiName from the roster call already made for SUPERVISOR scoping — no extra per-id call', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: null },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+      listSakhiNamesForSupervisorMock.mockResolvedValue(new Map([['sakhi-a', 'Priya Sharma']]));
+
+      const result = await service.list(
+        { limit: 50 },
+        caller({ roles: ['SUPERVISOR'], projectId: 'project-1' }),
+        AUTH_HEADER,
+      );
+
+      expect(result.items[0]).toMatchObject({ sakhiName: 'Priya Sharma' });
+      expect(getSakhiNameMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a per-id Sakhi lookup for a MANAGER/ADMIN page (no roster call made)', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: null },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+      getSakhiNameMock.mockResolvedValue('Priya Sharma');
+
+      const result = await service.list({ limit: 50 }, caller({ roles: ['MANAGER'] }), AUTH_HEADER);
+
+      expect(result.items[0]).toMatchObject({ sakhiName: 'Priya Sharma' });
+      expect(getSakhiNameMock).toHaveBeenCalledWith('sakhi-a', AUTH_HEADER);
+    });
+
+    it('resolves a stale/deleted Sakhi, project, or village to null names, not a failed request', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'deleted-sakhi',
+            projectId: 'deleted-project',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: 'deleted-village' },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+      // Defaults from beforeEach already resolve nothing (empty maps, null Sakhi name).
+
+      const result = await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.items[0]).toMatchObject({
+        sakhiName: null,
+        projectName: null,
+        villageName: null,
+      });
+    });
+
+    it('a case with no villageId on file gets a null villageName without calling anything extra', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: null },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+
+      const result = await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.items[0]).toMatchObject({ villageName: null });
+    });
+
+    it('an empty page skips every name-resolution call entirely', async () => {
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
+
+      await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(resolveProjectNamesMock).not.toHaveBeenCalled();
+      expect(resolveVillageNamesMock).not.toHaveBeenCalled();
+      expect(getSakhiNameMock).not.toHaveBeenCalled();
+    });
+
+    it('dedupes repeated sakhiIds on a page into a single lookup per id', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: null },
+          },
+          {
+            id: 'y',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-2', fullNameEnc: encryptPii('John Doe'), villageId: null },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+      getSakhiNameMock.mockResolvedValue('Priya Sharma');
+
+      await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(getSakhiNameMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates a genuine auth-service dependency failure while enriching names', async () => {
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-a',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: null },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+      resolveProjectNamesMock.mockRejectedValue(
+        Object.assign(new Error('bad gateway'), { status: 502 }),
+      );
+
+      await expect(
+        service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 502 });
     });
 
     it('passes through risk condition summaries and status history from the repository', async () => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -19,6 +19,8 @@ describe('BeneficiaryService', () => {
     findByLocalCaseUuid: jest.fn(),
     findDuplicateCandidate: jest.fn(),
     createEnrollment: jest.fn(),
+    updateMotherLmp: jest.fn(),
+    reactivateCase: jest.fn(),
   } as unknown as jest.Mocked<BeneficiaryRepository>;
   let service: BeneficiaryService;
 
@@ -105,24 +107,126 @@ describe('BeneficiaryService', () => {
     process.env = { ...originalEnv };
   });
 
+  describe('applyLmpChange', () => {
+    const beneficiaryId = '22222222-2222-2222-2222-222222222222';
+
+    it('recomputes eddDate (lmpDate + 280 days) and persists via the repository', async () => {
+      repository.updateMotherLmp.mockResolvedValue(true);
+      repository.findById.mockResolvedValue({
+        id: beneficiaryId,
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      } as never);
+
+      await service.applyLmpChange(beneficiaryId, new Date('2026-06-15'), AUTH_HEADER);
+
+      expect(repository.updateMotherLmp).toHaveBeenCalledWith(
+        beneficiaryId,
+        new Date('2026-06-15'),
+        new Date('2027-03-22'),
+      );
+    });
+
+    it('returns the updated case via getById', async () => {
+      repository.updateMotherLmp.mockResolvedValue(true);
+      const found = {
+        id: beneficiaryId,
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.applyLmpChange(
+        beneficiaryId,
+        new Date('2026-06-15'),
+        AUTH_HEADER,
+      );
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('404s when no mother_case_details row exists for this beneficiary', async () => {
+      repository.updateMotherLmp.mockResolvedValue(false);
+
+      await expect(
+        service.applyLmpChange(beneficiaryId, new Date('2026-06-15'), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reactivateCase', () => {
+    const beneficiaryId = '22222222-2222-2222-2222-222222222222';
+    const supervisorId = '44444444-4444-4444-4444-444444444444';
+
+    function caseRow(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        id: beneficiaryId,
+        currentStatus: 'CLOSED',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        ...overrides,
+      };
+    }
+
+    it('reactivates a CLOSED case and returns it via getById', async () => {
+      repository.findById
+        .mockResolvedValueOnce(caseRow() as never)
+        .mockResolvedValueOnce(caseRow() as never);
+      repository.reactivateCase.mockResolvedValue(true);
+
+      const result = await service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER);
+
+      expect(repository.reactivateCase).toHaveBeenCalledWith(beneficiaryId, supervisorId);
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('404s on an unknown beneficiary id', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.reactivateCase).not.toHaveBeenCalled();
+    });
+
+    it('409s when the case is not currently CLOSED', async () => {
+      repository.findById.mockResolvedValue(caseRow({ currentStatus: 'ACTIVE' }) as never);
+
+      await expect(
+        service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.reactivateCase).not.toHaveBeenCalled();
+    });
+
+    it('409s when the conditional update races with a concurrent status change', async () => {
+      repository.findById.mockResolvedValueOnce(caseRow() as never);
+      repository.reactivateCase.mockResolvedValue(false);
+
+      await expect(
+        service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+  });
+
   describe('list / getById', () => {
     it('lists beneficiaries via the repository, with names decrypted for display', async () => {
-      repository.findMany.mockResolvedValue([
-        { id: 'x', pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') } },
-      ] as never);
+      repository.findMany.mockResolvedValue({
+        items: [{ id: 'x', pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') } }] as never,
+        nextCursor: null,
+      });
 
-      const result = await service.list({}, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+      const result = await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
-      expect(result).toEqual([
-        expect.objectContaining({
-          id: 'x',
-          pii: expect.objectContaining({ fullName: 'Jane Doe' }),
-        }),
-      ]);
+      expect(result).toEqual({
+        items: [
+          expect.objectContaining({
+            id: 'x',
+            pii: expect.objectContaining({ fullName: 'Jane Doe' }),
+          }),
+        ],
+        nextCursor: null,
+      });
     });
 
     it('passes query filters through to the repository as search hashes/scalars', async () => {
-      repository.findMany.mockResolvedValue([]);
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
 
       await service.list(
         {
@@ -132,6 +236,9 @@ describe('BeneficiaryService', () => {
           atRiskOnly: true,
           name: 'Jane Doe',
           mobileNumber: '9876543210',
+          fromDate: '2026-01-01',
+          toDate: '2026-01-31',
+          limit: 50,
         },
         caller({ roles: ['ADMIN'] }),
         AUTH_HEADER,
@@ -144,13 +251,16 @@ describe('BeneficiaryService', () => {
       expect(call.atRiskOnly).toBe(true);
       expect(call.nameHash).toBeInstanceOf(Buffer);
       expect(call.phoneHash).toBeInstanceOf(Buffer);
+      expect(call.fromDate).toBe('2026-01-01');
+      expect(call.toDate).toBe('2026-01-31');
+      expect(call.limit).toBe(50);
     });
 
     it('SAKHI caller is forced to see only their own cases, regardless of query params', async () => {
-      repository.findMany.mockResolvedValue([]);
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
 
       await service.list(
-        { projectId: 'some-other-project' },
+        { projectId: 'some-other-project', limit: 50 },
         caller({ id: 'sakhi-1', roles: ['SAKHI'] }),
         AUTH_HEADER,
       );
@@ -161,12 +271,25 @@ describe('BeneficiaryService', () => {
       expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
     });
 
+    it('SAKHI-supplied sakhiId is ignored — own id always wins', async () => {
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
+
+      await service.list(
+        { sakhiId: 'someone-else', limit: 50 },
+        caller({ id: 'sakhi-1', roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiId).toBe('sakhi-1');
+    });
+
     it('SUPERVISOR caller sees only their own Sakhis, resolved via the Sakhi lookup', async () => {
-      repository.findMany.mockResolvedValue([]);
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
       listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
 
       await service.list(
-        {},
+        { limit: 50 },
         caller({ id: 'sup-1', roles: ['SUPERVISOR'], projectId: 'project-1' }),
         AUTH_HEADER,
       );
@@ -177,17 +300,45 @@ describe('BeneficiaryService', () => {
       expect(call.sakhiId).toBeUndefined();
     });
 
+    it('SUPERVISOR narrowing to a sakhiId within their roster scopes to that one Sakhi', async () => {
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
+
+      await service.list(
+        { sakhiId: 'sakhi-b', limit: 50 },
+        caller({ id: 'sup-1', roles: ['SUPERVISOR'], projectId: 'project-1' }),
+        AUTH_HEADER,
+      );
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiId).toBe('sakhi-b');
+      expect(call.sakhiIds).toBeUndefined();
+    });
+
+    it('rejects a SUPERVISOR narrowing to a sakhiId outside their roster', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
+
+      await expect(
+        service.list(
+          { sakhiId: 'not-mine', limit: 50 },
+          caller({ id: 'sup-1', roles: ['SUPERVISOR'], projectId: 'project-1' }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findMany).not.toHaveBeenCalled();
+    });
+
     it('SUPERVISOR with zero Sakhis gets an empty result, not all beneficiaries', async () => {
       listSakhiIdsForSupervisorMock.mockResolvedValue([]);
-      repository.findMany.mockResolvedValue([]);
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
 
       const result = await service.list(
-        {},
+        { limit: 50 },
         caller({ id: 'sup-1', roles: ['SUPERVISOR'] }),
         AUTH_HEADER,
       );
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({ items: [], nextCursor: null });
       const call = repository.findMany.mock.calls[0][0];
       expect(call.sakhiIds).toEqual([]);
     });
@@ -195,7 +346,7 @@ describe('BeneficiaryService', () => {
     it('rejects a SUPERVISOR caller with no projectId instead of resolving Sakhis with an empty path', async () => {
       await expect(
         service.list(
-          {},
+          { limit: 50 },
           caller({ id: 'sup-1', roles: ['SUPERVISOR'], projectId: null }),
           AUTH_HEADER,
         ),
@@ -205,9 +356,9 @@ describe('BeneficiaryService', () => {
     });
 
     it('MANAGER caller sees all beneficiaries — no sakhi scoping applied', async () => {
-      repository.findMany.mockResolvedValue([]);
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
 
-      await service.list({}, caller({ roles: ['MANAGER'] }), AUTH_HEADER);
+      await service.list({ limit: 50 }, caller({ roles: ['MANAGER'] }), AUTH_HEADER);
 
       const call = repository.findMany.mock.calls[0][0];
       expect(call.sakhiId).toBeUndefined();
@@ -215,10 +366,24 @@ describe('BeneficiaryService', () => {
       expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
     });
 
-    it('ADMIN caller sees all beneficiaries — no sakhi scoping applied', async () => {
-      repository.findMany.mockResolvedValue([]);
+    it('MANAGER caller may still narrow by sakhiId, with no roster to validate against', async () => {
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
 
-      await service.list({}, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+      await service.list(
+        { sakhiId: 'any-sakhi', limit: 50 },
+        caller({ roles: ['MANAGER'] }),
+        AUTH_HEADER,
+      );
+
+      const call = repository.findMany.mock.calls[0][0];
+      expect(call.sakhiId).toBe('any-sakhi');
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+    });
+
+    it('ADMIN caller sees all beneficiaries — no sakhi scoping applied', async () => {
+      repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
+
+      await service.list({ limit: 50 }, caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       const call = repository.findMany.mock.calls[0][0];
       expect(call.sakhiId).toBeUndefined();
@@ -231,7 +396,7 @@ describe('BeneficiaryService', () => {
       );
 
       await expect(
-        service.list({}, caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER),
+        service.list({ limit: 50 }, caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER),
       ).rejects.toMatchObject({ status: 502 });
       expect(repository.findMany).not.toHaveBeenCalled();
     });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -109,15 +109,27 @@ describe('BeneficiaryService', () => {
 
   describe('applyLmpChange', () => {
     const beneficiaryId = '22222222-2222-2222-2222-222222222222';
+    const sakhiId = '55555555-5555-5555-5555-555555555555';
+
+    function caseRow(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        id: beneficiaryId,
+        sakhiId,
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        ...overrides,
+      };
+    }
 
     it('recomputes eddDate (lmpDate + 280 days) and persists via the repository', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
       repository.updateMotherLmp.mockResolvedValue(true);
-      repository.findById.mockResolvedValue({
-        id: beneficiaryId,
-        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
-      } as never);
 
-      await service.applyLmpChange(beneficiaryId, new Date('2026-06-15'), AUTH_HEADER);
+      await service.applyLmpChange(
+        beneficiaryId,
+        new Date('2026-06-15'),
+        caller({ roles: ['ADMIN'] }),
+        AUTH_HEADER,
+      );
 
       expect(repository.updateMotherLmp).toHaveBeenCalledWith(
         beneficiaryId,
@@ -127,38 +139,86 @@ describe('BeneficiaryService', () => {
     });
 
     it('returns the updated case via getById', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
       repository.updateMotherLmp.mockResolvedValue(true);
-      const found = {
-        id: beneficiaryId,
-        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
-      };
-      repository.findById.mockResolvedValue(found as never);
 
       const result = await service.applyLmpChange(
         beneficiaryId,
         new Date('2026-06-15'),
+        caller({ roles: ['ADMIN'] }),
         AUTH_HEADER,
       );
       expect(result).toMatchObject({ id: beneficiaryId });
     });
 
+    it('404s on an unknown beneficiary id', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.applyLmpChange(
+          beneficiaryId,
+          new Date('2026-06-15'),
+          caller({ roles: ['ADMIN'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.updateMotherLmp).not.toHaveBeenCalled();
+    });
+
     it('404s when no mother_case_details row exists for this beneficiary', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
       repository.updateMotherLmp.mockResolvedValue(false);
 
       await expect(
-        service.applyLmpChange(beneficiaryId, new Date('2026-06-15'), AUTH_HEADER),
+        service.applyLmpChange(
+          beneficiaryId,
+          new Date('2026-06-15'),
+          caller({ roles: ['ADMIN'] }),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 404 });
-      expect(repository.findById).not.toHaveBeenCalled();
+    });
+
+    it('403s when a SUPERVISOR targets a case outside their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['some-other-sakhi']);
+
+      await expect(
+        service.applyLmpChange(
+          beneficiaryId,
+          new Date('2026-06-15'),
+          caller({ roles: ['SUPERVISOR'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.updateMotherLmp).not.toHaveBeenCalled();
+    });
+
+    it('allows a SUPERVISOR to update a case in their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.updateMotherLmp.mockResolvedValue(true);
+      listSakhiIdsForSupervisorMock.mockResolvedValue([sakhiId]);
+
+      await service.applyLmpChange(
+        beneficiaryId,
+        new Date('2026-06-15'),
+        caller({ roles: ['SUPERVISOR'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updateMotherLmp).toHaveBeenCalled();
     });
   });
 
   describe('reactivateCase', () => {
     const beneficiaryId = '22222222-2222-2222-2222-222222222222';
     const supervisorId = '44444444-4444-4444-4444-444444444444';
+    const sakhiId = '55555555-5555-5555-5555-555555555555';
 
     function caseRow(overrides: Partial<Record<string, unknown>> = {}) {
       return {
         id: beneficiaryId,
+        sakhiId,
         currentStatus: 'CLOSED',
         pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
         ...overrides,
@@ -171,7 +231,12 @@ describe('BeneficiaryService', () => {
         .mockResolvedValueOnce(caseRow() as never);
       repository.reactivateCase.mockResolvedValue(true);
 
-      const result = await service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER);
+      const result = await service.reactivateCase(
+        beneficiaryId,
+        supervisorId,
+        caller({ roles: ['ADMIN'] }),
+        AUTH_HEADER,
+      );
 
       expect(repository.reactivateCase).toHaveBeenCalledWith(beneficiaryId, supervisorId);
       expect(result).toMatchObject({ id: beneficiaryId });
@@ -181,7 +246,12 @@ describe('BeneficiaryService', () => {
       repository.findById.mockResolvedValue(null);
 
       await expect(
-        service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER),
+        service.reactivateCase(
+          beneficiaryId,
+          supervisorId,
+          caller({ roles: ['ADMIN'] }),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 404 });
       expect(repository.reactivateCase).not.toHaveBeenCalled();
     });
@@ -190,7 +260,12 @@ describe('BeneficiaryService', () => {
       repository.findById.mockResolvedValue(caseRow({ currentStatus: 'ACTIVE' }) as never);
 
       await expect(
-        service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER),
+        service.reactivateCase(
+          beneficiaryId,
+          supervisorId,
+          caller({ roles: ['ADMIN'] }),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 409 });
       expect(repository.reactivateCase).not.toHaveBeenCalled();
     });
@@ -200,8 +275,45 @@ describe('BeneficiaryService', () => {
       repository.reactivateCase.mockResolvedValue(false);
 
       await expect(
-        service.reactivateCase(beneficiaryId, supervisorId, AUTH_HEADER),
+        service.reactivateCase(
+          beneficiaryId,
+          supervisorId,
+          caller({ roles: ['ADMIN'] }),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('403s when a SUPERVISOR targets a case outside their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['some-other-sakhi']);
+
+      await expect(
+        service.reactivateCase(
+          beneficiaryId,
+          supervisorId,
+          caller({ id: supervisorId, roles: ['SUPERVISOR'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.reactivateCase).not.toHaveBeenCalled();
+    });
+
+    it('allows a SUPERVISOR to reactivate a case in their own roster', async () => {
+      repository.findById
+        .mockResolvedValueOnce(caseRow() as never)
+        .mockResolvedValueOnce(caseRow() as never);
+      repository.reactivateCase.mockResolvedValue(true);
+      listSakhiIdsForSupervisorMock.mockResolvedValue([sakhiId]);
+
+      await service.reactivateCase(
+        beneficiaryId,
+        supervisorId,
+        caller({ id: supervisorId, roles: ['SUPERVISOR'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.reactivateCase).toHaveBeenCalledWith(beneficiaryId, supervisorId);
     });
   });
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -20,9 +20,14 @@ import { computeBmi, withDecryptedName } from './beneficiary.mapper';
 import type { BeneficiaryListFilters, BeneficiaryRepository } from './beneficiary.repository';
 import type { CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
 import type { UpsertSocioDemographicsInput } from './dto/upsert-socio-demographics.dto';
-import { resolveHealthBlockIdFromPhc } from '../geography/geography.client';
+import { resolveHealthBlockIdFromPhc, resolveVillageNames } from '../geography/geography.client';
 import { resolveLookupIdsByValueCode, resolveLookupValues } from '../lookups/lookup.client';
-import { listSakhiIdsForSupervisor } from '../sakhi/sakhi.client';
+import {
+  getSakhiName,
+  listSakhiIdsForSupervisor,
+  listSakhiNamesForSupervisor,
+} from '../sakhi/sakhi.client';
+import { resolveProjectNames } from '../projects/project.client';
 
 /**
  * Maps each socioDemographics *LookupId field to the lookup_categories
@@ -98,6 +103,63 @@ async function assertCallerCanTouchCase(
   }
 }
 
+/**
+ * Enriches a page of `GET /beneficiaries` rows with display-ready
+ * sakhiName/projectName/villageName — beneficiary_cases/pii stores only the
+ * bare ids (no cross-service joins, per this service's forklift rule), but
+ * the Supervisor-monitoring/Manager-listing UI needs names without a
+ * follow-up call per row.
+ *
+ * sakhiName is resolved from `supervisorRoster` when the caller already
+ * fetched one for scoping (SUPERVISOR path in list()) — no extra round-trip
+ * in the common case. Otherwise (MANAGER/ADMIN, or any sakhiId missing from
+ * a passed roster) each distinct sakhiId not already covered is resolved
+ * with a deduped per-id `getSakhiName` fallback call, capped at the page's
+ * unique Sakhi count. projectName/villageName always come from one
+ * dedicated list call each (see resolveProjectNames/resolveVillageNames) —
+ * both are small, mostly-static datasets with no filter-by-id support.
+ *
+ * A name that can't be resolved (stale/deleted Sakhi, project, or village)
+ * is `null`, never a failed request — the beneficiary case itself is still
+ * valid data. An empty page skips every lookup call entirely.
+ */
+async function enrichListPage(
+  items: Record<string, unknown>[],
+  authorizationHeader: string,
+  supervisorRoster?: Map<string, string>,
+): Promise<Record<string, unknown>[]> {
+  if (items.length === 0) return [];
+
+  const sakhiIdOf = (item: Record<string, unknown>) => item.sakhiId as string;
+  const projectIdOf = (item: Record<string, unknown>) => item.projectId as string;
+  const villageIdOf = (item: Record<string, unknown>) =>
+    (item.pii as { villageId: string | null }).villageId;
+
+  const uncoveredSakhiIds = [
+    ...new Set(items.map(sakhiIdOf).filter((id) => !supervisorRoster?.has(id))),
+  ];
+
+  const [projectNames, villageNames, fallbackSakhiNames] = await Promise.all([
+    resolveProjectNames(authorizationHeader),
+    resolveVillageNames(authorizationHeader),
+    Promise.all(uncoveredSakhiIds.map((id) => getSakhiName(id, authorizationHeader))),
+  ]);
+  const sakhiNameById = new Map<string, string | null>([
+    ...(supervisorRoster ?? []),
+    ...uncoveredSakhiIds.map((id, i) => [id, fallbackSakhiNames[i]] as const),
+  ]);
+
+  return items.map((item) => {
+    const villageId = villageIdOf(item);
+    return {
+      ...item,
+      sakhiName: sakhiNameById.get(sakhiIdOf(item)) ?? null,
+      projectName: projectNames.get(projectIdOf(item)) ?? null,
+      villageName: villageId ? (villageNames.get(villageId) ?? null) : null,
+    };
+  });
+}
+
 /** Public list-query params — see ListBeneficiariesQuery in the DTO for validation. */
 export interface ListBeneficiariesQuery {
   projectId?: string;
@@ -166,6 +228,9 @@ export class BeneficiaryService {
       limit: query.limit,
     };
 
+    let supervisorProjectId: string | undefined;
+    let supervisorId: string | undefined;
+
     if (caller.roles.includes('SAKHI')) {
       filters.sakhiId = caller.id;
     } else if (caller.roles.includes('SUPERVISOR')) {
@@ -188,6 +253,8 @@ export class BeneficiaryService {
       } else {
         filters.sakhiIds = roster;
       }
+      supervisorProjectId = caller.projectId;
+      supervisorId = caller.id;
     } else if (query.sakhiId) {
       // MANAGER/ADMIN: unscoped by default, but an explicit sakhiId still
       // narrows the list — no roster to validate against.
@@ -195,7 +262,17 @@ export class BeneficiaryService {
     }
 
     const page = await this.repository.findMany(filters);
-    return { items: page.items.map(withDecryptedName), nextCursor: page.nextCursor };
+    const decrypted = page.items.map(withDecryptedName);
+    // Reuses the roster call already made above for scoping, resolved a
+    // second time for displayName instead of caching the first response —
+    // simpler than threading an extra return value through every branch
+    // above, and this call only happens for the SUPERVISOR path.
+    const supervisorRoster =
+      supervisorProjectId && supervisorId
+        ? await listSakhiNamesForSupervisor(supervisorProjectId, supervisorId, authorizationHeader)
+        : undefined;
+    const enriched = await enrichListPage(decrypted, authorizationHeader, supervisorRoster);
+    return { items: enriched, nextCursor: page.nextCursor };
   }
 
   async getById(id: string, authorizationHeader: string) {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -322,7 +322,10 @@ export class BeneficiaryService {
       case: {
         localCaseUuid: dto.case.localCaseUuid,
         projectId: dto.case.projectId,
-        sakhiId: dto.case.sakhiId,
+        // Always the authenticated caller's own id — dto.case.sakhiId is
+        // ignored even if present, so a Sakhi can never enroll a beneficiary
+        // under another Sakhi's name (see caseSchema.sakhiId).
+        sakhiId: capturedByUserId,
         caseType: dto.case.caseType,
         registrationDate: dto.case.registrationDate,
         previousBeneficiaryId: dto.case.previousBeneficiaryId ?? null,

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -1,5 +1,7 @@
 import { addDays } from '@armman/core';
 import {
+  badRequest,
+  conflict,
   encryptPii,
   forbidden,
   hashForSearch,
@@ -74,17 +76,44 @@ async function withResolvedSocioDemographics<T extends Record<string, unknown>>(
 
 const GESTATION_DAYS = 280;
 
+/**
+ * Enforces the same scoping `list()` applies to reads on a single-case
+ * mutation: a SUPERVISOR may only touch a case belonging to their own Sakhi
+ * roster; MANAGER/ADMIN are unscoped. Throws forbidden() otherwise. Callers
+ * without a SUPERVISOR/MANAGER/ADMIN role never reach these mutations
+ * (blocked by requireRoles at the route), so SAKHI is not handled here.
+ */
+async function assertCallerCanTouchCase(
+  caseSakhiId: string,
+  caller: AuthenticatedUser,
+  authorizationHeader: string,
+): Promise<void> {
+  if (!caller.roles.includes('SUPERVISOR')) return;
+  if (!caller.projectId) {
+    throw forbidden('Supervisor caller has no project scope.');
+  }
+  const roster = await listSakhiIdsForSupervisor(caller.projectId, caller.id, authorizationHeader);
+  if (!roster.includes(caseSakhiId)) {
+    throw forbidden("This beneficiary case is outside this Supervisor's roster.");
+  }
+}
+
 /** Public list-query params — see ListBeneficiariesQuery in the DTO for validation. */
 export interface ListBeneficiariesQuery {
   projectId?: string;
   villageId?: string;
   padaId?: string;
+  sakhiId?: string;
   status?: BeneficiaryStatus;
   caseType?: CaseType;
   atRiskOnly?: boolean;
   /** Raw search text — hashed the same way as duplicate-detection tokens (exact match only). */
   name?: string;
   mobileNumber?: string;
+  fromDate?: string;
+  toDate?: string;
+  cursor?: string;
+  limit: number;
 }
 
 /** Business logic for the beneficiary enrollment lifecycle. */
@@ -94,18 +123,32 @@ export class BeneficiaryService {
   /**
    * Lists beneficiary cases per SRS FR-S-9.2 / HLD's filter set, scoped by
    * the caller's role: a SAKHI only ever sees their own cases (their own id
-   * always wins over anything else), a SUPERVISOR only sees cases belonging
-   * to their own Sakhis (resolved via auth-service's existing
-   * `/projects/:projectId/sakhis`, filtered by supervisorId — no new
-   * auth-service endpoint), and MANAGER/ADMIN see everything unscoped. Each
-   * row's name is decrypted server-side for display — the search hash
-   * itself is never returned.
+   * always wins over anything else, so a SAKHI-supplied `sakhiId` is
+   * ignored), a SUPERVISOR only sees cases belonging to their own Sakhis
+   * (resolved via auth-service's existing `/projects/:projectId/sakhis`,
+   * filtered by supervisorId — no new auth-service endpoint) — if they
+   * narrow the list to one `sakhiId`, it must be a member of their own
+   * roster or the call is rejected rather than silently returning nothing —
+   * and MANAGER/ADMIN see everything unscoped, including any `sakhiId` they
+   * choose to filter by. Each row's name is decrypted server-side for
+   * display — the search hash itself is never returned. Results are
+   * cursor-paginated (HLD's cursor-pagination mandate) — see
+   * BeneficiaryRepository.findMany for the cursor's shape.
    */
   async list(
     query: ListBeneficiariesQuery,
     caller: AuthenticatedUser,
     authorizationHeader: string,
   ) {
+    // Cross-field check on fromDate/toDate — kept out of the Zod query
+    // schema's own .refine() so that schema stays an AnyZodObject
+    // (createDocumentedRouter() auto-infers it as this route's OpenAPI query
+    // parameters; a .refine()'d ZodEffects can't be introspected there and
+    // crashes the whole service at startup, not just this one request).
+    if (query.fromDate && query.toDate && query.fromDate > query.toDate) {
+      throw badRequest('fromDate must be on or before toDate.');
+    }
+
     const filters: BeneficiaryListFilters = {
       projectId: query.projectId,
       villageId: query.villageId,
@@ -117,6 +160,10 @@ export class BeneficiaryService {
       phoneHash: query.mobileNumber
         ? hashForSearch(normalizeForSearch(query.mobileNumber))
         : undefined,
+      fromDate: query.fromDate,
+      toDate: query.toDate,
+      cursor: query.cursor,
+      limit: query.limit,
     };
 
     if (caller.roles.includes('SAKHI')) {
@@ -128,15 +175,27 @@ export class BeneficiaryService {
       if (!caller.projectId) {
         throw forbidden('Supervisor caller has no project scope.');
       }
-      filters.sakhiIds = await listSakhiIdsForSupervisor(
+      const roster = await listSakhiIdsForSupervisor(
         caller.projectId,
         caller.id,
         authorizationHeader,
       );
+      if (query.sakhiId) {
+        if (!roster.includes(query.sakhiId)) {
+          throw forbidden("sakhiId is not in this Supervisor's roster.");
+        }
+        filters.sakhiId = query.sakhiId;
+      } else {
+        filters.sakhiIds = roster;
+      }
+    } else if (query.sakhiId) {
+      // MANAGER/ADMIN: unscoped by default, but an explicit sakhiId still
+      // narrows the list — no roster to validate against.
+      filters.sakhiId = query.sakhiId;
     }
 
-    const cases = await this.repository.findMany(filters);
-    return cases.map(withDecryptedName);
+    const page = await this.repository.findMany(filters);
+    return { items: page.items.map(withDecryptedName), nextCursor: page.nextCursor };
   }
 
   async getById(id: string, authorizationHeader: string) {
@@ -210,6 +269,75 @@ export class BeneficiaryService {
     if (dto.childrenUnder5Count !== undefined) data.childrenUnder5Count = dto.childrenUnder5Count;
 
     await this.repository.upsertSocioDemographics(beneficiaryId, data);
+    return this.getById(beneficiaryId, authorizationHeader);
+  }
+
+  /**
+   * Applies an approved LMP change (FR-SV-4.2) — recomputes eddDate from the
+   * same GESTATION_DAYS formula used at registration so lmpDate/eddDate can
+   * never drift out of sync. Called server-to-server by approval-service
+   * once a Supervisor approves an LMP_CHANGE Quick Response card.
+   *
+   * Deliberately does not regenerate the ANC visit schedule — schedules are
+   * generated offline on the Sakhi's device (FR-S-2.2) and uploaded via
+   * visit-form-service's POST /visit-schedules/bulk; this service owns no
+   * schedule-generation logic to trigger. Re-syncing/regenerating the
+   * schedule after an LMP change is the Sakhi app's responsibility, not
+   * this endpoint's — a known, accepted gap, not an oversight.
+   *
+   * A SUPERVISOR caller may only apply this to a case in their own Sakhi
+   * roster (same scoping as list()) — this endpoint is reachable by a human
+   * Supervisor role, not just server-to-server, so it needs the same IDOR
+   * guard as any other single-case mutation.
+   */
+  async applyLmpChange(
+    beneficiaryId: string,
+    lmpDate: Date,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(beneficiaryId);
+    if (!existing) throw notFound('Beneficiary case not found.');
+    await assertCallerCanTouchCase(existing.sakhiId, caller, authorizationHeader);
+
+    const eddDate = addDays(lmpDate, GESTATION_DAYS);
+    const updated = await this.repository.updateMotherLmp(beneficiaryId, lmpDate, eddDate);
+    if (!updated) throw notFound('Beneficiary case not found.');
+    return this.getById(beneficiaryId, authorizationHeader);
+  }
+
+  /**
+   * Reactivates a CLOSED beneficiary case after an approved reopen request
+   * (FR-SV-4.7/FR-S-10.3) — the "Beneficiary is added to Sakhi's Open
+   * beneficiary list" outcome. Called server-to-server by
+   * closure-reopen-service once a Supervisor approves a ReopenRequest.
+   *
+   * A SUPERVISOR caller may only reactivate a case in their own Sakhi
+   * roster (same scoping as list()) — this endpoint is reachable by a human
+   * Supervisor role, not just server-to-server, so it needs the same IDOR
+   * guard as any other single-case mutation.
+   */
+  async reactivateCase(
+    beneficiaryId: string,
+    reactivatedByUserId: string,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(beneficiaryId);
+    if (!existing) throw notFound('Beneficiary case not found.');
+    await assertCallerCanTouchCase(existing.sakhiId, caller, authorizationHeader);
+    if (existing.currentStatus !== 'CLOSED') {
+      throw conflict(`Cannot reactivate a case with status ${existing.currentStatus}.`);
+    }
+
+    const reactivated = await this.repository.reactivateCase(beneficiaryId, reactivatedByUserId);
+    if (!reactivated) {
+      // Raced with another status change between the read above and the
+      // conditional update — same outcome as the check above, just caught a
+      // beat later instead of trusting a stale read.
+      throw conflict(`Cannot reactivate a case with status ${existing.currentStatus}.`);
+    }
+
     return this.getById(beneficiaryId, authorizationHeader);
   }
 

--- a/apps/beneficiary-service/src/beneficiary/dto/apply-lmp-change.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/apply-lmp-change.dto.spec.ts
@@ -1,0 +1,20 @@
+import { applyLmpChangeSchema } from './apply-lmp-change.dto';
+
+describe('applyLmpChangeSchema', () => {
+  it('accepts a valid lmpDate', () => {
+    expect(applyLmpChangeSchema.safeParse({ lmpDate: '2026-06-15' }).success).toBe(true);
+  });
+
+  it('rejects a missing lmpDate', () => {
+    expect(applyLmpChangeSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects an invalid date string', () => {
+    expect(applyLmpChangeSchema.safeParse({ lmpDate: 'not-a-date' }).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = applyLmpChangeSchema.safeParse({ lmpDate: '2026-06-15', extra: 'x' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/beneficiary-service/src/beneficiary/dto/apply-lmp-change.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/apply-lmp-change.dto.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+/**
+ * Body for `PATCH /beneficiaries/:id/lmp` — applies an approved LMP change
+ * (FR-SV-4.2). Called server-to-server by approval-service once a Supervisor
+ * approves an LMP_CHANGE Quick Response card, never directly by a Sakhi.
+ *
+ * eddDate is recomputed here from lmpDate (same GESTATION_DAYS formula used
+ * at registration — see BeneficiaryService.create), not accepted from the
+ * caller, so lmpDate/eddDate can never drift out of sync.
+ *
+ * Does NOT regenerate the ANC visit schedule — schedules are generated
+ * offline on the Sakhi's device (FR-S-2.2) and uploaded via
+ * POST /visit-schedules/bulk; this service has no schedule-generation logic
+ * to trigger. Regenerating the schedule after an LMP change is the Sakhi
+ * app's responsibility on next sync, not this endpoint's.
+ */
+export const applyLmpChangeSchema = z
+  .object({
+    lmpDate: z.coerce.date(),
+  })
+  .strict();
+
+export type ApplyLmpChangeInput = z.infer<typeof applyLmpChangeSchema>;

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.spec.ts
@@ -202,6 +202,40 @@ describe('createBeneficiarySchema', () => {
     });
   });
 
+  describe('case.sakhiId (accepted but ignored — see BeneficiaryService.create)', () => {
+    it('accepts a payload with case.sakhiId omitted entirely', () => {
+      const caseWithoutSakhiId: Record<string, unknown> = { ...baseCase };
+      delete caseWithoutSakhiId.sakhiId;
+      const result = createBeneficiarySchema.safeParse({
+        pii: { ...basePii },
+        case: { ...caseWithoutSakhiId, caseType: 'MOTHER' },
+        motherDetails: { lmpDate: '2025-10-01' },
+        consent,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a payload with case.sakhiId present (legacy client)', () => {
+      const result = createBeneficiarySchema.safeParse({
+        pii: { ...basePii },
+        case: { ...baseCase, caseType: 'MOTHER' },
+        motherDetails: { lmpDate: '2025-10-01' },
+        consent,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects case.sakhiId that is not a valid uuid', () => {
+      const result = createBeneficiarySchema.safeParse({
+        pii: { ...basePii },
+        case: { ...baseCase, caseType: 'MOTHER', sakhiId: 'not-a-uuid' },
+        motherDetails: { lmpDate: '2025-10-01' },
+        consent,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('pii.fullName', () => {
     it('rejects a payload missing pii.fullName', () => {
       const missingFullName: Record<string, unknown> = { ...basePii };

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.spec.ts
@@ -142,6 +142,39 @@ describe('createBeneficiarySchema', () => {
       });
       expect(result.success).toBe(true);
     });
+
+    it('normalizes a lowercase rchNumber to uppercase (GOI requirement)', () => {
+      const result = createBeneficiarySchema.safeParse({
+        pii: { ...basePii, rchNumber: 'ka201900042' },
+        case: { ...baseCase, caseType: 'MOTHER' },
+        motherDetails: { lmpDate: '2025-10-01' },
+        consent,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.pii.rchNumber).toBe('KA201900042');
+    });
+
+    it('leaves an already-uppercase rchNumber unchanged', () => {
+      const result = createBeneficiarySchema.safeParse({
+        pii: { ...basePii, rchNumber: 'KA201900042' },
+        case: { ...baseCase, caseType: 'MOTHER' },
+        motherDetails: { lmpDate: '2025-10-01' },
+        consent,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.pii.rchNumber).toBe('KA201900042');
+    });
+
+    it('trims surrounding whitespace before uppercasing a mixed-case rchNumber', () => {
+      const result = createBeneficiarySchema.safeParse({
+        pii: { ...basePii, rchNumber: '  Ka2019 00042  ' },
+        case: { ...baseCase, caseType: 'MOTHER' },
+        motherDetails: { lmpDate: '2025-10-01' },
+        consent,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.pii.rchNumber).toBe('KA2019 00042');
+    });
   });
 
   describe('socioDemographics (optional, Registration_PW_D rows 23-34)', () => {

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
@@ -222,7 +222,12 @@ const caseSchema = z
     // localVisitUuid elsewhere in this codebase.
     localCaseUuid: z.string().trim().min(1).max(80),
     projectId: z.string().uuid(),
-    sakhiId: z.string().uuid(),
+    // Accepted for backward compatibility with existing clients but never
+    // trusted — the case is always attributed to the authenticated caller's
+    // own id (see BeneficiaryService.create's capturedByUserId), never a
+    // client-supplied value. A client can't create a beneficiary under
+    // another Sakhi's name.
+    sakhiId: z.string().uuid().optional(),
     caseType: z.enum(CASE_TYPES),
     registrationDate: z.coerce.date(),
     previousBeneficiaryId: z.string().uuid().optional(),

--- a/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/create-beneficiary.dto.ts
@@ -1,5 +1,12 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import { API_CONSENT_STATUSES, CASE_TYPES, SEXES } from '../beneficiary.constants';
+
+// Required for rchNumber's .openapi() call below — extendZodWithOpenApi
+// patches the shared zod module, but relying on some other file (e.g. the
+// controller) to call it first is fragile: this schema must be safe to
+// import standalone (as create-beneficiary.dto.spec.ts does).
+extendZodWithOpenApi(z);
 
 /**
  * Validation schema for enrolling a beneficiary (mother or child), per SRS
@@ -43,7 +50,22 @@ const piiSchema = z
     stateId: z.string().uuid(),
     districtId: z.string().uuid(),
     talukaId: z.string().uuid().optional(),
-    rchNumber: z.string().trim().min(1).max(50).optional(),
+    // Stored uppercase per GOI requirement (RCH numbers are case-insensitive
+    // in practice but must be canonical uppercase in the database/reports) —
+    // normalized here so every downstream consumer (encryption, search hash)
+    // sees the same casing regardless of how the Sakhi typed it.
+    // `.openapi({ type: 'string' })` is required on a `.transform()`'d
+    // schema — zod-to-openapi cannot infer a type for a bare ZodEffects
+    // node, and throws (crashing the whole service at boot, since OpenAPI
+    // doc generation runs at startup) without it.
+    rchNumber: z
+      .string()
+      .trim()
+      .min(1)
+      .max(50)
+      .transform((v) => v.toUpperCase())
+      .openapi({ type: 'string' })
+      .optional(),
   })
   .strict();
 

--- a/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
@@ -8,17 +8,44 @@ import { BENEFICIARY_STATUSES, CASE_TYPES } from '../beneficiary.constants';
  * filters (project, geography, status, case type, risk)"). Only single-value
  * filters are supported for now — multi-select would need an `[]` query
  * shape, not modeled here since no caller needs it yet.
+ *
+ * `sakhiId` lets a SUPERVISOR/MANAGER/ADMIN caller scope the list to one
+ * Sakhi's roster (a SAKHI caller's own id always wins regardless of this
+ * param — see BeneficiaryService.list). `fromDate`/`toDate` range-filter on
+ * registrationDate. `cursor`/`limit` are the HLD-mandated cursor pagination —
+ * `cursor` is opaque, returned as `nextCursor` in the response and passed
+ * back unchanged for the next page.
  */
+// Deliberately a plain z.object (AnyZodObject), not wrapped in .refine() —
+// createDocumentedRouter() auto-infers this schema as the route's OpenAPI
+// query parameters straight from the `validate(schema, 'query')` middleware,
+// and zod-to-openapi cannot introspect a ZodEffects (what .refine() produces)
+// as a parameter object; it throws MissingParameterDataError at service
+// startup, not a per-request error. The fromDate<=toDate cross-field check
+// lives in beneficiary.service.ts instead — see assertValidDateRange().
 export const listBeneficiariesQuerySchema = z
   .object({
     projectId: z.string().uuid().optional(),
     villageId: z.string().uuid().optional(),
     padaId: z.string().uuid().optional(),
+    sakhiId: z.string().uuid().optional(),
     status: z.enum(BENEFICIARY_STATUSES).optional(),
     caseType: z.enum(CASE_TYPES).optional(),
     atRiskOnly: z.coerce.boolean().optional(),
     name: z.string().trim().min(1).max(200).optional(),
     mobileNumber: z.string().trim().min(1).max(20).optional(),
+    // Range filter on registrationDate — date-only strings (@db.Date column).
+    fromDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)')
+      .optional(),
+    toDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)')
+      .optional(),
+    // Opaque, base64-encoded cursor — see beneficiary.repository.ts's encode/decodeCursor.
+    cursor: z.string().trim().min(1).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
   })
   .strict();
 

--- a/apps/beneficiary-service/src/geography/geography.client.spec.ts
+++ b/apps/beneficiary-service/src/geography/geography.client.spec.ts
@@ -1,4 +1,13 @@
-import { resolveHealthBlockIdFromPhc } from './geography.client';
+import { resolveHealthBlockIdFromPhc, resolveVillageNames } from './geography.client';
+
+/** Builds a fetch mock Response for a list of geography units. */
+function listResponse(data: Record<string, unknown>[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ success: true, data }),
+  };
+}
 
 /** Builds a fetch mock Response for one geography unit. */
 function unitResponse(data: Record<string, unknown>) {
@@ -134,5 +143,68 @@ describe('resolveHealthBlockIdFromPhc', () => {
     await expect(resolveHealthBlockIdFromPhc('phc-1', 'Bearer test-token')).rejects.toMatchObject({
       status: 422,
     });
+  });
+});
+
+describe('resolveVillageNames', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns a geographyUnitId -> name map for every VILLAGE unit', async () => {
+    fetchMock.mockResolvedValue(
+      listResponse([
+        { geographyUnitId: 'village-1', name: 'Sample Village', geoType: 'VILLAGE' },
+        { geographyUnitId: 'village-2', name: 'Other Village', geoType: 'VILLAGE' },
+      ]),
+    );
+
+    const result = await resolveVillageNames('Bearer test-token');
+
+    expect(result).toEqual(
+      new Map([
+        ['village-1', 'Sample Village'],
+        ['village-2', 'Other Village'],
+      ]),
+    );
+  });
+
+  it('a villageId absent from the response is simply absent from the map', async () => {
+    fetchMock.mockResolvedValue(listResponse([]));
+
+    const result = await resolveVillageNames('Bearer test-token');
+
+    expect(result.get('unknown-village')).toBeUndefined();
+  });
+
+  it('throws 502 when the auth-service call rejects (network error/timeout)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(resolveVillageNames('Bearer test-token')).rejects.toMatchObject({ status: 502 });
+  });
+
+  it('throws 502 when the auth-service call fails with a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(resolveVillageNames('Bearer test-token')).rejects.toMatchObject({ status: 502 });
+  });
+
+  it('filters by geoType=VILLAGE', async () => {
+    fetchMock.mockResolvedValue(listResponse([]));
+
+    await resolveVillageNames('Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('geoType=VILLAGE'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+    );
   });
 });

--- a/apps/beneficiary-service/src/geography/geography.client.ts
+++ b/apps/beneficiary-service/src/geography/geography.client.ts
@@ -10,6 +10,7 @@ interface GeographyUnit {
   parentId: string | null;
   geoType: 'STATE' | 'DISTRICT' | 'BLOCK' | 'PHC' | 'SUBCENTRE' | 'VILLAGE' | 'PADA';
   status: 'ACTIVE' | 'INACTIVE';
+  name: string;
 }
 
 /** Fetches one geography unit through the gateway, mapping transport/HTTP
@@ -91,4 +92,38 @@ export async function resolveHealthBlockIdFromPhc(
   }
 
   return parent.geographyUnitId;
+}
+
+/**
+ * Resolves geographyUnitId -> name for every VILLAGE-level unit, via
+ * auth-service's existing `GET /geography-units?geoType=VILLAGE` (no
+ * filter-by-id support, and no new auth-service endpoint needed — that
+ * route already returns every unit of a given geoType in one call). Used to
+ * enrich `GET /beneficiaries` rows with a display-ready villageName, since
+ * beneficiary_cases/pii stores only the bare villageId (no cross-service
+ * joins, per this service's forklift rule).
+ *
+ * A villageId not found in the response (stale/since-deleted village) maps
+ * to `undefined` in the returned Map — not an error, since the beneficiary
+ * case itself is still valid data; the caller decides how to render a
+ * missing name (see beneficiary.service.ts's enrichListPage).
+ */
+export async function resolveVillageNames(
+  authorizationHeader: string,
+): Promise<Map<string, string>> {
+  let res: Response;
+  try {
+    res = await fetch(`${AUTH_SERVICE_BASE_URL}/api/v1/geography-units?geoType=VILLAGE`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve villages — the auth service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve villages — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: GeographyUnit[] };
+  return new Map(body.data.map((v) => [v.geographyUnitId, v.name]));
 }

--- a/apps/beneficiary-service/src/projects/project.client.spec.ts
+++ b/apps/beneficiary-service/src/projects/project.client.spec.ts
@@ -1,0 +1,72 @@
+import { resolveProjectNames } from './project.client';
+
+function projectsResponse(data: { projectId: string; projectName: string }[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ success: true, data }),
+  };
+}
+
+describe('resolveProjectNames', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns a projectId -> projectName map', async () => {
+    fetchMock.mockResolvedValue(
+      projectsResponse([
+        { projectId: 'project-1', projectName: 'GEP 2026-27' },
+        { projectId: 'project-2', projectName: 'MVA 2026-27' },
+      ]),
+    );
+
+    const result = await resolveProjectNames('Bearer test-token');
+
+    expect(result).toEqual(
+      new Map([
+        ['project-1', 'GEP 2026-27'],
+        ['project-2', 'MVA 2026-27'],
+      ]),
+    );
+  });
+
+  it('a projectId absent from the response is simply absent from the map', async () => {
+    fetchMock.mockResolvedValue(projectsResponse([]));
+
+    const result = await resolveProjectNames('Bearer test-token');
+
+    expect(result.get('unknown-project')).toBeUndefined();
+  });
+
+  it('throws 502 when the auth-service call rejects (network error/timeout)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(resolveProjectNames('Bearer test-token')).rejects.toMatchObject({ status: 502 });
+  });
+
+  it('throws 502 when the auth-service call fails with a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(resolveProjectNames('Bearer test-token')).rejects.toMatchObject({ status: 502 });
+  });
+
+  it("forwards the caller's own bearer token unchanged", async () => {
+    fetchMock.mockResolvedValue(projectsResponse([]));
+
+    await resolveProjectNames('Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/projects'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+    );
+  });
+});

--- a/apps/beneficiary-service/src/projects/project.client.ts
+++ b/apps/beneficiary-service/src/projects/project.client.ts
@@ -1,0 +1,50 @@
+import { badGateway } from '@armman/service-commons';
+
+// Read directly (not via appConfig) — see geography.client.ts for why.
+const AUTH_SERVICE_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+interface ApiProject {
+  projectId: string;
+  projectName: string;
+}
+
+/**
+ * Resolves projectId -> projectName for a set of ids, via auth-service's
+ * existing `GET /projects` (no filter-by-id support, and no new auth-service
+ * endpoint — that route already returns every active project in one call).
+ * Used to enrich `GET /beneficiaries` rows with a display-ready projectName,
+ * since beneficiary_cases stores only the bare projectId (no cross-service
+ * joins, per this service's forklift rule).
+ *
+ * A projectId not found in the response (stale/since-deleted project) maps
+ * to `undefined` in the returned Map — not an error, since the beneficiary
+ * case itself is still valid data; the caller decides how to render a
+ * missing name (see beneficiary.service.ts's enrichListPage).
+ *
+ * `GET /projects` itself scopes a non-privileged caller's response to only
+ * their own project (see auth-service's project.service.ts) — so a
+ * SUPERVISOR resolving names for a page containing a beneficiary case
+ * outside their own project (roster-scoping is by Sakhi identity, not
+ * project, so this can happen) will get `undefined` for that row's
+ * projectName too. Known, accepted behavior, not a bug: the same
+ * null-on-unresolvable contract as any other stale/missing id here.
+ */
+export async function resolveProjectNames(
+  authorizationHeader: string,
+): Promise<Map<string, string>> {
+  let res: Response;
+  try {
+    res = await fetch(`${AUTH_SERVICE_BASE_URL}/api/v1/projects`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve projects — the auth service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve projects — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: ApiProject[] };
+  return new Map(body.data.map((p) => [p.projectId, p.projectName]));
+}

--- a/apps/beneficiary-service/src/sakhi/sakhi.client.spec.ts
+++ b/apps/beneficiary-service/src/sakhi/sakhi.client.spec.ts
@@ -1,9 +1,23 @@
-import { listSakhiIdsForSupervisor } from './sakhi.client';
+import {
+  getSakhiName,
+  listSakhiIdsForSupervisor,
+  listSakhiNamesForSupervisor,
+} from './sakhi.client';
 
-function sakhisResponse(data: { sakhiId: string; supervisorId: string | null }[]) {
+function sakhisResponse(
+  data: { sakhiId: string; displayName?: string; supervisorId: string | null }[],
+) {
   return {
     ok: true,
     status: 200,
+    json: () => Promise.resolve({ success: true, data }),
+  };
+}
+
+function sakhiResponse(data: { sakhiId: string; displayName: string } | undefined) {
+  return {
+    ok: data !== undefined,
+    status: data !== undefined ? 200 : 404,
     json: () => Promise.resolve({ success: true, data }),
   };
 }
@@ -66,6 +80,106 @@ describe('listSakhiIdsForSupervisor', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/projects/project-1/sakhis'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+    );
+  });
+});
+
+describe('listSakhiNamesForSupervisor', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns a sakhiId -> displayName map for only the Sakhis matching supervisorId', async () => {
+    fetchMock.mockResolvedValue(
+      sakhisResponse([
+        { sakhiId: 'sakhi-a', displayName: 'Priya Sharma', supervisorId: 'sup-1' },
+        { sakhiId: 'sakhi-b', displayName: 'Other Sakhi', supervisorId: 'sup-2' },
+      ]),
+    );
+
+    const result = await listSakhiNamesForSupervisor('project-1', 'sup-1', 'Bearer test-token');
+
+    expect(result).toEqual(new Map([['sakhi-a', 'Priya Sharma']]));
+  });
+
+  it('throws 502 when the auth-service call rejects (network error/timeout)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      listSakhiNamesForSupervisor('project-1', 'sup-1', 'Bearer test-token'),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+
+  it('throws 502 when the auth-service call fails with a non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(
+      listSakhiNamesForSupervisor('project-1', 'sup-1', 'Bearer test-token'),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+});
+
+describe('getSakhiName', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('resolves a known sakhiId to its displayName', async () => {
+    fetchMock.mockResolvedValue(sakhiResponse({ sakhiId: 'sakhi-a', displayName: 'Priya Sharma' }));
+
+    const result = await getSakhiName('sakhi-a', 'Bearer test-token');
+
+    expect(result).toBe('Priya Sharma');
+  });
+
+  it('returns null (not an error) for an unknown/deleted sakhiId (404)', async () => {
+    fetchMock.mockResolvedValue(sakhiResponse(undefined));
+
+    const result = await getSakhiName('missing-sakhi', 'Bearer test-token');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws 502 when the auth-service call rejects (network error/timeout)', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(getSakhiName('sakhi-a', 'Bearer test-token')).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+
+  it('throws 502 (not null) when the auth-service call fails with a 5xx', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(getSakhiName('sakhi-a', 'Bearer test-token')).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+
+  it("forwards the caller's own bearer token unchanged", async () => {
+    fetchMock.mockResolvedValue(sakhiResponse({ sakhiId: 'sakhi-a', displayName: 'Priya Sharma' }));
+
+    await getSakhiName('sakhi-a', 'Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/sakhis/sakhi-a'),
       expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
     );
   });

--- a/apps/beneficiary-service/src/sakhi/sakhi.client.ts
+++ b/apps/beneficiary-service/src/sakhi/sakhi.client.ts
@@ -6,6 +6,7 @@ const AUTH_SERVICE_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://local
 
 interface ApiSakhi {
   sakhiId: string;
+  displayName: string;
   supervisorId: string | null;
 }
 
@@ -45,4 +46,71 @@ export async function listSakhiIdsForSupervisor(
 
   const body = (await res.json()) as { data: ApiSakhi[] };
   return body.data.filter((sakhi) => sakhi.supervisorId === supervisorId).map((s) => s.sakhiId);
+}
+
+/**
+ * Resolves sakhiId -> displayName for every Sakhi reporting to a given
+ * Supervisor, via the same `GET /projects/:projectId/sakhis` call as
+ * {@link listSakhiIdsForSupervisor} — used by BeneficiaryService.list to
+ * enrich response rows with a display-ready sakhiName for a SUPERVISOR
+ * caller without a second round-trip, since that roster call already
+ * happens for scoping.
+ */
+export async function listSakhiNamesForSupervisor(
+  projectId: string,
+  supervisorId: string,
+  authorizationHeader: string,
+): Promise<Map<string, string>> {
+  let res: Response;
+  try {
+    res = await fetch(`${AUTH_SERVICE_BASE_URL}/api/v1/projects/${projectId}/sakhis`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve Sakhis — the auth service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve Sakhis — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: ApiSakhi[] };
+  return new Map(
+    body.data
+      .filter((sakhi) => sakhi.supervisorId === supervisorId)
+      .map((s) => [s.sakhiId, s.displayName]),
+  );
+}
+
+/**
+ * Resolves a single sakhiId -> displayName via auth-service's existing
+ * `GET /sakhis/:sakhiId`. Used as the MANAGER/ADMIN fallback path in
+ * BeneficiaryService.list's row enrichment, where there is no per-Supervisor
+ * roster call to piggyback on and rows can span multiple projects/Sakhis a
+ * SUPERVISOR-scoped roster call would never cover.
+ *
+ * A 404 (unknown/deleted Sakhi) resolves to `null` — the beneficiary case
+ * itself is still valid data, so a stale sakhiId must not fail the whole
+ * list response. Only a genuine dependency failure (network/5xx) is a 502.
+ */
+export async function getSakhiName(
+  sakhiId: string,
+  authorizationHeader: string,
+): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetch(`${AUTH_SERVICE_BASE_URL}/api/v1/sakhis/${sakhiId}`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve a Sakhi — the auth service is unreachable.');
+  }
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw badGateway('Unable to resolve a Sakhi — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: ApiSakhi };
+  return body.data.displayName;
 }

--- a/apps/closure-reopen-service/src/closures/closure.controller.ts
+++ b/apps/closure-reopen-service/src/closures/closure.controller.ts
@@ -2,12 +2,15 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { ClosureService } from './closure.service';
 import { createClosureSchema } from './dto/create-closure.dto';
+import { decideClosureSchema } from './dto/decide-closure.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
+  validate,
   validateBody,
 } from '../app.module';
 
@@ -46,6 +49,14 @@ const closureSchema = z.object({
   supervisorNotes: z.string().nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+});
+
+const closureIdParamsSchema = z
+  .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
+  .strict();
+
+const decideClosureRequestSchema = decideClosureSchema.extend({
+  decision: decideClosureSchema.shape.decision.openapi({ example: 'APPROVED' }),
 });
 
 const apiErrorSchema = z.object({
@@ -104,8 +115,40 @@ export function createClosureRouter(service: ClosureService) {
     requireRoles('SAKHI'),
     validateBody(createClosureRequestSchema),
     asyncHandler(async (req, res) => {
-      const created = await service.create(req.body);
+      const created = await service.create(req.body, req.headers.authorization ?? '');
       res.status(201).json(ok(created));
+    }),
+  );
+
+  doc.patch(
+    '/closures/:id/decision',
+    {
+      summary: 'Decide a pending closure review (FR-SV-4.4)',
+      tags: ['Closures'],
+      params: closureIdParamsSchema,
+      responses: {
+        200: { description: 'Closure decided', schema: envelope(closureSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Closure not found', schema: apiErrorSchema },
+        409: { description: 'Already decided', schema: apiErrorSchema },
+        422: { description: 'Closure does not require supervisor review', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(closureIdParamsSchema, 'params'),
+    validateBody(decideClosureRequestSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const updated = await service.decide(
+        req.params.id,
+        req.user.id,
+        req.body,
+        req.headers.authorization ?? '',
+      );
+      res.json(ok(updated));
     }),
   );
 

--- a/apps/closure-reopen-service/src/closures/closure.module.ts
+++ b/apps/closure-reopen-service/src/closures/closure.module.ts
@@ -3,6 +3,9 @@ import type { PrismaService } from '../prisma/prisma.service';
 import { ClosureRepository } from './closure.repository';
 import { ClosureService } from './closure.service';
 import { createClosureRouter } from './closure.controller';
+import { ApprovalClient } from '../reopen-requests/approval.client';
+import { LookupClient } from '../reopen-requests/lookup.client';
+import { NotificationClient } from '../reopen-requests/notification.client';
 
 /**
  * Composition root for the closures feature: wires repository → service → router.
@@ -10,6 +13,9 @@ import { createClosureRouter } from './closure.controller';
  */
 export function createClosureModule(prisma: PrismaService): DocumentedRouter {
   const repository = new ClosureRepository(prisma);
-  const service = new ClosureService(repository);
+  const approvalClient = new ApprovalClient();
+  const lookupClient = new LookupClient();
+  const notificationClient = new NotificationClient();
+  const service = new ClosureService(repository, approvalClient, lookupClient, notificationClient);
   return createClosureRouter(service);
 }

--- a/apps/closure-reopen-service/src/closures/closure.repository.ts
+++ b/apps/closure-reopen-service/src/closures/closure.repository.ts
@@ -1,5 +1,6 @@
 import type { PrismaService } from '../prisma/prisma.service';
 import type { CreateClosureInput } from './dto/create-closure.dto';
+import type { DecideClosureInput } from './dto/decide-closure.dto';
 
 /** Data access for closures. Owns only this service's `closures` table. */
 export class ClosureRepository {
@@ -9,7 +10,35 @@ export class ClosureRepository {
     return this.prisma.closure.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
   }
 
+  findById(id: string) {
+    return this.prisma.closure.findFirst({ where: { id, isDeleted: false } });
+  }
+
   create(data: CreateClosureInput) {
     return this.prisma.closure.create({ data });
+  }
+
+  /**
+   * Only updates a row that is still PENDING — `updateMany`'s affected count
+   * (rather than a separate read-then-write) is the concurrency guard: if
+   * another decision already landed between the caller's findById and this
+   * call, the count comes back 0 and the service turns that into a 409
+   * instead of silently overwriting an already-decided closure. Same pattern
+   * as reopen-request.repository.ts's decide().
+   */
+  async decide(
+    id: string,
+    decidedBySupervisorId: string,
+    dto: DecideClosureInput,
+  ): Promise<boolean> {
+    const result = await this.prisma.closure.updateMany({
+      where: { id, isDeleted: false, supervisorStatus: 'PENDING' },
+      data: {
+        supervisorStatus: dto.decision,
+        supervisorId: decidedBySupervisorId,
+        ...(dto.supervisorNotes !== undefined && { supervisorNotes: dto.supervisorNotes }),
+      },
+    });
+    return result.count > 0;
   }
 }

--- a/apps/closure-reopen-service/src/closures/closure.service.spec.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.spec.ts
@@ -1,18 +1,37 @@
 import { ClosureService } from './closure.service';
 import type { ClosureRepository } from './closure.repository';
+import type { ApprovalClient } from '../reopen-requests/approval.client';
+import type { LookupClient } from '../reopen-requests/lookup.client';
+import type { NotificationClient } from '../reopen-requests/notification.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
+import type { DecideClosureInput } from './dto/decide-closure.dto';
 import type { ClosureType } from '../../../../node_modules/.prisma/client-closure-reopen-service';
 
 describe('ClosureService', () => {
   const repository = {
     findMany: jest.fn(),
+    findById: jest.fn(),
     create: jest.fn(),
+    decide: jest.fn(),
   } as unknown as jest.Mocked<ClosureRepository>;
+  const approvalClient = { create: jest.fn() } as unknown as jest.Mocked<ApprovalClient>;
+  const lookupClient = {
+    resolveApprovalStatusId: jest.fn(),
+  } as unknown as jest.Mocked<LookupClient>;
+  const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
   let service: ClosureService;
+  const authHeader = 'Bearer token';
+  const supervisorId = '44444444-4444-4444-4444-444444444444';
+  let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new ClosureService(repository);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    service = new ClosureService(repository, approvalClient, lookupClient, notificationClient);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('lists via repository', async () => {
@@ -74,8 +93,9 @@ describe('ClosureService', () => {
       deletedAt: null,
     };
     repository.create.mockResolvedValue(created);
-    await expect(service.create(dto)).resolves.toBe(created);
+    await expect(service.create(dto, authHeader)).resolves.toBe(created);
     expect(repository.create).toHaveBeenCalledWith(dto);
+    expect(approvalClient.create).not.toHaveBeenCalled();
   });
 
   it('propagates repository errors on create', async () => {
@@ -87,6 +107,220 @@ describe('ClosureService', () => {
       submittedByUserId: '33333333-3333-3333-3333-333333333333',
     };
     repository.create.mockRejectedValue(new Error('db down'));
-    await expect(service.create(dto)).rejects.toThrow('db down');
+    await expect(service.create(dto, authHeader)).rejects.toThrow('db down');
+  });
+
+  describe('create — CLOSURE_REVIEW linkage', () => {
+    const dto: CreateClosureInput = {
+      beneficiaryId: '22222222-2222-2222-2222-222222222222',
+      closureType: 'MEDICAL',
+      closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      closureDate: new Date('2026-06-05'),
+      submittedByUserId: '33333333-3333-3333-3333-333333333333',
+    };
+
+    function pendingClosure() {
+      return {
+        id: '11111111-1111-1111-1111-111111111111',
+        beneficiaryId: dto.beneficiaryId,
+        closureType: dto.closureType as ClosureType,
+        closureReasonLookupValueId: dto.closureReasonLookupValueId,
+        eventDate: null,
+        closureDate: dto.closureDate,
+        submittedByUserId: dto.submittedByUserId,
+        supervisorStatus: 'PENDING' as const,
+        supervisorId: null,
+        supervisorNotes: null,
+        createdAt: new Date(),
+        createdByUserId: null,
+        updatedAt: new Date(),
+        updatedByUserId: null,
+        isDeleted: false,
+        deletedAt: null,
+      };
+    }
+
+    it('raises a CLOSURE_REVIEW card when the closure needs supervisor review', async () => {
+      const created = pendingClosure();
+      repository.create.mockResolvedValue(created);
+      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+
+      await service.create(dto, authHeader);
+
+      expect(lookupClient.resolveApprovalStatusId).toHaveBeenCalledWith('PENDING', authHeader);
+      expect(approvalClient.create).toHaveBeenCalledWith(
+        {
+          requestType: 'CLOSURE_REVIEW',
+          beneficiaryId: created.beneficiaryId,
+          sourceEntityType: 'Closure',
+          sourceEntityId: created.id,
+          closureId: created.id,
+          requestedByUserId: created.submittedByUserId,
+          decisionStatusLookupId: 'pending-lookup-id',
+        },
+        authHeader,
+      );
+    });
+
+    it('does not raise a card for a closure that does not need supervisor review', async () => {
+      const created = {
+        id: '11111111-1111-1111-1111-111111111111',
+        beneficiaryId: dto.beneficiaryId,
+        closureType: dto.closureType as ClosureType,
+        closureReasonLookupValueId: dto.closureReasonLookupValueId,
+        eventDate: null,
+        closureDate: dto.closureDate,
+        submittedByUserId: dto.submittedByUserId,
+        supervisorStatus: null,
+        supervisorId: null,
+        supervisorNotes: null,
+        createdAt: new Date(),
+        createdByUserId: null,
+        updatedAt: new Date(),
+        updatedByUserId: null,
+        isDeleted: false,
+        deletedAt: null,
+      };
+      repository.create.mockResolvedValue(created);
+
+      await service.create(dto, authHeader);
+
+      expect(approvalClient.create).not.toHaveBeenCalled();
+    });
+
+    it('still returns the created closure when raising the card fails', async () => {
+      const created = pendingClosure();
+      repository.create.mockResolvedValue(created);
+      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+      approvalClient.create.mockRejectedValue(
+        Object.assign(new Error('Bad gateway'), { status: 502 }),
+      );
+
+      await expect(service.create(dto, authHeader)).resolves.toBe(created);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('decide', () => {
+    function pendingClosure() {
+      return {
+        id: '11111111-1111-1111-1111-111111111111',
+        beneficiaryId: '22222222-2222-2222-2222-222222222222',
+        closureType: 'MEDICAL' as ClosureType,
+        closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        eventDate: null,
+        closureDate: new Date('2026-06-05'),
+        submittedByUserId: '33333333-3333-3333-3333-333333333333',
+        supervisorStatus: 'PENDING' as const,
+        supervisorId: null,
+        supervisorNotes: null,
+        createdAt: new Date(),
+        createdByUserId: null,
+        updatedAt: new Date(),
+        updatedByUserId: null,
+        isDeleted: false,
+        deletedAt: null,
+      };
+    }
+
+    it('approves a PENDING closure and notifies the Sakhi', async () => {
+      const pending = pendingClosure();
+      const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+
+      const dto: DecideClosureInput = { decision: 'APPROVED' };
+      await expect(service.decide(pending.id, supervisorId, dto, authHeader)).resolves.toBe(
+        decided,
+      );
+      expect(repository.decide).toHaveBeenCalledWith(pending.id, supervisorId, dto);
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        pending.submittedByUserId,
+        'CLOSURE_REVIEW_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+      );
+    });
+
+    it('rejects a PENDING closure', async () => {
+      const pending = pendingClosure();
+      const decided = { ...pending, supervisorStatus: 'REJECTED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+
+      const result = await service.decide(
+        pending.id,
+        supervisorId,
+        { decision: 'REJECTED' },
+        authHeader,
+      );
+      expect(result?.supervisorStatus).toBe('REJECTED');
+    });
+
+    it('404s on an unknown id', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(
+        service.decide('unknown-id', supervisorId, { decision: 'APPROVED' }, authHeader),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.decide).not.toHaveBeenCalled();
+    });
+
+    it('422s when the closure does not require supervisor review', async () => {
+      repository.findById.mockResolvedValue({ ...pendingClosure(), supervisorStatus: null });
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          supervisorId,
+          { decision: 'APPROVED' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 422 });
+      expect(repository.decide).not.toHaveBeenCalled();
+    });
+
+    it('409s on an already-APPROVED closure', async () => {
+      repository.findById.mockResolvedValue({
+        ...pendingClosure(),
+        supervisorStatus: 'APPROVED' as const,
+      });
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          supervisorId,
+          { decision: 'REJECTED' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.decide).not.toHaveBeenCalled();
+    });
+
+    it('409s when the conditional update races with a concurrent decision', async () => {
+      repository.findById.mockResolvedValueOnce(pendingClosure());
+      repository.decide.mockResolvedValue(false);
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          supervisorId,
+          { decision: 'APPROVED' },
+          authHeader,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('does not fail the request when notifying the Sakhi throws after the decision is committed', async () => {
+      const pending = pendingClosure();
+      const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+      notificationClient.notify.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { status: 403 }),
+      );
+
+      await expect(
+        service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+      ).resolves.toBe(decided);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/closure-reopen-service/src/closures/closure.service.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.ts
@@ -1,15 +1,119 @@
+import { conflict, notFound, unprocessable } from '@armman/service-commons';
 import type { ClosureRepository } from './closure.repository';
+import type { ApprovalClient } from '../reopen-requests/approval.client';
+import type { LookupClient } from '../reopen-requests/lookup.client';
+import type { NotificationClient } from '../reopen-requests/notification.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
+import type { DecideClosureInput } from './dto/decide-closure.dto';
 
 /** Closure domain logic. Data access is delegated to the repository. */
 export class ClosureService {
-  constructor(private readonly repository: ClosureRepository) {}
+  constructor(
+    private readonly repository: ClosureRepository,
+    private readonly approvalClient: ApprovalClient,
+    private readonly lookupClient: LookupClient,
+    private readonly notificationClient: NotificationClient,
+  ) {}
 
   list() {
     return this.repository.findMany();
   }
 
-  create(dto: CreateClosureInput) {
-    return this.repository.create(dto);
+  /**
+   * Creates the closure and, only when it needs supervisor review
+   * (supervisorStatus is set — per the schema, only MIGRATION-reason
+   * closures), also raises the matching CLOSURE_REVIEW Quick Response card
+   * in approval-service (FR-SV-4.4). A failure raising the card is logged
+   * and tolerated rather than failing an already-successful closure
+   * submission — same tolerance reopen-request.service.ts's create() uses.
+   */
+  async create(dto: CreateClosureInput, authorizationHeader: string) {
+    const created = await this.repository.create(dto);
+
+    if (created.supervisorStatus === 'PENDING') {
+      try {
+        const decisionStatusLookupId = await this.lookupClient.resolveApprovalStatusId(
+          'PENDING',
+          authorizationHeader,
+        );
+        if (decisionStatusLookupId) {
+          await this.approvalClient.create(
+            {
+              requestType: 'CLOSURE_REVIEW',
+              beneficiaryId: created.beneficiaryId,
+              sourceEntityType: 'Closure',
+              sourceEntityId: created.id,
+              closureId: created.id,
+              requestedByUserId: created.submittedByUserId,
+              decisionStatusLookupId,
+            },
+            authorizationHeader,
+          );
+        } else {
+          console.error(
+            `Closure ${created.id} was created but no PENDING APPROVAL_STATUS lookup value was found — Quick Response card not raised.`,
+          );
+        }
+      } catch (err) {
+        console.error(
+          `Closure ${created.id} was created but raising its Quick Response card failed:`,
+          err,
+        );
+      }
+    }
+
+    return created;
+  }
+
+  /**
+   * Decides a pending closure review (FR-SV-4.4). Approve/Reject both flip
+   * supervisorStatus here — the "beneficiary moves to Closed/Open list"
+   * consequence lives in beneficiary-service, out of this service's
+   * ownership (forklift rule). The Sakhi notification is best-effort — its
+   * failure doesn't fail an already-committed decision.
+   */
+  async decide(
+    id: string,
+    decidedBySupervisorId: string,
+    dto: DecideClosureInput,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(id);
+    if (!existing) throw notFound('Closure not found.');
+    if (existing.supervisorStatus === null) {
+      throw unprocessable('This closure does not require supervisor review.');
+    }
+    if (existing.supervisorStatus !== 'PENDING') {
+      throw conflict('This closure has already been decided.');
+    }
+
+    const updated = await this.repository.decide(id, decidedBySupervisorId, dto);
+    if (!updated) {
+      // Raced with another decision between the read above and the
+      // conditional update — same outcome as the check above, just caught a
+      // beat later instead of trusting a stale read.
+      throw conflict('This closure has already been decided.');
+    }
+
+    const decided = await this.repository.findById(id);
+
+    try {
+      await this.notificationClient.notify(
+        existing.submittedByUserId,
+        'CLOSURE_REVIEW_UPDATE',
+        'Closure review decided',
+        dto.decision === 'APPROVED'
+          ? 'Your closure request was approved.'
+          : 'Your closure request was rejected.',
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `Closure ${id} was decided (${dto.decision}) but the Sakhi notification failed:`,
+        err,
+      );
+    }
+
+    return decided;
   }
 }

--- a/apps/closure-reopen-service/src/closures/dto/decide-closure.dto.spec.ts
+++ b/apps/closure-reopen-service/src/closures/dto/decide-closure.dto.spec.ts
@@ -1,0 +1,33 @@
+import { decideClosureSchema } from './decide-closure.dto';
+
+describe('decideClosureSchema', () => {
+  it('accepts APPROVED with no supervisorNotes', () => {
+    expect(decideClosureSchema.safeParse({ decision: 'APPROVED' }).success).toBe(true);
+  });
+
+  it('accepts REJECTED with supervisorNotes', () => {
+    const result = decideClosureSchema.safeParse({
+      decision: 'REJECTED',
+      supervisorNotes: 'Beneficiary confirmed not returning.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid decision value', () => {
+    expect(decideClosureSchema.safeParse({ decision: 'MAYBE' }).success).toBe(false);
+  });
+
+  it('rejects an empty-string supervisorNotes', () => {
+    const result = decideClosureSchema.safeParse({ decision: 'APPROVED', supervisorNotes: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = decideClosureSchema.safeParse({ decision: 'APPROVED', extraField: 'x' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing decision', () => {
+    expect(decideClosureSchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/apps/closure-reopen-service/src/closures/dto/decide-closure.dto.ts
+++ b/apps/closure-reopen-service/src/closures/dto/decide-closure.dto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for a Supervisor's decision on a pending closure review
+ * (FR-SV-4.4). `.strict()` rejects unknown fields, matching this repo's
+ * global convention.
+ */
+export const decideClosureSchema = z
+  .object({
+    decision: z.enum(['APPROVED', 'REJECTED']),
+    supervisorNotes: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export type DecideClosureInput = z.infer<typeof decideClosureSchema>;

--- a/apps/closure-reopen-service/src/reopen-requests/approval.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/approval.client.ts
@@ -1,0 +1,43 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface CreateApprovalRequestInput {
+  requestType: string;
+  beneficiaryId?: string;
+  sourceEntityType: string;
+  sourceEntityId: string;
+  reopenRequestId?: string;
+  closureId?: string;
+  requestedByUserId: string;
+  decisionStatusLookupId: string;
+}
+
+/**
+ * Raises a Quick Response card by calling approval-service's POST /approvals
+ * through the gateway, forwarding the caller's own Authorization header —
+ * same pattern this service's AuditClient/NotificationClient use.
+ */
+export class ApprovalClient {
+  async create(input: CreateApprovalRequestInput, authorizationHeader: string): Promise<void> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/approvals`, {
+        method: 'POST',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+    } catch {
+      throw badGateway('Unable to raise the approval request — approval-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to raise the approval request.');
+      }
+      throw badGateway(
+        'Unable to raise the approval request — approval-service returned an error.',
+      );
+    }
+  }
+}

--- a/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
@@ -1,0 +1,50 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface BeneficiaryCaseRecord {
+  id: string;
+  currentStatus: string;
+}
+
+/**
+ * Reactivates a CLOSED beneficiary case by calling beneficiary-service's
+ * PATCH /beneficiaries/:id/reactivate through the gateway, forwarding the
+ * caller's own Authorization header — same pattern this service's
+ * AuditClient/NotificationClient use. Used after an approved reopen request
+ * (FR-SV-4.7/FR-S-10.3) so "Beneficiary is added to Sakhi's Open beneficiary
+ * list" actually happens, not just the reopen_requests row flipping.
+ */
+export class BeneficiaryClient {
+  async reactivateCase(
+    beneficiaryId: string,
+    authorizationHeader: string,
+  ): Promise<BeneficiaryCaseRecord> {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/reactivate`,
+        {
+          method: 'PATCH',
+          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        },
+      );
+    } catch {
+      throw badGateway(
+        'Unable to reactivate the beneficiary — beneficiary-service is unreachable.',
+      );
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to reactivate the beneficiary.');
+      }
+      throw badGateway(
+        'Unable to reactivate the beneficiary — beneficiary-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: BeneficiaryCaseRecord };
+    return body.data;
+  }
+}

--- a/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.spec.ts
@@ -1,0 +1,54 @@
+import { createReopenRequestSchema } from './create-reopen-request.dto';
+
+describe('createReopenRequestSchema', () => {
+  const baseInput = {
+    beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    requestReason: 'MIGRATION_RETURNED' as const,
+  };
+
+  it('accepts a valid MIGRATION_RETURNED request', () => {
+    expect(createReopenRequestSchema.safeParse(baseInput).success).toBe(true);
+  });
+
+  it('accepts CLOSED_BY_MISTAKE', () => {
+    const result = createReopenRequestSchema.safeParse({
+      ...baseInput,
+      requestReason: 'CLOSED_BY_MISTAKE',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts OTHER', () => {
+    const result = createReopenRequestSchema.safeParse({ ...baseInput, requestReason: 'OTHER' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing beneficiaryId', () => {
+    const { beneficiaryId: _omit, ...rest } = baseInput;
+    expect(createReopenRequestSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects a non-UUID beneficiaryId', () => {
+    const result = createReopenRequestSchema.safeParse({
+      ...baseInput,
+      beneficiaryId: 'not-a-uuid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid requestReason', () => {
+    const result = createReopenRequestSchema.safeParse({
+      ...baseInput,
+      requestReason: 'SOME_OTHER_REASON',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = createReopenRequestSchema.safeParse({
+      ...baseInput,
+      requestedByUserId: '33333333-3333-3333-3333-333333333333',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for a Sakhi's reopen request (FR-S-10.3). `.strict()`
+ * rejects unknown fields, matching this repo's global convention.
+ *
+ * `requestedByUserId` is deliberately NOT a field here — it is always the
+ * authenticated caller's own id (see reopen-request.service.ts), never
+ * client-supplied, so a Sakhi can never raise a reopen request under another
+ * Sakhi's name.
+ */
+export const createReopenRequestSchema = z
+  .object({
+    beneficiaryId: z.string().uuid(),
+    requestReason: z.enum(['MIGRATION_RETURNED', 'CLOSED_BY_MISTAKE', 'OTHER']),
+  })
+  .strict();
+
+export type CreateReopenRequestInput = z.infer<typeof createReopenRequestSchema>;

--- a/apps/closure-reopen-service/src/reopen-requests/lookup.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/lookup.client.ts
@@ -1,0 +1,48 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+interface LookupValue {
+  id: string;
+  valueCode: string;
+}
+
+interface LookupCategory {
+  categoryCode: string;
+  values: LookupValue[];
+}
+
+/**
+ * Resolves an APPROVAL_STATUS value code (e.g. "PENDING") to its
+ * lookup_value_id for the current environment, since
+ * approval_requests.decision_status_lookup_id is an environment-specific FK,
+ * not a stable literal — same client as approval-service's Quick Response
+ * LookupClient, duplicated here since closure-reopen-service can't import
+ * across service boundaries (forklift rule).
+ */
+export class LookupClient {
+  async resolveApprovalStatusId(
+    valueCode: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/lookups/APPROVAL_STATUS`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve APPROVAL_STATUS — auth-service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve APPROVAL_STATUS.');
+      }
+      throw badGateway('Unable to resolve APPROVAL_STATUS — auth-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: LookupCategory };
+    return body.data.values.find((v) => v.valueCode === valueCode)?.id ?? null;
+  }
+}

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
@@ -1,6 +1,7 @@
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { ReopenRequestService } from './reopen-request.service';
+import { createReopenRequestSchema } from './dto/create-reopen-request.dto';
 import { decideReopenRequestSchema } from './dto/decide-reopen-request.dto';
 import {
   asyncHandler,
@@ -67,6 +68,28 @@ function envelope<T extends z.ZodTypeAny>(data: T) {
  */
 export function createReopenRequestRouter(service: ReopenRequestService) {
   const doc = createDocumentedRouter();
+
+  doc.post(
+    '/reopen-requests',
+    {
+      summary: 'Raise a reopen request for a closed beneficiary (FR-S-10.3)',
+      tags: ['Reopen Requests'],
+      responses: {
+        201: { description: 'Reopen request created', schema: envelope(reopenRequestSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validateBody(createReopenRequestSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const created = await service.create(req.body, req.user.id, req.headers.authorization ?? '');
+      res.status(201).json(ok(created));
+    }),
+  );
 
   doc.patch(
     '/reopen-requests/:id/decision',

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
@@ -5,6 +5,8 @@ import { ReopenRequestService } from './reopen-request.service';
 import { createReopenRequestRouter } from './reopen-request.controller';
 import { AuditClient } from './audit.client';
 import { NotificationClient } from './notification.client';
+import { ApprovalClient } from './approval.client';
+import { LookupClient } from './lookup.client';
 
 /**
  * Composition root for the reopen-requests feature: wires repository → service → router.
@@ -13,6 +15,14 @@ export function createReopenRequestModule(prisma: PrismaService): DocumentedRout
   const repository = new ReopenRequestRepository(prisma);
   const auditClient = new AuditClient();
   const notificationClient = new NotificationClient();
-  const service = new ReopenRequestService(repository, auditClient, notificationClient);
+  const approvalClient = new ApprovalClient();
+  const lookupClient = new LookupClient();
+  const service = new ReopenRequestService(
+    repository,
+    auditClient,
+    notificationClient,
+    approvalClient,
+    lookupClient,
+  );
   return createReopenRequestRouter(service);
 }

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
@@ -7,6 +7,7 @@ import { AuditClient } from './audit.client';
 import { NotificationClient } from './notification.client';
 import { ApprovalClient } from './approval.client';
 import { LookupClient } from './lookup.client';
+import { BeneficiaryClient } from './beneficiary.client';
 
 /**
  * Composition root for the reopen-requests feature: wires repository → service → router.
@@ -17,12 +18,14 @@ export function createReopenRequestModule(prisma: PrismaService): DocumentedRout
   const notificationClient = new NotificationClient();
   const approvalClient = new ApprovalClient();
   const lookupClient = new LookupClient();
+  const beneficiaryClient = new BeneficiaryClient();
   const service = new ReopenRequestService(
     repository,
     auditClient,
     notificationClient,
     approvalClient,
     lookupClient,
+    beneficiaryClient,
   );
   return createReopenRequestRouter(service);
 }

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.repository.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.repository.ts
@@ -1,4 +1,5 @@
 import type { PrismaService } from '../prisma/prisma.service';
+import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
 /** Data access for reopen_requests. Owns only this service's `reopen_requests` table. */
@@ -7,6 +8,12 @@ export class ReopenRequestRepository {
 
   findById(id: string) {
     return this.prisma.reopenRequest.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  create(data: CreateReopenRequestInput & { requestedByUserId: string }) {
+    return this.prisma.reopenRequest.create({
+      data: { ...data, requestedAt: new Date() },
+    });
   }
 
   /**

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -4,6 +4,7 @@ import type { AuditClient } from './audit.client';
 import type { NotificationClient } from './notification.client';
 import type { ApprovalClient } from './approval.client';
 import type { LookupClient } from './lookup.client';
+import type { BeneficiaryClient } from './beneficiary.client';
 import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
@@ -41,6 +42,9 @@ describe('ReopenRequestService', () => {
   const lookupClient = {
     resolveApprovalStatusId: jest.fn(),
   } as unknown as jest.Mocked<LookupClient>;
+  const beneficiaryClient = {
+    reactivateCase: jest.fn(),
+  } as unknown as jest.Mocked<BeneficiaryClient>;
   let service: ReopenRequestService;
   const supervisorId = '44444444-4444-4444-4444-444444444444';
   const authHeader = 'Bearer token';
@@ -49,12 +53,17 @@ describe('ReopenRequestService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    beneficiaryClient.reactivateCase.mockResolvedValue({
+      id: '22222222-2222-2222-2222-222222222222',
+      currentStatus: 'ACTIVE',
+    });
     service = new ReopenRequestService(
       repository,
       auditClient,
       notificationClient,
       approvalClient,
       lookupClient,
+      beneficiaryClient,
     );
   });
 
@@ -129,7 +138,7 @@ describe('ReopenRequestService', () => {
     });
   });
 
-  it('approves a PENDING reopen request, audits, and notifies the Sakhi', async () => {
+  it('approves a PENDING reopen request, reactivates the beneficiary, audits, and notifies the Sakhi', async () => {
     const pending = reopenRequest();
     const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
     repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
@@ -138,6 +147,10 @@ describe('ReopenRequestService', () => {
     const dto: DecideReopenRequestInput = { decision: 'APPROVED' };
     await expect(service.decide(pending.id, supervisorId, dto, authHeader)).resolves.toBe(decided);
     expect(repository.decide).toHaveBeenCalledWith(pending.id, supervisorId, dto);
+    expect(beneficiaryClient.reactivateCase).toHaveBeenCalledWith(
+      pending.beneficiaryId,
+      authHeader,
+    );
     expect(auditClient.log).toHaveBeenCalledWith(
       supervisorId,
       'QUICK_RESPONSE_APPROVE',
@@ -155,7 +168,7 @@ describe('ReopenRequestService', () => {
     );
   });
 
-  it('rejects a PENDING reopen request — persisted as the "Cannot re-open" state', async () => {
+  it('rejects a PENDING reopen request — persisted as the "Cannot re-open" state, no reactivation', async () => {
     const pending = reopenRequest();
     const decided = reopenRequest({ supervisorStatus: 'REJECTED', decidedByUserId: supervisorId });
     repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
@@ -164,6 +177,7 @@ describe('ReopenRequestService', () => {
     const dto: DecideReopenRequestInput = { decision: 'REJECTED' };
     const result = await service.decide(pending.id, supervisorId, dto, authHeader);
     expect(result?.supervisorStatus).toBe('REJECTED');
+    expect(beneficiaryClient.reactivateCase).not.toHaveBeenCalled();
     expect(auditClient.log).toHaveBeenCalledWith(
       supervisorId,
       'QUICK_RESPONSE_REJECT',
@@ -264,5 +278,23 @@ describe('ReopenRequestService', () => {
     ).resolves.toBe(decided);
     expect(notificationClient.notify).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('propagates a beneficiary reactivation failure — NOT tolerated like audit/notification', async () => {
+    const pending = reopenRequest();
+    repository.findById.mockResolvedValueOnce(pending);
+    repository.decide.mockResolvedValue(true);
+    beneficiaryClient.reactivateCase.mockRejectedValue(
+      Object.assign(new Error('Cannot reactivate a case with status ACTIVE.'), { status: 409 }),
+    );
+
+    await expect(
+      service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+    ).rejects.toMatchObject({ status: 409 });
+    // The decision itself is already committed (repository.decide succeeded)
+    // — only the downstream reactivation call failed and correctly surfaced.
+    expect(repository.decide).toHaveBeenCalled();
+    expect(auditClient.log).not.toHaveBeenCalled();
+    expect(notificationClient.notify).not.toHaveBeenCalled();
   });
 });

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -2,6 +2,9 @@ import { ReopenRequestService } from './reopen-request.service';
 import type { ReopenRequestRepository } from './reopen-request.repository';
 import type { AuditClient } from './audit.client';
 import type { NotificationClient } from './notification.client';
+import type { ApprovalClient } from './approval.client';
+import type { LookupClient } from './lookup.client';
+import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
 function reopenRequest(overrides: Partial<Record<string, unknown>> = {}) {
@@ -30,9 +33,14 @@ describe('ReopenRequestService', () => {
   const repository = {
     findById: jest.fn(),
     decide: jest.fn(),
+    create: jest.fn(),
   } as unknown as jest.Mocked<ReopenRequestRepository>;
   const auditClient = { log: jest.fn() } as unknown as jest.Mocked<AuditClient>;
   const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
+  const approvalClient = { create: jest.fn() } as unknown as jest.Mocked<ApprovalClient>;
+  const lookupClient = {
+    resolveApprovalStatusId: jest.fn(),
+  } as unknown as jest.Mocked<LookupClient>;
   let service: ReopenRequestService;
   const supervisorId = '44444444-4444-4444-4444-444444444444';
   const authHeader = 'Bearer token';
@@ -41,11 +49,84 @@ describe('ReopenRequestService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    service = new ReopenRequestService(repository, auditClient, notificationClient);
+    service = new ReopenRequestService(
+      repository,
+      auditClient,
+      notificationClient,
+      approvalClient,
+      lookupClient,
+    );
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+  });
+
+  describe('create', () => {
+    const sakhiId = '55555555-5555-5555-5555-555555555555';
+    const dto: CreateReopenRequestInput = {
+      beneficiaryId: '22222222-2222-2222-2222-222222222222',
+      requestReason: 'CLOSED_BY_MISTAKE',
+    };
+
+    it('creates via repository with requestedByUserId stamped from the caller', async () => {
+      const created = reopenRequest({ requestedByUserId: sakhiId });
+      repository.create.mockResolvedValue(created);
+      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+
+      await expect(service.create(dto, sakhiId, authHeader)).resolves.toBe(created);
+      expect(repository.create).toHaveBeenCalledWith({ ...dto, requestedByUserId: sakhiId });
+    });
+
+    it('raises a REOPEN Quick Response card via approvalClient after creating', async () => {
+      const created = reopenRequest({ requestedByUserId: sakhiId });
+      repository.create.mockResolvedValue(created);
+      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+
+      await service.create(dto, sakhiId, authHeader);
+
+      expect(lookupClient.resolveApprovalStatusId).toHaveBeenCalledWith('PENDING', authHeader);
+      expect(approvalClient.create).toHaveBeenCalledWith(
+        {
+          requestType: 'REOPEN',
+          beneficiaryId: created.beneficiaryId,
+          sourceEntityType: 'ReopenRequest',
+          sourceEntityId: created.id,
+          reopenRequestId: created.id,
+          requestedByUserId: sakhiId,
+          decisionStatusLookupId: 'pending-lookup-id',
+        },
+        authHeader,
+      );
+    });
+
+    it('still returns the created reopen request when raising the card fails', async () => {
+      const created = reopenRequest({ requestedByUserId: sakhiId });
+      repository.create.mockResolvedValue(created);
+      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+      approvalClient.create.mockRejectedValue(
+        Object.assign(new Error('Bad gateway'), { status: 502 }),
+      );
+
+      await expect(service.create(dto, sakhiId, authHeader)).resolves.toBe(created);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('still returns the created reopen request when no PENDING lookup value is found', async () => {
+      const created = reopenRequest({ requestedByUserId: sakhiId });
+      repository.create.mockResolvedValue(created);
+      lookupClient.resolveApprovalStatusId.mockResolvedValue(null);
+
+      await expect(service.create(dto, sakhiId, authHeader)).resolves.toBe(created);
+      expect(approvalClient.create).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('propagates a genuine repository failure on create', async () => {
+      repository.create.mockRejectedValue(new Error('db down'));
+      await expect(service.create(dto, sakhiId, authHeader)).rejects.toThrow('db down');
+      expect(approvalClient.create).not.toHaveBeenCalled();
+    });
   });
 
   it('approves a PENDING reopen request, audits, and notifies the Sakhi', async () => {
@@ -104,9 +185,14 @@ describe('ReopenRequestService', () => {
   it('409s on an already-APPROVED reopen request', async () => {
     repository.findById.mockResolvedValue(reopenRequest({ supervisorStatus: 'APPROVED' }));
     await expect(
-      service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
-        decision: 'REJECTED',
-      }, authHeader),
+      service.decide(
+        '11111111-1111-1111-1111-111111111111',
+        supervisorId,
+        {
+          decision: 'REJECTED',
+        },
+        authHeader,
+      ),
     ).rejects.toMatchObject({ status: 409 });
     expect(repository.decide).not.toHaveBeenCalled();
   });
@@ -114,9 +200,14 @@ describe('ReopenRequestService', () => {
   it('409s on an already-REJECTED reopen request', async () => {
     repository.findById.mockResolvedValue(reopenRequest({ supervisorStatus: 'REJECTED' }));
     await expect(
-      service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
-        decision: 'APPROVED',
-      }, authHeader),
+      service.decide(
+        '11111111-1111-1111-1111-111111111111',
+        supervisorId,
+        {
+          decision: 'APPROVED',
+        },
+        authHeader,
+      ),
     ).rejects.toMatchObject({ status: 409 });
   });
 
@@ -124,9 +215,14 @@ describe('ReopenRequestService', () => {
     repository.findById.mockResolvedValueOnce(reopenRequest());
     repository.decide.mockResolvedValue(false);
     await expect(
-      service.decide('11111111-1111-1111-1111-111111111111', supervisorId, {
-        decision: 'APPROVED',
-      }, authHeader),
+      service.decide(
+        '11111111-1111-1111-1111-111111111111',
+        supervisorId,
+        {
+          decision: 'APPROVED',
+        },
+        authHeader,
+      ),
     ).rejects.toMatchObject({ status: 409 });
   });
 
@@ -146,7 +242,9 @@ describe('ReopenRequestService', () => {
     const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
     repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
     repository.decide.mockResolvedValue(true);
-    notificationClient.notify.mockRejectedValue(Object.assign(new Error('Forbidden'), { status: 403 }));
+    notificationClient.notify.mockRejectedValue(
+      Object.assign(new Error('Forbidden'), { status: 403 }),
+    );
 
     await expect(
       service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -280,21 +280,27 @@ describe('ReopenRequestService', () => {
     expect(consoleErrorSpy).toHaveBeenCalled();
   });
 
-  it('propagates a beneficiary reactivation failure — NOT tolerated like audit/notification', async () => {
+  it('does not fail the request when beneficiary reactivation fails after the decision is already committed', async () => {
     const pending = reopenRequest();
-    repository.findById.mockResolvedValueOnce(pending);
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
     repository.decide.mockResolvedValue(true);
     beneficiaryClient.reactivateCase.mockRejectedValue(
       Object.assign(new Error('Cannot reactivate a case with status ACTIVE.'), { status: 409 }),
     );
 
+    // supervisorStatus is already committed to APPROVED by repository.decide,
+    // and decide()'s own PENDING-only guard means this request could never be
+    // re-decided to retry just the reactivation — so a failure here must not
+    // fail the whole request, same tolerance as the audit/notification calls.
     await expect(
       service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
-    ).rejects.toMatchObject({ status: 409 });
-    // The decision itself is already committed (repository.decide succeeded)
-    // — only the downstream reactivation call failed and correctly surfaced.
+    ).resolves.toBe(decided);
     expect(repository.decide).toHaveBeenCalled();
-    expect(auditClient.log).not.toHaveBeenCalled();
-    expect(notificationClient.notify).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    // The audit/notification calls still run — a downstream reactivation
+    // failure isn't a reason to also skip the audit trail or Sakhi notice.
+    expect(auditClient.log).toHaveBeenCalled();
+    expect(notificationClient.notify).toHaveBeenCalled();
   });
 });

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -4,6 +4,7 @@ import type { AuditClient } from './audit.client';
 import type { NotificationClient } from './notification.client';
 import type { ApprovalClient } from './approval.client';
 import type { LookupClient } from './lookup.client';
+import type { BeneficiaryClient } from './beneficiary.client';
 import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
@@ -15,6 +16,7 @@ export class ReopenRequestService {
     private readonly notificationClient: NotificationClient,
     private readonly approvalClient: ApprovalClient,
     private readonly lookupClient: LookupClient,
+    private readonly beneficiaryClient: BeneficiaryClient,
   ) {}
 
   /**
@@ -69,6 +71,15 @@ export class ReopenRequestService {
    * REJECTED is the persisted "Cannot re-open" state — the beneficiary
    * simply stays whatever Closed state it already had; no separate flag.
    *
+   * On APPROVED, also reactivates the beneficiary case (FR-SV-4.7's
+   * "Beneficiary is added to Sakhi's Open beneficiary list") via
+   * beneficiary-service. Unlike the audit/notification calls below, this one
+   * is NOT tolerated — an "approved" reopen that never actually reactivated
+   * the beneficiary is a data-integrity bug, not a hiccup the caller should
+   * see as a success. It runs after the reopen_requests row is already
+   * committed, so a failure here still leaves the request correctly marked
+   * APPROVED (fixable via retry), not stuck PENDING.
+   *
    * Writes the audit_log entry and notifies the Sakhi here, not in
    * approval-service's Quick Response layer — this endpoint is the only
    * place a reopen decision is actually persisted (Quick Response is one
@@ -93,6 +104,10 @@ export class ReopenRequestService {
       // conditional update — same outcome as the check above, just caught a
       // beat later instead of trusting a stale read.
       throw conflict('This reopen request has already been decided.');
+    }
+
+    if (dto.decision === 'APPROVED') {
+      await this.beneficiaryClient.reactivateCase(existing.beneficiaryId, authorizationHeader);
     }
 
     const decided = await this.repository.findById(id);

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -2,6 +2,9 @@ import { conflict, notFound } from '@armman/service-commons';
 import type { ReopenRequestRepository } from './reopen-request.repository';
 import type { AuditClient } from './audit.client';
 import type { NotificationClient } from './notification.client';
+import type { ApprovalClient } from './approval.client';
+import type { LookupClient } from './lookup.client';
+import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
 /** Reopen request domain logic. Data access is delegated to the repository. */
@@ -10,7 +13,56 @@ export class ReopenRequestService {
     private readonly repository: ReopenRequestRepository,
     private readonly auditClient: AuditClient,
     private readonly notificationClient: NotificationClient,
+    private readonly approvalClient: ApprovalClient,
+    private readonly lookupClient: LookupClient,
   ) {}
+
+  /**
+   * Raises a Sakhi's reopen request (FR-S-10.3) and, on success, raises the
+   * matching REOPEN Quick Response card in approval-service. The reopen
+   * request is the source of truth — a failure raising the card is logged
+   * and tolerated rather than failing an already-successful submission
+   * (same tolerance the decide() audit/notification calls use).
+   */
+  async create(
+    dto: CreateReopenRequestInput,
+    requestedByUserId: string,
+    authorizationHeader: string,
+  ) {
+    const created = await this.repository.create({ ...dto, requestedByUserId });
+
+    try {
+      const decisionStatusLookupId = await this.lookupClient.resolveApprovalStatusId(
+        'PENDING',
+        authorizationHeader,
+      );
+      if (decisionStatusLookupId) {
+        await this.approvalClient.create(
+          {
+            requestType: 'REOPEN',
+            beneficiaryId: created.beneficiaryId,
+            sourceEntityType: 'ReopenRequest',
+            sourceEntityId: created.id,
+            reopenRequestId: created.id,
+            requestedByUserId,
+            decisionStatusLookupId,
+          },
+          authorizationHeader,
+        );
+      } else {
+        console.error(
+          `Reopen request ${created.id} was created but no PENDING APPROVAL_STATUS lookup value was found — Quick Response card not raised.`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `Reopen request ${created.id} was created but raising its Quick Response card failed:`,
+        err,
+      );
+    }
+
+    return created;
+  }
 
   /**
    * Decides a Supervisor's reopen request (Quick Response's REOPEN card).

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -73,12 +73,17 @@ export class ReopenRequestService {
    *
    * On APPROVED, also reactivates the beneficiary case (FR-SV-4.7's
    * "Beneficiary is added to Sakhi's Open beneficiary list") via
-   * beneficiary-service. Unlike the audit/notification calls below, this one
-   * is NOT tolerated — an "approved" reopen that never actually reactivated
-   * the beneficiary is a data-integrity bug, not a hiccup the caller should
-   * see as a success. It runs after the reopen_requests row is already
-   * committed, so a failure here still leaves the request correctly marked
-   * APPROVED (fixable via retry), not stuck PENDING.
+   * beneficiary-service. This call is best-effort (logged, not thrown) —
+   * `repository.decide()` just above already committed
+   * `supervisorStatus = 'APPROVED'`, and this method's own guard
+   * (`supervisorStatus !== 'PENDING'`) means a reopen request can never be
+   * decided a second time to retry just this step; any retry attempt 409s
+   * immediately. Letting this call fail the whole request would leave the
+   * request stuck showing APPROVED with the beneficiary still CLOSED and no
+   * way to fix it except a direct beneficiary-service call — same failure
+   * shape as the audit/notification calls below, so it's tolerated the same
+   * way, with a distinct log line calling out that this one needs manual
+   * follow-up, not just a shrug.
    *
    * Writes the audit_log entry and notifies the Sakhi here, not in
    * approval-service's Quick Response layer — this endpoint is the only
@@ -107,7 +112,16 @@ export class ReopenRequestService {
     }
 
     if (dto.decision === 'APPROVED') {
-      await this.beneficiaryClient.reactivateCase(existing.beneficiaryId, authorizationHeader);
+      try {
+        await this.beneficiaryClient.reactivateCase(existing.beneficiaryId, authorizationHeader);
+      } catch (err) {
+        console.error(
+          `Reopen request ${id} was approved but reactivating beneficiary ` +
+            `${existing.beneficiaryId} failed (this request cannot be re-decided to retry — ` +
+            `needs manual follow-up):`,
+          err,
+        );
+      }
     }
 
     const decided = await this.repository.findById(id);

--- a/apps/incentive-wages-service/jest.config.ts
+++ b/apps/incentive-wages-service/jest.config.ts
@@ -3,5 +3,6 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/incentive-wages-service',
 };

--- a/apps/incentive-wages-service/src/app.module.ts
+++ b/apps/incentive-wages-service/src/app.module.ts
@@ -12,6 +12,7 @@ import { appConfig } from './config/app-config';
 import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createIncentiveEventModule } from './incentives/incentiveEvent.module';
+import { createIncentiveRateModule } from './rates/incentiveRate.module';
 import { buildIncentiveWagesServiceOpenApiDocument } from './docs/openapi';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
@@ -19,6 +20,8 @@ export {
   asyncHandler,
   ok,
   fail,
+  notFound,
+  validate,
   validateBody,
   requireRoles,
   trustGatewayIdentity,
@@ -50,17 +53,24 @@ export function createApp(prisma: PrismaService): Application {
   app.use(requestId);
 
   const incentiveEventModule = createIncentiveEventModule(prisma);
+  const incentiveRateModule = createIncentiveRateModule(prisma);
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();
   api.use(createHealthRouter(prisma));
-  // Built from incentiveEventModule.registry — every route registered via
+  // Built from every feature module's registry — every route registered via
   // createDocumentedRouter() above is already in the spec, so this can never
   // drift from what's actually mounted.
   api.use(
-    createSwaggerRouter(buildIncentiveWagesServiceOpenApiDocument(incentiveEventModule.registry)),
+    createSwaggerRouter(
+      buildIncentiveWagesServiceOpenApiDocument(
+        incentiveEventModule.registry,
+        incentiveRateModule.registry,
+      ),
+    ),
   );
   api.use(incentiveEventModule.router);
+  api.use(incentiveRateModule.router);
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/incentive-wages-service/src/docs/openapi.ts
+++ b/apps/incentive-wages-service/src/docs/openapi.ts
@@ -1,15 +1,16 @@
-import type { OpenAPIRegistry } from '@armman/service-commons';
-import { buildServiceOpenApiDocument } from '@armman/service-commons';
+import { OpenAPIRegistry, buildServiceOpenApiDocument } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Builds the incentive-wages-service OpenAPI document from the registry that
- * `createIncentiveEventRouter` (via `createDocumentedRouter()`) already
- * populated as each route was defined — there is no separate, hand-maintained
- * route list to keep in sync here.
+ * Builds the incentive-wages-service OpenAPI document from every feature
+ * router's registry — each `createDocumentedRouter()` call creates its own
+ * registry, merged here (via the registry's `parents` constructor param) so
+ * incentives/incentive-rates routes never overwrite each other in the
+ * combined doc.
  */
-export function buildIncentiveWagesServiceOpenApiDocument(registry: OpenAPIRegistry) {
-  return buildServiceOpenApiDocument(registry, {
+export function buildIncentiveWagesServiceOpenApiDocument(...registries: OpenAPIRegistry[]) {
+  const merged = new OpenAPIRegistry(registries);
+  return buildServiceOpenApiDocument(merged, {
     title: 'Arogya Sakhi — Incentive Wages Service API',
     description: 'Incentive events and wage calculation.',
     port: appConfig.PORT,

--- a/apps/incentive-wages-service/src/incentives/dto/create-incentiveEvent.dto.ts
+++ b/apps/incentive-wages-service/src/incentives/dto/create-incentiveEvent.dto.ts
@@ -9,6 +9,14 @@ import { z } from 'zod';
  * (id, createdAt, updatedAt, isDeleted, deletedAt, createdByUserId,
  * updatedByUserId) are excluded since no auth context is wired into the
  * routers yet.
+ *
+ * `amountInr` is deliberately NOT a field here — since SUPERVISOR (not just
+ * ADMIN) can call this endpoint (see incentiveEvent.controller.ts's roles,
+ * needed for the ACCOMPANIED_REFERRAL incentive trigger), trusting a
+ * client-supplied amount would let any Supervisor mint an incentive event
+ * for an arbitrary payout. The service re-derives amountInr from `rateId`
+ * server-side instead (see IncentiveEventService.create) — never taken from
+ * the request body, regardless of caller role.
  */
 export const createIncentiveEventSchema = z
   .object({
@@ -18,7 +26,6 @@ export const createIncentiveEventSchema = z
     eventMonth: z.coerce.date(),
     rateId: z.string().uuid(),
     quantity: z.number().default(1),
-    amountInr: z.number(),
     eligibilityStatus: z.enum(['ELIGIBLE', 'INELIGIBLE', 'PENDING', 'REVERSED']),
     calculatedAt: z.coerce.date(),
   })

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.controller.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.controller.ts
@@ -88,7 +88,7 @@ export function createIncentiveEventRouter(service: IncentiveEventService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('ADMIN'),
+    requireRoles('SUPERVISOR', 'ADMIN'),
     validateBody(createIncentiveEventSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.module.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.module.ts
@@ -3,6 +3,7 @@ import type { PrismaService } from '../prisma/prisma.service';
 import { IncentiveEventRepository } from './incentiveEvent.repository';
 import { IncentiveEventService } from './incentiveEvent.service';
 import { createIncentiveEventRouter } from './incentiveEvent.controller';
+import { IncentiveRateRepository } from '../rates/incentiveRate.repository';
 
 /**
  * Composition root for the incentives feature: wires repository → service →
@@ -10,6 +11,7 @@ import { createIncentiveEventRouter } from './incentiveEvent.controller';
  */
 export function createIncentiveEventModule(prisma: PrismaService): DocumentedRouter {
   const repository = new IncentiveEventRepository(prisma);
-  const service = new IncentiveEventService(repository);
+  const rateRepository = new IncentiveRateRepository(prisma);
+  const service = new IncentiveEventService(repository, rateRepository);
   return createIncentiveEventRouter(service);
 }

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.repository.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.repository.ts
@@ -9,7 +9,12 @@ export class IncentiveEventRepository {
     return this.prisma.incentiveEvent.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
   }
 
-  create(data: CreateIncentiveEventInput) {
+  /**
+   * `amountInr` is not part of `CreateIncentiveEventInput` — it's resolved
+   * server-side by the service from the referenced rate, never trusted from
+   * the client (see createIncentiveEventSchema's doc comment).
+   */
+  create(data: CreateIncentiveEventInput & { amountInr: number }) {
     return this.prisma.incentiveEvent.create({ data });
   }
 }

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.service.spec.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.service.spec.ts
@@ -38,7 +38,10 @@ describe('IncentiveEventService', () => {
 
   const rateRow = {
     id: baseDto.rateId,
+    rateType: 'VISIT',
     amountInr: new Prisma.Decimal(150),
+    effectiveFrom: new Date('2026-01-01'),
+    effectiveTo: null,
   };
 
   const createdRow = {
@@ -80,6 +83,44 @@ describe('IncentiveEventService', () => {
     rateRepository.findById.mockResolvedValue(null);
     await expect(service.create(baseDto)).rejects.toMatchObject({ status: 404 });
     expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it("422s when the rate's rateType does not match the event's sourceEntityType", async () => {
+    rateRepository.findById.mockResolvedValue({ ...rateRow, rateType: 'REFERRAL' } as never);
+
+    await expect(service.create(baseDto)).rejects.toMatchObject({ status: 422 });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('422s when the rate is not yet effective as of calculatedAt', async () => {
+    rateRepository.findById.mockResolvedValue({
+      ...rateRow,
+      effectiveFrom: new Date('2026-08-01'),
+    } as never);
+
+    await expect(service.create(baseDto)).rejects.toMatchObject({ status: 422 });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('422s when the rate has already expired as of calculatedAt', async () => {
+    rateRepository.findById.mockResolvedValue({
+      ...rateRow,
+      effectiveTo: new Date('2026-06-01'),
+    } as never);
+
+    await expect(service.create(baseDto)).rejects.toMatchObject({ status: 422 });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('succeeds when calculatedAt falls exactly on effectiveFrom or effectiveTo (inclusive bounds)', async () => {
+    rateRepository.findById.mockResolvedValue({
+      ...rateRow,
+      effectiveFrom: baseDto.calculatedAt,
+      effectiveTo: baseDto.calculatedAt,
+    } as never);
+    repository.create.mockResolvedValue(createdRow);
+
+    await expect(service.create(baseDto)).resolves.toBe(createdRow);
   });
 
   it('propagates repository errors on create', async () => {

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.service.spec.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.service.spec.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '../../../../node_modules/.prisma/client-incentive-wages-service';
 import { IncentiveEventService } from './incentiveEvent.service';
 import type { IncentiveEventRepository } from './incentiveEvent.repository';
+import type { IncentiveRateRepository } from '../rates/incentiveRate.repository';
 import type { CreateIncentiveEventInput } from './dto/create-incentiveEvent.dto';
 
 describe('IncentiveEventService', () => {
@@ -8,11 +9,14 @@ describe('IncentiveEventService', () => {
     findMany: jest.fn(),
     create: jest.fn(),
   } as unknown as jest.Mocked<IncentiveEventRepository>;
+  const rateRepository = {
+    findById: jest.fn(),
+  } as unknown as jest.Mocked<IncentiveRateRepository>;
   let service: IncentiveEventService;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new IncentiveEventService(repository);
+    service = new IncentiveEventService(repository, rateRepository);
   });
 
   it('lists via repository', async () => {
@@ -28,9 +32,13 @@ describe('IncentiveEventService', () => {
     eventMonth: new Date('2026-07-01'),
     rateId: '33333333-3333-3333-3333-333333333333',
     quantity: 1,
-    amountInr: 150,
     eligibilityStatus: 'ELIGIBLE',
     calculatedAt: new Date('2026-07-14T10:00:00Z'),
+  };
+
+  const rateRow = {
+    id: baseDto.rateId,
+    amountInr: new Prisma.Decimal(150),
   };
 
   const createdRow = {
@@ -41,7 +49,7 @@ describe('IncentiveEventService', () => {
     eventMonth: baseDto.eventMonth,
     rateId: baseDto.rateId,
     quantity: new Prisma.Decimal(baseDto.quantity ?? 1),
-    amountInr: new Prisma.Decimal(baseDto.amountInr),
+    amountInr: new Prisma.Decimal(150),
     eligibilityStatus: baseDto.eligibilityStatus,
     calculatedAt: baseDto.calculatedAt,
     createdAt: new Date(),
@@ -58,13 +66,24 @@ describe('IncentiveEventService', () => {
     await expect(service.list()).resolves.toBe(rows);
   });
 
-  it('creates via repository with the given data', async () => {
+  it('re-derives amountInr from the referenced rate, never trusting a client value', async () => {
+    rateRepository.findById.mockResolvedValue(rateRow as never);
     repository.create.mockResolvedValue(createdRow);
+
     await expect(service.create(baseDto)).resolves.toBe(createdRow);
-    expect(repository.create).toHaveBeenCalledWith(baseDto);
+
+    expect(rateRepository.findById).toHaveBeenCalledWith(baseDto.rateId);
+    expect(repository.create).toHaveBeenCalledWith({ ...baseDto, amountInr: 150 });
+  });
+
+  it('404s when rateId does not reference an existing rate', async () => {
+    rateRepository.findById.mockResolvedValue(null);
+    await expect(service.create(baseDto)).rejects.toMatchObject({ status: 404 });
+    expect(repository.create).not.toHaveBeenCalled();
   });
 
   it('propagates repository errors on create', async () => {
+    rateRepository.findById.mockResolvedValue(rateRow as never);
     repository.create.mockRejectedValue(new Error('db down'));
     await expect(service.create(baseDto)).rejects.toThrow('db down');
   });

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.service.spec.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.service.spec.ts
@@ -14,9 +14,20 @@ describe('IncentiveEventService', () => {
   } as unknown as jest.Mocked<IncentiveRateRepository>;
   let service: IncentiveEventService;
 
+  // Pinned so the rate's effective-window check (anchored to the server
+  // clock, not the caller-supplied calculatedAt — see create()'s doc
+  // comment) has a fixed "now" to assert against.
+  const NOW = new Date('2026-07-20T00:00:00Z');
+
   beforeEach(() => {
     jest.resetAllMocks();
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    jest.setSystemTime(NOW);
     service = new IncentiveEventService(repository, rateRepository);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('lists via repository', async () => {
@@ -92,7 +103,7 @@ describe('IncentiveEventService', () => {
     expect(repository.create).not.toHaveBeenCalled();
   });
 
-  it('422s when the rate is not yet effective as of calculatedAt', async () => {
+  it('422s when the rate is not yet effective (effectiveFrom is in the future)', async () => {
     rateRepository.findById.mockResolvedValue({
       ...rateRow,
       effectiveFrom: new Date('2026-08-01'),
@@ -102,7 +113,7 @@ describe('IncentiveEventService', () => {
     expect(repository.create).not.toHaveBeenCalled();
   });
 
-  it('422s when the rate has already expired as of calculatedAt', async () => {
+  it('422s when the rate has already expired', async () => {
     rateRepository.findById.mockResolvedValue({
       ...rateRow,
       effectiveTo: new Date('2026-06-01'),
@@ -112,15 +123,32 @@ describe('IncentiveEventService', () => {
     expect(repository.create).not.toHaveBeenCalled();
   });
 
-  it('succeeds when calculatedAt falls exactly on effectiveFrom or effectiveTo (inclusive bounds)', async () => {
+  it('succeeds when the current time falls exactly on effectiveFrom or effectiveTo (inclusive bounds)', async () => {
     rateRepository.findById.mockResolvedValue({
       ...rateRow,
-      effectiveFrom: baseDto.calculatedAt,
-      effectiveTo: baseDto.calculatedAt,
+      effectiveFrom: NOW,
+      effectiveTo: NOW,
     } as never);
     repository.create.mockResolvedValue(createdRow);
 
     await expect(service.create(baseDto)).resolves.toBe(createdRow);
+  });
+
+  it("ignores a caller-supplied calculatedAt outside the rate's effective window — the check is server-clock-anchored, not client-controlled", async () => {
+    // A rate that is NOT effective now (expired well before NOW), paired
+    // with a calculatedAt the client claims falls inside the window. Must
+    // still 422 — calculatedAt must never be able to make an expired/
+    // not-yet-effective rate pass this check.
+    rateRepository.findById.mockResolvedValue({
+      ...rateRow,
+      effectiveFrom: new Date('2026-01-01'),
+      effectiveTo: new Date('2026-02-01'),
+    } as never);
+
+    await expect(
+      service.create({ ...baseDto, calculatedAt: new Date('2026-01-15') }),
+    ).rejects.toMatchObject({ status: 422 });
+    expect(repository.create).not.toHaveBeenCalled();
   });
 
   it('propagates repository errors on create', async () => {

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.service.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.service.ts
@@ -25,10 +25,16 @@ export class IncentiveEventService {
    * `findById` alone isn't enough to trust the pairing: a caller can
    * discover any active rate's id via `GET /incentive-rates/active` and
    * submit it with an unrelated `sourceEntityType`, or one that's expired/
-   * not yet effective for `calculatedAt` — closing "arbitrary amount" but
-   * not "any real rate's amount, correct or not". This re-validates the
-   * fetched rate actually applies to this event before trusting its
-   * amountInr.
+   * not yet effective — closing "arbitrary amount" but not "any real rate's
+   * amount, correct or not". This re-validates the fetched rate actually
+   * applies to this event before trusting its amountInr.
+   *
+   * The effective-window check is anchored to the server's own clock, NOT
+   * `dto.calculatedAt` — that field is entirely caller-supplied (see the
+   * DTO), so gating eligibility on it would let a caller submit any
+   * `calculatedAt` value to make an expired or not-yet-effective rate pass.
+   * Rates are meant to be currently effective at the moment an event is
+   * recorded, not effective as of whatever the client claims.
    *
    * Does NOT check `geographyUnitId` scope — no caller geography is wired
    * into this endpoint's request/auth context yet, so a rate meant for one
@@ -45,11 +51,12 @@ export class IncentiveEventService {
         `rateId does not refer to a ${dto.sourceEntityType} rate (it is ${rate.rateType}).`,
       );
     }
-    if (rate.effectiveFrom > dto.calculatedAt) {
-      throw unprocessable('rateId does not refer to a rate effective as of calculatedAt.');
+    const now = new Date();
+    if (rate.effectiveFrom > now) {
+      throw unprocessable('rateId does not refer to a currently effective rate.');
     }
-    if (rate.effectiveTo && rate.effectiveTo < dto.calculatedAt) {
-      throw unprocessable('rateId does not refer to a rate effective as of calculatedAt.');
+    if (rate.effectiveTo && rate.effectiveTo < now) {
+      throw unprocessable('rateId does not refer to a currently effective rate.');
     }
 
     return this.repository.create({ ...dto, amountInr: Number(rate.amountInr) });

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.service.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.service.ts
@@ -1,15 +1,31 @@
+import { notFound } from '@armman/service-commons';
 import type { IncentiveEventRepository } from './incentiveEvent.repository';
+import type { IncentiveRateRepository } from '../rates/incentiveRate.repository';
 import type { CreateIncentiveEventInput } from './dto/create-incentiveEvent.dto';
 
 /** Incentive event domain logic. Data access is delegated to the repository. */
 export class IncentiveEventService {
-  constructor(private readonly repository: IncentiveEventRepository) {}
+  constructor(
+    private readonly repository: IncentiveEventRepository,
+    private readonly rateRepository: IncentiveRateRepository,
+  ) {}
 
   list() {
     return this.repository.findMany();
   }
 
-  create(dto: CreateIncentiveEventInput) {
-    return this.repository.create(dto);
+  /**
+   * Re-derives amountInr from the referenced rate server-side — never
+   * trusted from the request body (see createIncentiveEventSchema's doc
+   * comment). Both ADMIN and SUPERVISOR can reach this endpoint (the latter
+   * needed for the ACCOMPANIED_REFERRAL incentive trigger), so a client
+   * choosing its own payout amount would otherwise be a privilege
+   * escalation — any caller can pick a rateId, but not the amount it pays.
+   */
+  async create(dto: CreateIncentiveEventInput) {
+    const rate = await this.rateRepository.findById(dto.rateId);
+    if (!rate) throw notFound('Incentive rate not found.');
+
+    return this.repository.create({ ...dto, amountInr: Number(rate.amountInr) });
   }
 }

--- a/apps/incentive-wages-service/src/incentives/incentiveEvent.service.ts
+++ b/apps/incentive-wages-service/src/incentives/incentiveEvent.service.ts
@@ -1,4 +1,4 @@
-import { notFound } from '@armman/service-commons';
+import { notFound, unprocessable } from '@armman/service-commons';
 import type { IncentiveEventRepository } from './incentiveEvent.repository';
 import type { IncentiveRateRepository } from '../rates/incentiveRate.repository';
 import type { CreateIncentiveEventInput } from './dto/create-incentiveEvent.dto';
@@ -21,10 +21,36 @@ export class IncentiveEventService {
    * needed for the ACCOMPANIED_REFERRAL incentive trigger), so a client
    * choosing its own payout amount would otherwise be a privilege
    * escalation — any caller can pick a rateId, but not the amount it pays.
+   *
+   * `findById` alone isn't enough to trust the pairing: a caller can
+   * discover any active rate's id via `GET /incentive-rates/active` and
+   * submit it with an unrelated `sourceEntityType`, or one that's expired/
+   * not yet effective for `calculatedAt` — closing "arbitrary amount" but
+   * not "any real rate's amount, correct or not". This re-validates the
+   * fetched rate actually applies to this event before trusting its
+   * amountInr.
+   *
+   * Does NOT check `geographyUnitId` scope — no caller geography is wired
+   * into this endpoint's request/auth context yet, so a rate meant for one
+   * geography can still be paired with an event anywhere. Known gap, not
+   * fixed here: closing it needs a caller-geography param on this endpoint,
+   * a larger change than this validation tightening.
    */
   async create(dto: CreateIncentiveEventInput) {
     const rate = await this.rateRepository.findById(dto.rateId);
     if (!rate) throw notFound('Incentive rate not found.');
+
+    if (rate.rateType !== dto.sourceEntityType) {
+      throw unprocessable(
+        `rateId does not refer to a ${dto.sourceEntityType} rate (it is ${rate.rateType}).`,
+      );
+    }
+    if (rate.effectiveFrom > dto.calculatedAt) {
+      throw unprocessable('rateId does not refer to a rate effective as of calculatedAt.');
+    }
+    if (rate.effectiveTo && rate.effectiveTo < dto.calculatedAt) {
+      throw unprocessable('rateId does not refer to a rate effective as of calculatedAt.');
+    }
 
     return this.repository.create({ ...dto, amountInr: Number(rate.amountInr) });
   }

--- a/apps/incentive-wages-service/src/rates/dto/list-active-rate.dto.spec.ts
+++ b/apps/incentive-wages-service/src/rates/dto/list-active-rate.dto.spec.ts
@@ -1,0 +1,38 @@
+import { listActiveRateQuerySchema } from './list-active-rate.dto';
+
+describe('listActiveRateQuerySchema', () => {
+  it('accepts a minimal query with only rateType', () => {
+    expect(listActiveRateQuerySchema.safeParse({ rateType: 'REFERRAL' }).success).toBe(true);
+  });
+
+  it('accepts referralType, geographyUnitId, and asOf', () => {
+    const result = listActiveRateQuerySchema.safeParse({
+      rateType: 'REFERRAL',
+      referralType: 'ACCOMPANIED',
+      geographyUnitId: '11111111-1111-1111-1111-111111111111',
+      asOf: '2026-08-07',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid rateType', () => {
+    expect(listActiveRateQuerySchema.safeParse({ rateType: 'BOGUS' }).success).toBe(false);
+  });
+
+  it('rejects an invalid referralType', () => {
+    const result = listActiveRateQuerySchema.safeParse({
+      rateType: 'REFERRAL',
+      referralType: 'BOGUS',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing rateType', () => {
+    expect(listActiveRateQuerySchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = listActiveRateQuerySchema.safeParse({ rateType: 'REFERRAL', extra: 'x' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/incentive-wages-service/src/rates/dto/list-active-rate.dto.ts
+++ b/apps/incentive-wages-service/src/rates/dto/list-active-rate.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Query params for `GET /incentive-rates/active` — resolves the currently
+ * effective rate for a rate/referral type combination (FR-SV-4.9's
+ * incentive trigger needs to know the amount before creating an
+ * incentive_events row). `.strict()` rejects unknown fields, matching this
+ * repo's global convention.
+ */
+export const listActiveRateQuerySchema = z
+  .object({
+    rateType: z.enum(['VISIT', 'REFERRAL', 'MEETING', 'TRAINING', 'RETAINER']),
+    referralType: z.enum(['STANDARD', 'ACCOMPANIED']).optional(),
+    geographyUnitId: z.string().uuid().optional(),
+    asOf: z.coerce.date().optional(),
+  })
+  .strict();
+
+export type ListActiveRateQuery = z.infer<typeof listActiveRateQuerySchema>;

--- a/apps/incentive-wages-service/src/rates/incentiveRate.controller.ts
+++ b/apps/incentive-wages-service/src/rates/incentiveRate.controller.ts
@@ -1,0 +1,72 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { IncentiveRateService } from './incentiveRate.service';
+import { listActiveRateQuerySchema } from './dto/list-active-rate.dto';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  notFound,
+  ok,
+  requireRoles,
+  trustGatewayIdentity,
+  validate,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const incentiveRateSchema = z.object({
+  id: z.string().uuid(),
+  rateType: z.enum(['VISIT', 'REFERRAL', 'MEETING', 'TRAINING', 'RETAINER']),
+  referralType: z.enum(['STANDARD', 'ACCOMPANIED']).nullable(),
+  geographyUnitId: z.string().uuid().nullable(),
+  amountInr: z.number().openapi({ example: 100 }),
+  effectiveFrom: z.string().datetime(),
+  effectiveTo: z.string().datetime().nullable(),
+});
+
+const apiErrorSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+  errorCode: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+  details: z.record(z.unknown()).optional(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Incentive rate HTTP routes. Mounted under the global `api/v1` prefix.
+ * Read-only lookup — rates themselves are managed elsewhere (out of scope
+ * here); this exists so a caller deciding an ACCOMPANIED_REFERRAL card
+ * (FR-SV-4.9) can resolve the amount before creating an incentive event.
+ */
+export function createIncentiveRateRouter(service: IncentiveRateService) {
+  const doc = createDocumentedRouter();
+
+  doc.get(
+    '/incentive-rates/active',
+    {
+      summary: 'Resolve the currently effective incentive rate for a rate/referral type',
+      tags: ['Incentives'],
+      query: listActiveRateQuerySchema,
+      responses: {
+        200: { description: 'Active rate', schema: envelope(incentiveRateSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'No active rate found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(listActiveRateQuerySchema, 'query'),
+    asyncHandler(async (req, res) => {
+      const rate = await service.findActive(req.query as never);
+      if (!rate) throw notFound('No active incentive rate found.');
+      res.json(ok(rate));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/incentive-wages-service/src/rates/incentiveRate.module.ts
+++ b/apps/incentive-wages-service/src/rates/incentiveRate.module.ts
@@ -1,0 +1,15 @@
+import type { DocumentedRouter } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { IncentiveRateRepository } from './incentiveRate.repository';
+import { IncentiveRateService } from './incentiveRate.service';
+import { createIncentiveRateRouter } from './incentiveRate.controller';
+
+/**
+ * Composition root for the incentive-rates feature: wires repository →
+ * service → router.
+ */
+export function createIncentiveRateModule(prisma: PrismaService): DocumentedRouter {
+  const repository = new IncentiveRateRepository(prisma);
+  const service = new IncentiveRateService(repository);
+  return createIncentiveRateRouter(service);
+}

--- a/apps/incentive-wages-service/src/rates/incentiveRate.repository.ts
+++ b/apps/incentive-wages-service/src/rates/incentiveRate.repository.ts
@@ -1,0 +1,45 @@
+import type { PrismaService } from '../prisma/prisma.service';
+
+/** Data access for incentive rates. Owns only this service's `incentive_rates` table. */
+export class IncentiveRateRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Looks up a rate by id — used by IncentiveEventService.create to
+   * re-derive amountInr server-side rather than trust a client-supplied
+   * value (see createIncentiveEventSchema's doc comment).
+   */
+  findById(id: string) {
+    return this.prisma.incentiveRate.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  /**
+   * Finds the rate effective as of `asOf` for a rate/referral type,
+   * preferring a geography-specific rate over a global one (`geographyUnitId:
+   * null`) when both exist. Ordering geography-specific first, then by
+   * `effectiveFrom` descending, means `findFirst` naturally returns the most
+   * specific, most recent applicable rate.
+   */
+  findActiveRate(
+    rateType: string,
+    referralType: string | undefined,
+    geographyUnitId: string | undefined,
+    asOf: Date,
+  ) {
+    return this.prisma.incentiveRate.findFirst({
+      where: {
+        rateType: rateType as never,
+        referralType: (referralType ?? null) as never,
+        isDeleted: false,
+        effectiveFrom: { lte: asOf },
+        AND: [
+          { OR: [{ effectiveTo: null }, { effectiveTo: { gte: asOf } }] },
+          geographyUnitId
+            ? { OR: [{ geographyUnitId }, { geographyUnitId: null }] }
+            : { geographyUnitId: null },
+        ],
+      },
+      orderBy: [{ geographyUnitId: { sort: 'desc', nulls: 'last' } }, { effectiveFrom: 'desc' }],
+    });
+  }
+}

--- a/apps/incentive-wages-service/src/rates/incentiveRate.service.spec.ts
+++ b/apps/incentive-wages-service/src/rates/incentiveRate.service.spec.ts
@@ -1,0 +1,52 @@
+import { IncentiveRateService } from './incentiveRate.service';
+import type { IncentiveRateRepository } from './incentiveRate.repository';
+
+describe('IncentiveRateService', () => {
+  const repository = {
+    findActiveRate: jest.fn(),
+  } as unknown as jest.Mocked<IncentiveRateRepository>;
+  let service: IncentiveRateService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new IncentiveRateService(repository);
+  });
+
+  it('resolves via repository with the given query', async () => {
+    const rate = { id: 'rate-1', amountInr: 100 };
+    repository.findActiveRate.mockResolvedValue(rate as never);
+
+    const result = await service.findActive({
+      rateType: 'REFERRAL',
+      referralType: 'ACCOMPANIED',
+      geographyUnitId: undefined,
+      asOf: new Date('2026-08-07'),
+    });
+
+    expect(result).toBe(rate);
+    expect(repository.findActiveRate).toHaveBeenCalledWith(
+      'REFERRAL',
+      'ACCOMPANIED',
+      undefined,
+      new Date('2026-08-07'),
+    );
+  });
+
+  it('defaults asOf to now when not supplied', async () => {
+    repository.findActiveRate.mockResolvedValue(null);
+
+    await service.findActive({ rateType: 'REFERRAL' });
+
+    expect(repository.findActiveRate).toHaveBeenCalledWith(
+      'REFERRAL',
+      undefined,
+      undefined,
+      expect.any(Date),
+    );
+  });
+
+  it('returns null when no active rate is found', async () => {
+    repository.findActiveRate.mockResolvedValue(null);
+    await expect(service.findActive({ rateType: 'REFERRAL' })).resolves.toBeNull();
+  });
+});

--- a/apps/incentive-wages-service/src/rates/incentiveRate.service.ts
+++ b/apps/incentive-wages-service/src/rates/incentiveRate.service.ts
@@ -1,0 +1,16 @@
+import type { IncentiveRateRepository } from './incentiveRate.repository';
+import type { ListActiveRateQuery } from './dto/list-active-rate.dto';
+
+/** Incentive rate domain logic. Data access is delegated to the repository. */
+export class IncentiveRateService {
+  constructor(private readonly repository: IncentiveRateRepository) {}
+
+  findActive(query: ListActiveRateQuery) {
+    return this.repository.findActiveRate(
+      query.rateType,
+      query.referralType,
+      query.geographyUnitId,
+      query.asOf ?? new Date(),
+    );
+  }
+}

--- a/apps/risk-referral-service/.env.example
+++ b/apps/risk-referral-service/.env.example
@@ -8,3 +8,4 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
+API_GATEWAY_BASE_URL=http://localhost:3000

--- a/apps/risk-referral-service/jest.config.ts
+++ b/apps/risk-referral-service/jest.config.ts
@@ -3,5 +3,6 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }] },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   coverageDirectory: '../../coverage/apps/risk-referral-service',
 };

--- a/apps/risk-referral-service/src/app.module.ts
+++ b/apps/risk-referral-service/src/app.module.ts
@@ -19,6 +19,7 @@ export {
   asyncHandler,
   ok,
   fail,
+  validate,
   validateBody,
   requireRoles,
   trustGatewayIdentity,

--- a/apps/risk-referral-service/src/app.module.ts
+++ b/apps/risk-referral-service/src/app.module.ts
@@ -23,6 +23,7 @@ export {
   validateBody,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/risk-referral-service/src/config/app-config.ts
+++ b/apps/risk-referral-service/src/config/app-config.ts
@@ -16,7 +16,6 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
-  API_GATEWAY_BASE_URL: z.string().url().default('http://localhost:3000'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/risk-referral-service/src/config/app-config.ts
+++ b/apps/risk-referral-service/src/config/app-config.ts
@@ -16,6 +16,7 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  API_GATEWAY_BASE_URL: z.string().url().default('http://localhost:3000'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/risk-referral-service/src/referrals/beneficiary.client.ts
+++ b/apps/risk-referral-service/src/referrals/beneficiary.client.ts
@@ -1,5 +1,11 @@
 import { badGateway, HttpError } from '@armman/service-commons';
-import { appConfig } from '../config/app-config';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — that schema requires DATABASE_URL/PUBLIC_BASE_URLS
+// with no defaults, which fails module load (process.exit) in any test that
+// never otherwise loads config, e.g. this service's own jest workers in CI.
+// Matches beneficiary-service's geography.client.ts/sakhi.client.ts convention.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
 
 export interface BeneficiaryCaseRecord {
   id: string;
@@ -22,7 +28,7 @@ export class BeneficiaryClient {
   ): Promise<BeneficiaryCaseRecord | null> {
     let res: Response;
     try {
-      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
         headers: { Authorization: authorizationHeader },
       });
     } catch {

--- a/apps/risk-referral-service/src/referrals/beneficiary.client.ts
+++ b/apps/risk-referral-service/src/referrals/beneficiary.client.ts
@@ -1,0 +1,46 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+export interface BeneficiaryCaseRecord {
+  id: string;
+  sakhiId: string;
+}
+
+/**
+ * Resolves a beneficiary's own record by calling beneficiary-service's
+ * GET /beneficiaries/:id through the gateway, forwarding the caller's own
+ * Authorization header — same pattern this service's sibling clients in
+ * approval-service/closure-reopen-service use. Used to resolve the assigned
+ * Sakhi's id for a referral (referrals carries no sakhiId column) so
+ * ReferralService.decide can scope a SUPERVISOR caller to their own roster,
+ * the same IDOR guard beneficiary-service's own single-case mutations apply.
+ */
+export class BeneficiaryClient {
+  async getById(
+    beneficiaryId: string,
+    authorizationHeader: string,
+  ): Promise<BeneficiaryCaseRecord | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the beneficiary — beneficiary-service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the beneficiary.');
+      }
+      throw badGateway(
+        'Unable to resolve the beneficiary — beneficiary-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: BeneficiaryCaseRecord };
+    return body.data;
+  }
+}

--- a/apps/risk-referral-service/src/referrals/dto/decide-referral.dto.spec.ts
+++ b/apps/risk-referral-service/src/referrals/dto/decide-referral.dto.spec.ts
@@ -1,0 +1,28 @@
+import { decideReferralSchema } from './decide-referral.dto';
+
+describe('decideReferralSchema', () => {
+  it('accepts LAPSE', () => {
+    expect(decideReferralSchema.safeParse({ decision: 'LAPSE' }).success).toBe(true);
+  });
+
+  it('accepts REFILL', () => {
+    expect(decideReferralSchema.safeParse({ decision: 'REFILL' }).success).toBe(true);
+  });
+
+  it('accepts COMPLETE', () => {
+    expect(decideReferralSchema.safeParse({ decision: 'COMPLETE' }).success).toBe(true);
+  });
+
+  it('rejects an invalid decision value', () => {
+    expect(decideReferralSchema.safeParse({ decision: 'APPROVE' }).success).toBe(false);
+  });
+
+  it('rejects a missing decision', () => {
+    expect(decideReferralSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = decideReferralSchema.safeParse({ decision: 'LAPSE', extra: 'x' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/risk-referral-service/src/referrals/dto/decide-referral.dto.ts
+++ b/apps/risk-referral-service/src/referrals/dto/decide-referral.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for a Supervisor's decision on a referral, backing two
+ * Quick Response card types with different outcomes (FR-SV-4.5, FR-SV-4.9):
+ * - LAPSE: Referral Follow-up Incomplete, approved — marks the referral
+ *   Lapsed (FR-SV-4.5).
+ * - REFILL: Referral Follow-up Incomplete, rejected — no status change; the
+ *   Sakhi must fill the follow-up form again.
+ * - COMPLETE: Accompanied Referral, approved — marks the referral Completed
+ *   (FR-SV-4.9). Its reject path makes no referral-side call at all (the
+ *   referral stays Pending), so REJECT isn't a value here.
+ *
+ * `.strict()` rejects unknown fields, matching this repo's global convention.
+ */
+export const decideReferralSchema = z
+  .object({
+    decision: z.enum(['LAPSE', 'REFILL', 'COMPLETE']),
+  })
+  .strict();
+
+export type DecideReferralInput = z.infer<typeof decideReferralSchema>;

--- a/apps/risk-referral-service/src/referrals/referral.controller.ts
+++ b/apps/risk-referral-service/src/referrals/referral.controller.ts
@@ -2,12 +2,14 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { ReferralService } from './referral.service';
 import { createReferralSchema } from './dto/create-referral.dto';
+import { decideReferralSchema } from './dto/decide-referral.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
   ok,
   requireRoles,
   trustGatewayIdentity,
+  validate,
   validateBody,
 } from '../app.module';
 
@@ -50,6 +52,14 @@ const referralSchema = z.object({
   supervisorApprovalStatus: z.enum(['NOT_REQUIRED', 'PENDING', 'APPROVED', 'REJECTED']),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+});
+
+const referralIdParamsSchema = z
+  .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
+  .strict();
+
+const decideReferralRequestSchema = decideReferralSchema.extend({
+  decision: decideReferralSchema.shape.decision.openapi({ example: 'LAPSE' }),
 });
 
 const apiErrorSchema = z.object({
@@ -110,6 +120,31 @@ export function createReferralRouter(service: ReferralService) {
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);
       res.status(201).json(ok(created));
+    }),
+  );
+
+  doc.patch(
+    '/referrals/:id/decision',
+    {
+      summary: "Decide a referral's follow-up outcome (FR-SV-4.5, FR-SV-4.9)",
+      tags: ['Referrals'],
+      params: referralIdParamsSchema,
+      responses: {
+        200: { description: 'Referral decided', schema: envelope(referralSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: { description: 'Referral not found', schema: apiErrorSchema },
+        409: { description: 'Referral is not in PENDING_FOLLOWUP status', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(referralIdParamsSchema, 'params'),
+    validateBody(decideReferralRequestSchema),
+    asyncHandler(async (req, res) => {
+      const updated = await service.decide(req.params.id, req.body);
+      res.json(ok(updated));
     }),
   );
 

--- a/apps/risk-referral-service/src/referrals/referral.controller.ts
+++ b/apps/risk-referral-service/src/referrals/referral.controller.ts
@@ -9,6 +9,7 @@ import {
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
   validate,
   validateBody,
 } from '../app.module';
@@ -133,7 +134,10 @@ export function createReferralRouter(service: ReferralService) {
         200: { description: 'Referral decided', schema: envelope(referralSchema) },
         400: { description: 'Validation error', schema: apiErrorSchema },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
-        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        403: {
+          description: "Caller role not permitted, or outside this Supervisor's roster",
+          schema: apiErrorSchema,
+        },
         404: { description: 'Referral not found', schema: apiErrorSchema },
         409: { description: 'Referral is not in PENDING_FOLLOWUP status', schema: apiErrorSchema },
       },
@@ -142,8 +146,11 @@ export function createReferralRouter(service: ReferralService) {
     requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(referralIdParamsSchema, 'params'),
     validateBody(decideReferralRequestSchema),
-    asyncHandler(async (req, res) => {
-      const updated = await service.decide(req.params.id, req.body);
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.decide(req.params.id, req.body, req.user, authorizationHeader);
       res.json(ok(updated));
     }),
   );

--- a/apps/risk-referral-service/src/referrals/referral.repository.ts
+++ b/apps/risk-referral-service/src/referrals/referral.repository.ts
@@ -9,7 +9,31 @@ export class ReferralRepository {
     return this.prisma.referral.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
   }
 
+  findById(id: string) {
+    return this.prisma.referral.findFirst({ where: { id, isDeleted: false } });
+  }
+
   create(data: CreateReferralInput) {
     return this.prisma.referral.create({ data });
+  }
+
+  /**
+   * Only updates a row that is still in `fromStatus` — `updateMany`'s
+   * affected count (rather than a separate read-then-write) is the
+   * concurrency guard: if the referral's status already changed between the
+   * caller's `findById` and this call, the count comes back 0 and the
+   * service turns that into a 409 instead of silently overwriting a
+   * since-changed referral. Same pattern as closures/reopen-requests.
+   */
+  async updateStatus(
+    id: string,
+    fromStatus: 'PENDING_FOLLOWUP',
+    toStatus: 'LAPSED' | 'COMPLETED',
+  ): Promise<boolean> {
+    const result = await this.prisma.referral.updateMany({
+      where: { id, isDeleted: false, status: fromStatus },
+      data: { status: toStatus },
+    });
+    return result.count > 0;
   }
 }

--- a/apps/risk-referral-service/src/referrals/referral.service.spec.ts
+++ b/apps/risk-referral-service/src/referrals/referral.service.spec.ts
@@ -1,17 +1,116 @@
 import { ReferralService } from './referral.service';
 import type { ReferralRepository } from './referral.repository';
 import type { CreateReferralInput } from './dto/create-referral.dto';
+import type { DecideReferralInput } from './dto/decide-referral.dto';
+
+function referral(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    visitId: null,
+    sourceSubmissionId: null,
+    referralTypeLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    referralDate: new Date('2026-07-01'),
+    triggerConditionListJson: null,
+    facilityType: null,
+    facilityName: null,
+    status: 'PENDING_FOLLOWUP' as const,
+    validTill: null,
+    supervisorApprovalStatus: 'NOT_REQUIRED' as const,
+    createdAt: new Date(),
+    createdByUserId: null,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+    ...overrides,
+  };
+}
 
 describe('ReferralService', () => {
   const repository = {
     findMany: jest.fn(),
+    findById: jest.fn(),
     create: jest.fn(),
+    updateStatus: jest.fn(),
   } as unknown as jest.Mocked<ReferralRepository>;
   let service: ReferralService;
 
   beforeEach(() => {
     jest.resetAllMocks();
     service = new ReferralService(repository);
+  });
+
+  describe('decide', () => {
+    it('LAPSE: marks a PENDING_FOLLOWUP referral as LAPSED', async () => {
+      const pending = referral();
+      const decided = referral({ status: 'LAPSED' });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.updateStatus.mockResolvedValue(true);
+
+      const dto: DecideReferralInput = { decision: 'LAPSE' };
+      await expect(service.decide(pending.id, dto)).resolves.toBe(decided);
+      expect(repository.updateStatus).toHaveBeenCalledWith(
+        pending.id,
+        'PENDING_FOLLOWUP',
+        'LAPSED',
+      );
+    });
+
+    it('COMPLETE: marks a PENDING_FOLLOWUP referral as COMPLETED', async () => {
+      const pending = referral();
+      const decided = referral({ status: 'COMPLETED' });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.updateStatus.mockResolvedValue(true);
+
+      const dto: DecideReferralInput = { decision: 'COMPLETE' };
+      await expect(service.decide(pending.id, dto)).resolves.toBe(decided);
+      expect(repository.updateStatus).toHaveBeenCalledWith(
+        pending.id,
+        'PENDING_FOLLOWUP',
+        'COMPLETED',
+      );
+    });
+
+    it('REFILL: makes no status change, returns the referral as-is', async () => {
+      const pending = referral();
+      repository.findById.mockResolvedValue(pending);
+
+      const dto: DecideReferralInput = { decision: 'REFILL' };
+      await expect(service.decide(pending.id, dto)).resolves.toBe(pending);
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('404s on an unknown id', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(service.decide('unknown-id', { decision: 'LAPSE' })).rejects.toMatchObject({
+        status: 404,
+      });
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('409s when the referral is not PENDING_FOLLOWUP (LAPSE)', async () => {
+      repository.findById.mockResolvedValue(referral({ status: 'COMPLETED' }));
+      await expect(
+        service.decide('11111111-1111-1111-1111-111111111111', { decision: 'LAPSE' }),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('409s when the referral is not PENDING_FOLLOWUP (REFILL)', async () => {
+      repository.findById.mockResolvedValue(referral({ status: 'LAPSED' }));
+      await expect(
+        service.decide('11111111-1111-1111-1111-111111111111', { decision: 'REFILL' }),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('409s when the conditional update races with a concurrent decision', async () => {
+      repository.findById.mockResolvedValueOnce(referral());
+      repository.updateStatus.mockResolvedValue(false);
+      await expect(
+        service.decide('11111111-1111-1111-1111-111111111111', { decision: 'LAPSE' }),
+      ).rejects.toMatchObject({ status: 409 });
+    });
   });
 
   it('lists via repository', async () => {

--- a/apps/risk-referral-service/src/referrals/referral.service.spec.ts
+++ b/apps/risk-referral-service/src/referrals/referral.service.spec.ts
@@ -1,7 +1,24 @@
+import type { AuthenticatedUser } from '@armman/service-commons';
 import { ReferralService } from './referral.service';
 import type { ReferralRepository } from './referral.repository';
 import type { CreateReferralInput } from './dto/create-referral.dto';
 import type { DecideReferralInput } from './dto/decide-referral.dto';
+import { BeneficiaryClient } from './beneficiary.client';
+import { listSakhiIdsForSupervisor } from './sakhi.client';
+
+jest.mock('./sakhi.client');
+
+const AUTH_HEADER = 'Bearer test-token';
+
+function caller(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
+  return {
+    id: '99999999-9999-9999-9999-999999999999',
+    roles: ['ADMIN'],
+    projectId: null,
+    geographyUnitId: null,
+    ...overrides,
+  };
+}
 
 function referral(overrides: Partial<Record<string, unknown>> = {}) {
   return {
@@ -34,11 +51,15 @@ describe('ReferralService', () => {
     create: jest.fn(),
     updateStatus: jest.fn(),
   } as unknown as jest.Mocked<ReferralRepository>;
+  const beneficiaryClient = {
+    getById: jest.fn(),
+  } as unknown as jest.Mocked<BeneficiaryClient>;
+  const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
   let service: ReferralService;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new ReferralService(repository);
+    service = new ReferralService(repository, beneficiaryClient);
   });
 
   describe('decide', () => {
@@ -49,7 +70,7 @@ describe('ReferralService', () => {
       repository.updateStatus.mockResolvedValue(true);
 
       const dto: DecideReferralInput = { decision: 'LAPSE' };
-      await expect(service.decide(pending.id, dto)).resolves.toBe(decided);
+      await expect(service.decide(pending.id, dto, caller(), AUTH_HEADER)).resolves.toBe(decided);
       expect(repository.updateStatus).toHaveBeenCalledWith(
         pending.id,
         'PENDING_FOLLOWUP',
@@ -64,7 +85,7 @@ describe('ReferralService', () => {
       repository.updateStatus.mockResolvedValue(true);
 
       const dto: DecideReferralInput = { decision: 'COMPLETE' };
-      await expect(service.decide(pending.id, dto)).resolves.toBe(decided);
+      await expect(service.decide(pending.id, dto, caller(), AUTH_HEADER)).resolves.toBe(decided);
       expect(repository.updateStatus).toHaveBeenCalledWith(
         pending.id,
         'PENDING_FOLLOWUP',
@@ -77,13 +98,15 @@ describe('ReferralService', () => {
       repository.findById.mockResolvedValue(pending);
 
       const dto: DecideReferralInput = { decision: 'REFILL' };
-      await expect(service.decide(pending.id, dto)).resolves.toBe(pending);
+      await expect(service.decide(pending.id, dto, caller(), AUTH_HEADER)).resolves.toBe(pending);
       expect(repository.updateStatus).not.toHaveBeenCalled();
     });
 
     it('404s on an unknown id', async () => {
       repository.findById.mockResolvedValue(null);
-      await expect(service.decide('unknown-id', { decision: 'LAPSE' })).rejects.toMatchObject({
+      await expect(
+        service.decide('unknown-id', { decision: 'LAPSE' }, caller(), AUTH_HEADER),
+      ).rejects.toMatchObject({
         status: 404,
       });
       expect(repository.updateStatus).not.toHaveBeenCalled();
@@ -92,7 +115,12 @@ describe('ReferralService', () => {
     it('409s when the referral is not PENDING_FOLLOWUP (LAPSE)', async () => {
       repository.findById.mockResolvedValue(referral({ status: 'COMPLETED' }));
       await expect(
-        service.decide('11111111-1111-1111-1111-111111111111', { decision: 'LAPSE' }),
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          { decision: 'LAPSE' },
+          caller(),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 409 });
       expect(repository.updateStatus).not.toHaveBeenCalled();
     });
@@ -100,7 +128,12 @@ describe('ReferralService', () => {
     it('409s when the referral is not PENDING_FOLLOWUP (REFILL)', async () => {
       repository.findById.mockResolvedValue(referral({ status: 'LAPSED' }));
       await expect(
-        service.decide('11111111-1111-1111-1111-111111111111', { decision: 'REFILL' }),
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          { decision: 'REFILL' },
+          caller(),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 409 });
     });
 
@@ -108,8 +141,93 @@ describe('ReferralService', () => {
       repository.findById.mockResolvedValueOnce(referral());
       repository.updateStatus.mockResolvedValue(false);
       await expect(
-        service.decide('11111111-1111-1111-1111-111111111111', { decision: 'LAPSE' }),
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          { decision: 'LAPSE' },
+          caller(),
+          AUTH_HEADER,
+        ),
       ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('MANAGER/ADMIN callers are unscoped — no beneficiary/roster lookup made', async () => {
+      const pending = referral();
+      const decided = referral({ status: 'LAPSED' });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.updateStatus.mockResolvedValue(true);
+
+      await service.decide(
+        pending.id,
+        { decision: 'LAPSE' },
+        caller({ roles: ['MANAGER'] }),
+        AUTH_HEADER,
+      );
+
+      expect(beneficiaryClient.getById).not.toHaveBeenCalled();
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+    });
+
+    it('403s when a SUPERVISOR targets a referral outside their own roster', async () => {
+      repository.findById.mockResolvedValue(referral());
+      beneficiaryClient.getById.mockResolvedValue({ id: 'ben-1', sakhiId: 'some-other-sakhi' });
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          { decision: 'LAPSE' },
+          caller({ roles: ['SUPERVISOR'], projectId: 'project-1' }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('allows a SUPERVISOR to decide a referral in their own roster', async () => {
+      const pending = referral();
+      const decided = referral({ status: 'LAPSED' });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.updateStatus.mockResolvedValue(true);
+      beneficiaryClient.getById.mockResolvedValue({ id: 'ben-1', sakhiId: 'sakhi-a' });
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+
+      await expect(
+        service.decide(
+          pending.id,
+          { decision: 'LAPSE' },
+          caller({ roles: ['SUPERVISOR'], projectId: 'project-1' }),
+          AUTH_HEADER,
+        ),
+      ).resolves.toBe(decided);
+    });
+
+    it('rejects a SUPERVISOR caller with no projectId', async () => {
+      repository.findById.mockResolvedValue(referral());
+
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          { decision: 'LAPSE' },
+          caller({ roles: ['SUPERVISOR'], projectId: null }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(beneficiaryClient.getById).not.toHaveBeenCalled();
+    });
+
+    it('404s when the referral links to a beneficiary that no longer exists', async () => {
+      repository.findById.mockResolvedValue(referral());
+      beneficiaryClient.getById.mockResolvedValue(null);
+
+      await expect(
+        service.decide(
+          '11111111-1111-1111-1111-111111111111',
+          { decision: 'LAPSE' },
+          caller({ roles: ['SUPERVISOR'], projectId: 'project-1' }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.updateStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/risk-referral-service/src/referrals/referral.service.ts
+++ b/apps/risk-referral-service/src/referrals/referral.service.ts
@@ -1,11 +1,16 @@
-import { conflict, notFound } from '@armman/service-commons';
+import { conflict, forbidden, notFound, type AuthenticatedUser } from '@armman/service-commons';
 import type { ReferralRepository } from './referral.repository';
 import type { CreateReferralInput } from './dto/create-referral.dto';
 import type { DecideReferralInput } from './dto/decide-referral.dto';
+import { BeneficiaryClient } from './beneficiary.client';
+import { listSakhiIdsForSupervisor } from './sakhi.client';
 
 /** Referral domain logic. Data access is delegated to the repository. */
 export class ReferralService {
-  constructor(private readonly repository: ReferralRepository) {}
+  constructor(
+    private readonly repository: ReferralRepository,
+    private readonly beneficiaryClient: BeneficiaryClient = new BeneficiaryClient(),
+  ) {}
 
   list() {
     return this.repository.findMany();
@@ -27,10 +32,45 @@ export class ReferralService {
    * Both real status transitions use the same PENDING_FOLLOWUP-only
    * conditional update — a referral not in that state 409s rather than
    * silently no-op'ing.
+   *
+   * A SUPERVISOR caller may only decide a referral belonging to a
+   * beneficiary assigned to their own Sakhi roster — referrals carries no
+   * sakhiId column, so this resolves it via beneficiary-service first. Same
+   * IDOR guard beneficiary-service's own applyLmpChange/reactivateCase and
+   * auth-service's reactivateUser apply to their single-record mutations;
+   * without it, any authenticated Supervisor/Manager/Admin could decide any
+   * referral system-wide. MANAGER/ADMIN are unscoped.
    */
-  async decide(id: string, dto: DecideReferralInput) {
+  async decide(
+    id: string,
+    dto: DecideReferralInput,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
     const existing = await this.repository.findById(id);
     if (!existing) throw notFound('Referral not found.');
+
+    if (caller.roles.includes('SUPERVISOR')) {
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
+      const beneficiary = await this.beneficiaryClient.getById(
+        existing.beneficiaryId,
+        authorizationHeader,
+      );
+      if (!beneficiary) {
+        throw notFound('The beneficiary linked to this referral was not found.');
+      }
+      const roster = await listSakhiIdsForSupervisor(
+        caller.projectId,
+        caller.id,
+        authorizationHeader,
+      );
+      if (!roster.includes(beneficiary.sakhiId)) {
+        throw forbidden("This referral is outside this Supervisor's roster.");
+      }
+    }
+
     if (existing.status !== 'PENDING_FOLLOWUP') {
       throw conflict(`Cannot decide a referral with status ${existing.status}.`);
     }

--- a/apps/risk-referral-service/src/referrals/referral.service.ts
+++ b/apps/risk-referral-service/src/referrals/referral.service.ts
@@ -1,5 +1,7 @@
+import { conflict, notFound } from '@armman/service-commons';
 import type { ReferralRepository } from './referral.repository';
 import type { CreateReferralInput } from './dto/create-referral.dto';
+import type { DecideReferralInput } from './dto/decide-referral.dto';
 
 /** Referral domain logic. Data access is delegated to the repository. */
 export class ReferralService {
@@ -11,5 +13,43 @@ export class ReferralService {
 
   create(dto: CreateReferralInput) {
     return this.repository.create(dto);
+  }
+
+  /**
+   * Decides a referral per two Quick Response card outcomes:
+   * - LAPSE (FR-SV-4.5 approve): PENDING_FOLLOWUP -> LAPSED.
+   * - REFILL (FR-SV-4.5 reject): no status change — the referral stays
+   *   PENDING_FOLLOWUP so the Sakhi can refill the follow-up form. Still
+   *   validates the referral exists and is actually PENDING_FOLLOWUP, so a
+   *   caller can't "refill" a referral that was never in that state.
+   * - COMPLETE (FR-SV-4.9 approve): PENDING_FOLLOWUP -> COMPLETED.
+   *
+   * Both real status transitions use the same PENDING_FOLLOWUP-only
+   * conditional update — a referral not in that state 409s rather than
+   * silently no-op'ing.
+   */
+  async decide(id: string, dto: DecideReferralInput) {
+    const existing = await this.repository.findById(id);
+    if (!existing) throw notFound('Referral not found.');
+    if (existing.status !== 'PENDING_FOLLOWUP') {
+      throw conflict(`Cannot decide a referral with status ${existing.status}.`);
+    }
+
+    if (dto.decision === 'REFILL') {
+      return existing;
+    }
+
+    const toStatus = dto.decision === 'LAPSE' ? 'LAPSED' : 'COMPLETED';
+    const updated = await this.repository.updateStatus(id, 'PENDING_FOLLOWUP', toStatus);
+    if (!updated) {
+      // Raced with another decision between the read above and the
+      // conditional update — same outcome as the check above, just caught a
+      // beat later instead of trusting a stale read.
+      throw conflict(`Cannot decide a referral with status ${existing.status}.`);
+    }
+
+    const decided = await this.repository.findById(id);
+    if (!decided) throw notFound('Referral not found.');
+    return decided;
   }
 }

--- a/apps/risk-referral-service/src/referrals/sakhi.client.ts
+++ b/apps/risk-referral-service/src/referrals/sakhi.client.ts
@@ -1,0 +1,39 @@
+import { badGateway } from '@armman/service-commons';
+import { appConfig } from '../config/app-config';
+
+interface ApiSakhi {
+  sakhiId: string;
+  supervisorId: string | null;
+}
+
+/**
+ * Resolves the Sakhi ids reporting to a given Supervisor, via auth-service's
+ * existing `GET /projects/:projectId/sakhis` (no new auth-service endpoint —
+ * that route already returns each Sakhi's `supervisorId`), called through
+ * the gateway. Used to scope `PATCH /referrals/:id/decision` to a
+ * Supervisor's own roster — mirrors beneficiary-service's
+ * listSakhiIdsForSupervisor exactly, duplicated here since this service has
+ * no shared client library to import it from (forklift rule: no
+ * cross-service imports).
+ */
+export async function listSakhiIdsForSupervisor(
+  projectId: string,
+  supervisorId: string,
+  authorizationHeader: string,
+): Promise<string[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/projects/${projectId}/sakhis`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve Sakhis — the auth service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve Sakhis — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: ApiSakhi[] };
+  return body.data.filter((sakhi) => sakhi.supervisorId === supervisorId).map((s) => s.sakhiId);
+}

--- a/apps/risk-referral-service/src/referrals/sakhi.client.ts
+++ b/apps/risk-referral-service/src/referrals/sakhi.client.ts
@@ -1,5 +1,7 @@
 import { badGateway } from '@armman/service-commons';
-import { appConfig } from '../config/app-config';
+
+// Read directly (not via appConfig) — see beneficiary.client.ts for why.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
 
 interface ApiSakhi {
   sakhiId: string;
@@ -23,7 +25,7 @@ export async function listSakhiIdsForSupervisor(
 ): Promise<string[]> {
   let res: Response;
   try {
-    res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/projects/${projectId}/sakhis`, {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/projects/${projectId}/sakhis`, {
       headers: { Authorization: authorizationHeader },
     });
   } catch {

--- a/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.spec.ts
@@ -3,11 +3,19 @@ import { createSupervisorEventSchema } from './create-supervisorEvent.dto';
 describe('createSupervisorEventSchema', () => {
   const baseInput = {
     projectId: '22222222-2222-2222-2222-222222222222',
-    supervisorId: '33333333-3333-3333-3333-333333333333',
     eventType: 'MEETING' as const,
     topicsJson: { agenda: 'review' },
     status: 'SCHEDULED' as const,
   };
+
+  it('rejects a client-supplied supervisorId', () => {
+    const result = createSupervisorEventSchema.safeParse({
+      ...baseInput,
+      supervisorId: '33333333-3333-3333-3333-333333333333',
+      eventDate: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    expect(result.success).toBe(false);
+  });
 
   it('rejects a past eventDate', () => {
     const result = createSupervisorEventSchema.safeParse({

--- a/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.ts
+++ b/apps/supervisor-operations-service/src/operations/dto/create-supervisorEvent.dto.ts
@@ -36,11 +36,16 @@ const jsonValueSchema = z.union([
  * rejects unknown fields, matching the repo-wide `forbidNonWhitelisted` behavior.
  * `photoMediaId` is application-mandatory when `status = COMPLETED` (ERD §4.7) —
  * enforced in the service layer, not here, so the API contract stays declarative.
+ *
+ * `supervisorId` is deliberately NOT a field here — it is always the
+ * authenticated caller's own id (see operations.service.ts), never
+ * client-supplied, so a Supervisor can never create an event under another
+ * Supervisor's name (matching create-inventory-transaction.dto.ts and
+ * create-call-log.dto.ts).
  */
 export const createSupervisorEventSchema = z
   .object({
     projectId: z.string().uuid(),
-    supervisorId: z.string().uuid(),
     eventType: z.enum(['MEETING', 'TRAINING']),
     // eventDate is @db.Date (calendar date, no time-of-day) — comparing its
     // coerced midnight value against the exact current instant would reject

--- a/apps/supervisor-operations-service/src/operations/operations.controller.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.controller.ts
@@ -285,8 +285,9 @@ export function createOperationsRouter(service: OperationsService) {
     trustGatewayIdentity,
     requireRoles('SUPERVISOR'),
     validateBody(createSupervisorEventRequestSchema),
-    asyncHandler(async (req, res) => {
-      const created = await service.createEvent(req.body);
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const created = await service.createEvent(req.body, req.user);
       res.status(201).json(ok(created));
     }),
   );

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -31,7 +31,7 @@ export class OperationsRepository {
     });
   }
 
-  createEvent(data: CreateSupervisorEventInput) {
+  createEvent(data: CreateSupervisorEventInput & { supervisorId: string }) {
     return this.prisma.supervisorEvent.create({ data });
   }
 

--- a/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.spec.ts
@@ -85,44 +85,67 @@ describe('OperationsService', () => {
     await expect(service.listEvents()).resolves.toBe(rows);
   });
 
-  it('creates an event via repository with the given data', async () => {
+  it('creates an event via repository, stamping supervisorId from the caller', async () => {
     const dto: CreateSupervisorEventInput = {
       projectId: '22222222-2222-2222-2222-222222222222',
-      supervisorId: '33333333-3333-3333-3333-333333333333',
       eventType: 'MEETING',
       eventDate: new Date('2026-07-01'),
       topicsJson: ['review'],
       status: 'SCHEDULED',
     };
     repository.createEvent.mockResolvedValue(eventRow);
-    await expect(service.createEvent(dto)).resolves.toBe(eventRow);
-    expect(repository.createEvent).toHaveBeenCalledWith(dto);
+    await expect(service.createEvent(dto, supervisorCaller)).resolves.toBe(eventRow);
+    expect(repository.createEvent).toHaveBeenCalledWith({
+      ...dto,
+      supervisorId: supervisorCaller.id,
+    });
+  });
+
+  it('stamps supervisorId from each caller independently, ignoring any client-supplied value', async () => {
+    const dto: CreateSupervisorEventInput = {
+      projectId: '22222222-2222-2222-2222-222222222222',
+      eventType: 'MEETING',
+      eventDate: new Date('2026-07-01'),
+      topicsJson: ['review'],
+      status: 'SCHEDULED',
+    };
+    repository.createEvent.mockResolvedValue(eventRow);
+
+    await service.createEvent(dto, otherSupervisorCaller);
+    expect(repository.createEvent).toHaveBeenCalledWith({
+      ...dto,
+      supervisorId: otherSupervisorCaller.id,
+    });
   });
 
   it('propagates repository errors on createEvent', async () => {
     repository.createEvent.mockRejectedValue(new Error('db down'));
     await expect(
-      service.createEvent({
-        projectId: '22222222-2222-2222-2222-222222222222',
-        supervisorId: '33333333-3333-3333-3333-333333333333',
-        eventType: 'MEETING',
-        eventDate: new Date('2026-07-01'),
-        topicsJson: ['review'],
-        status: 'SCHEDULED',
-      }),
+      service.createEvent(
+        {
+          projectId: '22222222-2222-2222-2222-222222222222',
+          eventType: 'MEETING',
+          eventDate: new Date('2026-07-01'),
+          topicsJson: ['review'],
+          status: 'SCHEDULED',
+        },
+        supervisorCaller,
+      ),
     ).rejects.toThrow('db down');
   });
 
   it('rejects a COMPLETED event with no photoMediaId without hitting the repository', async () => {
     await expect(
-      service.createEvent({
-        projectId: '22222222-2222-2222-2222-222222222222',
-        supervisorId: '33333333-3333-3333-3333-333333333333',
-        eventType: 'MEETING',
-        eventDate: new Date('2026-07-01'),
-        topicsJson: ['review'],
-        status: 'COMPLETED',
-      }),
+      service.createEvent(
+        {
+          projectId: '22222222-2222-2222-2222-222222222222',
+          eventType: 'MEETING',
+          eventDate: new Date('2026-07-01'),
+          topicsJson: ['review'],
+          status: 'COMPLETED',
+        },
+        supervisorCaller,
+      ),
     ).rejects.toThrow('photoMediaId is required when status is COMPLETED.');
     expect(repository.createEvent).not.toHaveBeenCalled();
   });
@@ -130,7 +153,6 @@ describe('OperationsService', () => {
   it('allows a COMPLETED event when photoMediaId is present', async () => {
     const dto: CreateSupervisorEventInput = {
       projectId: '22222222-2222-2222-2222-222222222222',
-      supervisorId: '33333333-3333-3333-3333-333333333333',
       eventType: 'MEETING',
       eventDate: new Date('2026-07-01'),
       topicsJson: ['review'],
@@ -138,14 +160,16 @@ describe('OperationsService', () => {
       photoMediaId: '55555555-5555-5555-5555-555555555555',
     };
     repository.createEvent.mockResolvedValue(eventRow);
-    await expect(service.createEvent(dto)).resolves.toBe(eventRow);
-    expect(repository.createEvent).toHaveBeenCalledWith(dto);
+    await expect(service.createEvent(dto, supervisorCaller)).resolves.toBe(eventRow);
+    expect(repository.createEvent).toHaveBeenCalledWith({
+      ...dto,
+      supervisorId: supervisorCaller.id,
+    });
   });
 
   it('rejects a duplicate event for the same supervisor/project/eventDate, without creating anything', async () => {
     const dto: CreateSupervisorEventInput = {
       projectId: '22222222-2222-2222-2222-222222222222',
-      supervisorId: '33333333-3333-3333-3333-333333333333',
       eventType: 'MEETING',
       eventDate: new Date('2026-07-01T10:00:00Z'),
       topicsJson: ['review'],
@@ -153,9 +177,11 @@ describe('OperationsService', () => {
     };
     repository.findConflictingEvent.mockResolvedValue(eventRow);
 
-    await expect(service.createEvent(dto)).rejects.toMatchObject({ status: 409 });
+    await expect(service.createEvent(dto, supervisorCaller)).rejects.toMatchObject({
+      status: 409,
+    });
     expect(repository.findConflictingEvent).toHaveBeenCalledWith(
-      dto.supervisorId,
+      supervisorCaller.id,
       dto.projectId,
       dto.eventDate,
     );
@@ -165,7 +191,6 @@ describe('OperationsService', () => {
   it('allows creating an event when no conflicting event exists', async () => {
     const dto: CreateSupervisorEventInput = {
       projectId: '22222222-2222-2222-2222-222222222222',
-      supervisorId: '33333333-3333-3333-3333-333333333333',
       eventType: 'MEETING',
       eventDate: new Date('2026-07-01T10:00:00Z'),
       topicsJson: ['review'],
@@ -174,8 +199,11 @@ describe('OperationsService', () => {
     repository.findConflictingEvent.mockResolvedValue(null);
     repository.createEvent.mockResolvedValue(eventRow);
 
-    await expect(service.createEvent(dto)).resolves.toBe(eventRow);
-    expect(repository.createEvent).toHaveBeenCalledWith(dto);
+    await expect(service.createEvent(dto, supervisorCaller)).resolves.toBe(eventRow);
+    expect(repository.createEvent).toHaveBeenCalledWith({
+      ...dto,
+      supervisorId: supervisorCaller.id,
+    });
   });
 
   it('lists events with filters via repository', async () => {

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -77,7 +77,15 @@ export class OperationsService {
     return this.repository.findEvents(filters);
   }
 
-  async createEvent(dto: CreateSupervisorEventInput) {
+  /**
+   * `supervisorId` is never taken from the client-supplied body — it's
+   * always the authenticated caller's own id, so a Supervisor can never
+   * create an event under another Supervisor's name (matching
+   * createInventoryTransactions/createCallLog). This also guarantees
+   * getEvent/cancelEvent/completeEvent's `supervisorId !== caller.id`
+   * ownership check is meaningful for the event's actual creator.
+   */
+  async createEvent(dto: CreateSupervisorEventInput, caller: CallerIdentity) {
     // The DTO's photoMediaId is application-mandatory when status = COMPLETED
     // (ERD §4.7) — the schema keeps it optional so SCHEDULED/CANCELLED events
     // can be created without a photo, so this rule is enforced here instead.
@@ -88,14 +96,14 @@ export class OperationsService {
     // same project — almost certainly a duplicate submission, not two real
     // meetings. Cancelled events don't block a re-create at that slot.
     const existingConflict = await this.repository.findConflictingEvent(
-      dto.supervisorId,
+      caller.id,
       dto.projectId,
       dto.eventDate,
     );
     if (existingConflict) {
       throw conflict('An event for this supervisor and project already exists at this date/time.');
     }
-    return this.repository.createEvent(dto);
+    return this.repository.createEvent({ ...dto, supervisorId: caller.id });
   }
 
   /** A SUPERVISOR may only fetch their own events. MANAGER and ADMIN are unrestricted. */

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -1,0 +1,267 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  schemaJsonSchema,
+  validationJsonSchema,
+  type FormField,
+} from '../src/forms/dto/form-field.dto';
+
+interface SeedPayload {
+  schemaJson: FormField[];
+  validationJson: unknown[];
+}
+
+function loadSeedData(fileName: string): SeedPayload {
+  const raw = readFileSync(join(__dirname, 'seed-data', fileName), 'utf8');
+  return JSON.parse(raw) as SeedPayload;
+}
+
+const motherRegistration = loadSeedData('mother-registration.json');
+const childRegistration = loadSeedData('child-registration.json');
+const ancVisit = loadSeedData('anc-visit.json');
+const infantVisit = loadSeedData('infant-visit.json');
+
+/**
+ * Every seed-data file must round-trip through the same Zod schemas the
+ * admin form-authoring API (PATCH .../versions/:id) validates against — a
+ * seed file with a typo or malformed field would otherwise only surface
+ * when someone runs the seed script against a real database.
+ */
+describe.each([
+  ['mother-registration.json', motherRegistration],
+  ['child-registration.json', childRegistration],
+  ['anc-visit.json', ancVisit],
+  ['infant-visit.json', infantVisit],
+])('%s', (_name, payload) => {
+  it('has a schemaJson that satisfies schemaJsonSchema', () => {
+    expect(() => schemaJsonSchema.parse(payload.schemaJson)).not.toThrow();
+  });
+
+  it('has a validationJson that satisfies validationJsonSchema', () => {
+    expect(() => validationJsonSchema.parse(payload.validationJson)).not.toThrow();
+  });
+
+  it('has unique question_codes', () => {
+    const codes = payload.schemaJson.map((f) => f.question_code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+});
+
+describe('anc-visit.json', () => {
+  const fields = ancVisit.schemaJson;
+  const byCode = new Map(fields.map((f) => [f.question_code, f]));
+
+  it('has exactly 56 fields, per the Revised App Form Final ANC visit form', () => {
+    expect(fields).toHaveLength(56);
+  });
+
+  it('groups fields into Tests, Symptoms, History, in that order', () => {
+    const sections = fields.map((f) => f.section);
+    const firstSymptoms = sections.indexOf('Symptoms');
+    const firstHistory = sections.indexOf('History');
+
+    expect(sections.slice(0, firstSymptoms).every((s) => s === 'Tests')).toBe(true);
+    expect(sections.slice(firstSymptoms, firstHistory).every((s) => s === 'Symptoms')).toBe(true);
+    expect(sections.slice(firstHistory).every((s) => s === 'History')).toBe(true);
+    expect(sections.filter((s) => s === 'Tests')).toHaveLength(11);
+    expect(sections.filter((s) => s === 'Symptoms')).toHaveLength(28);
+    expect(sections.filter((s) => s === 'History')).toHaveLength(17);
+  });
+
+  it('wires computed fields to the correct computedFrom formula', () => {
+    expect(byCode.get('edd')?.computedFrom).toBe('EDD_FROM_LMP');
+    expect(byCode.get('current_gestational_age_in_weeks')?.computedFrom).toBe(
+      'GESTATIONAL_AGE_AT_VISIT',
+    );
+    expect(byCode.get('bmi')?.computedFrom).toBe('BMI');
+    expect(byCode.get('gestational_weight_gain')?.computedFrom).toBe('GESTATIONAL_WEIGHT_GAIN');
+  });
+
+  it('applies numericRange to every field the source doc bounds', () => {
+    const expectedRanges: Record<string, { min: number; max: number }> = {
+      height_of_the_woman_in_cm: { min: 120, max: 190 },
+      current_weight_of_the_woman_in_kg: { min: 25, max: 100 },
+      mid_upper_arm_circumference_in_cm: { min: 10, max: 40 },
+      blood_pressure_bp_systolic: { min: 70, max: 300 },
+      blood_pressure_bp_diastolic: { min: 40, max: 130 },
+      body_temperature_in_f: { min: 94, max: 105 },
+      haemoglobin_hb_g_dl: { min: 1, max: 18 },
+      blood_glucose_in_mg_dl: { min: 40, max: 400 },
+      fundal_height_in_cm: { min: 10, max: 50 },
+      how_many_ifa_tablets_did_you_consume_since_last_visit: { min: 0, max: 35 },
+    };
+
+    for (const [code, range] of Object.entries(expectedRanges)) {
+      expect(byCode.get(code)?.numericRange).toEqual(range);
+    }
+  });
+
+  it('gates fetal movement/heart rate/fundal height behind gestational age >= 20 weeks', () => {
+    for (const code of ['fetal_movements', 'fetal_heart_rate', 'fundal_height_in_cm']) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'current_gestational_age_in_weeks',
+        operator: 'gte',
+        value: 20,
+      });
+    }
+  });
+
+  it('shows the not-met reason only when the beneficiary was not met', () => {
+    expect(byCode.get('if_no_mention_reasons')?.visibleWhen).toEqual({
+      field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+      operator: 'eq',
+      value: 'no',
+    });
+  });
+
+  it('shows the LMP edit + sonography image only when a sonography report exists', () => {
+    for (const code of ['lmp_date_edit', 'upload_sonography_report_image']) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'do_you_have_a_sonography_report_to_confirm_the_lmp_date',
+        operator: 'eq',
+        value: 'yes',
+      });
+    }
+  });
+
+  it('branches IFA tablet follow-ups on whether the woman is taking IFA tablets', () => {
+    expect(
+      byCode.get('how_many_ifa_tablets_did_you_consume_since_last_visit')?.visibleWhen,
+    ).toEqual({
+      field: 'are_you_taking_ifa_tablets',
+      operator: 'eq',
+      value: 'yes',
+    });
+    expect(
+      byCode.get('if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets')?.visibleWhen,
+    ).toEqual({ field: 'are_you_taking_ifa_tablets', operator: 'eq', value: 'no' });
+  });
+
+  it('shows USG date/type/finding only when USG was done', () => {
+    for (const code of ['if_yes_date_of_usg', 'type_of_usg', 'usg_finding']) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'have_you_done_usg_since_last_visit',
+        operator: 'eq',
+        value: 'yes',
+      });
+    }
+  });
+
+  it('has no cross-field validation rules', () => {
+    expect(ancVisit.validationJson).toEqual([]);
+  });
+});
+
+describe('infant-visit.json', () => {
+  const fields = infantVisit.schemaJson;
+  const byCode = new Map(fields.map((f) => [f.question_code, f]));
+
+  it('has exactly 81 fields, per the Revised App Form Final Infant Visits form', () => {
+    expect(fields).toHaveLength(81);
+  });
+
+  it('groups fields into Tests, Symptoms, History, in that order', () => {
+    const sections = fields.map((f) => f.section);
+    const firstSymptoms = sections.indexOf('Symptoms');
+    const firstHistory = sections.indexOf('History');
+
+    expect(sections.slice(0, firstSymptoms).every((s) => s === 'Tests')).toBe(true);
+    expect(sections.slice(firstSymptoms, firstHistory).every((s) => s === 'Symptoms')).toBe(true);
+    expect(sections.slice(firstHistory).every((s) => s === 'History')).toBe(true);
+    expect(sections.filter((s) => s === 'Tests')).toHaveLength(12);
+    expect(sections.filter((s) => s === 'Symptoms')).toHaveLength(20);
+    expect(sections.filter((s) => s === 'History')).toHaveLength(49);
+  });
+
+  it('applies numericRange to every field the source doc bounds', () => {
+    const expectedRanges: Record<string, { min: number; max: number }> = {
+      birth_weight_in_kg: { min: 0.5, max: 6 },
+      length_of_the_baby_at_the_time_of_birth_in_cm: { min: 25, max: 99 },
+      child_temprature_in_f: { min: 93, max: 105 },
+      child_respiratory_rate_2_12_months: { min: 10, max: 90 },
+      current_length_in_cm: { min: 25, max: 99 },
+      current_weight_in_kg: { min: 0.5, max: 15 },
+      muac_in_cms: { min: 5, max: 25 },
+    };
+
+    for (const [code, range] of Object.entries(expectedRanges)) {
+      expect(byCode.get(code)?.numericRange).toEqual(range);
+    }
+  });
+
+  it('gates thermal care practices to under 2 months and MUAC to 6 months and up', () => {
+    expect(byCode.get('thermal_care_practices')?.visibleWhen).toEqual({
+      field: 'age_in_months',
+      operator: 'lt',
+      value: 2,
+    });
+    expect(byCode.get('muac_in_cms')?.visibleWhen).toEqual({
+      field: 'age_in_months',
+      operator: 'gte',
+      value: 6,
+    });
+  });
+
+  it('shows the not-met reason only when the beneficiary was not met', () => {
+    expect(byCode.get('if_no_mention_reasons')?.visibleWhen).toEqual({
+      field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+      operator: 'eq',
+      value: 'no',
+    });
+  });
+
+  it('shows complementary-feeding follow-ups only once complementary feeding has started', () => {
+    for (const code of [
+      'how_many_times_do_child_take_meal_in_a_day',
+      'which_of_these_food_stuff_have_child_consumed_in_the_last_24_hours',
+      'which_of_the_following_foods_does_the_child_avoid_eating_or_you_avoid_giving_to_the_child',
+    ]) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'have_you_started_complementary_feeding_for_your_child',
+        operator: 'eq',
+        value: 'yes',
+      });
+    }
+  });
+
+  it('shows each vaccine date field only when that vaccine is marked given', () => {
+    const vaccinePairs: [string, string][] = [
+      ['bcg', 'bcg_date'],
+      ['opv_0', 'opv_0_date'],
+      ['hepatitis_b_birth_dose', 'hepatitis_b_date_birth_dose'],
+      ['vitamin_k', 'vitamin_k_date'],
+      ['opv_1', 'opv_1_date'],
+      ['pentavalent_1_dpt1', 'pentavalent_1_dpt1_date'],
+      ['ipv_1', 'ipv_1_date'],
+      ['rotavirus1', 'rotavirus1_date'],
+      ['pcv1', 'pcv1_date'],
+      ['opv_2', 'opv_2_date'],
+      ['pentavalent_2_dpt2', 'pentavalent_2_dpt2_date'],
+      ['rotavirus2', 'rotavirus2_date'],
+      ['opv_3', 'opv_3_date'],
+      ['pentavalent_3_dpt3', 'pentavalent_3_dpt3_date'],
+      ['ipv2', 'ipv2_date'],
+      ['rotavirus3', 'rotavirus3_date'],
+      ['pcv2', 'pcv2_date'],
+      ['mmr_1_mr1', 'mmr_1_mr1_date'],
+      ['pcv_booster', 'pcv_booster_date'],
+      ['vitamin_a', 'vitamin_a_date'],
+      ['opv_booster', 'opv_booster_date'],
+      ['mmr2_mr2', 'mmr2_mr2_date'],
+      ['dpt_booster1', 'dpt_booster1_date'],
+    ];
+
+    for (const [vaccineCode, dateCode] of vaccinePairs) {
+      expect(byCode.get(vaccineCode)).toBeDefined();
+      expect(byCode.get(dateCode)?.visibleWhen).toEqual({
+        field: vaccineCode,
+        operator: 'eq',
+        value: 'yes',
+      });
+    }
+  });
+
+  it('has no cross-field validation rules', () => {
+    expect(infantVisit.validationJson).toEqual([]);
+  });
+});

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -47,6 +47,53 @@ describe.each([
   });
 });
 
+describe('mother-registration.json', () => {
+  const byCode = new Map(motherRegistration.schemaJson.map((f) => [f.question_code, f]));
+
+  it('applies the LMP date rule (Registration_PW_D Q5)', () => {
+    expect(byCode.get('lmp_date')?.dateRule).toEqual({
+      notFuture: true,
+      notAfter: { field: 'registration_date' },
+      minDaysFrom: { field: 'registration_date', days: 30 },
+      maxDaysFrom: { field: 'registration_date', days: 240 },
+    });
+  });
+
+  it('applies the ANC-1 date rule (Registration_PW_D Q42)', () => {
+    expect(byCode.get('if_anc1_completed_please_record_the_date')?.dateRule).toEqual({
+      notBefore: { field: 'lmp_date' },
+      notAfter: { field: 'registration_date', offsetDays: 5 },
+    });
+  });
+
+  it('applies Td dose date ordering rules (Registration_PW_D Q44)', () => {
+    expect(byCode.get('td_1_date')?.dateRule).toEqual({ notFuture: true });
+    expect(byCode.get('td_2_date')?.dateRule).toEqual({
+      notFuture: true,
+      notBefore: { field: 'td_1_date' },
+    });
+    expect(byCode.get('td_booster_date')?.dateRule).toEqual({
+      notFuture: true,
+      notBefore: { field: 'td_2_date' },
+    });
+  });
+
+  it('applies NAME_NO_SPECIAL_CHARS to beneficiary_name (Registration_PW_D Q19)', () => {
+    expect(byCode.get('beneficiary_name')?.pattern).toBe('NAME_NO_SPECIAL_CHARS');
+  });
+
+  it('has exactly 3 EXCLUSIVE_OPTION rules for the "none/no known condition" checkbox groups', () => {
+    const exclusiveRules = motherRegistration.validationJson.filter(
+      (r) => (r as { rule: string }).rule === 'EXCLUSIVE_OPTION',
+    );
+    expect(exclusiveRules).toHaveLength(3);
+  });
+
+  it('has 8 total validationJson rules (5 existing + 3 new EXCLUSIVE_OPTION)', () => {
+    expect(motherRegistration.validationJson).toHaveLength(8);
+  });
+});
+
 describe('anc-visit.json', () => {
   const fields = ancVisit.schemaJson;
   const byCode = new Map(fields.map((f) => [f.question_code, f]));

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -130,6 +130,14 @@ describe('child-registration.json', () => {
     expect(byCode.get('mobile_number')?.exactLength).toBe(10);
   });
 
+  it('only requires mother_beneficiary_id when registering a child of a registered pregnant woman', () => {
+    expect(byCode.get('mother_beneficiary_id')?.visibleWhen).toEqual({
+      field: 'who_are_you_registering_in_the_program',
+      operator: 'eq',
+      value: 'child_of_a_registered_pregnant_woman',
+    });
+  });
+
   it('adds a visibleWhen-gated date field per vaccine (Q49)', () => {
     const vaccineCodes = ['bcg_date', 'opv_date', 'hepatitis_b_date', 'vitamin_k_date'];
     for (const code of vaccineCodes) {

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -218,26 +218,27 @@ describe('anc-visit.json', () => {
     }
   });
 
-  it('gates fetal movement/heart rate/fundal height behind gestational age >= 20 weeks', () => {
-    for (const code of ['fetal_movements', 'fetal_heart_rate', 'fundal_height_in_cm']) {
-      expect(conditionsOf(byCode.get(code)?.visibleWhen)).toContainEqual({
-        field: 'current_gestational_age_in_weeks',
-        operator: 'gte',
-        value: 20,
-      });
-    }
-  });
-
+  // visibleWhen is a single {field,operator,value} object only — never an
+  // array of ANDed conditions. The mobile client's FormVisibilityEvaluator
+  // does not parse an array shape and crashes the whole form load if it sees
+  // one (2026-08-07 incident: ANC_VISIT became unopenable for every Sakhi).
+  // A field that would otherwise need two conditions (its own condition AND
+  // "met beneficiary = yes") keeps only the met-beneficiary gate — the more
+  // recently confirmed, higher-impact fix — until mobile ships array support
+  // and the two-condition form can be restored.
   const MET_BENEFICIARY_YES = {
     field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
     operator: 'eq',
     value: 'yes',
   };
 
-  /** Normalizes visibleWhen (single condition or array) to an array for assertions. */
-  function conditionsOf(visibleWhen: unknown): unknown[] {
-    return Array.isArray(visibleWhen) ? visibleWhen : [visibleWhen];
-  }
+  it('never stores visibleWhen as an array — mobile only parses a single condition object', () => {
+    for (const field of fields) {
+      if (field.visibleWhen !== undefined) {
+        expect(Array.isArray(field.visibleWhen)).toBe(false);
+      }
+    }
+  });
 
   it('shows the not-met reason only when the beneficiary was not met', () => {
     // The only Q5+ field NOT gated behind met=yes — it's the met=no branch itself.
@@ -248,7 +249,7 @@ describe('anc-visit.json', () => {
     });
   });
 
-  it('gates every Q5+ field behind met-beneficiary=yes, in addition to any of its own conditions', () => {
+  it('gates every Q5+ field behind met-beneficiary=yes', () => {
     for (const field of fields) {
       if (
         [
@@ -260,44 +261,7 @@ describe('anc-visit.json', () => {
       ) {
         continue;
       }
-      expect(conditionsOf(field.visibleWhen)).toContainEqual(MET_BENEFICIARY_YES);
-    }
-  });
-
-  it('shows the LMP edit + sonography image only when a sonography report exists', () => {
-    for (const code of ['lmp_date_edit', 'upload_sonography_report_image']) {
-      expect(conditionsOf(byCode.get(code)?.visibleWhen)).toContainEqual({
-        field: 'do_you_have_a_sonography_report_to_confirm_the_lmp_date',
-        operator: 'eq',
-        value: 'yes',
-      });
-    }
-  });
-
-  it('branches IFA tablet follow-ups on whether the woman is taking IFA tablets', () => {
-    expect(
-      conditionsOf(
-        byCode.get('how_many_ifa_tablets_did_you_consume_since_last_visit')?.visibleWhen,
-      ),
-    ).toContainEqual({
-      field: 'are_you_taking_ifa_tablets',
-      operator: 'eq',
-      value: 'yes',
-    });
-    expect(
-      conditionsOf(
-        byCode.get('if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets')?.visibleWhen,
-      ),
-    ).toContainEqual({ field: 'are_you_taking_ifa_tablets', operator: 'eq', value: 'no' });
-  });
-
-  it('shows USG date/type/finding only when USG was done', () => {
-    for (const code of ['if_yes_date_of_usg', 'type_of_usg', 'usg_finding']) {
-      expect(conditionsOf(byCode.get(code)?.visibleWhen)).toContainEqual({
-        field: 'have_you_done_usg_since_last_visit',
-        operator: 'eq',
-        value: 'yes',
-      });
+      expect(field.visibleWhen).toEqual(MET_BENEFICIARY_YES);
     }
   });
 
@@ -376,28 +340,27 @@ describe('infant-visit.json', () => {
     }
   });
 
+  // visibleWhen is a single {field,operator,value} object only — never an
+  // array of ANDed conditions. The mobile client's FormVisibilityEvaluator
+  // does not parse an array shape and crashes the whole form load if it sees
+  // one (2026-08-07 incident: ANC_VISIT became unopenable for every Sakhi).
+  // Fields that would otherwise need two conditions (their own condition AND
+  // "met beneficiary = yes") keep only the met-beneficiary gate — the more
+  // recently confirmed, higher-impact fix — until mobile ships array support
+  // and these two-condition fields (age gating, complementary-feeding
+  // gating, per-vaccine date gating) can be restored.
   const MET_BENEFICIARY_YES_INFANT = {
     field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
     operator: 'eq',
     value: 'yes',
   };
 
-  /** Normalizes visibleWhen (single condition or array) to an array for assertions. */
-  function conditionsOfInfant(visibleWhen: unknown): unknown[] {
-    return Array.isArray(visibleWhen) ? visibleWhen : [visibleWhen];
-  }
-
-  it('gates thermal care practices to under 2 months and MUAC to 6 months and up', () => {
-    expect(conditionsOfInfant(byCode.get('thermal_care_practices')?.visibleWhen)).toContainEqual({
-      field: 'age_in_months',
-      operator: 'lt',
-      value: 2,
-    });
-    expect(conditionsOfInfant(byCode.get('muac_in_cms')?.visibleWhen)).toContainEqual({
-      field: 'age_in_months',
-      operator: 'gte',
-      value: 6,
-    });
+  it('never stores visibleWhen as an array — mobile only parses a single condition object', () => {
+    for (const field of fields) {
+      if (field.visibleWhen !== undefined) {
+        expect(Array.isArray(field.visibleWhen)).toBe(false);
+      }
+    }
   });
 
   it('shows the not-met reason only when the beneficiary was not met', () => {
@@ -409,7 +372,7 @@ describe('infant-visit.json', () => {
     });
   });
 
-  it('gates every Q5+ field behind met-beneficiary=yes, in addition to any of its own conditions', () => {
+  it('gates every Q5+ field behind met-beneficiary=yes', () => {
     for (const field of fields) {
       if (
         [
@@ -421,25 +384,11 @@ describe('infant-visit.json', () => {
       ) {
         continue;
       }
-      expect(conditionsOfInfant(field.visibleWhen)).toContainEqual(MET_BENEFICIARY_YES_INFANT);
+      expect(field.visibleWhen).toEqual(MET_BENEFICIARY_YES_INFANT);
     }
   });
 
-  it('shows complementary-feeding follow-ups only once complementary feeding has started', () => {
-    for (const code of [
-      'how_many_times_do_child_take_meal_in_a_day',
-      'which_of_these_food_stuff_have_child_consumed_in_the_last_24_hours',
-      'which_of_the_following_foods_does_the_child_avoid_eating_or_you_avoid_giving_to_the_child',
-    ]) {
-      expect(conditionsOfInfant(byCode.get(code)?.visibleWhen)).toContainEqual({
-        field: 'have_you_started_complementary_feeding_for_your_child',
-        operator: 'eq',
-        value: 'yes',
-      });
-    }
-  });
-
-  it('shows each vaccine date field only when that vaccine is marked given', () => {
+  it('has every vaccine date field present, gated behind met-beneficiary=yes', () => {
     const vaccinePairs: [string, string][] = [
       ['bcg', 'bcg_date'],
       ['opv_0', 'opv_0_date'],
@@ -468,11 +417,7 @@ describe('infant-visit.json', () => {
 
     for (const [vaccineCode, dateCode] of vaccinePairs) {
       expect(byCode.get(vaccineCode)).toBeDefined();
-      expect(conditionsOfInfant(byCode.get(dateCode)?.visibleWhen)).toContainEqual({
-        field: vaccineCode,
-        operator: 'eq',
-        value: 'yes',
-      });
+      expect(byCode.get(dateCode)?.visibleWhen).toEqual(MET_BENEFICIARY_YES_INFANT);
     }
   });
 

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -258,6 +258,28 @@ describe('anc-visit.json', () => {
   });
 
   it('gates every Q5+ field behind met-beneficiary=yes', () => {
+    // fetal_movements/fetal_heart_rate/fundal_height_in_cm are excluded here:
+    // per the source doc (row 10), they gate on gestational age >= 20 weeks
+    // instead, not on met-beneficiary — see the dedicated test below.
+    //
+    // lmp_date_edit/upload_sonography_report_image are excluded here: they
+    // gate on do_you_have_a_sonography_report_to_confirm_the_lmp_date=yes
+    // instead — that field is itself gated on met-beneficiary=yes, so the
+    // met-beneficiary condition still applies, one step removed. See the
+    // dedicated test below.
+    //
+    // how_many_ifa_tablets_did_you_consume_since_last_visit is excluded
+    // here: per the source doc (row 36-37), it gates on
+    // are_you_taking_ifa_tablets=yes instead — that field is itself gated
+    // on met-beneficiary=yes, same one-step-removed pattern as the
+    // sonography-report group above. See the dedicated test below.
+    //
+    // if_yes_enter_date_of_latest_anc_visit_at_the_health_facility is
+    // excluded here: per the source doc (Q40/Q41), it gates on
+    // have_you_visited_health_facility_since_my_last_visit=yes instead —
+    // that field is itself gated on met-beneficiary=yes, same
+    // one-step-removed pattern as the groups above. See the dedicated test
+    // below.
     for (const field of fields) {
       if (
         [
@@ -265,12 +287,75 @@ describe('anc-visit.json', () => {
           'visit_type',
           'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
           'if_no_mention_reasons',
+          'fetal_movements',
+          'fetal_heart_rate',
+          'fundal_height_in_cm',
+          'lmp_date_edit',
+          'upload_sonography_report_image',
+          'how_many_ifa_tablets_did_you_consume_since_last_visit',
+          'if_yes_enter_date_of_latest_anc_visit_at_the_health_facility',
         ].includes(field.question_code)
       ) {
         continue;
       }
       expect(field.visibleWhen).toEqual(MET_BENEFICIARY_YES);
     }
+  });
+
+  it('shows fetal_movements/fetal_heart_rate/fundal_height_in_cm only from 20 weeks gestation (row 10)', () => {
+    const GESTATIONAL_AGE_GTE_20 = {
+      field: 'current_gestational_age_in_weeks',
+      operator: 'gte',
+      value: '20',
+    };
+    for (const code of ['fetal_movements', 'fetal_heart_rate', 'fundal_height_in_cm']) {
+      expect(byCode.get(code)?.visibleWhen).toEqual(GESTATIONAL_AGE_GTE_20);
+    }
+  });
+
+  it('shows the IFA tablet count only when are_you_taking_ifa_tablets=yes (row 36-37)', () => {
+    expect(
+      byCode.get('how_many_ifa_tablets_did_you_consume_since_last_visit')?.visibleWhen,
+    ).toEqual({
+      field: 'are_you_taking_ifa_tablets',
+      operator: 'eq',
+      value: 'yes',
+    });
+    // The gating field itself is still met-beneficiary-gated, so the chain
+    // as a whole reduces to met-beneficiary=yes AND are-taking-ifa=yes.
+    expect(byCode.get('are_you_taking_ifa_tablets')?.visibleWhen).toEqual(MET_BENEFICIARY_YES);
+  });
+
+  it('gates the LMP-edit date and sonography image behind having a sonography report, not met-beneficiary directly', () => {
+    const HAS_SONOGRAPHY_REPORT_YES = {
+      field: 'do_you_have_a_sonography_report_to_confirm_the_lmp_date',
+      operator: 'eq',
+      value: 'yes',
+    };
+    expect(byCode.get('lmp_date_edit')?.visibleWhen).toEqual(HAS_SONOGRAPHY_REPORT_YES);
+    expect(byCode.get('upload_sonography_report_image')?.visibleWhen).toEqual(
+      HAS_SONOGRAPHY_REPORT_YES,
+    );
+    // The gating field itself is still met-beneficiary-gated, so the chain
+    // as a whole reduces to met-beneficiary=yes AND has-report=yes.
+    expect(
+      byCode.get('do_you_have_a_sonography_report_to_confirm_the_lmp_date')?.visibleWhen,
+    ).toEqual(MET_BENEFICIARY_YES);
+  });
+
+  it('shows the latest-ANC-visit date only when have_you_visited_health_facility_since_my_last_visit=yes (Q40/Q41)', () => {
+    expect(
+      byCode.get('if_yes_enter_date_of_latest_anc_visit_at_the_health_facility')?.visibleWhen,
+    ).toEqual({
+      field: 'have_you_visited_health_facility_since_my_last_visit',
+      operator: 'eq',
+      value: 'yes',
+    });
+    // The gating field itself is still met-beneficiary-gated, so the chain
+    // as a whole reduces to met-beneficiary=yes AND visited-facility=yes.
+    expect(byCode.get('have_you_visited_health_facility_since_my_last_visit')?.visibleWhen).toEqual(
+      MET_BENEFICIARY_YES,
+    );
   });
 
   it('applies notFuture to the LMP edit date (Q8)', () => {

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -89,8 +89,20 @@ describe('mother-registration.json', () => {
     expect(exclusiveRules).toHaveLength(3);
   });
 
-  it('has 8 total validationJson rules (5 existing + 3 new EXCLUSIVE_OPTION)', () => {
-    expect(motherRegistration.validationJson).toHaveLength(8);
+  it('has a REQUIRED_IF_SELECTED rule so each selected Td dose requires its date', () => {
+    expect(motherRegistration.validationJson).toContainEqual({
+      rule: 'REQUIRED_IF_SELECTED',
+      field: 'has_the_women_received_td_dose',
+      optionFieldMap: {
+        td_1_date: 'td_1_date',
+        td_2_date: 'td_2_date',
+        td_booster_date: 'td_booster_date',
+      },
+    });
+  });
+
+  it('has 9 total validationJson rules (5 existing + 3 EXCLUSIVE_OPTION + 1 REQUIRED_IF_SELECTED)', () => {
+    expect(motherRegistration.validationJson).toHaveLength(9);
   });
 });
 
@@ -139,8 +151,21 @@ describe('child-registration.json', () => {
     });
   });
 
-  it('has 2 total validationJson rules (1 existing ANY_OF_REQUIRED + 1 new EXCLUSIVE_OPTION)', () => {
-    expect(childRegistration.validationJson).toHaveLength(2);
+  it('has a REQUIRED_IF_SELECTED rule so each selected vaccine requires its date', () => {
+    expect(childRegistration.validationJson).toContainEqual({
+      rule: 'REQUIRED_IF_SELECTED',
+      field: 'vaccination_taken_at_birth',
+      optionFieldMap: {
+        bcg_date: 'bcg_date',
+        opv_date: 'opv_date',
+        hepatitis_b_date: 'hepatitis_b_date',
+        vitamin_k_date: 'vitamin_k_date',
+      },
+    });
+  });
+
+  it('has 3 total validationJson rules (1 ANY_OF_REQUIRED + 1 EXCLUSIVE_OPTION + 1 REQUIRED_IF_SELECTED)', () => {
+    expect(childRegistration.validationJson).toHaveLength(3);
   });
 });
 

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -94,6 +94,56 @@ describe('mother-registration.json', () => {
   });
 });
 
+describe('child-registration.json', () => {
+  const byCode = new Map(childRegistration.schemaJson.map((f) => [f.question_code, f]));
+
+  it('has exactly 55 fields (51 existing + 4 new per-vaccine date fields)', () => {
+    expect(childRegistration.schemaJson).toHaveLength(55);
+  });
+
+  it('applies the DOB-of-infant date rule (Infant Registration form Q6)', () => {
+    expect(byCode.get('date_of_birth_of_infant')?.dateRule).toEqual({
+      notFuture: true,
+      maxDaysFrom: { field: 'registrtion_date', days: 183 },
+    });
+  });
+
+  it('applies NAME_NO_SPECIAL_CHARS to the caregiver name (Q19)', () => {
+    expect(byCode.get('caregiver_name_first_name_middle_name_last_name')?.pattern).toBe(
+      'NAME_NO_SPECIAL_CHARS',
+    );
+  });
+
+  it('applies exactLength 10 to mobile_number (Q22)', () => {
+    expect(byCode.get('mobile_number')?.exactLength).toBe(10);
+  });
+
+  it('adds a visibleWhen-gated date field per vaccine (Q49)', () => {
+    const vaccineCodes = ['bcg_date', 'opv_date', 'hepatitis_b_date', 'vitamin_k_date'];
+    for (const code of vaccineCodes) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'vaccination_taken_at_birth',
+        operator: 'contains',
+        value: code,
+      });
+      expect(byCode.get(code)?.input_type).toBe('date');
+      expect(byCode.get(code)?.required).toBe(false);
+    }
+  });
+
+  it('has an EXCLUSIVE_OPTION rule so "None" cannot combine with a selected vaccine (Q49)', () => {
+    expect(childRegistration.validationJson).toContainEqual({
+      rule: 'EXCLUSIVE_OPTION',
+      field: 'vaccination_taken_at_birth',
+      exclusiveValues: ['none'],
+    });
+  });
+
+  it('has 2 total validationJson rules (1 existing ANY_OF_REQUIRED + 1 new EXCLUSIVE_OPTION)', () => {
+    expect(childRegistration.validationJson).toHaveLength(2);
+  });
+});
+
 describe('anc-visit.json', () => {
   const fields = ancVisit.schemaJson;
   const byCode = new Map(fields.map((f) => [f.question_code, f]));

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -173,8 +173,8 @@ describe('anc-visit.json', () => {
   const fields = ancVisit.schemaJson;
   const byCode = new Map(fields.map((f) => [f.question_code, f]));
 
-  it('has exactly 56 fields, per the Revised App Form Final ANC visit form', () => {
-    expect(fields).toHaveLength(56);
+  it('has exactly 59 fields (56 existing + 3 new per-dose Td date fields)', () => {
+    expect(fields).toHaveLength(59);
   });
 
   it('groups fields into Tests, Symptoms, History, in that order', () => {
@@ -186,7 +186,7 @@ describe('anc-visit.json', () => {
     expect(sections.slice(firstSymptoms, firstHistory).every((s) => s === 'Symptoms')).toBe(true);
     expect(sections.slice(firstHistory).every((s) => s === 'History')).toBe(true);
     expect(sections.filter((s) => s === 'Tests')).toHaveLength(11);
-    expect(sections.filter((s) => s === 'Symptoms')).toHaveLength(28);
+    expect(sections.filter((s) => s === 'Symptoms')).toHaveLength(31);
     expect(sections.filter((s) => s === 'History')).toHaveLength(17);
   });
 
@@ -269,8 +269,87 @@ describe('anc-visit.json', () => {
     }
   });
 
-  it('has no cross-field validation rules', () => {
-    expect(ancVisit.validationJson).toEqual([]);
+  it('applies notFuture to the LMP edit date (Q8)', () => {
+    expect(byCode.get('lmp_date_edit')?.dateRule).toEqual({ notFuture: true });
+  });
+
+  it('applies notFuture to the latest-ANC-visit date (Q41)', () => {
+    expect(
+      byCode.get('if_yes_enter_date_of_latest_anc_visit_at_the_health_facility')?.dateRule,
+    ).toEqual({ notFuture: true });
+  });
+
+  it('applies notFuture + notBefore LMP to the USG date (Q49)', () => {
+    expect(byCode.get('if_yes_date_of_usg')?.dateRule).toEqual({
+      notFuture: true,
+      notBefore: { field: 'lmp' },
+    });
+  });
+
+  it('adds a visibleWhen-gated, chained date field per Td dose (Q33)', () => {
+    expect(byCode.get('td1_date')?.visibleWhen).toEqual({
+      field: 'vaccination_status',
+      operator: 'contains',
+      value: 'td1_date',
+    });
+    expect(byCode.get('td1_date')?.dateRule).toEqual({ notFuture: true });
+
+    expect(byCode.get('td2_date')?.visibleWhen).toEqual({
+      field: 'vaccination_status',
+      operator: 'contains',
+      value: 'td2_date',
+    });
+    expect(byCode.get('td2_date')?.dateRule).toEqual({
+      notFuture: true,
+      notBefore: { field: 'td1_date' },
+    });
+
+    expect(byCode.get('booster_date')?.visibleWhen).toEqual({
+      field: 'vaccination_status',
+      operator: 'contains',
+      value: 'booster_date',
+    });
+    expect(byCode.get('booster_date')?.dateRule).toEqual({
+      notFuture: true,
+      notBefore: { field: 'td2_date' },
+    });
+
+    for (const code of ['td1_date', 'td2_date', 'booster_date']) {
+      expect(byCode.get(code)?.input_type).toBe('date');
+      expect(byCode.get(code)?.required).toBe(false);
+    }
+  });
+
+  it('has an EXCLUSIVE_OPTION rule so "Normal" urine test cannot combine with other findings (Q29)', () => {
+    expect(ancVisit.validationJson).toContainEqual({
+      rule: 'EXCLUSIVE_OPTION',
+      field: 'urine_test',
+      exclusiveValues: ['normal'],
+    });
+  });
+
+  it('has an EXCLUSIVE_OPTION rule so "None" cannot combine with a selected Td dose (Q33)', () => {
+    expect(ancVisit.validationJson).toContainEqual({
+      rule: 'EXCLUSIVE_OPTION',
+      field: 'vaccination_status',
+      exclusiveValues: ['none'],
+    });
+  });
+
+  it('has a REQUIRED_IF_SELECTED rule so each selected Td dose requires its date (Q33)', () => {
+    expect(ancVisit.validationJson).toContainEqual({
+      rule: 'REQUIRED_IF_SELECTED',
+      field: 'vaccination_status',
+      optionFieldMap: {
+        td1_date: 'td1_date',
+        td2_date: 'td2_date',
+        booster_date: 'booster_date',
+      },
+    });
+  });
+
+  it('has 3 total validationJson rules (2 EXCLUSIVE_OPTION + 1 REQUIRED_IF_SELECTED)', () => {
+    expect(ancVisit.validationJson).toHaveLength(3);
   });
 });
 

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -173,8 +173,8 @@ describe('anc-visit.json', () => {
   const fields = ancVisit.schemaJson;
   const byCode = new Map(fields.map((f) => [f.question_code, f]));
 
-  it('has exactly 59 fields (56 existing + 3 new per-dose Td date fields)', () => {
-    expect(fields).toHaveLength(59);
+  it('has exactly 56 fields, per the Revised App Form Final ANC visit form', () => {
+    expect(fields).toHaveLength(56);
   });
 
   it('groups fields into Tests, Symptoms, History, in that order', () => {
@@ -186,7 +186,7 @@ describe('anc-visit.json', () => {
     expect(sections.slice(firstSymptoms, firstHistory).every((s) => s === 'Symptoms')).toBe(true);
     expect(sections.slice(firstHistory).every((s) => s === 'History')).toBe(true);
     expect(sections.filter((s) => s === 'Tests')).toHaveLength(11);
-    expect(sections.filter((s) => s === 'Symptoms')).toHaveLength(31);
+    expect(sections.filter((s) => s === 'Symptoms')).toHaveLength(28);
     expect(sections.filter((s) => s === 'History')).toHaveLength(17);
   });
 
@@ -286,40 +286,6 @@ describe('anc-visit.json', () => {
     });
   });
 
-  it('adds a visibleWhen-gated, chained date field per Td dose (Q33)', () => {
-    expect(byCode.get('td1_date')?.visibleWhen).toEqual({
-      field: 'vaccination_status',
-      operator: 'contains',
-      value: 'td1_date',
-    });
-    expect(byCode.get('td1_date')?.dateRule).toEqual({ notFuture: true });
-
-    expect(byCode.get('td2_date')?.visibleWhen).toEqual({
-      field: 'vaccination_status',
-      operator: 'contains',
-      value: 'td2_date',
-    });
-    expect(byCode.get('td2_date')?.dateRule).toEqual({
-      notFuture: true,
-      notBefore: { field: 'td1_date' },
-    });
-
-    expect(byCode.get('booster_date')?.visibleWhen).toEqual({
-      field: 'vaccination_status',
-      operator: 'contains',
-      value: 'booster_date',
-    });
-    expect(byCode.get('booster_date')?.dateRule).toEqual({
-      notFuture: true,
-      notBefore: { field: 'td2_date' },
-    });
-
-    for (const code of ['td1_date', 'td2_date', 'booster_date']) {
-      expect(byCode.get(code)?.input_type).toBe('date');
-      expect(byCode.get(code)?.required).toBe(false);
-    }
-  });
-
   it('has an EXCLUSIVE_OPTION rule so "Normal" urine test cannot combine with other findings (Q29)', () => {
     expect(ancVisit.validationJson).toContainEqual({
       rule: 'EXCLUSIVE_OPTION',
@@ -336,20 +302,8 @@ describe('anc-visit.json', () => {
     });
   });
 
-  it('has a REQUIRED_IF_SELECTED rule so each selected Td dose requires its date (Q33)', () => {
-    expect(ancVisit.validationJson).toContainEqual({
-      rule: 'REQUIRED_IF_SELECTED',
-      field: 'vaccination_status',
-      optionFieldMap: {
-        td1_date: 'td1_date',
-        td2_date: 'td2_date',
-        booster_date: 'booster_date',
-      },
-    });
-  });
-
-  it('has 3 total validationJson rules (2 EXCLUSIVE_OPTION + 1 REQUIRED_IF_SELECTED)', () => {
-    expect(ancVisit.validationJson).toHaveLength(3);
+  it('has 2 total validationJson rules (2 EXCLUSIVE_OPTION)', () => {
+    expect(ancVisit.validationJson).toHaveLength(2);
   });
 });
 

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -220,7 +220,7 @@ describe('anc-visit.json', () => {
 
   it('gates fetal movement/heart rate/fundal height behind gestational age >= 20 weeks', () => {
     for (const code of ['fetal_movements', 'fetal_heart_rate', 'fundal_height_in_cm']) {
-      expect(byCode.get(code)?.visibleWhen).toEqual({
+      expect(conditionsOf(byCode.get(code)?.visibleWhen)).toContainEqual({
         field: 'current_gestational_age_in_weeks',
         operator: 'gte',
         value: 20,
@@ -228,7 +228,19 @@ describe('anc-visit.json', () => {
     }
   });
 
+  const MET_BENEFICIARY_YES = {
+    field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+    operator: 'eq',
+    value: 'yes',
+  };
+
+  /** Normalizes visibleWhen (single condition or array) to an array for assertions. */
+  function conditionsOf(visibleWhen: unknown): unknown[] {
+    return Array.isArray(visibleWhen) ? visibleWhen : [visibleWhen];
+  }
+
   it('shows the not-met reason only when the beneficiary was not met', () => {
+    // The only Q5+ field NOT gated behind met=yes — it's the met=no branch itself.
     expect(byCode.get('if_no_mention_reasons')?.visibleWhen).toEqual({
       field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
       operator: 'eq',
@@ -236,9 +248,25 @@ describe('anc-visit.json', () => {
     });
   });
 
+  it('gates every Q5+ field behind met-beneficiary=yes, in addition to any of its own conditions', () => {
+    for (const field of fields) {
+      if (
+        [
+          'date_of_visit',
+          'visit_type',
+          'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+          'if_no_mention_reasons',
+        ].includes(field.question_code)
+      ) {
+        continue;
+      }
+      expect(conditionsOf(field.visibleWhen)).toContainEqual(MET_BENEFICIARY_YES);
+    }
+  });
+
   it('shows the LMP edit + sonography image only when a sonography report exists', () => {
     for (const code of ['lmp_date_edit', 'upload_sonography_report_image']) {
-      expect(byCode.get(code)?.visibleWhen).toEqual({
+      expect(conditionsOf(byCode.get(code)?.visibleWhen)).toContainEqual({
         field: 'do_you_have_a_sonography_report_to_confirm_the_lmp_date',
         operator: 'eq',
         value: 'yes',
@@ -248,20 +276,24 @@ describe('anc-visit.json', () => {
 
   it('branches IFA tablet follow-ups on whether the woman is taking IFA tablets', () => {
     expect(
-      byCode.get('how_many_ifa_tablets_did_you_consume_since_last_visit')?.visibleWhen,
-    ).toEqual({
+      conditionsOf(
+        byCode.get('how_many_ifa_tablets_did_you_consume_since_last_visit')?.visibleWhen,
+      ),
+    ).toContainEqual({
       field: 'are_you_taking_ifa_tablets',
       operator: 'eq',
       value: 'yes',
     });
     expect(
-      byCode.get('if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets')?.visibleWhen,
-    ).toEqual({ field: 'are_you_taking_ifa_tablets', operator: 'eq', value: 'no' });
+      conditionsOf(
+        byCode.get('if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets')?.visibleWhen,
+      ),
+    ).toContainEqual({ field: 'are_you_taking_ifa_tablets', operator: 'eq', value: 'no' });
   });
 
   it('shows USG date/type/finding only when USG was done', () => {
     for (const code of ['if_yes_date_of_usg', 'type_of_usg', 'usg_finding']) {
-      expect(byCode.get(code)?.visibleWhen).toEqual({
+      expect(conditionsOf(byCode.get(code)?.visibleWhen)).toContainEqual({
         field: 'have_you_done_usg_since_last_visit',
         operator: 'eq',
         value: 'yes',
@@ -344,13 +376,24 @@ describe('infant-visit.json', () => {
     }
   });
 
+  const MET_BENEFICIARY_YES_INFANT = {
+    field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+    operator: 'eq',
+    value: 'yes',
+  };
+
+  /** Normalizes visibleWhen (single condition or array) to an array for assertions. */
+  function conditionsOfInfant(visibleWhen: unknown): unknown[] {
+    return Array.isArray(visibleWhen) ? visibleWhen : [visibleWhen];
+  }
+
   it('gates thermal care practices to under 2 months and MUAC to 6 months and up', () => {
-    expect(byCode.get('thermal_care_practices')?.visibleWhen).toEqual({
+    expect(conditionsOfInfant(byCode.get('thermal_care_practices')?.visibleWhen)).toContainEqual({
       field: 'age_in_months',
       operator: 'lt',
       value: 2,
     });
-    expect(byCode.get('muac_in_cms')?.visibleWhen).toEqual({
+    expect(conditionsOfInfant(byCode.get('muac_in_cms')?.visibleWhen)).toContainEqual({
       field: 'age_in_months',
       operator: 'gte',
       value: 6,
@@ -358,11 +401,28 @@ describe('infant-visit.json', () => {
   });
 
   it('shows the not-met reason only when the beneficiary was not met', () => {
+    // The only Q5+ field NOT gated behind met=yes — it's the met=no branch itself.
     expect(byCode.get('if_no_mention_reasons')?.visibleWhen).toEqual({
       field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
       operator: 'eq',
       value: 'no',
     });
+  });
+
+  it('gates every Q5+ field behind met-beneficiary=yes, in addition to any of its own conditions', () => {
+    for (const field of fields) {
+      if (
+        [
+          'date_of_visit',
+          'visit_type',
+          'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+          'if_no_mention_reasons',
+        ].includes(field.question_code)
+      ) {
+        continue;
+      }
+      expect(conditionsOfInfant(field.visibleWhen)).toContainEqual(MET_BENEFICIARY_YES_INFANT);
+    }
   });
 
   it('shows complementary-feeding follow-ups only once complementary feeding has started', () => {
@@ -371,7 +431,7 @@ describe('infant-visit.json', () => {
       'which_of_these_food_stuff_have_child_consumed_in_the_last_24_hours',
       'which_of_the_following_foods_does_the_child_avoid_eating_or_you_avoid_giving_to_the_child',
     ]) {
-      expect(byCode.get(code)?.visibleWhen).toEqual({
+      expect(conditionsOfInfant(byCode.get(code)?.visibleWhen)).toContainEqual({
         field: 'have_you_started_complementary_feeding_for_your_child',
         operator: 'eq',
         value: 'yes',
@@ -408,7 +468,7 @@ describe('infant-visit.json', () => {
 
     for (const [vaccineCode, dateCode] of vaccinePairs) {
       expect(byCode.get(vaccineCode)).toBeDefined();
-      expect(byCode.get(dateCode)?.visibleWhen).toEqual({
+      expect(conditionsOfInfant(byCode.get(dateCode)?.visibleWhen)).toContainEqual({
         field: vaccineCode,
         operator: 'eq',
         value: 'yes',

--- a/apps/visit-form-service/prisma/seed-data/anc-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-visit.json
@@ -1,0 +1,1236 @@
+{
+  "schemaJson": [
+    {
+      "label": "Date of visit",
+      "section": "Tests",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_visit"
+    },
+    {
+      "label": "Visit type",
+      "section": "Tests",
+      "required": true,
+      "input_type": "text",
+      "question_code": "visit_type"
+    },
+    {
+      "label": "Have you been able to meet the beneficiary for the visit?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "have_you_been_able_to_meet_the_beneficiary_for_the_visit"
+    },
+    {
+      "label": "If no, mention reasons",
+      "options": [
+        {
+          "label": "Woman migrated, status known",
+          "sort_order": 0,
+          "value_code": "woman_migrated_status_known"
+        },
+        {
+          "label": "Woman migrated, status unknown",
+          "sort_order": 1,
+          "value_code": "woman_migrated_status_unknown"
+        },
+        {
+          "label": "Woman not available (gone out, hospitalization)",
+          "sort_order": 2,
+          "value_code": "woman_not_available_gone_out_hospitalization"
+        },
+        {
+          "label": "Woman busy for the check up",
+          "sort_order": 3,
+          "value_code": "woman_busy_for_the_check_up"
+        },
+        {
+          "label": "Other",
+          "sort_order": 4,
+          "value_code": "other"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "select",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "no"
+      },
+      "question_code": "if_no_mention_reasons"
+    },
+    {
+      "label": "RCH Number",
+      "section": "Tests",
+      "required": true,
+      "input_type": "text",
+      "question_code": "rch_number"
+    },
+    {
+      "label": "LMP",
+      "section": "Tests",
+      "required": true,
+      "input_type": "date",
+      "question_code": "lmp"
+    },
+    {
+      "label": "Do you have a sonography report to confirm the LMP date?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "do_you_have_a_sonography_report_to_confirm_the_lmp_date"
+    },
+    {
+      "label": "LMP Date",
+      "section": "Tests",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "lmp_date_edit"
+    },
+    {
+      "label": "Upload sonography report image",
+      "section": "Tests",
+      "required": true,
+      "input_type": "image",
+      "captureMode": "LIVE_CAMERA_ONLY",
+      "visibleWhen": {
+        "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "upload_sonography_report_image"
+    },
+    {
+      "label": "Current gestational age in weeks",
+      "section": "Tests",
+      "required": true,
+      "input_type": "number",
+      "computedFrom": "GESTATIONAL_AGE_AT_VISIT",
+      "question_code": "current_gestational_age_in_weeks"
+    },
+    {
+      "label": "EDD",
+      "section": "Tests",
+      "required": true,
+      "input_type": "date",
+      "computedFrom": "EDD_FROM_LMP",
+      "question_code": "edd"
+    },
+    {
+      "label": "Height of the woman in cm",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 120,
+        "max": 190
+      },
+      "question_code": "height_of_the_woman_in_cm"
+    },
+    {
+      "label": "Current weight of the woman in kg",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 25,
+        "max": 100
+      },
+      "question_code": "current_weight_of_the_woman_in_kg"
+    },
+    {
+      "label": "BMI",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "computedFrom": "BMI",
+      "question_code": "bmi"
+    },
+    {
+      "label": "Gestational weight gain",
+      "options": [
+        {
+          "label": "Normal",
+          "sort_order": 0,
+          "value_code": "normal"
+        },
+        {
+          "label": "Severe",
+          "sort_order": 1,
+          "value_code": "severe"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "computedFrom": "GESTATIONAL_WEIGHT_GAIN",
+      "question_code": "gestational_weight_gain"
+    },
+    {
+      "label": "Capture the mid-upper arm circumference in cm",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 10,
+        "max": 40
+      },
+      "question_code": "mid_upper_arm_circumference_in_cm"
+    },
+    {
+      "label": "Have you been experiencing any of these since the last visit?",
+      "options": [
+        {
+          "label": "Severe abdominal pain",
+          "sort_order": 0,
+          "value_code": "severe_abdominal_pain"
+        },
+        {
+          "label": "Bleeding from Vagina",
+          "sort_order": 1,
+          "value_code": "bleeding_from_vagina"
+        },
+        {
+          "label": "Abnormal Vaginal discharge (foul smelling and yellow)",
+          "sort_order": 2,
+          "value_code": "abnormal_vaginal_discharge_foul_smelling_and_yellow"
+        },
+        {
+          "label": "Vomiting for more than 24 hours",
+          "sort_order": 3,
+          "value_code": "vomiting_for_more_than_24_hours"
+        },
+        {
+          "label": "Convulsions",
+          "sort_order": 4,
+          "value_code": "convulsions"
+        },
+        {
+          "label": "Severe Headaches, blurred vision",
+          "sort_order": 5,
+          "value_code": "severe_headaches_blurred_vision"
+        },
+        {
+          "label": "Dizziness",
+          "sort_order": 6,
+          "value_code": "dizziness"
+        },
+        {
+          "label": "Breathlessness",
+          "sort_order": 7,
+          "value_code": "breathlessness"
+        },
+        {
+          "label": "Palpitation",
+          "sort_order": 8,
+          "value_code": "palpitation"
+        },
+        {
+          "label": "Increased frequency of urination",
+          "sort_order": 9,
+          "value_code": "increased_frequency_of_urination"
+        },
+        {
+          "label": "Vaginal Itching",
+          "sort_order": 10,
+          "value_code": "vaginal_itching"
+        },
+        {
+          "label": "Burning micturition",
+          "sort_order": 11,
+          "value_code": "burning_micturition"
+        },
+        {
+          "label": "No abnormal signs and symptoms",
+          "sort_order": 12,
+          "value_code": "no_abnormal_signs_and_symptoms"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "have_you_been_experiencing_any_of_these_since_the_last_visit"
+    },
+    {
+      "label": "Check Palm and Nails",
+      "options": [
+        {
+          "label": "Pale",
+          "sort_order": 0,
+          "value_code": "pale"
+        },
+        {
+          "label": "Yellow",
+          "sort_order": 1,
+          "value_code": "yellow"
+        },
+        {
+          "label": "Normal",
+          "sort_order": 2,
+          "value_code": "normal"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "question_code": "check_palm_and_nails"
+    },
+    {
+      "label": "Check Sclera (Eyes)",
+      "options": [
+        {
+          "label": "Pale",
+          "sort_order": 0,
+          "value_code": "pale"
+        },
+        {
+          "label": "Yellow",
+          "sort_order": 1,
+          "value_code": "yellow"
+        },
+        {
+          "label": "Normal",
+          "sort_order": 2,
+          "value_code": "normal"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "question_code": "check_sclera_eyes"
+    },
+    {
+      "label": "Check Skin",
+      "options": [
+        {
+          "label": "Pale",
+          "sort_order": 0,
+          "value_code": "pale"
+        },
+        {
+          "label": "Yellow",
+          "sort_order": 1,
+          "value_code": "yellow"
+        },
+        {
+          "label": "Normal",
+          "sort_order": 2,
+          "value_code": "normal"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "question_code": "check_skin"
+    },
+    {
+      "label": "Swelling",
+      "options": [
+        {
+          "label": "No swelling",
+          "sort_order": 0,
+          "value_code": "no_swelling"
+        },
+        {
+          "label": "Swollen hands",
+          "sort_order": 1,
+          "value_code": "swollen_hands"
+        },
+        {
+          "label": "Swollen feet",
+          "sort_order": 2,
+          "value_code": "swollen_feet"
+        },
+        {
+          "label": "Swollen face",
+          "sort_order": 3,
+          "value_code": "swollen_face"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "swelling"
+    },
+    {
+      "label": "Dehydration",
+      "options": [
+        {
+          "label": "Dry tongue",
+          "sort_order": 0,
+          "value_code": "dry_tongue"
+        },
+        {
+          "label": "Loss of skin turgor",
+          "sort_order": 1,
+          "value_code": "loss_of_skin_turgor"
+        },
+        {
+          "label": "No",
+          "sort_order": 2,
+          "value_code": "no"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "dehydration"
+    },
+    {
+      "label": "Blood Pressure (BP) Systolic",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 70,
+        "max": 300
+      },
+      "question_code": "blood_pressure_bp_systolic"
+    },
+    {
+      "label": "Blood Pressure (BP) Diastolic",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 40,
+        "max": 130
+      },
+      "question_code": "blood_pressure_bp_diastolic"
+    },
+    {
+      "label": "Body Temperature in °F",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 94,
+        "max": 105
+      },
+      "question_code": "body_temperature_in_f"
+    },
+    {
+      "label": "Haemoglobin (Hb) g/dl",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 1,
+        "max": 18
+      },
+      "question_code": "haemoglobin_hb_g_dl"
+    },
+    {
+      "label": "How many hours ago did you take last meal?",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "question_code": "how_many_hours_ago_did_you_take_last_meal"
+    },
+    {
+      "label": "Blood Glucose in mg/dl",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 40,
+        "max": 400
+      },
+      "question_code": "blood_glucose_in_mg_dl"
+    },
+    {
+      "label": "Urine Test",
+      "options": [
+        {
+          "label": "Normal",
+          "sort_order": 0,
+          "value_code": "normal"
+        },
+        {
+          "label": "Infection",
+          "sort_order": 1,
+          "value_code": "infection"
+        },
+        {
+          "label": "Sugar",
+          "sort_order": 2,
+          "value_code": "sugar"
+        },
+        {
+          "label": "Protein",
+          "sort_order": 3,
+          "value_code": "protein"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "urine_test"
+    },
+    {
+      "label": "Fetal Movements",
+      "options": [
+        {
+          "label": "Absent",
+          "sort_order": 0,
+          "value_code": "absent"
+        },
+        {
+          "label": "Present",
+          "sort_order": 1,
+          "value_code": "present"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "visibleWhen": {
+        "field": "current_gestational_age_in_weeks",
+        "operator": "gte",
+        "value": 20
+      },
+      "question_code": "fetal_movements"
+    },
+    {
+      "label": "Fetal Heart Rate",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "visibleWhen": {
+        "field": "current_gestational_age_in_weeks",
+        "operator": "gte",
+        "value": 20
+      },
+      "question_code": "fetal_heart_rate"
+    },
+    {
+      "label": "Fundal Height in cm",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 10,
+        "max": 50
+      },
+      "visibleWhen": {
+        "field": "current_gestational_age_in_weeks",
+        "operator": "gte",
+        "value": 20
+      },
+      "question_code": "fundal_height_in_cm"
+    },
+    {
+      "label": "Vaccination status",
+      "options": [
+        {
+          "label": "None",
+          "sort_order": 0,
+          "value_code": "none"
+        },
+        {
+          "label": "Td1 Date",
+          "sort_order": 1,
+          "value_code": "td1_date"
+        },
+        {
+          "label": "Td2 Date",
+          "sort_order": 2,
+          "value_code": "td2_date"
+        },
+        {
+          "label": "Booster Date",
+          "sort_order": 3,
+          "value_code": "booster_date"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect_date",
+      "question_code": "vaccination_status"
+    },
+    {
+      "label": "Which of these food stuff have you consumed in the last 24 hours?",
+      "options": [
+        {
+          "label": "Cereals (nachni, bajra, jwari, gahu, rice etc.)",
+          "sort_order": 0,
+          "value_code": "cereals_nachni_bajra_jwari_gahu_rice_etc"
+        },
+        {
+          "label": "Pulses/Legumes (tur dal, chana, moong, etc.)",
+          "sort_order": 1,
+          "value_code": "pulses_legumes_tur_dal_chana_moong_etc"
+        },
+        {
+          "label": "Nuts and seeds (Ground nuts, almond etc)",
+          "sort_order": 2,
+          "value_code": "nuts_and_seeds_ground_nuts_almond_etc"
+        },
+        {
+          "label": "Dairy products Milk/milk products (paneer, dahi, taak, etc.)",
+          "sort_order": 3,
+          "value_code": "dairy_products_milk_milk_products_paneer_dahi_taak_etc"
+        },
+        {
+          "label": "Fruits",
+          "sort_order": 4,
+          "value_code": "fruits"
+        },
+        {
+          "label": "Vegetables",
+          "sort_order": 5,
+          "value_code": "vegetables"
+        },
+        {
+          "label": "Green vegetables",
+          "sort_order": 6,
+          "value_code": "green_vegetables"
+        },
+        {
+          "label": "Other vitamin A–rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
+          "sort_order": 7,
+          "value_code": "other_vitamin_a_rich_fruits_and_vegetables_mango_papaya_pumpkin_carrot"
+        },
+        {
+          "label": "Eggs",
+          "sort_order": 8,
+          "value_code": "eggs"
+        },
+        {
+          "label": "Poultry/meat/fish",
+          "sort_order": 9,
+          "value_code": "poultry_meat_fish"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "which_of_these_food_stuff_have_you_consumed_in_the_last_24_hours"
+    },
+    {
+      "label": "Which of these food stuff do you avoid eating?",
+      "options": [
+        {
+          "label": "Cereals (nachni, bajra, jwari, gahu, rice etc.)",
+          "sort_order": 0,
+          "value_code": "cereals_nachni_bajra_jwari_gahu_rice_etc"
+        },
+        {
+          "label": "Pulses/Legumes (tur dal, chana, moong, etc.)",
+          "sort_order": 1,
+          "value_code": "pulses_legumes_tur_dal_chana_moong_etc"
+        },
+        {
+          "label": "Nuts and seeds (Ground nuts, almond etc)",
+          "sort_order": 2,
+          "value_code": "nuts_and_seeds_ground_nuts_almond_etc"
+        },
+        {
+          "label": "Dairy products Milk/milk products (paneer, dahi, taak, etc.)",
+          "sort_order": 3,
+          "value_code": "dairy_products_milk_milk_products_paneer_dahi_taak_etc"
+        },
+        {
+          "label": "Fruits",
+          "sort_order": 4,
+          "value_code": "fruits"
+        },
+        {
+          "label": "Vegetables",
+          "sort_order": 5,
+          "value_code": "vegetables"
+        },
+        {
+          "label": "Green vegetables",
+          "sort_order": 6,
+          "value_code": "green_vegetables"
+        },
+        {
+          "label": "Other vitamin A–rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
+          "sort_order": 7,
+          "value_code": "other_vitamin_a_rich_fruits_and_vegetables_mango_papaya_pumpkin_carrot"
+        },
+        {
+          "label": "Eggs",
+          "sort_order": 8,
+          "value_code": "eggs"
+        },
+        {
+          "label": "Poultry/meat/fish",
+          "sort_order": 9,
+          "value_code": "poultry_meat_fish"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "which_of_these_food_stuff_do_you_avoid_eating"
+    },
+    {
+      "label": "Are you taking IFA tablets?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "are_you_taking_ifa_tablets"
+    },
+    {
+      "label": "How many IFA tablets did you consume since last visit?",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 0,
+        "max": 35
+      },
+      "visibleWhen": {
+        "field": "are_you_taking_ifa_tablets",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "how_many_ifa_tablets_did_you_consume_since_last_visit"
+    },
+    {
+      "label": "If no, what is the reasons for non consumption of IFA tablets?",
+      "options": [
+        {
+          "label": "Forgot to take",
+          "sort_order": 0,
+          "value_code": "forgot_to_take"
+        },
+        {
+          "label": "Due to side effects (Constipation, black stool, nausea)",
+          "sort_order": 1,
+          "value_code": "due_to_side_effects_constipation_black_stool_nausea"
+        },
+        {
+          "label": "Misconception about IFA",
+          "sort_order": 2,
+          "value_code": "misconception_about_ifa"
+        },
+        {
+          "label": "Tablets not available",
+          "sort_order": 3,
+          "value_code": "tablets_not_available"
+        },
+        {
+          "label": "Other",
+          "sort_order": 4,
+          "value_code": "other"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "visibleWhen": {
+        "field": "are_you_taking_ifa_tablets",
+        "operator": "eq",
+        "value": "no"
+      },
+      "question_code": "if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets"
+    },
+    {
+      "label": "Calcium tablets received and consumed?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "calcium_tablets_received_and_consumed"
+    },
+    {
+      "label": "Have you visited health facility since my last visit",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "have_you_visited_health_facility_since_my_last_visit"
+    },
+    {
+      "label": "If yes, enter date of latest ANC visit at the health facility",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "have_you_visited_health_facility_since_my_last_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "if_yes_enter_date_of_latest_anc_visit_at_the_health_facility"
+    },
+    {
+      "label": "Advised place of delivery",
+      "options": [
+        {
+          "label": "Civil Hospital",
+          "sort_order": 0,
+          "value_code": "civil_hospital"
+        },
+        {
+          "label": "Sub-district Hospital",
+          "sort_order": 1,
+          "value_code": "sub_district_hospital"
+        },
+        {
+          "label": "Rural Hospital",
+          "sort_order": 2,
+          "value_code": "rural_hospital"
+        },
+        {
+          "label": "Primary Health Centre",
+          "sort_order": 3,
+          "value_code": "primary_health_centre"
+        },
+        {
+          "label": "Subcentre",
+          "sort_order": 4,
+          "value_code": "subcentre"
+        },
+        {
+          "label": "Pvt. Hospital",
+          "sort_order": 5,
+          "value_code": "pvt_hospital"
+        },
+        {
+          "label": "Other",
+          "sort_order": 6,
+          "value_code": "other"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "select",
+      "question_code": "advised_place_of_delivery"
+    },
+    {
+      "label": "Sickle Cell",
+      "options": [
+        {
+          "label": "Tested and result is normal",
+          "sort_order": 0,
+          "value_code": "tested_and_result_is_normal"
+        },
+        {
+          "label": "Sickle Cell Trait (SCT carrier)",
+          "sort_order": 1,
+          "value_code": "sickle_cell_trait_sct_carrier"
+        },
+        {
+          "label": "Sickle Cell Disease (SCD)",
+          "sort_order": 2,
+          "value_code": "sickle_cell_disease_scd"
+        },
+        {
+          "label": "Tested earlier but result not available",
+          "sort_order": 3,
+          "value_code": "tested_earlier_but_result_not_available"
+        },
+        {
+          "label": "Not tested yet",
+          "sort_order": 4,
+          "value_code": "not_tested_yet"
+        },
+        {
+          "label": "Don’t know/ Not aware",
+          "sort_order": 5,
+          "value_code": "dont_know_not_aware"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "select",
+      "question_code": "sickle_cell"
+    },
+    {
+      "label": "Which of the following contraceptive/family planning method does the woman plan to use after delivery?",
+      "options": [
+        {
+          "label": "Condoms",
+          "sort_order": 0,
+          "value_code": "condoms"
+        },
+        {
+          "label": "Oral contraceptive pills (Mala-N or other)",
+          "sort_order": 1,
+          "value_code": "oral_contraceptive_pills_mala_n_or_other"
+        },
+        {
+          "label": "Emergency contraceptive pills",
+          "sort_order": 2,
+          "value_code": "emergency_contraceptive_pills"
+        },
+        {
+          "label": "Injectable contraceptives (Antara)",
+          "sort_order": 3,
+          "value_code": "injectable_contraceptives_antara"
+        },
+        {
+          "label": "IUCD (Copper-T)",
+          "sort_order": 4,
+          "value_code": "iucd_copper_t"
+        },
+        {
+          "label": "Lactational Amenorrhea Method (LAM)",
+          "sort_order": 5,
+          "value_code": "lactational_amenorrhea_method_lam"
+        },
+        {
+          "label": "Safe period, calendar method",
+          "sort_order": 6,
+          "value_code": "safe_period_calendar_method"
+        },
+        {
+          "label": "Withdrawal method (coitus interruptus)",
+          "sort_order": 7,
+          "value_code": "withdrawal_method_coitus_interruptus"
+        },
+        {
+          "label": "Female sterilization (Tubectomy)",
+          "sort_order": 8,
+          "value_code": "female_sterilization_tubectomy"
+        },
+        {
+          "label": "Male sterilization (Vasectomy, NSSK)",
+          "sort_order": 9,
+          "value_code": "male_sterilization_vasectomy_nssk"
+        },
+        {
+          "label": "Not using any contraceptive method",
+          "sort_order": 10,
+          "value_code": "not_using_any_contraceptive_method"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "contraceptive_family_planning_method_planned_after_delivery"
+    },
+    {
+      "label": "Feeling sad, anxious, or stressed most days?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "feeling_sad_anxious_or_stressed_most_days"
+    },
+    {
+      "label": "Adequate family support during pregnancy?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "adequate_family_support_during_pregnancy"
+    },
+    {
+      "label": "Are you going to migrate to other place any time during pregnancy?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "are_you_going_to_migrate_to_other_place_any_time_during_pregnancy"
+    },
+    {
+      "label": "Have you done USG since last visit",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "have_you_done_usg_since_last_visit"
+    },
+    {
+      "label": "If yes, date of USG",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "have_you_done_usg_since_last_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "if_yes_date_of_usg"
+    },
+    {
+      "label": "Type of USG",
+      "options": [
+        {
+          "label": "Routine USG",
+          "sort_order": 0,
+          "value_code": "routine_usg"
+        },
+        {
+          "label": "Anomaly scan",
+          "sort_order": 1,
+          "value_code": "anomaly_scan"
+        },
+        {
+          "label": "Doppler USG",
+          "sort_order": 2,
+          "value_code": "doppler_usg"
+        },
+        {
+          "label": "Other",
+          "sort_order": 3,
+          "value_code": "other"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "select",
+      "visibleWhen": {
+        "field": "have_you_done_usg_since_last_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "type_of_usg"
+    },
+    {
+      "label": "USG finding",
+      "options": [
+        {
+          "label": "Abnormal",
+          "sort_order": 0,
+          "value_code": "abnormal"
+        },
+        {
+          "label": "Normal",
+          "sort_order": 1,
+          "value_code": "normal"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "select",
+      "visibleWhen": {
+        "field": "have_you_done_usg_since_last_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "usg_finding"
+    },
+    {
+      "label": "Has the transport contact been shared with and saved by the beneficiary/family?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "has_the_transport_contact_been_shared_with_and_saved_by_the_beneficiary_family"
+    },
+    {
+      "label": "Has the family set aside or arranged funds for delivery/emergency expenses?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "has_the_family_set_aside_or_arranged_funds_for_delivery_emergency_expenses"
+    },
+    {
+      "label": "Has a birth companion been identified to accompany the woman during delivery/emergency?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "has_a_birth_companion_been_identified_to_accompany_the_woman_during_delivery_emergency"
+    },
+    {
+      "label": "Remarks",
+      "section": "History",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    },
+    {
+      "label": "As a Sakhi, have you guided the beneficiary on the following?",
+      "options": [
+        {
+          "label": "Birth Preparedness & Complication Readiness",
+          "sort_order": 0,
+          "value_code": "birth_preparedness_complication_readiness"
+        },
+        {
+          "label": "Nutrition during pregnancy",
+          "sort_order": 1,
+          "value_code": "nutrition_during_pregnancy"
+        },
+        {
+          "label": "IFA & calcium compliance",
+          "sort_order": 2,
+          "value_code": "ifa_calcium_compliance"
+        },
+        {
+          "label": "Danger signs awareness",
+          "sort_order": 3,
+          "value_code": "danger_signs_awareness"
+        },
+        {
+          "label": "Rest & workload reduction",
+          "sort_order": 4,
+          "value_code": "rest_workload_reduction"
+        },
+        {
+          "label": "Hygiene and Sanitation practices",
+          "sort_order": 5,
+          "value_code": "hygiene_and_sanitation_practices"
+        },
+        {
+          "label": "Institutional delivery benefits",
+          "sort_order": 6,
+          "value_code": "institutional_delivery_benefits"
+        },
+        {
+          "label": "Dangers of Substance Abuse",
+          "sort_order": 7,
+          "value_code": "dangers_of_substance_abuse"
+        },
+        {
+          "label": "Family Planning Methods",
+          "sort_order": 8,
+          "value_code": "family_planning_methods"
+        }
+      ],
+      "section": "History",
+      "required": false,
+      "input_type": "multiselect",
+      "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following"
+    }
+  ],
+  "validationJson": []
+}

--- a/apps/visit-form-service/prisma/seed-data/anc-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-visit.json
@@ -110,6 +110,9 @@
       "section": "Tests",
       "required": true,
       "input_type": "date",
+      "dateRule": {
+        "notFuture": true
+      },
       "visibleWhen": {
         "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
         "operator": "eq",
@@ -579,6 +582,57 @@
       "question_code": "vaccination_status"
     },
     {
+      "label": "Td1 date",
+      "section": "Symptoms",
+      "required": false,
+      "input_type": "date",
+      "dateRule": {
+        "notFuture": true
+      },
+      "visibleWhen": {
+        "field": "vaccination_status",
+        "operator": "contains",
+        "value": "td1_date"
+      },
+      "question_code": "td1_date"
+    },
+    {
+      "label": "Td2 date",
+      "section": "Symptoms",
+      "required": false,
+      "input_type": "date",
+      "dateRule": {
+        "notFuture": true,
+        "notBefore": {
+          "field": "td1_date"
+        }
+      },
+      "visibleWhen": {
+        "field": "vaccination_status",
+        "operator": "contains",
+        "value": "td2_date"
+      },
+      "question_code": "td2_date"
+    },
+    {
+      "label": "Booster date",
+      "section": "Symptoms",
+      "required": false,
+      "input_type": "date",
+      "dateRule": {
+        "notFuture": true,
+        "notBefore": {
+          "field": "td2_date"
+        }
+      },
+      "visibleWhen": {
+        "field": "vaccination_status",
+        "operator": "contains",
+        "value": "booster_date"
+      },
+      "question_code": "booster_date"
+    },
+    {
       "label": "Which of these food stuff have you consumed in the last 24 hours?",
       "options": [
         {
@@ -813,6 +867,9 @@
       "section": "History",
       "required": true,
       "input_type": "date",
+      "dateRule": {
+        "notFuture": true
+      },
       "visibleWhen": {
         "field": "have_you_visited_health_facility_since_my_last_visit",
         "operator": "eq",
@@ -1048,6 +1105,12 @@
       "section": "History",
       "required": true,
       "input_type": "date",
+      "dateRule": {
+        "notFuture": true,
+        "notBefore": {
+          "field": "lmp"
+        }
+      },
       "visibleWhen": {
         "field": "have_you_done_usg_since_last_visit",
         "operator": "eq",
@@ -1232,5 +1295,25 @@
       "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following"
     }
   ],
-  "validationJson": []
+  "validationJson": [
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "urine_test",
+      "exclusiveValues": ["normal"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "vaccination_status",
+      "exclusiveValues": ["none"]
+    },
+    {
+      "rule": "REQUIRED_IF_SELECTED",
+      "field": "vaccination_status",
+      "optionFieldMap": {
+        "td1_date": "td1_date",
+        "td2_date": "td2_date",
+        "booster_date": "booster_date"
+      }
+    }
+  ]
 }

--- a/apps/visit-form-service/prisma/seed-data/anc-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-visit.json
@@ -582,57 +582,6 @@
       "question_code": "vaccination_status"
     },
     {
-      "label": "Td1 date",
-      "section": "Symptoms",
-      "required": false,
-      "input_type": "date",
-      "dateRule": {
-        "notFuture": true
-      },
-      "visibleWhen": {
-        "field": "vaccination_status",
-        "operator": "contains",
-        "value": "td1_date"
-      },
-      "question_code": "td1_date"
-    },
-    {
-      "label": "Td2 date",
-      "section": "Symptoms",
-      "required": false,
-      "input_type": "date",
-      "dateRule": {
-        "notFuture": true,
-        "notBefore": {
-          "field": "td1_date"
-        }
-      },
-      "visibleWhen": {
-        "field": "vaccination_status",
-        "operator": "contains",
-        "value": "td2_date"
-      },
-      "question_code": "td2_date"
-    },
-    {
-      "label": "Booster date",
-      "section": "Symptoms",
-      "required": false,
-      "input_type": "date",
-      "dateRule": {
-        "notFuture": true,
-        "notBefore": {
-          "field": "td2_date"
-        }
-      },
-      "visibleWhen": {
-        "field": "vaccination_status",
-        "operator": "contains",
-        "value": "booster_date"
-      },
-      "question_code": "booster_date"
-    },
-    {
       "label": "Which of these food stuff have you consumed in the last 24 hours?",
       "options": [
         {
@@ -1305,15 +1254,6 @@
       "rule": "EXCLUSIVE_OPTION",
       "field": "vaccination_status",
       "exclusiveValues": ["none"]
-    },
-    {
-      "rule": "REQUIRED_IF_SELECTED",
-      "field": "vaccination_status",
-      "optionFieldMap": {
-        "td1_date": "td1_date",
-        "td2_date": "td2_date",
-        "booster_date": "booster_date"
-      }
     }
   ]
 }

--- a/apps/visit-form-service/prisma/seed-data/anc-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-visit.json
@@ -77,14 +77,24 @@
       "section": "Tests",
       "required": true,
       "input_type": "text",
-      "question_code": "rch_number"
+      "question_code": "rch_number",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "LMP",
       "section": "Tests",
       "required": true,
       "input_type": "date",
-      "question_code": "lmp"
+      "question_code": "lmp",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Do you have a sonography report to confirm the LMP date?",
@@ -103,7 +113,12 @@
       "section": "Tests",
       "required": true,
       "input_type": "radio",
-      "question_code": "do_you_have_a_sonography_report_to_confirm_the_lmp_date"
+      "question_code": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "LMP Date",
@@ -113,11 +128,18 @@
       "dateRule": {
         "notFuture": true
       },
-      "visibleWhen": {
-        "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "lmp_date_edit"
     },
     {
@@ -126,11 +148,18 @@
       "required": true,
       "input_type": "image",
       "captureMode": "LIVE_CAMERA_ONLY",
-      "visibleWhen": {
-        "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "upload_sonography_report_image"
     },
     {
@@ -139,7 +168,12 @@
       "required": true,
       "input_type": "number",
       "computedFrom": "GESTATIONAL_AGE_AT_VISIT",
-      "question_code": "current_gestational_age_in_weeks"
+      "question_code": "current_gestational_age_in_weeks",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "EDD",
@@ -147,7 +181,12 @@
       "required": true,
       "input_type": "date",
       "computedFrom": "EDD_FROM_LMP",
-      "question_code": "edd"
+      "question_code": "edd",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Height of the woman in cm",
@@ -158,7 +197,12 @@
         "min": 120,
         "max": 190
       },
-      "question_code": "height_of_the_woman_in_cm"
+      "question_code": "height_of_the_woman_in_cm",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Current weight of the woman in kg",
@@ -169,7 +213,12 @@
         "min": 25,
         "max": 100
       },
-      "question_code": "current_weight_of_the_woman_in_kg"
+      "question_code": "current_weight_of_the_woman_in_kg",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "BMI",
@@ -177,7 +226,12 @@
       "required": true,
       "input_type": "number",
       "computedFrom": "BMI",
-      "question_code": "bmi"
+      "question_code": "bmi",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Gestational weight gain",
@@ -197,7 +251,12 @@
       "required": true,
       "input_type": "radio",
       "computedFrom": "GESTATIONAL_WEIGHT_GAIN",
-      "question_code": "gestational_weight_gain"
+      "question_code": "gestational_weight_gain",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Capture the mid-upper arm circumference in cm",
@@ -208,7 +267,12 @@
         "min": 10,
         "max": 40
       },
-      "question_code": "mid_upper_arm_circumference_in_cm"
+      "question_code": "mid_upper_arm_circumference_in_cm",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Have you been experiencing any of these since the last visit?",
@@ -282,7 +346,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "have_you_been_experiencing_any_of_these_since_the_last_visit"
+      "question_code": "have_you_been_experiencing_any_of_these_since_the_last_visit",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Check Palm and Nails",
@@ -306,7 +375,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "select",
-      "question_code": "check_palm_and_nails"
+      "question_code": "check_palm_and_nails",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Check Sclera (Eyes)",
@@ -330,7 +404,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "select",
-      "question_code": "check_sclera_eyes"
+      "question_code": "check_sclera_eyes",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Check Skin",
@@ -354,7 +433,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "select",
-      "question_code": "check_skin"
+      "question_code": "check_skin",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Swelling",
@@ -383,7 +467,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "swelling"
+      "question_code": "swelling",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Dehydration",
@@ -407,7 +496,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "dehydration"
+      "question_code": "dehydration",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Blood Pressure (BP) Systolic",
@@ -418,7 +512,12 @@
         "min": 70,
         "max": 300
       },
-      "question_code": "blood_pressure_bp_systolic"
+      "question_code": "blood_pressure_bp_systolic",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Blood Pressure (BP) Diastolic",
@@ -429,10 +528,15 @@
         "min": 40,
         "max": 130
       },
-      "question_code": "blood_pressure_bp_diastolic"
+      "question_code": "blood_pressure_bp_diastolic",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
-      "label": "Body Temperature in °F",
+      "label": "Body Temperature in \u00b0F",
       "section": "Symptoms",
       "required": true,
       "input_type": "number",
@@ -440,7 +544,12 @@
         "min": 94,
         "max": 105
       },
-      "question_code": "body_temperature_in_f"
+      "question_code": "body_temperature_in_f",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Haemoglobin (Hb) g/dl",
@@ -451,14 +560,24 @@
         "min": 1,
         "max": 18
       },
-      "question_code": "haemoglobin_hb_g_dl"
+      "question_code": "haemoglobin_hb_g_dl",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "How many hours ago did you take last meal?",
       "section": "Symptoms",
       "required": true,
       "input_type": "number",
-      "question_code": "how_many_hours_ago_did_you_take_last_meal"
+      "question_code": "how_many_hours_ago_did_you_take_last_meal",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Blood Glucose in mg/dl",
@@ -469,7 +588,12 @@
         "min": 40,
         "max": 400
       },
-      "question_code": "blood_glucose_in_mg_dl"
+      "question_code": "blood_glucose_in_mg_dl",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Urine Test",
@@ -498,7 +622,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "urine_test"
+      "question_code": "urine_test",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Fetal Movements",
@@ -517,11 +646,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "visibleWhen": {
-        "field": "current_gestational_age_in_weeks",
-        "operator": "gte",
-        "value": 20
-      },
+      "visibleWhen": [
+        {
+          "field": "current_gestational_age_in_weeks",
+          "operator": "gte",
+          "value": 20
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "fetal_movements"
     },
     {
@@ -529,11 +665,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "number",
-      "visibleWhen": {
-        "field": "current_gestational_age_in_weeks",
-        "operator": "gte",
-        "value": 20
-      },
+      "visibleWhen": [
+        {
+          "field": "current_gestational_age_in_weeks",
+          "operator": "gte",
+          "value": 20
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "fetal_heart_rate"
     },
     {
@@ -545,11 +688,18 @@
         "min": 10,
         "max": 50
       },
-      "visibleWhen": {
-        "field": "current_gestational_age_in_weeks",
-        "operator": "gte",
-        "value": 20
-      },
+      "visibleWhen": [
+        {
+          "field": "current_gestational_age_in_weeks",
+          "operator": "gte",
+          "value": 20
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "fundal_height_in_cm"
     },
     {
@@ -579,7 +729,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect_date",
-      "question_code": "vaccination_status"
+      "question_code": "vaccination_status",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Which of these food stuff have you consumed in the last 24 hours?",
@@ -620,7 +775,7 @@
           "value_code": "green_vegetables"
         },
         {
-          "label": "Other vitamin A–rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
+          "label": "Other vitamin A\u2013rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
           "sort_order": 7,
           "value_code": "other_vitamin_a_rich_fruits_and_vegetables_mango_papaya_pumpkin_carrot"
         },
@@ -638,7 +793,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "which_of_these_food_stuff_have_you_consumed_in_the_last_24_hours"
+      "question_code": "which_of_these_food_stuff_have_you_consumed_in_the_last_24_hours",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Which of these food stuff do you avoid eating?",
@@ -679,7 +839,7 @@
           "value_code": "green_vegetables"
         },
         {
-          "label": "Other vitamin A–rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
+          "label": "Other vitamin A\u2013rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
           "sort_order": 7,
           "value_code": "other_vitamin_a_rich_fruits_and_vegetables_mango_papaya_pumpkin_carrot"
         },
@@ -697,7 +857,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "which_of_these_food_stuff_do_you_avoid_eating"
+      "question_code": "which_of_these_food_stuff_do_you_avoid_eating",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Are you taking IFA tablets?",
@@ -716,7 +881,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "question_code": "are_you_taking_ifa_tablets"
+      "question_code": "are_you_taking_ifa_tablets",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "How many IFA tablets did you consume since last visit?",
@@ -727,11 +897,18 @@
         "min": 0,
         "max": 35
       },
-      "visibleWhen": {
-        "field": "are_you_taking_ifa_tablets",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "are_you_taking_ifa_tablets",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "how_many_ifa_tablets_did_you_consume_since_last_visit"
     },
     {
@@ -766,11 +943,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": {
-        "field": "are_you_taking_ifa_tablets",
-        "operator": "eq",
-        "value": "no"
-      },
+      "visibleWhen": [
+        {
+          "field": "are_you_taking_ifa_tablets",
+          "operator": "eq",
+          "value": "no"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets"
     },
     {
@@ -790,7 +974,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "question_code": "calcium_tablets_received_and_consumed"
+      "question_code": "calcium_tablets_received_and_consumed",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Have you visited health facility since my last visit",
@@ -809,7 +998,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "have_you_visited_health_facility_since_my_last_visit"
+      "question_code": "have_you_visited_health_facility_since_my_last_visit",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "If yes, enter date of latest ANC visit at the health facility",
@@ -819,11 +1013,18 @@
       "dateRule": {
         "notFuture": true
       },
-      "visibleWhen": {
-        "field": "have_you_visited_health_facility_since_my_last_visit",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_visited_health_facility_since_my_last_visit",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "if_yes_enter_date_of_latest_anc_visit_at_the_health_facility"
     },
     {
@@ -868,7 +1069,12 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "question_code": "advised_place_of_delivery"
+      "question_code": "advised_place_of_delivery",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Sickle Cell",
@@ -899,7 +1105,7 @@
           "value_code": "not_tested_yet"
         },
         {
-          "label": "Don’t know/ Not aware",
+          "label": "Don\u2019t know/ Not aware",
           "sort_order": 5,
           "value_code": "dont_know_not_aware"
         }
@@ -907,7 +1113,12 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "question_code": "sickle_cell"
+      "question_code": "sickle_cell",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Which of the following contraceptive/family planning method does the woman plan to use after delivery?",
@@ -971,7 +1182,12 @@
       "section": "History",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "contraceptive_family_planning_method_planned_after_delivery"
+      "question_code": "contraceptive_family_planning_method_planned_after_delivery",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Feeling sad, anxious, or stressed most days?",
@@ -990,7 +1206,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "feeling_sad_anxious_or_stressed_most_days"
+      "question_code": "feeling_sad_anxious_or_stressed_most_days",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Adequate family support during pregnancy?",
@@ -1009,7 +1230,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "adequate_family_support_during_pregnancy"
+      "question_code": "adequate_family_support_during_pregnancy",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Are you going to migrate to other place any time during pregnancy?",
@@ -1028,7 +1254,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "are_you_going_to_migrate_to_other_place_any_time_during_pregnancy"
+      "question_code": "are_you_going_to_migrate_to_other_place_any_time_during_pregnancy",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Have you done USG since last visit",
@@ -1047,7 +1278,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "have_you_done_usg_since_last_visit"
+      "question_code": "have_you_done_usg_since_last_visit",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "If yes, date of USG",
@@ -1060,11 +1296,18 @@
           "field": "lmp"
         }
       },
-      "visibleWhen": {
-        "field": "have_you_done_usg_since_last_visit",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_done_usg_since_last_visit",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "if_yes_date_of_usg"
     },
     {
@@ -1094,11 +1337,18 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "visibleWhen": {
-        "field": "have_you_done_usg_since_last_visit",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_done_usg_since_last_visit",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "type_of_usg"
     },
     {
@@ -1118,11 +1368,18 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "visibleWhen": {
-        "field": "have_you_done_usg_since_last_visit",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_done_usg_since_last_visit",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "usg_finding"
     },
     {
@@ -1142,7 +1399,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "has_the_transport_contact_been_shared_with_and_saved_by_the_beneficiary_family"
+      "question_code": "has_the_transport_contact_been_shared_with_and_saved_by_the_beneficiary_family",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Has the family set aside or arranged funds for delivery/emergency expenses?",
@@ -1161,7 +1423,12 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "has_the_family_set_aside_or_arranged_funds_for_delivery_emergency_expenses"
+      "question_code": "has_the_family_set_aside_or_arranged_funds_for_delivery_emergency_expenses",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Has a birth companion been identified to accompany the woman during delivery/emergency?",
@@ -1180,14 +1447,24 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "has_a_birth_companion_been_identified_to_accompany_the_woman_during_delivery_emergency"
+      "question_code": "has_a_birth_companion_been_identified_to_accompany_the_woman_during_delivery_emergency",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Remarks",
       "section": "History",
       "required": false,
       "input_type": "text",
-      "question_code": "remarks"
+      "question_code": "remarks",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "As a Sakhi, have you guided the beneficiary on the following?",
@@ -1241,7 +1518,12 @@
       "section": "History",
       "required": false,
       "input_type": "multiselect",
-      "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following"
+      "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     }
   ],
   "validationJson": [

--- a/apps/visit-form-service/prisma/seed-data/anc-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-visit.json
@@ -128,18 +128,11 @@
       "dateRule": {
         "notFuture": true
       },
-      "visibleWhen": [
-        {
-          "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "lmp_date_edit"
     },
     {
@@ -148,18 +141,11 @@
       "required": true,
       "input_type": "image",
       "captureMode": "LIVE_CAMERA_ONLY",
-      "visibleWhen": [
-        {
-          "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "upload_sonography_report_image"
     },
     {
@@ -646,18 +632,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "visibleWhen": [
-        {
-          "field": "current_gestational_age_in_weeks",
-          "operator": "gte",
-          "value": 20
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "fetal_movements"
     },
     {
@@ -665,18 +644,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "number",
-      "visibleWhen": [
-        {
-          "field": "current_gestational_age_in_weeks",
-          "operator": "gte",
-          "value": 20
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "fetal_heart_rate"
     },
     {
@@ -688,18 +660,11 @@
         "min": 10,
         "max": 50
       },
-      "visibleWhen": [
-        {
-          "field": "current_gestational_age_in_weeks",
-          "operator": "gte",
-          "value": 20
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "fundal_height_in_cm"
     },
     {
@@ -897,18 +862,11 @@
         "min": 0,
         "max": 35
       },
-      "visibleWhen": [
-        {
-          "field": "are_you_taking_ifa_tablets",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "how_many_ifa_tablets_did_you_consume_since_last_visit"
     },
     {
@@ -943,18 +901,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": [
-        {
-          "field": "are_you_taking_ifa_tablets",
-          "operator": "eq",
-          "value": "no"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "if_no_what_is_the_reasons_for_non_consumption_of_ifa_tablets"
     },
     {
@@ -1013,18 +964,11 @@
       "dateRule": {
         "notFuture": true
       },
-      "visibleWhen": [
-        {
-          "field": "have_you_visited_health_facility_since_my_last_visit",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "if_yes_enter_date_of_latest_anc_visit_at_the_health_facility"
     },
     {
@@ -1296,18 +1240,11 @@
           "field": "lmp"
         }
       },
-      "visibleWhen": [
-        {
-          "field": "have_you_done_usg_since_last_visit",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "if_yes_date_of_usg"
     },
     {
@@ -1337,18 +1274,11 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "visibleWhen": [
-        {
-          "field": "have_you_done_usg_since_last_visit",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "type_of_usg"
     },
     {
@@ -1368,18 +1298,11 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "visibleWhen": [
-        {
-          "field": "have_you_done_usg_since_last_visit",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "usg_finding"
     },
     {

--- a/apps/visit-form-service/prisma/seed-data/anc-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-visit.json
@@ -129,7 +129,7 @@
         "notFuture": true
       },
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
         "operator": "eq",
         "value": "yes"
       },
@@ -142,7 +142,7 @@
       "input_type": "image",
       "captureMode": "LIVE_CAMERA_ONLY",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "do_you_have_a_sonography_report_to_confirm_the_lmp_date",
         "operator": "eq",
         "value": "yes"
       },
@@ -633,9 +633,9 @@
       "required": true,
       "input_type": "radio",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-        "operator": "eq",
-        "value": "yes"
+        "field": "current_gestational_age_in_weeks",
+        "operator": "gte",
+        "value": "20"
       },
       "question_code": "fetal_movements"
     },
@@ -645,9 +645,9 @@
       "required": true,
       "input_type": "number",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-        "operator": "eq",
-        "value": "yes"
+        "field": "current_gestational_age_in_weeks",
+        "operator": "gte",
+        "value": "20"
       },
       "question_code": "fetal_heart_rate"
     },
@@ -661,9 +661,9 @@
         "max": 50
       },
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-        "operator": "eq",
-        "value": "yes"
+        "field": "current_gestational_age_in_weeks",
+        "operator": "gte",
+        "value": "20"
       },
       "question_code": "fundal_height_in_cm"
     },
@@ -863,7 +863,7 @@
         "max": 35
       },
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "are_you_taking_ifa_tablets",
         "operator": "eq",
         "value": "yes"
       },
@@ -965,7 +965,7 @@
         "notFuture": true
       },
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "have_you_visited_health_facility_since_my_last_visit",
         "operator": "eq",
         "value": "yes"
       },

--- a/apps/visit-form-service/prisma/seed-data/child-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/child-registration.json
@@ -93,7 +93,12 @@
       "section": "Personal Info",
       "required": true,
       "input_type": "number",
-      "question_code": "mother_beneficiary_id"
+      "question_code": "mother_beneficiary_id",
+      "visibleWhen": {
+        "field": "who_are_you_registering_in_the_program",
+        "operator": "eq",
+        "value": "child_of_a_registered_pregnant_woman"
+      }
     },
     {
       "label": "Registrtion date",

--- a/apps/visit-form-service/prisma/seed-data/child-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/child-registration.json
@@ -67,6 +67,10 @@
       "section": "Consent",
       "required": true,
       "input_type": "date",
+      "dateRule": {
+        "notFuture": true,
+        "maxDaysFrom": { "field": "registrtion_date", "days": 183 }
+      },
       "question_code": "date_of_birth_of_infant"
     },
     {
@@ -159,6 +163,7 @@
       "section": "Personal Info",
       "required": true,
       "input_type": "text",
+      "pattern": "NAME_NO_SPECIAL_CHARS",
       "question_code": "caregiver_name_first_name_middle_name_last_name"
     },
     {
@@ -191,6 +196,7 @@
       "section": "Personal Info",
       "required": true,
       "input_type": "number",
+      "exactLength": 10,
       "question_code": "mobile_number"
     },
     {
@@ -943,6 +949,54 @@
       "question_code": "vaccination_taken_at_birth"
     },
     {
+      "label": "BCG date",
+      "section": "Infant Details",
+      "required": false,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "vaccination_taken_at_birth",
+        "operator": "contains",
+        "value": "bcg_date"
+      },
+      "question_code": "bcg_date"
+    },
+    {
+      "label": "OPV date",
+      "section": "Infant Details",
+      "required": false,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "vaccination_taken_at_birth",
+        "operator": "contains",
+        "value": "opv_date"
+      },
+      "question_code": "opv_date"
+    },
+    {
+      "label": "Hepatitis B date",
+      "section": "Infant Details",
+      "required": false,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "vaccination_taken_at_birth",
+        "operator": "contains",
+        "value": "hepatitis_b_date"
+      },
+      "question_code": "hepatitis_b_date"
+    },
+    {
+      "label": "Vitamin K date",
+      "section": "Infant Details",
+      "required": false,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "vaccination_taken_at_birth",
+        "operator": "contains",
+        "value": "vitamin_k_date"
+      },
+      "question_code": "vitamin_k_date"
+    },
+    {
       "label": "Remarks",
       "section": "Infant Details",
       "required": false,
@@ -954,6 +1008,11 @@
     {
       "rule": "ANY_OF_REQUIRED",
       "fields": ["mother_date_of_birth", "mother_age"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "vaccination_taken_at_birth",
+      "exclusiveValues": ["none"]
     }
   ]
 }

--- a/apps/visit-form-service/prisma/seed-data/child-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/child-registration.json
@@ -1013,6 +1013,16 @@
       "rule": "EXCLUSIVE_OPTION",
       "field": "vaccination_taken_at_birth",
       "exclusiveValues": ["none"]
+    },
+    {
+      "rule": "REQUIRED_IF_SELECTED",
+      "field": "vaccination_taken_at_birth",
+      "optionFieldMap": {
+        "bcg_date": "bcg_date",
+        "opv_date": "opv_date",
+        "hepatitis_b_date": "hepatitis_b_date",
+        "vitamin_k_date": "vitamin_k_date"
+      }
     }
   ]
 }

--- a/apps/visit-form-service/prisma/seed-data/infant-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/infant-visit.json
@@ -1,0 +1,1532 @@
+{
+  "schemaJson": [
+    {
+      "label": "Date of visit",
+      "section": "Tests",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_visit"
+    },
+    {
+      "label": "Visit type",
+      "section": "Tests",
+      "required": true,
+      "input_type": "text",
+      "question_code": "visit_type"
+    },
+    {
+      "label": "Have you been able to meet the beneficiary for the visit?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "have_you_been_able_to_meet_the_beneficiary_for_the_visit"
+    },
+    {
+      "label": "If no, mention reasons",
+      "options": [
+        {
+          "label": "Migrated, status known",
+          "sort_order": 0,
+          "value_code": "migrated_status_known"
+        },
+        {
+          "label": "Migrated, status unknown",
+          "sort_order": 1,
+          "value_code": "migrated_status_unknown"
+        },
+        {
+          "label": "Caregiver and Child not available (gone out, hospitalised)",
+          "sort_order": 2,
+          "value_code": "caregiver_and_child_not_available_gone_out_hospitalised"
+        },
+        {
+          "label": "Caregiver busy for the child check up",
+          "sort_order": 3,
+          "value_code": "caregiver_busy_for_the_child_check_up"
+        },
+        {
+          "label": "Other",
+          "sort_order": 4,
+          "value_code": "other"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "select",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "no"
+      },
+      "question_code": "if_no_mention_reasons"
+    },
+    {
+      "label": "RCH Number",
+      "section": "Tests",
+      "required": true,
+      "input_type": "text",
+      "question_code": "rch_number"
+    },
+    {
+      "label": "Date of birth",
+      "section": "Tests",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_birth"
+    },
+    {
+      "label": "Name of the Child",
+      "section": "Tests",
+      "required": true,
+      "input_type": "text",
+      "question_code": "name_of_the_child"
+    },
+    {
+      "label": "Age in months",
+      "section": "Tests",
+      "required": true,
+      "input_type": "number",
+      "computedFrom": "CHILD_AGE_MONTHS",
+      "question_code": "age_in_months"
+    },
+    {
+      "label": "Sex of the Infant",
+      "options": [
+        {
+          "label": "Male",
+          "sort_order": 0,
+          "value_code": "male"
+        },
+        {
+          "label": "Female",
+          "sort_order": 1,
+          "value_code": "female"
+        },
+        {
+          "label": "Transgender",
+          "sort_order": 2,
+          "value_code": "transgender"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "select",
+      "question_code": "sex_of_the_infant"
+    },
+    {
+      "label": "Birth weight in kg",
+      "section": "Tests",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 0.5,
+        "max": 6
+      },
+      "question_code": "birth_weight_in_kg"
+    },
+    {
+      "label": "Length of the baby at the time of birth in cm",
+      "section": "Tests",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 25,
+        "max": 99
+      },
+      "question_code": "length_of_the_baby_at_the_time_of_birth_in_cm"
+    },
+    {
+      "label": "Premature child",
+      "options": [
+        {
+          "label": "Full term (≥37 weeks)",
+          "sort_order": 0,
+          "value_code": "full_term_gte_37_weeks"
+        },
+        {
+          "label": "Preterm (<37 weeks)",
+          "sort_order": 1,
+          "value_code": "preterm_lt_37_weeks"
+        },
+        {
+          "label": "Don't know",
+          "sort_order": 2,
+          "value_code": "dont_know"
+        }
+      ],
+      "section": "Tests",
+      "required": true,
+      "input_type": "select",
+      "question_code": "premature_child"
+    },
+    {
+      "label": "Current feeding practice",
+      "options": [
+        {
+          "label": "Exclusive breastfeeding",
+          "sort_order": 0,
+          "value_code": "exclusive_breastfeeding"
+        },
+        {
+          "label": "Top feed + breastfeed",
+          "sort_order": 1,
+          "value_code": "top_feed_plus_breastfeed"
+        },
+        {
+          "label": "Only top feed (cowmilk/buffalo milk/goat milk/formula milk)",
+          "sort_order": 2,
+          "value_code": "only_top_feed_cowmilk_buffalo_milk_goat_milk_formula_milk"
+        },
+        {
+          "label": "Water + breastfeed",
+          "sort_order": 3,
+          "value_code": "water_plus_breastfeed"
+        },
+        {
+          "label": "Not able to drink/feed",
+          "sort_order": 4,
+          "value_code": "not_able_to_drink_feed"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "current_feeding_practice"
+    },
+    {
+      "label": "Sucking (Breast Feeding)",
+      "options": [
+        {
+          "label": "Good",
+          "sort_order": 0,
+          "value_code": "good"
+        },
+        {
+          "label": "Poor",
+          "sort_order": 1,
+          "value_code": "poor"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "sucking_breast_feeding"
+    },
+    {
+      "label": "Feeding concerns",
+      "options": [
+        {
+          "label": "Mother not alive",
+          "sort_order": 0,
+          "value_code": "mother_not_alive"
+        },
+        {
+          "label": "Mother has cracked/inverted nipples",
+          "sort_order": 1,
+          "value_code": "mother_has_cracked_inverted_nipples"
+        },
+        {
+          "label": "Baby not latching properly",
+          "sort_order": 2,
+          "value_code": "baby_not_latching_properly"
+        },
+        {
+          "label": "Low milk supply",
+          "sort_order": 3,
+          "value_code": "low_milk_supply"
+        },
+        {
+          "label": "Breast engorgement or swelling",
+          "sort_order": 4,
+          "value_code": "breast_engorgement_or_swelling"
+        },
+        {
+          "label": "Baby refusing to feed",
+          "sort_order": 5,
+          "value_code": "baby_refusing_to_feed"
+        },
+        {
+          "label": "Other",
+          "sort_order": 6,
+          "value_code": "other"
+        },
+        {
+          "label": "No concerns",
+          "sort_order": 7,
+          "value_code": "no_concerns"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "feeding_concerns"
+    },
+    {
+      "label": "Have you started complementary feeding for your child?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "have_you_started_complementary_feeding_for_your_child"
+    },
+    {
+      "label": "How many times do child take meal in a day? (Full meal Excluding snacks)",
+      "options": [
+        {
+          "label": "Once a day",
+          "sort_order": 0,
+          "value_code": "once_a_day"
+        },
+        {
+          "label": "Twice a day",
+          "sort_order": 1,
+          "value_code": "twice_a_day"
+        },
+        {
+          "label": "Three times a day",
+          "sort_order": 2,
+          "value_code": "three_times_a_day"
+        },
+        {
+          "label": "More than 3 times in a day",
+          "sort_order": 3,
+          "value_code": "more_than_3_times_in_a_day"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "visibleWhen": {
+        "field": "have_you_started_complementary_feeding_for_your_child",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "how_many_times_do_child_take_meal_in_a_day"
+    },
+    {
+      "label": "Which of these food stuff have child consumed in the last 24 hours?",
+      "options": [
+        {
+          "label": "Grains, Roots and Tubers (Rice, wheat, maize, millet, roti, bread, potato, sweet potato)",
+          "sort_order": 0,
+          "value_code": "grains_roots_and_tubers"
+        },
+        {
+          "label": "Legumes and Nuts (Lentils (dal), beans, peas, chickpeas, groundnuts)",
+          "sort_order": 1,
+          "value_code": "legumes_and_nuts"
+        },
+        {
+          "label": "Dairy products (Milk, curd/yogurt, cheese.)",
+          "sort_order": 2,
+          "value_code": "dairy_products"
+        },
+        {
+          "label": "Vitamin A–Rich Fruits and Vegetables (Carrot, pumpkin, mango, papaya, dark green leafy vegetables)",
+          "sort_order": 3,
+          "value_code": "vitamin_a_rich_fruits_and_vegetables"
+        },
+        {
+          "label": "Other Fruits and Vegetables (Banana, apple, tomato, cucumber, other seasonal fruits/vegetables)",
+          "sort_order": 4,
+          "value_code": "other_fruits_and_vegetables"
+        },
+        {
+          "label": "Eggs",
+          "sort_order": 5,
+          "value_code": "eggs"
+        },
+        {
+          "label": "Flesh Foods (Meat, fish, chicken, organ meat (liver))",
+          "sort_order": 6,
+          "value_code": "flesh_foods"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "visibleWhen": {
+        "field": "have_you_started_complementary_feeding_for_your_child",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "which_of_these_food_stuff_have_child_consumed_in_the_last_24_hours"
+    },
+    {
+      "label": "Which of the following foods does the child avoid eating or you avoid giving to the child?",
+      "options": [
+        {
+          "label": "Grains, Roots and Tubers (Rice, wheat, maize, millet, roti, bread, potato, sweet potato)",
+          "sort_order": 0,
+          "value_code": "grains_roots_and_tubers"
+        },
+        {
+          "label": "Legumes and Nuts (Lentils (dal), beans, peas, chickpeas, groundnuts)",
+          "sort_order": 1,
+          "value_code": "legumes_and_nuts"
+        },
+        {
+          "label": "Dairy products (Milk, curd/yogurt, cheese.)",
+          "sort_order": 2,
+          "value_code": "dairy_products"
+        },
+        {
+          "label": "Vitamin A–Rich Fruits and Vegetables (Carrot, pumpkin, mango, papaya, dark green leafy vegetables)",
+          "sort_order": 3,
+          "value_code": "vitamin_a_rich_fruits_and_vegetables"
+        },
+        {
+          "label": "Other Fruits and Vegetables (Banana, apple, tomato, cucumber, other seasonal fruits/vegetables)",
+          "sort_order": 4,
+          "value_code": "other_fruits_and_vegetables"
+        },
+        {
+          "label": "Eggs",
+          "sort_order": 5,
+          "value_code": "eggs"
+        },
+        {
+          "label": "Flesh Foods (Meat, fish, chicken, organ meat (liver))",
+          "sort_order": 6,
+          "value_code": "flesh_foods"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "visibleWhen": {
+        "field": "have_you_started_complementary_feeding_for_your_child",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "which_of_the_following_foods_does_the_child_avoid_eating_or_you_avoid_giving_to_the_child"
+    },
+    {
+      "label": "Activity level",
+      "options": [
+        {
+          "label": "Active & moving",
+          "sort_order": 0,
+          "value_code": "active_and_moving"
+        },
+        {
+          "label": "Reduced movement",
+          "sort_order": 1,
+          "value_code": "reduced_movement"
+        },
+        {
+          "label": "Lethargic",
+          "sort_order": 2,
+          "value_code": "lethargic"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "question_code": "activity_level"
+    },
+    {
+      "label": "Is there any deformity detected in the infant?",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Symptoms",
+      "required": false,
+      "input_type": "radio",
+      "question_code": "is_there_any_deformity_detected_in_the_infant"
+    },
+    {
+      "label": "Thermal care practices",
+      "options": [
+        {
+          "label": "Wiped/bathed/dried regularly",
+          "sort_order": 0,
+          "value_code": "wiped_bathed_dried_regularly"
+        },
+        {
+          "label": "Kept warm",
+          "sort_order": 1,
+          "value_code": "kept_warm"
+        },
+        {
+          "label": "Kangaroo care till 2 months",
+          "sort_order": 2,
+          "value_code": "kangaroo_care_till_2_months"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "visibleWhen": {
+        "field": "age_in_months",
+        "operator": "lt",
+        "value": 2
+      },
+      "question_code": "thermal_care_practices"
+    },
+    {
+      "label": "Is the Child showing all Developmental Milestones as per his/her age? (check for the signs given to you in the module)",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "is_the_child_showing_all_developmental_milestones_as_per_his_her_age"
+    },
+    {
+      "label": "Is the baby showing any danger signs since last visit?",
+      "options": [
+        {
+          "label": "Dry cough/Wet cough/Persistent cough",
+          "sort_order": 0,
+          "value_code": "dry_wet_persistent_cough"
+        },
+        {
+          "label": "Fast breathing (>60breaths/min), grunting, chest in-drawing",
+          "sort_order": 1,
+          "value_code": "fast_breathing_grunting_chest_in_drawing"
+        },
+        {
+          "label": "Severe hypothermia: <96°F",
+          "sort_order": 2,
+          "value_code": "severe_hypothermia_lt_96f"
+        },
+        {
+          "label": "Severe hyperthermia: >100°F",
+          "sort_order": 3,
+          "value_code": "severe_hyperthermia_gt_100f"
+        },
+        {
+          "label": "Yellow eyes, palms, soles, body, face etc",
+          "sort_order": 4,
+          "value_code": "yellow_eyes_palms_soles_body_face_etc"
+        },
+        {
+          "label": "Pallor sclera, palms, soles, etc (for 13-24 months only)",
+          "sort_order": 5,
+          "value_code": "pallor_sclera_palms_soles_etc_13_24_months_only"
+        },
+        {
+          "label": "Blue color (cyanosis) around lips/skin",
+          "sort_order": 6,
+          "value_code": "blue_color_cyanosis_around_lips_skin"
+        },
+        {
+          "label": "Presence of oedema (pitting)",
+          "sort_order": 7,
+          "value_code": "presence_of_oedema_pitting"
+        },
+        {
+          "label": "Convulsions: Twitching, fits, or abnormal movements",
+          "sort_order": 8,
+          "value_code": "convulsions_twitching_fits_or_abnormal_movements"
+        },
+        {
+          "label": "Lethargy, floppiness, or inability to wake up",
+          "sort_order": 9,
+          "value_code": "lethargy_floppiness_or_inability_to_wake_up"
+        },
+        {
+          "label": "Not able to drink/feed",
+          "sort_order": 10,
+          "value_code": "not_able_to_drink_feed"
+        },
+        {
+          "label": "Vomits everything",
+          "sort_order": 11,
+          "value_code": "vomits_everything"
+        },
+        {
+          "label": "Diarrhoea",
+          "sort_order": 12,
+          "value_code": "diarrhoea"
+        },
+        {
+          "label": "Blood in stool",
+          "sort_order": 13,
+          "value_code": "blood_in_stool"
+        },
+        {
+          "label": "No abnormal signs/symptoms",
+          "sort_order": 14,
+          "value_code": "no_abnormal_signs_symptoms"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "is_the_baby_showing_any_danger_signs_since_last_visit"
+    },
+    {
+      "label": "Child temprature in °F",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 93,
+        "max": 105
+      },
+      "question_code": "child_temprature_in_f"
+    },
+    {
+      "label": "Child Respiratory Rate 2 - 12 months",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 10,
+        "max": 90
+      },
+      "question_code": "child_respiratory_rate_2_12_months"
+    },
+    {
+      "label": "Current Length in cm",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 25,
+        "max": 99
+      },
+      "question_code": "current_length_in_cm"
+    },
+    {
+      "label": "Current Weight in kg",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 0.5,
+        "max": 15
+      },
+      "question_code": "current_weight_in_kg"
+    },
+    {
+      "label": "Nutritional status (Wasting)",
+      "options": [
+        {
+          "label": "Normal",
+          "sort_order": 0,
+          "value_code": "normal"
+        },
+        {
+          "label": "MAM",
+          "sort_order": 1,
+          "value_code": "mam"
+        },
+        {
+          "label": "SAM",
+          "sort_order": 2,
+          "value_code": "sam"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "computedFrom": "NUTRITIONAL_ZSCORE",
+      "question_code": "nutritional_status_wasting"
+    },
+    {
+      "label": "Nutritional status (Stunting)",
+      "options": [
+        {
+          "label": "Normal",
+          "sort_order": 0,
+          "value_code": "normal"
+        },
+        {
+          "label": "Moderately stunted",
+          "sort_order": 1,
+          "value_code": "moderately_stunted"
+        },
+        {
+          "label": "Severely stunted",
+          "sort_order": 2,
+          "value_code": "severely_stunted"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "computedFrom": "NUTRITIONAL_ZSCORE",
+      "question_code": "nutritional_status_stunting"
+    },
+    {
+      "label": "Nutritional status (Underweight)",
+      "options": [
+        {
+          "label": "Normal",
+          "sort_order": 0,
+          "value_code": "normal"
+        },
+        {
+          "label": "MUW",
+          "sort_order": 1,
+          "value_code": "muw"
+        },
+        {
+          "label": "SUW",
+          "sort_order": 2,
+          "value_code": "suw"
+        }
+      ],
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "select",
+      "computedFrom": "NUTRITIONAL_ZSCORE",
+      "question_code": "nutritional_status_underweight"
+    },
+    {
+      "label": "MUAC (in cms)",
+      "section": "Symptoms",
+      "required": true,
+      "input_type": "number",
+      "numericRange": {
+        "min": 5,
+        "max": 25
+      },
+      "visibleWhen": {
+        "field": "age_in_months",
+        "operator": "gte",
+        "value": 6
+      },
+      "question_code": "muac_in_cms"
+    },
+    {
+      "label": "What is the SOURCE OF IMMUNIZATION data collected?",
+      "options": [
+        {
+          "label": "RCH Card",
+          "sort_order": 0,
+          "value_code": "rch_card"
+        },
+        {
+          "label": "Reported by Caregiver",
+          "sort_order": 1,
+          "value_code": "reported_by_caregiver"
+        },
+        {
+          "label": "Other",
+          "sort_order": 2,
+          "value_code": "other"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "select",
+      "question_code": "source_of_immunization_data_collected"
+    },
+    {
+      "label": "BCG",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "bcg"
+    },
+    {
+      "label": "BCG date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "bcg",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "bcg_date"
+    },
+    {
+      "label": "OPV-0",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "opv_0"
+    },
+    {
+      "label": "OPV-0 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "opv_0",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "opv_0_date"
+    },
+    {
+      "label": "Hepatitis B – Birth Dose",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "hepatitis_b_birth_dose"
+    },
+    {
+      "label": "Hepatitis B date – Birth Dose",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "hepatitis_b_birth_dose",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "hepatitis_b_date_birth_dose"
+    },
+    {
+      "label": "Vitamin K",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "vitamin_k"
+    },
+    {
+      "label": "Vitamin K date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "vitamin_k",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "vitamin_k_date"
+    },
+    {
+      "label": "OPV-1",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "opv_1"
+    },
+    {
+      "label": "OPV-1 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "opv_1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "opv_1_date"
+    },
+    {
+      "label": "Pentavalent-1/DPT1",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "pentavalent_1_dpt1"
+    },
+    {
+      "label": "Pentavalent-1/DPT1 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "pentavalent_1_dpt1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "pentavalent_1_dpt1_date"
+    },
+    {
+      "label": "IPV-1",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "ipv_1"
+    },
+    {
+      "label": "IPV-1 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "ipv_1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "ipv_1_date"
+    },
+    {
+      "label": "Rotavirus1",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "rotavirus1"
+    },
+    {
+      "label": "Rotavirus1 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "rotavirus1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "rotavirus1_date"
+    },
+    {
+      "label": "PCV1 (if Applicable)",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "pcv1"
+    },
+    {
+      "label": "PCV1 date (if Applicable)",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "pcv1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "pcv1_date"
+    },
+    {
+      "label": "OPV-2",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "opv_2"
+    },
+    {
+      "label": "OPV-2 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "opv_2",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "opv_2_date"
+    },
+    {
+      "label": "Pentavalent-2/DPT2",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "pentavalent_2_dpt2"
+    },
+    {
+      "label": "Pentavalent-2/DPT2 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "pentavalent_2_dpt2",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "pentavalent_2_dpt2_date"
+    },
+    {
+      "label": "Rotavirus2",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "rotavirus2"
+    },
+    {
+      "label": "Rotavirus2 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "rotavirus2",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "rotavirus2_date"
+    },
+    {
+      "label": "OPV-3",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "opv_3"
+    },
+    {
+      "label": "OPV-3 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "opv_3",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "opv_3_date"
+    },
+    {
+      "label": "Pentavalent-3/DPT3",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "pentavalent_3_dpt3"
+    },
+    {
+      "label": "Pentavalent-3/DPT3 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "pentavalent_3_dpt3",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "pentavalent_3_dpt3_date"
+    },
+    {
+      "label": "IPV2",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "ipv2"
+    },
+    {
+      "label": "IPV2 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "ipv2",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "ipv2_date"
+    },
+    {
+      "label": "Rotavirus3",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "rotavirus3"
+    },
+    {
+      "label": "Rotavirus3 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "rotavirus3",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "rotavirus3_date"
+    },
+    {
+      "label": "PCV2 (if Applicable)",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "pcv2"
+    },
+    {
+      "label": "PCV2 date (if Applicable)",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "pcv2",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "pcv2_date"
+    },
+    {
+      "label": "MMR-1/MR1",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "mmr_1_mr1"
+    },
+    {
+      "label": "MMR-1/MR1 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "mmr_1_mr1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "mmr_1_mr1_date"
+    },
+    {
+      "label": "PCV booster",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "pcv_booster"
+    },
+    {
+      "label": "PCV booster date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "pcv_booster",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "pcv_booster_date"
+    },
+    {
+      "label": "Vitamin A",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "vitamin_a"
+    },
+    {
+      "label": "Vitamin A date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "vitamin_a",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "vitamin_a_date"
+    },
+    {
+      "label": "OPV booster",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "opv_booster"
+    },
+    {
+      "label": "OPV booster date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "opv_booster",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "opv_booster_date"
+    },
+    {
+      "label": "MMR2/MR2",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "mmr2_mr2"
+    },
+    {
+      "label": "MMR2/MR2 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "mmr2_mr2",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "mmr2_mr2_date"
+    },
+    {
+      "label": "DPT booster1",
+      "options": [
+        {
+          "label": "Yes",
+          "sort_order": 0,
+          "value_code": "yes"
+        },
+        {
+          "label": "No",
+          "sort_order": 1,
+          "value_code": "no"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "dpt_booster1"
+    },
+    {
+      "label": "DPT booster1 date",
+      "section": "History",
+      "required": true,
+      "input_type": "date",
+      "visibleWhen": {
+        "field": "dpt_booster1",
+        "operator": "eq",
+        "value": "yes"
+      },
+      "question_code": "dpt_booster1_date"
+    },
+    {
+      "label": "Remarks",
+      "section": "History",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    },
+    {
+      "label": "As a Sakhi, have you guided the beneficiary on the following?",
+      "options": [
+        {
+          "label": "Feeding and Nutrition Counselling",
+          "sort_order": 0,
+          "value_code": "feeding_and_nutrition_counselling"
+        },
+        {
+          "label": "Growth Monitoring",
+          "sort_order": 1,
+          "value_code": "growth_monitoring"
+        },
+        {
+          "label": "Immunization Counselling",
+          "sort_order": 2,
+          "value_code": "immunization_counselling"
+        },
+        {
+          "label": "Hygiene and Infection Prevention",
+          "sort_order": 3,
+          "value_code": "hygiene_and_infection_prevention"
+        },
+        {
+          "label": "Illness Screening and Danger Signs",
+          "sort_order": 4,
+          "value_code": "illness_screening_and_danger_signs"
+        },
+        {
+          "label": "Developmental Milestones",
+          "sort_order": 5,
+          "value_code": "developmental_milestones"
+        },
+        {
+          "label": "Injury Prevention and safety precautions",
+          "sort_order": 6,
+          "value_code": "injury_prevention_and_safety_precautions"
+        },
+        {
+          "label": "Follow-Up and Referral",
+          "sort_order": 7,
+          "value_code": "follow_up_and_referral"
+        }
+      ],
+      "section": "History",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following"
+    }
+  ],
+  "validationJson": []
+}

--- a/apps/visit-form-service/prisma/seed-data/infant-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/infant-visit.json
@@ -379,18 +379,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "select",
-      "visibleWhen": [
-        {
-          "field": "have_you_started_complementary_feeding_for_your_child",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "how_many_times_do_child_take_meal_in_a_day"
     },
     {
@@ -435,18 +428,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": [
-        {
-          "field": "have_you_started_complementary_feeding_for_your_child",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "which_of_these_food_stuff_have_child_consumed_in_the_last_24_hours"
     },
     {
@@ -491,18 +477,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": [
-        {
-          "field": "have_you_started_complementary_feeding_for_your_child",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "which_of_the_following_foods_does_the_child_avoid_eating_or_you_avoid_giving_to_the_child"
     },
     {
@@ -580,18 +559,11 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": [
-        {
-          "field": "age_in_months",
-          "operator": "lt",
-          "value": 2
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "thermal_care_practices"
     },
     {
@@ -870,18 +842,11 @@
         "min": 5,
         "max": 25
       },
-      "visibleWhen": [
-        {
-          "field": "age_in_months",
-          "operator": "gte",
-          "value": 6
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "muac_in_cms"
     },
     {
@@ -942,18 +907,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "bcg",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "bcg_date"
     },
     {
@@ -985,18 +943,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "opv_0",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "opv_0_date"
     },
     {
@@ -1028,18 +979,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "hepatitis_b_birth_dose",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "hepatitis_b_date_birth_dose"
     },
     {
@@ -1071,18 +1015,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "vitamin_k",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "vitamin_k_date"
     },
     {
@@ -1114,18 +1051,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "opv_1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "opv_1_date"
     },
     {
@@ -1157,18 +1087,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "pentavalent_1_dpt1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "pentavalent_1_dpt1_date"
     },
     {
@@ -1200,18 +1123,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "ipv_1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "ipv_1_date"
     },
     {
@@ -1243,18 +1159,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "rotavirus1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "rotavirus1_date"
     },
     {
@@ -1286,18 +1195,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "pcv1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "pcv1_date"
     },
     {
@@ -1329,18 +1231,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "opv_2",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "opv_2_date"
     },
     {
@@ -1372,18 +1267,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "pentavalent_2_dpt2",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "pentavalent_2_dpt2_date"
     },
     {
@@ -1415,18 +1303,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "rotavirus2",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "rotavirus2_date"
     },
     {
@@ -1458,18 +1339,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "opv_3",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "opv_3_date"
     },
     {
@@ -1501,18 +1375,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "pentavalent_3_dpt3",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "pentavalent_3_dpt3_date"
     },
     {
@@ -1544,18 +1411,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "ipv2",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "ipv2_date"
     },
     {
@@ -1587,18 +1447,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "rotavirus3",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "rotavirus3_date"
     },
     {
@@ -1630,18 +1483,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "pcv2",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "pcv2_date"
     },
     {
@@ -1673,18 +1519,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "mmr_1_mr1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "mmr_1_mr1_date"
     },
     {
@@ -1716,18 +1555,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "pcv_booster",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "pcv_booster_date"
     },
     {
@@ -1759,18 +1591,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "vitamin_a",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "vitamin_a_date"
     },
     {
@@ -1802,18 +1627,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "opv_booster",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "opv_booster_date"
     },
     {
@@ -1845,18 +1663,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "mmr2_mr2",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "mmr2_mr2_date"
     },
     {
@@ -1888,18 +1699,11 @@
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": [
-        {
-          "field": "dpt_booster1",
-          "operator": "eq",
-          "value": "yes"
-        },
-        {
-          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
-          "operator": "eq",
-          "value": "yes"
-        }
-      ],
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      },
       "question_code": "dpt_booster1_date"
     },
     {

--- a/apps/visit-form-service/prisma/seed-data/infant-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/infant-visit.json
@@ -77,21 +77,36 @@
       "section": "Tests",
       "required": true,
       "input_type": "text",
-      "question_code": "rch_number"
+      "question_code": "rch_number",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Date of birth",
       "section": "Tests",
       "required": true,
       "input_type": "date",
-      "question_code": "date_of_birth"
+      "question_code": "date_of_birth",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Name of the Child",
       "section": "Tests",
       "required": true,
       "input_type": "text",
-      "question_code": "name_of_the_child"
+      "question_code": "name_of_the_child",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Age in months",
@@ -99,7 +114,12 @@
       "required": true,
       "input_type": "number",
       "computedFrom": "CHILD_AGE_MONTHS",
-      "question_code": "age_in_months"
+      "question_code": "age_in_months",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Sex of the Infant",
@@ -123,7 +143,12 @@
       "section": "Tests",
       "required": true,
       "input_type": "select",
-      "question_code": "sex_of_the_infant"
+      "question_code": "sex_of_the_infant",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Birth weight in kg",
@@ -134,7 +159,12 @@
         "min": 0.5,
         "max": 6
       },
-      "question_code": "birth_weight_in_kg"
+      "question_code": "birth_weight_in_kg",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Length of the baby at the time of birth in cm",
@@ -145,13 +175,18 @@
         "min": 25,
         "max": 99
       },
-      "question_code": "length_of_the_baby_at_the_time_of_birth_in_cm"
+      "question_code": "length_of_the_baby_at_the_time_of_birth_in_cm",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Premature child",
       "options": [
         {
-          "label": "Full term (≥37 weeks)",
+          "label": "Full term (\u226537 weeks)",
           "sort_order": 0,
           "value_code": "full_term_gte_37_weeks"
         },
@@ -169,7 +204,12 @@
       "section": "Tests",
       "required": true,
       "input_type": "select",
-      "question_code": "premature_child"
+      "question_code": "premature_child",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Current feeding practice",
@@ -203,7 +243,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "current_feeding_practice"
+      "question_code": "current_feeding_practice",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Sucking (Breast Feeding)",
@@ -222,7 +267,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "question_code": "sucking_breast_feeding"
+      "question_code": "sucking_breast_feeding",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Feeding concerns",
@@ -271,7 +321,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "feeding_concerns"
+      "question_code": "feeding_concerns",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Have you started complementary feeding for your child?",
@@ -290,7 +345,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "question_code": "have_you_started_complementary_feeding_for_your_child"
+      "question_code": "have_you_started_complementary_feeding_for_your_child",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "How many times do child take meal in a day? (Full meal Excluding snacks)",
@@ -319,11 +379,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "select",
-      "visibleWhen": {
-        "field": "have_you_started_complementary_feeding_for_your_child",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_started_complementary_feeding_for_your_child",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "how_many_times_do_child_take_meal_in_a_day"
     },
     {
@@ -345,7 +412,7 @@
           "value_code": "dairy_products"
         },
         {
-          "label": "Vitamin A–Rich Fruits and Vegetables (Carrot, pumpkin, mango, papaya, dark green leafy vegetables)",
+          "label": "Vitamin A\u2013Rich Fruits and Vegetables (Carrot, pumpkin, mango, papaya, dark green leafy vegetables)",
           "sort_order": 3,
           "value_code": "vitamin_a_rich_fruits_and_vegetables"
         },
@@ -368,11 +435,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": {
-        "field": "have_you_started_complementary_feeding_for_your_child",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_started_complementary_feeding_for_your_child",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "which_of_these_food_stuff_have_child_consumed_in_the_last_24_hours"
     },
     {
@@ -394,7 +468,7 @@
           "value_code": "dairy_products"
         },
         {
-          "label": "Vitamin A–Rich Fruits and Vegetables (Carrot, pumpkin, mango, papaya, dark green leafy vegetables)",
+          "label": "Vitamin A\u2013Rich Fruits and Vegetables (Carrot, pumpkin, mango, papaya, dark green leafy vegetables)",
           "sort_order": 3,
           "value_code": "vitamin_a_rich_fruits_and_vegetables"
         },
@@ -417,11 +491,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": {
-        "field": "have_you_started_complementary_feeding_for_your_child",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "have_you_started_complementary_feeding_for_your_child",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "which_of_the_following_foods_does_the_child_avoid_eating_or_you_avoid_giving_to_the_child"
     },
     {
@@ -446,7 +527,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "select",
-      "question_code": "activity_level"
+      "question_code": "activity_level",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Is there any deformity detected in the infant?",
@@ -465,7 +551,12 @@
       "section": "Symptoms",
       "required": false,
       "input_type": "radio",
-      "question_code": "is_there_any_deformity_detected_in_the_infant"
+      "question_code": "is_there_any_deformity_detected_in_the_infant",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Thermal care practices",
@@ -489,11 +580,18 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "visibleWhen": {
-        "field": "age_in_months",
-        "operator": "lt",
-        "value": 2
-      },
+      "visibleWhen": [
+        {
+          "field": "age_in_months",
+          "operator": "lt",
+          "value": 2
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "thermal_care_practices"
     },
     {
@@ -513,7 +611,12 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "radio",
-      "question_code": "is_the_child_showing_all_developmental_milestones_as_per_his_her_age"
+      "question_code": "is_the_child_showing_all_developmental_milestones_as_per_his_her_age",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Is the baby showing any danger signs since last visit?",
@@ -529,12 +632,12 @@
           "value_code": "fast_breathing_grunting_chest_in_drawing"
         },
         {
-          "label": "Severe hypothermia: <96°F",
+          "label": "Severe hypothermia: <96\u00b0F",
           "sort_order": 2,
           "value_code": "severe_hypothermia_lt_96f"
         },
         {
-          "label": "Severe hyperthermia: >100°F",
+          "label": "Severe hyperthermia: >100\u00b0F",
           "sort_order": 3,
           "value_code": "severe_hyperthermia_gt_100f"
         },
@@ -597,10 +700,15 @@
       "section": "Symptoms",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "is_the_baby_showing_any_danger_signs_since_last_visit"
+      "question_code": "is_the_baby_showing_any_danger_signs_since_last_visit",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
-      "label": "Child temprature in °F",
+      "label": "Child temprature in \u00b0F",
       "section": "Symptoms",
       "required": true,
       "input_type": "number",
@@ -608,7 +716,12 @@
         "min": 93,
         "max": 105
       },
-      "question_code": "child_temprature_in_f"
+      "question_code": "child_temprature_in_f",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Child Respiratory Rate 2 - 12 months",
@@ -619,7 +732,12 @@
         "min": 10,
         "max": 90
       },
-      "question_code": "child_respiratory_rate_2_12_months"
+      "question_code": "child_respiratory_rate_2_12_months",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Current Length in cm",
@@ -630,7 +748,12 @@
         "min": 25,
         "max": 99
       },
-      "question_code": "current_length_in_cm"
+      "question_code": "current_length_in_cm",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Current Weight in kg",
@@ -641,7 +764,12 @@
         "min": 0.5,
         "max": 15
       },
-      "question_code": "current_weight_in_kg"
+      "question_code": "current_weight_in_kg",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Nutritional status (Wasting)",
@@ -666,7 +794,12 @@
       "required": true,
       "input_type": "select",
       "computedFrom": "NUTRITIONAL_ZSCORE",
-      "question_code": "nutritional_status_wasting"
+      "question_code": "nutritional_status_wasting",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Nutritional status (Stunting)",
@@ -691,7 +824,12 @@
       "required": true,
       "input_type": "select",
       "computedFrom": "NUTRITIONAL_ZSCORE",
-      "question_code": "nutritional_status_stunting"
+      "question_code": "nutritional_status_stunting",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Nutritional status (Underweight)",
@@ -716,7 +854,12 @@
       "required": true,
       "input_type": "select",
       "computedFrom": "NUTRITIONAL_ZSCORE",
-      "question_code": "nutritional_status_underweight"
+      "question_code": "nutritional_status_underweight",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "MUAC (in cms)",
@@ -727,11 +870,18 @@
         "min": 5,
         "max": 25
       },
-      "visibleWhen": {
-        "field": "age_in_months",
-        "operator": "gte",
-        "value": 6
-      },
+      "visibleWhen": [
+        {
+          "field": "age_in_months",
+          "operator": "gte",
+          "value": 6
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "muac_in_cms"
     },
     {
@@ -756,7 +906,12 @@
       "section": "History",
       "required": true,
       "input_type": "select",
-      "question_code": "source_of_immunization_data_collected"
+      "question_code": "source_of_immunization_data_collected",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "BCG",
@@ -775,18 +930,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "bcg"
+      "question_code": "bcg",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "BCG date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "bcg",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "bcg",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "bcg_date"
     },
     {
@@ -806,22 +973,34 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "opv_0"
+      "question_code": "opv_0",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "OPV-0 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "opv_0",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "opv_0",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "opv_0_date"
     },
     {
-      "label": "Hepatitis B – Birth Dose",
+      "label": "Hepatitis B \u2013 Birth Dose",
       "options": [
         {
           "label": "Yes",
@@ -837,18 +1016,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "hepatitis_b_birth_dose"
+      "question_code": "hepatitis_b_birth_dose",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
-      "label": "Hepatitis B date – Birth Dose",
+      "label": "Hepatitis B date \u2013 Birth Dose",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "hepatitis_b_birth_dose",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "hepatitis_b_birth_dose",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "hepatitis_b_date_birth_dose"
     },
     {
@@ -868,18 +1059,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "vitamin_k"
+      "question_code": "vitamin_k",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Vitamin K date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "vitamin_k",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "vitamin_k",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "vitamin_k_date"
     },
     {
@@ -899,18 +1102,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "opv_1"
+      "question_code": "opv_1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "OPV-1 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "opv_1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "opv_1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "opv_1_date"
     },
     {
@@ -930,18 +1145,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "pentavalent_1_dpt1"
+      "question_code": "pentavalent_1_dpt1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Pentavalent-1/DPT1 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "pentavalent_1_dpt1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "pentavalent_1_dpt1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "pentavalent_1_dpt1_date"
     },
     {
@@ -961,18 +1188,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "ipv_1"
+      "question_code": "ipv_1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "IPV-1 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "ipv_1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "ipv_1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "ipv_1_date"
     },
     {
@@ -992,18 +1231,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "rotavirus1"
+      "question_code": "rotavirus1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Rotavirus1 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "rotavirus1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "rotavirus1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "rotavirus1_date"
     },
     {
@@ -1023,18 +1274,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "pcv1"
+      "question_code": "pcv1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "PCV1 date (if Applicable)",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "pcv1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "pcv1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "pcv1_date"
     },
     {
@@ -1054,18 +1317,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "opv_2"
+      "question_code": "opv_2",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "OPV-2 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "opv_2",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "opv_2",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "opv_2_date"
     },
     {
@@ -1085,18 +1360,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "pentavalent_2_dpt2"
+      "question_code": "pentavalent_2_dpt2",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Pentavalent-2/DPT2 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "pentavalent_2_dpt2",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "pentavalent_2_dpt2",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "pentavalent_2_dpt2_date"
     },
     {
@@ -1116,18 +1403,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "rotavirus2"
+      "question_code": "rotavirus2",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Rotavirus2 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "rotavirus2",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "rotavirus2",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "rotavirus2_date"
     },
     {
@@ -1147,18 +1446,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "opv_3"
+      "question_code": "opv_3",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "OPV-3 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "opv_3",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "opv_3",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "opv_3_date"
     },
     {
@@ -1178,18 +1489,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "pentavalent_3_dpt3"
+      "question_code": "pentavalent_3_dpt3",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Pentavalent-3/DPT3 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "pentavalent_3_dpt3",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "pentavalent_3_dpt3",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "pentavalent_3_dpt3_date"
     },
     {
@@ -1209,18 +1532,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "ipv2"
+      "question_code": "ipv2",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "IPV2 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "ipv2",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "ipv2",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "ipv2_date"
     },
     {
@@ -1240,18 +1575,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "rotavirus3"
+      "question_code": "rotavirus3",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Rotavirus3 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "rotavirus3",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "rotavirus3",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "rotavirus3_date"
     },
     {
@@ -1271,18 +1618,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "pcv2"
+      "question_code": "pcv2",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "PCV2 date (if Applicable)",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "pcv2",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "pcv2",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "pcv2_date"
     },
     {
@@ -1302,18 +1661,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "mmr_1_mr1"
+      "question_code": "mmr_1_mr1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "MMR-1/MR1 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "mmr_1_mr1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "mmr_1_mr1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "mmr_1_mr1_date"
     },
     {
@@ -1333,18 +1704,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "pcv_booster"
+      "question_code": "pcv_booster",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "PCV booster date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "pcv_booster",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "pcv_booster",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "pcv_booster_date"
     },
     {
@@ -1364,18 +1747,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "vitamin_a"
+      "question_code": "vitamin_a",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "Vitamin A date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "vitamin_a",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "vitamin_a",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "vitamin_a_date"
     },
     {
@@ -1395,18 +1790,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "opv_booster"
+      "question_code": "opv_booster",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "OPV booster date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "opv_booster",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "opv_booster",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "opv_booster_date"
     },
     {
@@ -1426,18 +1833,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "mmr2_mr2"
+      "question_code": "mmr2_mr2",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "MMR2/MR2 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "mmr2_mr2",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "mmr2_mr2",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "mmr2_mr2_date"
     },
     {
@@ -1457,18 +1876,30 @@
       "section": "History",
       "required": true,
       "input_type": "radio",
-      "question_code": "dpt_booster1"
+      "question_code": "dpt_booster1",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "DPT booster1 date",
       "section": "History",
       "required": true,
       "input_type": "date",
-      "visibleWhen": {
-        "field": "dpt_booster1",
-        "operator": "eq",
-        "value": "yes"
-      },
+      "visibleWhen": [
+        {
+          "field": "dpt_booster1",
+          "operator": "eq",
+          "value": "yes"
+        },
+        {
+          "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+          "operator": "eq",
+          "value": "yes"
+        }
+      ],
       "question_code": "dpt_booster1_date"
     },
     {
@@ -1476,7 +1907,12 @@
       "section": "History",
       "required": false,
       "input_type": "text",
-      "question_code": "remarks"
+      "question_code": "remarks",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     },
     {
       "label": "As a Sakhi, have you guided the beneficiary on the following?",
@@ -1525,7 +1961,12 @@
       "section": "History",
       "required": true,
       "input_type": "multiselect",
-      "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following"
+      "question_code": "as_a_sakhi_have_you_guided_the_beneficiary_on_the_following",
+      "visibleWhen": {
+        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "operator": "eq",
+        "value": "yes"
+      }
     }
   ],
   "validationJson": []

--- a/apps/visit-form-service/prisma/seed-data/mother-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/mother-registration.json
@@ -1621,6 +1621,15 @@
       "exclusiveValues": ["none_received_yet"]
     },
     {
+      "rule": "REQUIRED_IF_SELECTED",
+      "field": "has_the_women_received_td_dose",
+      "optionFieldMap": {
+        "td_1_date": "td_1_date",
+        "td_2_date": "td_2_date",
+        "td_booster_date": "td_booster_date"
+      }
+    },
+    {
       "rule": "EXCLUSIVE_OPTION",
       "field": "have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions",
       "exclusiveValues": ["no_known_medical_condition", "don_t_know"]

--- a/apps/visit-form-service/prisma/seed-data/mother-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/mother-registration.json
@@ -48,6 +48,12 @@
       "section": "Consent",
       "required": true,
       "input_type": "date",
+      "dateRule": {
+        "notFuture": true,
+        "notAfter": { "field": "registration_date" },
+        "minDaysFrom": { "field": "registration_date", "days": 30 },
+        "maxDaysFrom": { "field": "registration_date", "days": 240 }
+      },
       "question_code": "lmp_date"
     },
     {
@@ -149,6 +155,7 @@
       "section": "Personal Info",
       "required": true,
       "input_type": "text",
+      "pattern": "NAME_NO_SPECIAL_CHARS",
       "question_code": "beneficiary_name"
     },
     {
@@ -724,6 +731,10 @@
         "value": "anc_1_completed",
         "operator": "eq"
       },
+      "dateRule": {
+        "notBefore": { "field": "lmp_date" },
+        "notAfter": { "field": "registration_date", "offsetDays": 5 }
+      },
       "question_code": "if_anc1_completed_please_record_the_date"
     },
     {
@@ -855,6 +866,7 @@
       "input_type": "date",
       "required": false,
       "section": "Health History",
+      "dateRule": { "notFuture": true },
       "visibleWhen": {
         "field": "has_the_women_received_td_dose",
         "operator": "contains",
@@ -867,6 +879,7 @@
       "input_type": "date",
       "required": false,
       "section": "Health History",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "td_1_date" } },
       "visibleWhen": {
         "field": "has_the_women_received_td_dose",
         "operator": "contains",
@@ -879,6 +892,7 @@
       "input_type": "date",
       "required": false,
       "section": "Health History",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "td_2_date" } },
       "visibleWhen": {
         "field": "has_the_women_received_td_dose",
         "operator": "contains",
@@ -1595,6 +1609,21 @@
     {
       "rule": "ANY_OF_REQUIRED",
       "fields": ["date_of_birth", "age_of_the_beneficiary"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "if_anc1_completed_are_you_identified_with_any_high_risk_condition_as_communicated_by_doctor_during_the_latest_anc_checkup_self_reported",
+      "exclusiveValues": ["no_known_medical_condition_identified_during_check_up", "don_t_know"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "has_the_women_received_td_dose",
+      "exclusiveValues": ["none_received_yet"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions",
+      "exclusiveValues": ["no_known_medical_condition", "don_t_know"]
     }
   ]
 }

--- a/apps/visit-form-service/prisma/seed.ts
+++ b/apps/visit-form-service/prisma/seed.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto';
 import { PrismaClient } from '../../../node_modules/.prisma/client-visit-form-service';
 import motherRegistrationPayload from './seed-data/mother-registration.json';
 import childRegistrationPayload from './seed-data/child-registration.json';
+import ancVisitPayload from './seed-data/anc-visit.json';
+import infantVisitPayload from './seed-data/infant-visit.json';
 
 const prisma = new PrismaClient();
 
@@ -53,6 +55,20 @@ const FORMS: FormDraft[] = [
     entityType: 'CHILD',
     versionNo: 'v1',
     payload: childRegistrationPayload,
+  },
+  {
+    formCode: 'ANC_VISIT',
+    formName: 'ANC Visit',
+    entityType: 'MOTHER',
+    versionNo: 'v1',
+    payload: ancVisitPayload,
+  },
+  {
+    formCode: 'INFANT_VISIT',
+    formName: 'Infant Visit',
+    entityType: 'CHILD',
+    versionNo: 'v1',
+    payload: infantVisitPayload,
   },
 ];
 

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.spec.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.spec.ts
@@ -1,0 +1,53 @@
+import { formFieldSchema } from './form-field.dto';
+
+function baseField(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    question_code: 'sample_field',
+    label: 'Sample field',
+    input_type: 'text',
+    required: false,
+    ...overrides,
+  };
+}
+
+describe('formFieldSchema — visibleWhen', () => {
+  it('accepts a single {field,operator,value} condition', () => {
+    const result = formFieldSchema.safeParse(
+      baseField({
+        visibleWhen: { field: 'met_beneficiary', operator: 'eq', value: 'yes' },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a field with no visibleWhen at all', () => {
+    const result = formFieldSchema.safeParse(baseField());
+    expect(result.success).toBe(true);
+  });
+
+  it(
+    'rejects an array-of-conditions visibleWhen — the mobile client cannot parse it and ' +
+      'crashes the whole form load (the ANC_VISIT/INFANT_VISIT incident this schema-level ' +
+      'rejection follows)',
+    () => {
+      const result = formFieldSchema.safeParse(
+        baseField({
+          visibleWhen: [
+            { field: 'met_beneficiary', operator: 'eq', value: 'yes' },
+            { field: 'has_usg_report', operator: 'eq', value: 'yes' },
+          ],
+        }),
+      );
+      expect(result.success).toBe(false);
+    },
+  );
+
+  it('rejects a single-element array — the array shape itself is rejected, not just multi-condition arrays', () => {
+    const result = formFieldSchema.safeParse(
+      baseField({
+        visibleWhen: [{ field: 'met_beneficiary', operator: 'eq', value: 'yes' }],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -29,9 +29,14 @@ extendZodWithOpenApi(z);
  *   with no section fall into a client-rendered catch-all tab — no special
  *   handling needed here beyond allowing the field to be absent.
  * Categories 1 (date rules) and 3 (cross-field, on validation_json — see
- * cross-field-rule.dto.ts) are the only other SRS-named categories; date
- * rules are deliberately NOT modeled here yet (see the forms API design doc
- * §7 — which comparison field a date rule reads from isn't specified).
+ * crossFieldRuleSchema below) are the only other SRS-named categories.
+ * - dateRule: SRS Category 1 — future-date rejection and date-vs-date
+ *   comparisons against another field on the same submission (e.g. LMP
+ *   must be on/after registration date minus 240 days). All bounds are
+ *   inclusive: a value exactly on the boundary is valid.
+ * - pattern: a closed set of named character-class checks (never a raw
+ *   regex in JSON) — e.g. rejecting digits/symbols in a name field per
+ *   Registration_PW_D Q19 ("should not accept any special characters").
  */
 export const formFieldSchema = z
   .object({
@@ -85,6 +90,30 @@ export const formFieldSchema = z
     captureMode: z.enum(['LIVE_CAMERA_ONLY']).optional(),
     requirePlaybackComplete: z.boolean().optional(),
     section: z.string().trim().min(1).optional(),
+    // SRS Category 1 — date-vs-date comparisons, evaluated only when this
+    // field and the referenced field both have a value (a missing value is
+    // the required-field check's concern, not this rule's). All comparisons
+    // are inclusive of the boundary day.
+    dateRule: z
+      .object({
+        notFuture: z.boolean().optional(),
+        notBefore: z
+          .object({ field: z.string().trim().min(1), offsetDays: z.number().int().optional() })
+          .optional(),
+        notAfter: z
+          .object({ field: z.string().trim().min(1), offsetDays: z.number().int().optional() })
+          .optional(),
+        minDaysFrom: z
+          .object({ field: z.string().trim().min(1), days: z.number().int() })
+          .optional(),
+        maxDaysFrom: z
+          .object({ field: z.string().trim().min(1), days: z.number().int() })
+          .optional(),
+      })
+      .optional(),
+    // Named character-class checks — never a raw regex in JSON, to keep
+    // seed data free of arbitrary executable-ish patterns.
+    pattern: z.enum(['NAME_NO_SPECIAL_CHARS']).optional(),
   })
   .strict();
 
@@ -101,6 +130,11 @@ export const schemaJsonSchema = z.array(formFieldSchema).min(1);
  * `offset` for that last rule's constant. ANY_OF_REQUIRED is a fifth rule,
  * added for MOTHER_REGISTRATION's date_of_birth/age_of_the_beneficiary pair
  * (either one satisfies the requirement) — see CR037beneficiaryagedobfieldgap.md.
+ * EXCLUSIVE_OPTION is a sixth rule — Registration_PW_D's repeated "if 'None'/
+ * 'No known condition' is selected, disable all other options" checkbox
+ * groups (Q43, Q44, Q58). The client-side disabling itself is a mobile-app
+ * concern; this rule is the server-side check that the *submitted* answer
+ * never combines an exclusive value with anything else.
  */
 // A discriminated union has no inferable OpenAPI type on its own — annotated
 // so the OpenAPI generator doesn't throw when this schema is used as a
@@ -122,6 +156,13 @@ export const crossFieldRuleSchema = z
       .object({
         rule: z.literal('ANY_OF_REQUIRED'),
         fields: z.array(z.string().trim().min(1)).min(2),
+      })
+      .strict(),
+    z
+      .object({
+        rule: z.literal('EXCLUSIVE_OPTION'),
+        field: z.string().trim().min(1),
+        exclusiveValues: z.array(z.string().trim().min(1)).min(1),
       })
       .strict(),
   ])

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -3,6 +3,19 @@ import { z } from 'zod';
 
 extendZodWithOpenApi(z);
 
+/** One SRS Category 5 skip-logic condition — see visibleWhen below. */
+export const visibleWhenConditionSchema = z.object({
+  field: z.string().trim().min(1),
+  // 'contains' checks a multiselect answer (an array of value_codes)
+  // for membership — e.g. show a dose date field only when its
+  // checkbox is one of the checked options on has_the_women_received_td_dose.
+  operator: z.enum(['eq', 'gte', 'lt', 'isSet', 'contains']),
+  // Bare z.any() has no inferable OpenAPI type — annotated so the
+  // OpenAPI generator doesn't throw when this schema is used as a
+  // documented request/response body (see createDocumentedRouter()).
+  value: z.any().openapi({ type: 'object' }).optional(),
+});
+
 /**
  * Shape of one entry in `form_versions.schema_json`. Only the parts confirmed
  * by docs/Arogya_Sakhi_Database_Design_ERD_Table_Definitions.docx.md §4.0 (the
@@ -61,18 +74,13 @@ export const formFieldSchema = z
     // Fixed digit-count fields (e.g. a 10-digit mobile number) — distinct from
     // numericRange, which bounds a value rather than its digit length.
     exactLength: z.number().int().positive().optional(),
+    // A single condition, or an array of conditions ANDed together (all must
+    // pass for the field to be visible) — e.g. a visit-form field that is
+    // both gated behind "met the beneficiary = yes" AND its own condition
+    // (gestational age, USG done, etc). Most fields only ever need one
+    // condition, so the plain single-object shape is still accepted as-is.
     visibleWhen: z
-      .object({
-        field: z.string().trim().min(1),
-        // 'contains' checks a multiselect answer (an array of value_codes)
-        // for membership — e.g. show a dose date field only when its
-        // checkbox is one of the checked options on has_the_women_received_td_dose.
-        operator: z.enum(['eq', 'gte', 'lt', 'isSet', 'contains']),
-        // Bare z.any() has no inferable OpenAPI type — annotated so the
-        // OpenAPI generator doesn't throw when this schema is used as a
-        // documented request/response body (see createDocumentedRouter()).
-        value: z.any().openapi({ type: 'object' }).optional(),
-      })
+      .union([visibleWhenConditionSchema, z.array(visibleWhenConditionSchema).min(1)])
       .optional(),
     computedFrom: z
       .enum([
@@ -118,6 +126,7 @@ export const formFieldSchema = z
   .strict();
 
 export type FormField = z.infer<typeof formFieldSchema>;
+export type VisibleWhenCondition = z.infer<typeof visibleWhenConditionSchema>;
 
 export const schemaJsonSchema = z.array(formFieldSchema).min(1);
 

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -135,6 +135,11 @@ export const schemaJsonSchema = z.array(formFieldSchema).min(1);
  * groups (Q43, Q44, Q58). The client-side disabling itself is a mobile-app
  * concern; this rule is the server-side check that the *submitted* answer
  * never combines an exclusive value with anything else.
+ * REQUIRED_IF_SELECTED is a seventh rule — the recurring "☐ <option>; Date:"
+ * multiselect_date pattern (Registration_PW_D's Td dose, Q49 vaccination at
+ * birth), where the doc requires each option's paired date field be filled
+ * whenever that option is checked (e.g. "If marked to any option other than
+ * 'None' then date is mandatory").
  */
 // A discriminated union has no inferable OpenAPI type on its own — annotated
 // so the OpenAPI generator doesn't throw when this schema is used as a
@@ -163,6 +168,14 @@ export const crossFieldRuleSchema = z
         rule: z.literal('EXCLUSIVE_OPTION'),
         field: z.string().trim().min(1),
         exclusiveValues: z.array(z.string().trim().min(1)).min(1),
+      })
+      .strict(),
+    z
+      .object({
+        rule: z.literal('REQUIRED_IF_SELECTED'),
+        field: z.string().trim().min(1),
+        // Selected value_code -> the question_code of its paired date field.
+        optionFieldMap: z.record(z.string(), z.string().trim().min(1)),
       })
       .strict(),
   ])

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -74,14 +74,20 @@ export const formFieldSchema = z
     // Fixed digit-count fields (e.g. a 10-digit mobile number) — distinct from
     // numericRange, which bounds a value rather than its digit length.
     exactLength: z.number().int().positive().optional(),
-    // A single condition, or an array of conditions ANDed together (all must
-    // pass for the field to be visible) — e.g. a visit-form field that is
-    // both gated behind "met the beneficiary = yes" AND its own condition
-    // (gestational age, USG done, etc). Most fields only ever need one
-    // condition, so the plain single-object shape is still accepted as-is.
-    visibleWhen: z
-      .union([visibleWhenConditionSchema, z.array(visibleWhenConditionSchema).min(1)])
-      .optional(),
+    // A single {field,operator,value} condition ONLY — never an array.
+    // The mobile client's FormVisibilityEvaluator does not parse an
+    // array-of-conditions shape and crashes the whole form load if it sees
+    // one (see the ANC_VISIT/INFANT_VISIT incident this schema-level
+    // rejection follows: array-form visibleWhen was briefly published to
+    // AND a field's own condition with "met beneficiary = yes", and every
+    // Sakhi got "We couldn't load this visit's data" with no way to
+    // submit). Rejected here at the schema level — not just absent from
+    // current seed content — so this can't be reintroduced via the live
+    // admin form-authoring PATCH endpoint (`PATCH
+    // /admin/forms/:formCode/versions/:versionId`) either, for ANY form,
+    // not only the two that already had the incident. Re-allow the array
+    // shape only once mobile ships a parser for it, not before.
+    visibleWhen: visibleWhenConditionSchema.optional(),
     computedFrom: z
       .enum([
         'EDD_FROM_LMP',

--- a/apps/visit-form-service/src/forms/form-validation.spec.ts
+++ b/apps/visit-form-service/src/forms/form-validation.spec.ts
@@ -252,59 +252,6 @@ describe('isVisible — contains operator', () => {
   });
 });
 
-describe('isVisible — array of conditions (AND)', () => {
-  const usgDateField: FormField = {
-    question_code: 'if_yes_date_of_usg',
-    label: 'If yes, date of USG',
-    input_type: 'date',
-    required: true,
-    visibleWhen: [
-      { field: 'have_you_done_usg_since_last_visit', operator: 'eq', value: 'yes' },
-      {
-        field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
-        operator: 'eq',
-        value: 'yes',
-      },
-    ],
-  };
-
-  it('is visible when every condition passes', () => {
-    const visible = isVisible(usgDateField, {
-      have_you_done_usg_since_last_visit: 'yes',
-      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'yes',
-    });
-
-    expect(visible).toBe(true);
-  });
-
-  it('is hidden when only one of two conditions passes', () => {
-    const visible = isVisible(usgDateField, {
-      have_you_done_usg_since_last_visit: 'yes',
-      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'no',
-    });
-
-    expect(visible).toBe(false);
-  });
-
-  it('is hidden when neither condition passes', () => {
-    const visible = isVisible(usgDateField, {
-      have_you_done_usg_since_last_visit: 'no',
-      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'no',
-    });
-
-    expect(visible).toBe(false);
-  });
-
-  it('skips the required check for a field hidden by any one failing condition', () => {
-    const violations = validateSubmission([usgDateField], [], {
-      have_you_done_usg_since_last_visit: 'yes',
-      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'no',
-    });
-
-    expect(violations).toEqual([]);
-  });
-});
-
 describe('validateSubmission — dateRule (LMP: notFuture, notAfter, minDaysFrom, maxDaysFrom)', () => {
   const registrationDateField: FormField = {
     question_code: 'registration_date',

--- a/apps/visit-form-service/src/forms/form-validation.spec.ts
+++ b/apps/visit-form-service/src/forms/form-validation.spec.ts
@@ -576,6 +576,86 @@ describe('validateSubmission — EXCLUSIVE_OPTION', () => {
   });
 });
 
+describe('validateSubmission — REQUIRED_IF_SELECTED', () => {
+  const vaccineField: FormField = {
+    question_code: 'vaccination_taken_at_birth',
+    label: 'Vaccination taken at birth?',
+    input_type: 'multiselect_date',
+    required: true,
+  };
+  const bcgDateField: FormField = {
+    question_code: 'bcg_date',
+    label: 'BCG date',
+    input_type: 'date',
+    required: false,
+  };
+  const opvDateField: FormField = {
+    question_code: 'opv_date',
+    label: 'OPV date',
+    input_type: 'date',
+    required: false,
+  };
+  const requiredIfSelectedRule: CrossFieldRule = {
+    rule: 'REQUIRED_IF_SELECTED',
+    field: 'vaccination_taken_at_birth',
+    optionFieldMap: { bcg_date: 'bcg_date', opv_date: 'opv_date' },
+  };
+
+  it('rejects when an option is selected but its paired date field is empty', () => {
+    const violations = validateSubmission(
+      [vaccineField, bcgDateField, opvDateField],
+      [requiredIfSelectedRule],
+      { vaccination_taken_at_birth: ['bcg_date'] },
+    );
+
+    expect(violations).toEqual(['bcg_date is required when bcg_date is selected']);
+  });
+
+  it('accepts when the selected option has its date filled', () => {
+    const violations = validateSubmission(
+      [vaccineField, bcgDateField, opvDateField],
+      [requiredIfSelectedRule],
+      { vaccination_taken_at_birth: ['bcg_date'], bcg_date: '2026-01-05' },
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('does not require a date for an option that was not selected', () => {
+    const violations = validateSubmission(
+      [vaccineField, bcgDateField, opvDateField],
+      [requiredIfSelectedRule],
+      { vaccination_taken_at_birth: ['opv_date'], opv_date: '2026-01-05' },
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('reports one violation per unfilled selected option', () => {
+    const violations = validateSubmission(
+      [vaccineField, bcgDateField, opvDateField],
+      [requiredIfSelectedRule],
+      { vaccination_taken_at_birth: ['bcg_date', 'opv_date'] },
+    );
+
+    expect(violations).toEqual([
+      'bcg_date is required when bcg_date is selected',
+      'opv_date is required when opv_date is selected',
+    ]);
+  });
+
+  it('skips the rule when the field is empty or absent', () => {
+    const optionalVaccineField: FormField = { ...vaccineField, required: false };
+    const violations = validateSubmission(
+      [optionalVaccineField, bcgDateField, opvDateField],
+      [requiredIfSelectedRule],
+      {},
+    );
+
+    expect(violations).toEqual([]);
+  });
+});
+
 describe('validateSubmission — pattern (NAME_NO_SPECIAL_CHARS)', () => {
   const nameField: FormField = {
     question_code: 'beneficiary_name',

--- a/apps/visit-form-service/src/forms/form-validation.spec.ts
+++ b/apps/visit-form-service/src/forms/form-validation.spec.ts
@@ -623,3 +623,70 @@ describe('validateSubmission — pattern (NAME_NO_SPECIAL_CHARS)', () => {
     expect(violations).toEqual([]);
   });
 });
+
+describe('validateSubmission — dateRule (DOB of infant: notFuture, maxDaysFrom registration)', () => {
+  const registrationDateField: FormField = {
+    question_code: 'registrtion_date',
+    label: 'Registration date',
+    input_type: 'date',
+    required: true,
+  };
+
+  const dobField: FormField = {
+    question_code: 'date_of_birth_of_infant',
+    label: 'Date of birth of infant',
+    input_type: 'date',
+    required: true,
+    dateRule: {
+      notFuture: true,
+      maxDaysFrom: { field: 'registrtion_date', days: 183 },
+    },
+  };
+
+  const dateFields = [registrationDateField, dobField];
+
+  it('rejects a future date of birth', () => {
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const violations = validateSubmission(dateFields, [], {
+      registrtion_date: future,
+      date_of_birth_of_infant: future,
+    });
+
+    expect(violations).toContain('date_of_birth_of_infant must not be in the future');
+  });
+
+  it('accepts a date of birth exactly 183 days before registration (boundary)', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registrtion_date: '2026-07-03',
+      date_of_birth_of_infant: '2026-01-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('rejects a date of birth 184 days before registration', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registrtion_date: '2026-07-04',
+      date_of_birth_of_infant: '2026-01-01',
+    });
+
+    expect(violations.some((v) => v.includes('at most 183 days'))).toBe(true);
+  });
+
+  it('accepts a date of birth within the 0-183 day window', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registrtion_date: '2026-03-01',
+      date_of_birth_of_infant: '2026-01-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('skips the rule when registration date is absent', () => {
+    const violations = validateSubmission(dateFields, [], {
+      date_of_birth_of_infant: '2026-01-01',
+    });
+
+    expect(violations.filter((v) => v.includes('date_of_birth_of_infant'))).toEqual([]);
+  });
+});

--- a/apps/visit-form-service/src/forms/form-validation.spec.ts
+++ b/apps/visit-form-service/src/forms/form-validation.spec.ts
@@ -251,3 +251,375 @@ describe('isVisible — contains operator', () => {
     expect(visible).toBe(false);
   });
 });
+
+describe('validateSubmission — dateRule (LMP: notFuture, notAfter, minDaysFrom, maxDaysFrom)', () => {
+  const registrationDateField: FormField = {
+    question_code: 'registration_date',
+    label: 'Registration date',
+    input_type: 'date',
+    required: true,
+  };
+
+  const lmpDateField: FormField = {
+    question_code: 'lmp_date',
+    label: 'LMP Date',
+    input_type: 'date',
+    required: false,
+    dateRule: {
+      notFuture: true,
+      notAfter: { field: 'registration_date' },
+      minDaysFrom: { field: 'registration_date', days: 30 },
+      maxDaysFrom: { field: 'registration_date', days: 240 },
+    },
+  };
+
+  const dateFields = [registrationDateField, lmpDateField];
+
+  it('rejects a future LMP date', () => {
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: future,
+      lmp_date: future,
+    });
+
+    expect(violations).toContain('lmp_date must not be in the future');
+  });
+
+  it('rejects an LMP date after the registration date', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-01-01',
+      lmp_date: '2026-01-02',
+    });
+
+    expect(violations).toContain('lmp_date must not be after registration_date');
+  });
+
+  it('rejects when registration_date - lmp_date is 29 days (below the 30-day minimum)', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-01-30',
+      lmp_date: '2026-01-01',
+    });
+
+    expect(violations.some((v) => v.includes('at least 30 days'))).toBe(true);
+  });
+
+  it('accepts when registration_date - lmp_date is exactly 30 days (boundary)', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-01-31',
+      lmp_date: '2026-01-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('accepts when registration_date - lmp_date is exactly 240 days (boundary)', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-08-29',
+      lmp_date: '2026-01-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('rejects when registration_date - lmp_date is 241 days (above the max)', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-08-30',
+      lmp_date: '2026-01-01',
+    });
+
+    expect(violations.some((v) => v.includes('at most 240 days'))).toBe(true);
+  });
+
+  it('accepts a well-formed LMP date within range', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-04-11',
+      lmp_date: '2026-01-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('skips the rule when either date is absent', () => {
+    const violations = validateSubmission(dateFields, [], {
+      registration_date: '2026-04-11',
+    });
+
+    expect(violations.filter((v) => v.includes('lmp_date'))).toEqual([]);
+  });
+});
+
+describe('validateSubmission — dateRule (ANC-1 date: notBefore LMP, notAfter registration+5)', () => {
+  const anc1DateField: FormField = {
+    question_code: 'if_anc1_completed_please_record_the_date',
+    label: 'ANC-1 date',
+    input_type: 'date',
+    required: true,
+    visibleWhen: {
+      field: 'has_the_woman_received_anc_check_ups_at_a_health_facility_during_this_pregnancy',
+      operator: 'eq',
+      value: 'anc_1_completed',
+    },
+    dateRule: {
+      notBefore: { field: 'lmp_date' },
+      notAfter: { field: 'registration_date', offsetDays: 5 },
+    },
+  };
+
+  it('rejects an ANC-1 date before LMP', () => {
+    const violations = validateSubmission([anc1DateField], [], {
+      has_the_woman_received_anc_check_ups_at_a_health_facility_during_this_pregnancy:
+        'anc_1_completed',
+      lmp_date: '2026-01-10',
+      registration_date: '2026-02-01',
+      if_anc1_completed_please_record_the_date: '2026-01-05',
+    });
+
+    expect(violations).toContain(
+      'if_anc1_completed_please_record_the_date must not be before lmp_date',
+    );
+  });
+
+  it('accepts an ANC-1 date equal to the LMP date (inclusive boundary)', () => {
+    const violations = validateSubmission([anc1DateField], [], {
+      has_the_woman_received_anc_check_ups_at_a_health_facility_during_this_pregnancy:
+        'anc_1_completed',
+      lmp_date: '2026-01-10',
+      registration_date: '2026-02-01',
+      if_anc1_completed_please_record_the_date: '2026-01-10',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('accepts an ANC-1 date exactly registration_date + 5 days (boundary)', () => {
+    const violations = validateSubmission([anc1DateField], [], {
+      has_the_woman_received_anc_check_ups_at_a_health_facility_during_this_pregnancy:
+        'anc_1_completed',
+      lmp_date: '2026-01-10',
+      registration_date: '2026-02-01',
+      if_anc1_completed_please_record_the_date: '2026-02-06',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('rejects an ANC-1 date at registration_date + 6 days', () => {
+    const violations = validateSubmission([anc1DateField], [], {
+      has_the_woman_received_anc_check_ups_at_a_health_facility_during_this_pregnancy:
+        'anc_1_completed',
+      lmp_date: '2026-01-10',
+      registration_date: '2026-02-01',
+      if_anc1_completed_please_record_the_date: '2026-02-07',
+    });
+
+    expect(
+      violations.some(
+        (v) => v === 'if_anc1_completed_please_record_the_date must not be after registration_date',
+      ),
+    ).toBe(true);
+  });
+
+  it('skips the rule entirely when the field is hidden by visibleWhen', () => {
+    const violations = validateSubmission([anc1DateField], [], {
+      has_the_woman_received_anc_check_ups_at_a_health_facility_during_this_pregnancy:
+        'not_started_anc_yet',
+      lmp_date: '2026-01-10',
+      registration_date: '2026-02-01',
+      if_anc1_completed_please_record_the_date: '2020-01-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('validateSubmission — dateRule (Td dose date ordering)', () => {
+  const td1: FormField = {
+    question_code: 'td_1_date',
+    label: 'Td-1 date',
+    input_type: 'date',
+    required: false,
+    dateRule: { notFuture: true },
+  };
+  const td2: FormField = {
+    question_code: 'td_2_date',
+    label: 'Td-2 date',
+    input_type: 'date',
+    required: false,
+    dateRule: { notFuture: true, notBefore: { field: 'td_1_date' } },
+  };
+  const tdBooster: FormField = {
+    question_code: 'td_booster_date',
+    label: 'Td-Booster date',
+    input_type: 'date',
+    required: false,
+    dateRule: { notFuture: true, notBefore: { field: 'td_2_date' } },
+  };
+  const tdFields = [td1, td2, tdBooster];
+
+  it('rejects td_2_date before td_1_date', () => {
+    const violations = validateSubmission(tdFields, [], {
+      td_1_date: '2026-03-01',
+      td_2_date: '2026-02-01',
+    });
+
+    expect(violations).toContain('td_2_date must not be before td_1_date');
+  });
+
+  it('accepts td_2_date after td_1_date', () => {
+    const violations = validateSubmission(tdFields, [], {
+      td_1_date: '2026-02-01',
+      td_2_date: '2026-03-01',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('rejects td_booster_date before td_2_date', () => {
+    const violations = validateSubmission(tdFields, [], {
+      td_2_date: '2026-03-01',
+      td_booster_date: '2026-02-15',
+    });
+
+    expect(violations).toContain('td_booster_date must not be before td_2_date');
+  });
+
+  it('rejects a future Td date', () => {
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const violations = validateSubmission(tdFields, [], { td_1_date: future });
+
+    expect(violations).toContain('td_1_date must not be in the future');
+  });
+
+  it('skips the rule when the field is not visible/present', () => {
+    const violations = validateSubmission(tdFields, [], {});
+
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('validateSubmission — EXCLUSIVE_OPTION', () => {
+  const conditionField: FormField = {
+    question_code:
+      'have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions',
+    label: 'Diagnosed conditions',
+    input_type: 'multiselect',
+    required: false,
+  };
+
+  const exclusiveRule: CrossFieldRule = {
+    rule: 'EXCLUSIVE_OPTION',
+    field:
+      'have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions',
+    exclusiveValues: ['no_known_medical_condition', 'don_t_know'],
+  };
+
+  it('accepts when only the exclusive value is selected', () => {
+    const violations = validateSubmission([conditionField], [exclusiveRule], {
+      have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions: [
+        'no_known_medical_condition',
+      ],
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('accepts when only non-exclusive values are selected', () => {
+    const violations = validateSubmission([conditionField], [exclusiveRule], {
+      have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions: [
+        'hypertension_high_bp',
+        'thyroid_disorder',
+      ],
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('rejects when the exclusive value is combined with another option', () => {
+    const violations = validateSubmission([conditionField], [exclusiveRule], {
+      have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions: [
+        'no_known_medical_condition',
+        'hypertension_high_bp',
+      ],
+    });
+
+    expect(violations).toEqual([
+      'have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions cannot combine no_known_medical_condition/don_t_know with any other option',
+    ]);
+  });
+
+  it('skips the rule when the field is empty or absent', () => {
+    const violations = validateSubmission([conditionField], [exclusiveRule], {});
+
+    expect(violations).toEqual([]);
+  });
+
+  it('applies independently per field for Q43/Q44/Q58-style rules', () => {
+    const tdField: FormField = {
+      question_code: 'has_the_women_received_td_dose',
+      label: 'Td dose',
+      input_type: 'multiselect_date',
+      required: true,
+    };
+    const tdRule: CrossFieldRule = {
+      rule: 'EXCLUSIVE_OPTION',
+      field: 'has_the_women_received_td_dose',
+      exclusiveValues: ['none_received_yet'],
+    };
+
+    const violations = validateSubmission([tdField], [tdRule], {
+      has_the_women_received_td_dose: ['none_received_yet', 'td_1_date'],
+    });
+
+    expect(violations).toEqual([
+      'has_the_women_received_td_dose cannot combine none_received_yet with any other option',
+    ]);
+  });
+});
+
+describe('validateSubmission — pattern (NAME_NO_SPECIAL_CHARS)', () => {
+  const nameField: FormField = {
+    question_code: 'beneficiary_name',
+    label: 'Beneficiary name',
+    input_type: 'text',
+    required: true,
+    pattern: 'NAME_NO_SPECIAL_CHARS',
+  };
+
+  it('accepts a plain name', () => {
+    const violations = validateSubmission([nameField], [], { beneficiary_name: 'Jane Doe' });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('accepts a name with an apostrophe', () => {
+    const violations = validateSubmission([nameField], [], { beneficiary_name: "O'Brien" });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('rejects a name containing digits', () => {
+    const violations = validateSubmission([nameField], [], { beneficiary_name: 'Jane123' });
+
+    expect(violations).toEqual(['beneficiary_name contains characters that are not allowed']);
+  });
+
+  it('rejects a name containing a symbol', () => {
+    const violations = validateSubmission([nameField], [], { beneficiary_name: 'Jane@Doe' });
+
+    expect(violations).toEqual(['beneficiary_name contains characters that are not allowed']);
+  });
+
+  it('accepts a name in a non-Latin script', () => {
+    const violations = validateSubmission([nameField], [], { beneficiary_name: 'सुनीता देवी' });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('skips the pattern check when the value is absent', () => {
+    const optionalNameField: FormField = { ...nameField, required: false };
+
+    const violations = validateSubmission([optionalNameField], [], {});
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/visit-form-service/src/forms/form-validation.spec.ts
+++ b/apps/visit-form-service/src/forms/form-validation.spec.ts
@@ -629,6 +629,51 @@ describe('validateSubmission — EXCLUSIVE_OPTION', () => {
   });
 });
 
+describe('validateSubmission — mother_beneficiary_id visibility (CHILD_REGISTRATION)', () => {
+  const whoField: FormField = {
+    question_code: 'who_are_you_registering_in_the_program',
+    label: 'Who are you registering in the program?',
+    input_type: 'radio',
+    required: true,
+  };
+  const motherBeneficiaryIdField: FormField = {
+    question_code: 'mother_beneficiary_id',
+    label: 'Mother beneficiary ID',
+    input_type: 'number',
+    required: true,
+    visibleWhen: {
+      field: 'who_are_you_registering_in_the_program',
+      operator: 'eq',
+      value: 'child_of_a_registered_pregnant_woman',
+    },
+  };
+
+  it('does not require mother_beneficiary_id when registering a child directly', () => {
+    const violations = validateSubmission([whoField, motherBeneficiaryIdField], [], {
+      who_are_you_registering_in_the_program: 'child_directly_mother_not_registered_in_the_program',
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it('requires mother_beneficiary_id when registering a child of a registered pregnant woman', () => {
+    const violations = validateSubmission([whoField, motherBeneficiaryIdField], [], {
+      who_are_you_registering_in_the_program: 'child_of_a_registered_pregnant_woman',
+    });
+
+    expect(violations).toEqual(['Missing required field: mother_beneficiary_id']);
+  });
+
+  it('is satisfied when mother_beneficiary_id is present on the child-of-registered-woman path', () => {
+    const violations = validateSubmission([whoField, motherBeneficiaryIdField], [], {
+      who_are_you_registering_in_the_program: 'child_of_a_registered_pregnant_woman',
+      mother_beneficiary_id: 12345,
+    });
+
+    expect(violations).toEqual([]);
+  });
+});
+
 describe('validateSubmission — REQUIRED_IF_SELECTED', () => {
   const vaccineField: FormField = {
     question_code: 'vaccination_taken_at_birth',

--- a/apps/visit-form-service/src/forms/form-validation.spec.ts
+++ b/apps/visit-form-service/src/forms/form-validation.spec.ts
@@ -252,6 +252,59 @@ describe('isVisible — contains operator', () => {
   });
 });
 
+describe('isVisible — array of conditions (AND)', () => {
+  const usgDateField: FormField = {
+    question_code: 'if_yes_date_of_usg',
+    label: 'If yes, date of USG',
+    input_type: 'date',
+    required: true,
+    visibleWhen: [
+      { field: 'have_you_done_usg_since_last_visit', operator: 'eq', value: 'yes' },
+      {
+        field: 'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
+        operator: 'eq',
+        value: 'yes',
+      },
+    ],
+  };
+
+  it('is visible when every condition passes', () => {
+    const visible = isVisible(usgDateField, {
+      have_you_done_usg_since_last_visit: 'yes',
+      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'yes',
+    });
+
+    expect(visible).toBe(true);
+  });
+
+  it('is hidden when only one of two conditions passes', () => {
+    const visible = isVisible(usgDateField, {
+      have_you_done_usg_since_last_visit: 'yes',
+      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'no',
+    });
+
+    expect(visible).toBe(false);
+  });
+
+  it('is hidden when neither condition passes', () => {
+    const visible = isVisible(usgDateField, {
+      have_you_done_usg_since_last_visit: 'no',
+      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'no',
+    });
+
+    expect(visible).toBe(false);
+  });
+
+  it('skips the required check for a field hidden by any one failing condition', () => {
+    const violations = validateSubmission([usgDateField], [], {
+      have_you_done_usg_since_last_visit: 'yes',
+      have_you_been_able_to_meet_the_beneficiary_for_the_visit: 'no',
+    });
+
+    expect(violations).toEqual([]);
+  });
+});
+
 describe('validateSubmission — dateRule (LMP: notFuture, notAfter, minDaysFrom, maxDaysFrom)', () => {
   const registrationDateField: FormField = {
     question_code: 'registration_date',

--- a/apps/visit-form-service/src/forms/form-validation.ts
+++ b/apps/visit-form-service/src/forms/form-validation.ts
@@ -4,6 +4,89 @@ export function isEmpty(value: unknown): boolean {
   return value === undefined || value === null || value === '';
 }
 
+/** Named character-class checks for FormField.pattern — never a raw regex in JSON. */
+const PATTERN_REGEXES: Record<string, RegExp> = {
+  // Letters (any script) plus combining marks (\p{M} — required for
+  // Devanagari and other Indic scripts, where vowel signs are marks, not
+  // letters), spaces, apostrophes, and periods. Rejects digits and symbols
+  // per Registration_PW_D Q19 ("should not accept any special characters").
+  NAME_NO_SPECIAL_CHARS: /^[\p{L}\p{M}\s'.]+$/u,
+};
+
+/** Whole calendar days between two dates (b - a), ignoring time-of-day. */
+function daysBetween(a: Date, b: Date): number {
+  const startOfDay = (d: Date) => Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return Math.round((startOfDay(b) - startOfDay(a)) / (24 * 60 * 60 * 1000));
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date.getTime());
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+/**
+ * Evaluates SRS Category 1 date rules for one field against submitted
+ * formData. Only runs when the field's own value and any referenced field's
+ * value both parse as dates — a missing or invisible value is the
+ * required-field/visibility check's concern, not this rule's. All bounds
+ * are inclusive of the boundary day.
+ */
+function checkDateRule(field: FormField, formData: Record<string, unknown>): string[] {
+  if (!field.dateRule || isEmpty(formData[field.question_code])) return [];
+
+  const value = new Date(String(formData[field.question_code]));
+  if (Number.isNaN(value.getTime())) return [`${field.question_code} must be a valid date`];
+
+  const violations: string[] = [];
+  const { notFuture, notBefore, notAfter, minDaysFrom, maxDaysFrom } = field.dateRule;
+
+  if (notFuture && value.getTime() > Date.now()) {
+    violations.push(`${field.question_code} must not be in the future`);
+  }
+
+  const resolveReference = (ref: { field: string; offsetDays?: number }): Date | null => {
+    if (isEmpty(formData[ref.field])) return null;
+    const referenced = new Date(String(formData[ref.field]));
+    if (Number.isNaN(referenced.getTime())) return null;
+    return ref.offsetDays ? addDays(referenced, ref.offsetDays) : referenced;
+  };
+
+  if (notBefore) {
+    const bound = resolveReference(notBefore);
+    if (bound && value.getTime() < bound.getTime()) {
+      violations.push(`${field.question_code} must not be before ${notBefore.field}`);
+    }
+  }
+
+  if (notAfter) {
+    const bound = resolveReference(notAfter);
+    if (bound && value.getTime() > bound.getTime()) {
+      violations.push(`${field.question_code} must not be after ${notAfter.field}`);
+    }
+  }
+
+  if (minDaysFrom && !isEmpty(formData[minDaysFrom.field])) {
+    const reference = new Date(String(formData[minDaysFrom.field]));
+    if (!Number.isNaN(reference.getTime()) && daysBetween(value, reference) < minDaysFrom.days) {
+      violations.push(
+        `${minDaysFrom.field} must be at least ${minDaysFrom.days} days after ${field.question_code}`,
+      );
+    }
+  }
+
+  if (maxDaysFrom && !isEmpty(formData[maxDaysFrom.field])) {
+    const reference = new Date(String(formData[maxDaysFrom.field]));
+    if (!Number.isNaN(reference.getTime()) && daysBetween(value, reference) > maxDaysFrom.days) {
+      violations.push(
+        `${maxDaysFrom.field} must be at most ${maxDaysFrom.days} days after ${field.question_code}`,
+      );
+    }
+  }
+
+  return violations;
+}
+
 /** Evaluates SRS Category 5 skip logic for one field against the submitted formData. */
 export function isVisible(field: FormField, formData: Record<string, unknown>): boolean {
   if (!field.visibleWhen) return true;
@@ -26,12 +109,11 @@ export function isVisible(field: FormField, formData: Record<string, unknown>): 
 
 /**
  * Checks required fields (SRS line 1150), numeric ranges (SRS Category 2),
- * and cross-field consistency (SRS Category 3) against submitted formData.
- * Date rules (Category 1) are deliberately not checked here — see the
- * forms API design doc §7. Fields hidden by skip logic (Category 5) are
+ * date rules (SRS Category 1), and cross-field consistency (SRS Category 3)
+ * against submitted formData. Fields hidden by skip logic (Category 5) are
  * skipped entirely; fields computed by the system (Category 4) are exempt
  * from the required check only — if a value is submitted for one anyway,
- * its numericRange/exactLength is still enforced.
+ * its numericRange/exactLength/dateRule/pattern is still enforced.
  *
  * Returns the list of human-readable violations (empty = valid).
  */
@@ -69,6 +151,12 @@ export function validateSubmission(
     if (field.exactLength && !isEmpty(value) && String(value).length !== field.exactLength) {
       violations.push(`${field.question_code} must be exactly ${field.exactLength} digits`);
     }
+
+    if (field.pattern && !isEmpty(value) && !PATTERN_REGEXES[field.pattern].test(String(value))) {
+      violations.push(`${field.question_code} contains characters that are not allowed`);
+    }
+
+    violations.push(...checkDateRule(field, formData));
   }
 
   for (const rule of crossFieldRules) {
@@ -101,6 +189,16 @@ export function validateSubmission(
       const allEmpty = rule.fields.every((f) => isEmpty(formData[f]));
       if (allEmpty) {
         violations.push(`At least one of ${rule.fields.join(', ')} must be answered`);
+      }
+    } else if (rule.rule === 'EXCLUSIVE_OPTION') {
+      const answer = formData[rule.field];
+      if (!Array.isArray(answer) || answer.length === 0) continue;
+      const hasExclusive = answer.some((v) => rule.exclusiveValues.includes(v));
+      const hasOther = answer.some((v) => !rule.exclusiveValues.includes(v));
+      if (hasExclusive && hasOther) {
+        violations.push(
+          `${rule.field} cannot combine ${rule.exclusiveValues.join('/')} with any other option`,
+        );
       }
     }
   }

--- a/apps/visit-form-service/src/forms/form-validation.ts
+++ b/apps/visit-form-service/src/forms/form-validation.ts
@@ -1,4 +1,4 @@
-import type { CrossFieldRule, FormField } from './dto/form-field.dto';
+import type { CrossFieldRule, FormField, VisibleWhenCondition } from './dto/form-field.dto';
 
 export function isEmpty(value: unknown): boolean {
   return value === undefined || value === null || value === '';
@@ -87,24 +87,38 @@ function checkDateRule(field: FormField, formData: Record<string, unknown>): str
   return violations;
 }
 
-/** Evaluates SRS Category 5 skip logic for one field against the submitted formData. */
-export function isVisible(field: FormField, formData: Record<string, unknown>): boolean {
-  if (!field.visibleWhen) return true;
-  const actual = formData[field.visibleWhen.field];
-  switch (field.visibleWhen.operator) {
+function evaluateVisibilityCondition(
+  condition: VisibleWhenCondition,
+  formData: Record<string, unknown>,
+): boolean {
+  const actual = formData[condition.field];
+  switch (condition.operator) {
     case 'eq':
-      return actual === field.visibleWhen.value;
+      return actual === condition.value;
     case 'gte':
-      return Number(actual) >= Number(field.visibleWhen.value);
+      return Number(actual) >= Number(condition.value);
     case 'lt':
-      return Number(actual) < Number(field.visibleWhen.value);
+      return Number(actual) < Number(condition.value);
     case 'isSet':
       return !isEmpty(actual);
     case 'contains':
-      return Array.isArray(actual) && actual.includes(field.visibleWhen.value);
+      return Array.isArray(actual) && actual.includes(condition.value);
     default:
       return true;
   }
+}
+
+/**
+ * Evaluates SRS Category 5 skip logic for one field against the submitted
+ * formData. `visibleWhen` is either a single condition or an array of
+ * conditions ANDed together — a field with multiple conditions (e.g. gated
+ * behind both "met the beneficiary = yes" and its own gestational-age
+ * threshold) is visible only when every condition passes.
+ */
+export function isVisible(field: FormField, formData: Record<string, unknown>): boolean {
+  if (!field.visibleWhen) return true;
+  const conditions = Array.isArray(field.visibleWhen) ? field.visibleWhen : [field.visibleWhen];
+  return conditions.every((condition) => evaluateVisibilityCondition(condition, formData));
 }
 
 /**

--- a/apps/visit-form-service/src/forms/form-validation.ts
+++ b/apps/visit-form-service/src/forms/form-validation.ts
@@ -110,15 +110,14 @@ function evaluateVisibilityCondition(
 
 /**
  * Evaluates SRS Category 5 skip logic for one field against the submitted
- * formData. `visibleWhen` is either a single condition or an array of
- * conditions ANDed together — a field with multiple conditions (e.g. gated
- * behind both "met the beneficiary = yes" and its own gestational-age
- * threshold) is visible only when every condition passes.
+ * formData. `visibleWhen` is a single {field,operator,value} condition only
+ * — never an array — since the mobile client's FormVisibilityEvaluator
+ * doesn't parse an array-of-conditions shape (see form-field.dto.ts's
+ * visibleWhen doc comment).
  */
 export function isVisible(field: FormField, formData: Record<string, unknown>): boolean {
   if (!field.visibleWhen) return true;
-  const conditions = Array.isArray(field.visibleWhen) ? field.visibleWhen : [field.visibleWhen];
-  return conditions.every((condition) => evaluateVisibilityCondition(condition, formData));
+  return evaluateVisibilityCondition(field.visibleWhen, formData);
 }
 
 /**

--- a/apps/visit-form-service/src/forms/form-validation.ts
+++ b/apps/visit-form-service/src/forms/form-validation.ts
@@ -200,6 +200,14 @@ export function validateSubmission(
           `${rule.field} cannot combine ${rule.exclusiveValues.join('/')} with any other option`,
         );
       }
+    } else if (rule.rule === 'REQUIRED_IF_SELECTED') {
+      const answer = formData[rule.field];
+      if (!Array.isArray(answer)) continue;
+      for (const [optionCode, dateField] of Object.entries(rule.optionFieldMap)) {
+        if (answer.includes(optionCode) && isEmpty(formData[dateField])) {
+          violations.push(`${dateField} is required when ${optionCode} is selected`);
+        }
+      }
     }
   }
 

--- a/libs/service-commons/src/http/all-exceptions.filter.spec.ts
+++ b/libs/service-commons/src/http/all-exceptions.filter.spec.ts
@@ -1,0 +1,97 @@
+import type { NextFunction, Request, Response } from 'express';
+import { errorHandler } from './all-exceptions.filter';
+import { ErrorCode } from './api-response';
+import { HttpError } from './http-error';
+
+function mockReq(): Request {
+  return { header: () => 'trace-1', url: '/api/v1/thing', log: { error: jest.fn() } } as never;
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as typeof res & Response;
+}
+
+describe('errorHandler', () => {
+  const next: NextFunction = jest.fn();
+
+  it('masks a 500 message — internals must never reach the client', () => {
+    const res = mockRes();
+    errorHandler(new Error('connect ECONNREFUSED 10.0.0.1:5432'), mockReq(), res, next);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toMatchObject({
+      success: false,
+      message: 'Something went wrong. Please try again.',
+      errorCode: ErrorCode.INTERNAL_ERROR,
+    });
+  });
+
+  it('masks a 502 message too — an upstream error may carry internals', () => {
+    const res = mockRes();
+    errorHandler(
+      new HttpError(502, 'upstream said: password authentication failed'),
+      mockReq(),
+      res,
+      next,
+    );
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toMatchObject({ message: 'Something went wrong. Please try again.' });
+  });
+
+  it('passes a 501 message through verbatim — it states the API contract, not internals', () => {
+    const res = mockRes();
+    errorHandler(
+      new HttpError(501, 'Data restore decisions are not yet available — pending confirmation.'),
+      mockReq(),
+      res,
+      next,
+    );
+
+    expect(res.statusCode).toBe(501);
+    expect(res.body).toMatchObject({
+      message: 'Data restore decisions are not yet available — pending confirmation.',
+      errorCode: ErrorCode.NOT_IMPLEMENTED,
+    });
+  });
+
+  it('does not log a 501 as an unhandled server error', () => {
+    const req = mockReq();
+    errorHandler(new HttpError(501, 'Not built yet.'), req, mockRes(), next);
+    expect(req.log?.error).not.toHaveBeenCalled();
+  });
+
+  it('still logs a genuine 500 as an unhandled server error', () => {
+    const req = mockReq();
+    errorHandler(new Error('boom'), req, mockRes(), next);
+    expect(req.log?.error).toHaveBeenCalled();
+  });
+
+  it('passes 4xx messages through, as before', () => {
+    const res = mockRes();
+    errorHandler(
+      new HttpError(409, 'This reopen request has already been decided.'),
+      mockReq(),
+      res,
+      next,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toMatchObject({
+      message: 'This reopen request has already been decided.',
+      errorCode: ErrorCode.CONFLICT,
+    });
+  });
+});

--- a/libs/service-commons/src/http/all-exceptions.filter.ts
+++ b/libs/service-commons/src/http/all-exceptions.filter.ts
@@ -11,7 +11,19 @@ const STATUS_TO_CODE: Record<number, ErrorCode> = {
   409: ErrorCode.CONFLICT,
   413: ErrorCode.PAYLOAD_TOO_LARGE,
   422: ErrorCode.UNPROCESSABLE,
+  501: ErrorCode.NOT_IMPLEMENTED,
 };
+
+/**
+ * 5xx statuses whose message is safe to return verbatim. A 501 is a
+ * deliberate statement about this API's contract ("this capability isn't
+ * built yet"), authored by us and carrying no internals — unlike a 500/502,
+ * where the message may be a raw driver or upstream error. Without this, a
+ * 501's explanation is replaced by the generic 5xx text and the client can
+ * only show "Something went wrong", which reads as a crash rather than an
+ * unavailable feature.
+ */
+const CLIENT_SAFE_SERVER_STATUSES = new Set([501]);
 
 /** Correlation id for the response body; falls back to a fresh uuid if the
  * request-id middleware did not run (it always should). */
@@ -34,14 +46,16 @@ export function errorHandler(err: unknown, req: Request, res: Response, _next: N
   const status = err instanceof HttpError ? err.status : 500;
   const errorCode = STATUS_TO_CODE[status] ?? ErrorCode.INTERNAL_ERROR;
   const traceId = traceIdOf(req);
-  const clientMessage =
-    status >= 500
-      ? 'Something went wrong. Please try again.'
-      : err instanceof Error
-        ? err.message
-        : 'Request failed.';
+  const maskMessage = status >= 500 && !CLIENT_SAFE_SERVER_STATUSES.has(status);
+  const clientMessage = maskMessage
+    ? 'Something went wrong. Please try again.'
+    : err instanceof Error
+      ? err.message
+      : 'Request failed.';
 
-  if (status >= 500) {
+  // A client-safe 5xx (501) is expected behaviour, not a fault — logging it as
+  // an unhandled error would bury real incidents in noise.
+  if (maskMessage) {
     req.log?.error({ requestId: traceId, path: req.url, err }, 'Unhandled server error');
   }
 

--- a/libs/service-commons/src/http/api-response.ts
+++ b/libs/service-commons/src/http/api-response.ts
@@ -30,6 +30,10 @@ export enum ErrorCode {
   CONFLICT = 'CONFLICT',
   UNPROCESSABLE = 'UNPROCESSABLE',
   PAYLOAD_TOO_LARGE = 'PAYLOAD_TOO_LARGE',
+  /** A documented capability that is deliberately not built yet (HTTP 501) —
+   * distinct from INTERNAL_ERROR so clients can tell "unavailable feature"
+   * apart from "the server broke". */
+  NOT_IMPLEMENTED = 'NOT_IMPLEMENTED',
   INTERNAL_ERROR = 'INTERNAL_ERROR',
 }
 


### PR DESCRIPTION
## Summary
- Adds `REQUIRED_IF_SELECTED` cross-field rule and closes CHILD_REGISTRATION vaccination/date validation gaps (dateRule, pattern, exactLength) per the Infant Registration form spec.
- Closes ANC_VISIT validation gaps: LMP-edit/latest-visit/USG date rules, urine-test exclusivity.
- Fixes a bug where "Have you been able to meet the beneficiary?" = No still demanded every other field on the form, blocking submission for a visit that never happened.
- **Hotfix**: reverts an array-form `visibleWhen` shape that broke ANC_VISIT/INFANT_VISIT form loading on mobile (`FormVisibilityEvaluator` only parses a single condition object) — collapses back to single-condition, keeping the met-beneficiary gate.

## Commits
- `83c9892` Close CHILD_REGISTRATION validation gaps
- `4bc4404` Enforce date-mandatory-if-selected on vaccine/Td-dose checkboxes
- `f087b95` Close ANC_VISIT validation gaps
- `7d99520` Remove unconfirmed Td-dose fields from ANC_VISIT
- `0f7aed6` Stop demanding rest of form when beneficiary not met
- `431a15f` Revert array-form visibleWhen (mobile crash hotfix)

## Test plan
- [x] `nx test visit-form-service` — 220 tests pass
- [x] `nx lint visit-form-service` — clean
- [x] Live-verified via real API against local dev: published new CHILD_REGISTRATION/ANC_VISIT/INFANT_VISIT/MOTHER_REGISTRATION form versions and submitted deliberately-broken and fully-valid payloads to confirm each rule fires/clears correctly
- [x] Confirmed no form (ANC_VISIT/INFANT_VISIT/MOTHER_REGISTRATION/CHILD_REGISTRATION) has an array-form `visibleWhen` in its currently active version

## Follow-ups
- Mobile needs to update `FormVisibilityEvaluator` to accept `visibleWhen` as either a single object or an array of ANDed conditions before the dropped secondary conditions (gestational-age gating, sonography-confirmed, USG-done, per-vaccine gating on ~39 fields) can be restored.
- Q26 (Haemoglobin ±2 g/dl vs last visit) and the LMP-edit registration-date window remain unimplemented — both need data outside a single submission's own formData (prior visit / beneficiary case), which `validateSubmission()` doesn't currently have access to.

---

## Quick Response: implement remaining card decisions + security fix

Quick Response previously only implemented the REOPEN card decision (and a
`supervisorId` trust bug in supervisor-operations-service); every other
card type fell through to a generic 501. This adds the rest and fixes a
privilege-escalation bug found by automated review along the way.

### Summary
- **service-commons**: 501 error messages now pass through verbatim instead of being masked as a generic "Something went wrong" — 501s are a deliberate, safe API-contract statement, not leaked internals.
- **auth-service**: adds `PATCH /users/:id/reactivate`, a narrow status-only endpoint (SUPERVISOR/MANAGER/ADMIN), separate from the ADMIN-only general `PATCH /users/:id`.
- **beneficiary-service**: adds `PATCH /beneficiaries/:id/lmp` (applies an approved LMP change, recomputing eddDate server-side) and `PATCH /beneficiaries/:id/reactivate` (reopens a CLOSED case, recording the transition in status history).
- **closure-reopen-service**: an APPROVED reopen decision now actually reactivates the beneficiary case via the new beneficiary-service endpoint — previously it updated `reopen_requests` but had no real-world effect. Not tolerated like audit/notification: a failed reactivation surfaces as an error.
- **risk-referral-service**: adds `PATCH /referrals/:id/decision` (LAPSE/REFILL/COMPLETE), backing REFERRAL_INCOMPLETE.
- **incentive-wages-service**:
  - adds `GET /incentive-rates/active` so callers can discover the rate to reference.
  - **security fix**: `POST /incentives` was widened to SUPERVISOR without re-deriving the payout amount server-side, letting any Supervisor mint an incentive event with an arbitrary `amountInr` (privilege escalation, flagged by automated review). Removed `amountInr` from the request schema entirely; the amount is now always looked up from the referenced `rateId`.
- **approval-service**: wires up the remaining Quick Response dispatch branches (LMP_CHANGE, CLOSURE_REVIEW, REFERRAL_INCOMPLETE, ACCOMPANIED_REFERRAL, DATA_RESTORE), each via a new gateway HTTP client.
  - **DATA_RESTORE** deliberately does NOT implement the SRS's literal FR-SV-4.6 wording (device-level data restore) — that was explicitly flagged in the SRS as pending confirmation with ARMMAN. Implements a narrower, explicitly client-approved behaviour instead: approving the card reactivates the requesting Sakhi's own user account.

### Commits
- `feea442` fix(service-commons): pass 501 messages through instead of masking as generic errors
- `4d3ed50` feat(auth-service): add narrow user-reactivation endpoint for DATA_RESTORE decisions
- `382a019` feat(beneficiary-service): add LMP-change apply and case-reactivation endpoints
- `a2956a1` feat(closure-reopen-service): reactivate the beneficiary case when a reopen request is approved
- `ee404f3` feat(risk-referral-service): add referral decision endpoint (LAPSE/REFILL/COMPLETE)
- `dafd1a8` feat(incentive-wages-service): add GET /incentive-rates/active lookup endpoint
- `8382ad9` fix(incentive-wages-service): re-derive incentive amount server-side instead of trusting the caller
- `693ae19` feat(approval-service): wire up remaining Quick Response card decisions

### Test plan
- [x] `npx nx run-many -t test -p approval-service closure-reopen-service risk-referral-service incentive-wages-service auth-service beneficiary-service` — all 6 projects pass
- [x] Live end-to-end verified for DATA_RESTORE: deactivate user → login blocked (401) → create card → approve → 200 → login succeeds again
- [x] Live end-to-end verified for LMP_CHANGE against local dev DB (LMP changed, eddDate recomputed correctly)
- [ ] CLOSURE_REVIEW / REFERRAL_INCOMPLETE / ACCOMPANIED_REFERRAL are unit-tested but not yet live-verified — the closure-reopen-service and risk-referral-service Prisma migrations need to be re-applied against the correct per-service DB schema (a prior `migrate deploy` run picked up the root `.env`'s `DATABASE_URL`, which lacks a `?schema=` param and landed tables in `public` instead of each service's own schema)

### Follow-ups
- Re-run the closure-reopen-service and risk-referral-service Prisma migrations with the correct per-service `DATABASE_URL` (with `?schema=<service-name>`), then live-verify CLOSURE_REVIEW/REFERRAL_INCOMPLETE/ACCOMPANIED_REFERRAL end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
