### PR TITLE
fix(media-service): Allow SUPERVISOR to register a media asset via POST /media

### DIFF
--- a/apps/media-service/src/media/mediaAsset.controller.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.ts
@@ -136,7 +136,7 @@ export function createMediaAssetRouter(service: MediaAssetService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI'),
+    requireRoles('SAKHI', 'SUPERVISOR'),
     validateBody(createMediaAssetSchema),
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -530,7 +530,9 @@ export class OperationsService {
     }
 
     const gatheringTopics = await this.repository.findGatheringTopics(dto.gatheringId);
-    const belongsToGathering = gatheringTopics.some((gt) => gt.topicId === topicId);
+    const belongsToGathering = gatheringTopics.some(
+      (gt: (typeof gatheringTopics)[number]) => gt.topicId === topicId,
+    );
     if (!belongsToGathering) {
       throw unprocessable('topicId: this topic is not part of the referenced gathering.');
     }


### PR DESCRIPTION
## Summary
- Allow `SUPERVISOR` (in addition to `SAKHI`) to call `POST /media`, closing the last gap in the event-photo flow: a supervisor could already get a presigned upload URL and PUT the photo to S3, but could never register it against their event.
- Fix a `noImplicitAny` build failure in `OperationsService.upsertTopicMark` by explicitly typing the `gt` callback parameter.

## Test plan
- [ ] `npm run lint && npm run affected:test`
- [ ] Manually verify a SUPERVISOR token can call `POST /media` end-to-end (presigned URL -> S3 PUT -> POST /media) and get a 201
- [ ] Confirm SAKHI behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)