### PR TITLE
fix: Gateway CORS preflight headers and SAKHI 502 on GET /beneficiaries

### DIFF
--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -13,6 +13,7 @@ import { createHealthRouter } from './health/health.controller';
 import { createInfoRouter } from './info/info.controller';
 import { createDocsRouter } from './docs/docs.controller';
 import { registerProxies } from './proxy/register-proxies';
+import { buildCorsMiddleware } from './cors/cors-middleware';
 
 export {
   asyncHandler,
@@ -39,18 +40,7 @@ export function createApp(signer: Pick<TokenSigner, 'verify'>): Application {
 
   app.use(pinoHttp(buildLoggerOptions(appConfig.LOG_LEVEL)));
   app.use(helmet());
-  app.use((req, res, next) => {
-    const origin = req.header('origin');
-    if (origin && appConfig.CORS_ORIGINS.includes(origin)) {
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Access-Control-Allow-Credentials', 'true');
-    }
-    if (req.method === 'OPTIONS') {
-      res.sendStatus(204);
-      return;
-    }
-    next();
-  });
+  app.use(buildCorsMiddleware(appConfig.CORS_ORIGINS));
   app.use(requestId);
 
   registerProxies(app, signer);

--- a/apps/api-gateway/src/cors/cors-middleware.spec.ts
+++ b/apps/api-gateway/src/cors/cors-middleware.spec.ts
@@ -59,6 +59,16 @@ describe('buildCorsMiddleware', () => {
     expect(next).toHaveBeenCalled();
   });
 
+  it('sets Vary: Origin on every response, since Allow-Origin is echoed conditionally per request', () => {
+    const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+    const req = mockReq({ origin: ALLOWED_ORIGIN });
+    const res = mockRes();
+
+    middleware(req, res as never, jest.fn());
+
+    expect(res.headers['Vary']).toBe('Origin');
+  });
+
   describe('OPTIONS preflight', () => {
     it('echoes back the browser-requested method and headers', () => {
       const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
@@ -113,6 +123,21 @@ describe('buildCorsMiddleware', () => {
 
       expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
       expect(res.sendStatus).toHaveBeenCalledWith(204);
+    });
+
+    it('sets Vary to include the preflight request headers, so a cache keys on them too', () => {
+      const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+      const req = mockReq(
+        { origin: ALLOWED_ORIGIN, 'access-control-request-method': 'PATCH' },
+        'OPTIONS',
+      );
+      const res = mockRes();
+
+      middleware(req, res as never, jest.fn());
+
+      expect(res.headers['Vary']).toBe(
+        'Origin, Access-Control-Request-Method, Access-Control-Request-Headers',
+      );
     });
   });
 });

--- a/apps/api-gateway/src/cors/cors-middleware.spec.ts
+++ b/apps/api-gateway/src/cors/cors-middleware.spec.ts
@@ -1,0 +1,118 @@
+import { buildCorsMiddleware } from './cors-middleware';
+
+const ALLOWED_ORIGIN = 'http://localhost:5173';
+
+function mockReq(overrides: Record<string, string | undefined> = {}, method = 'GET') {
+  const headers = overrides;
+  return {
+    method,
+    header: (name: string) => headers[name.toLowerCase()],
+  } as never;
+}
+
+function mockRes() {
+  const headers: Record<string, string> = {};
+  return {
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name] = value;
+    }),
+    sendStatus: jest.fn(),
+    headers,
+  } as unknown as { setHeader: jest.Mock; sendStatus: jest.Mock; headers: Record<string, string> };
+}
+
+describe('buildCorsMiddleware', () => {
+  it('allows an origin present in corsOrigins', () => {
+    const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+    const req = mockReq({ origin: ALLOWED_ORIGIN });
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res as never, next);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBe(ALLOWED_ORIGIN);
+    expect(res.headers['Access-Control-Allow-Credentials']).toBe('true');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('sets no Allow-Origin header for an origin not in corsOrigins', () => {
+    const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+    const req = mockReq({ origin: 'https://evil.example.com' });
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res as never, next);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('calls next() and skips CORS headers entirely when no Origin header is present', () => {
+    const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+    const req = mockReq({});
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res as never, next);
+
+    expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  describe('OPTIONS preflight', () => {
+    it('echoes back the browser-requested method and headers', () => {
+      const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+      const req = mockReq(
+        {
+          origin: ALLOWED_ORIGIN,
+          'access-control-request-method': 'PATCH',
+          'access-control-request-headers': 'content-type,x-request-id',
+        },
+        'OPTIONS',
+      );
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware(req, res as never, next);
+
+      expect(res.headers['Access-Control-Allow-Methods']).toBe('PATCH');
+      expect(res.headers['Access-Control-Allow-Headers']).toBe('content-type,x-request-id');
+      expect(res.headers['Access-Control-Max-Age']).toBe('86400');
+      expect(res.sendStatus).toHaveBeenCalledWith(204);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the default methods list when the browser sends no Access-Control-Request-Method', () => {
+      const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+      const req = mockReq({ origin: ALLOWED_ORIGIN }, 'OPTIONS');
+      const res = mockRes();
+
+      middleware(req, res as never, jest.fn());
+
+      expect(res.headers['Access-Control-Allow-Methods']).toBe('GET,POST,PATCH,PUT,DELETE,OPTIONS');
+    });
+
+    it('falls back to a default header list (including Authorization) when the browser sends no Access-Control-Request-Headers', () => {
+      const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+      const req = mockReq({ origin: ALLOWED_ORIGIN }, 'OPTIONS');
+      const res = mockRes();
+
+      middleware(req, res as never, jest.fn());
+
+      expect(res.headers['Access-Control-Allow-Headers']).toBe(
+        'Content-Type,Authorization,x-request-id',
+      );
+    });
+
+    it('still responds 204 to a preflight from a disallowed origin, but without Allow-Origin', () => {
+      const middleware = buildCorsMiddleware([ALLOWED_ORIGIN]);
+      const req = mockReq({ origin: 'https://evil.example.com' }, 'OPTIONS');
+      const res = mockRes();
+
+      middleware(req, res as never, jest.fn());
+
+      expect(res.headers['Access-Control-Allow-Origin']).toBeUndefined();
+      expect(res.sendStatus).toHaveBeenCalledWith(204);
+    });
+  });
+});

--- a/apps/api-gateway/src/cors/cors-middleware.ts
+++ b/apps/api-gateway/src/cors/cors-middleware.ts
@@ -1,0 +1,48 @@
+import type { NextFunction, Request, Response } from 'express';
+
+/** Headers every real client call needs — sent whenever the browser's own
+ * preflight omits Access-Control-Request-Headers (some browsers skip it for
+ * requests that carry no non-simple headers other than the ones listed
+ * here), so a preflight for an authenticated JSON request never fails open
+ * with a missing Allow-Headers response. */
+const DEFAULT_ALLOWED_HEADERS = 'Content-Type,Authorization,x-request-id';
+
+const DEFAULT_ALLOWED_METHODS = 'GET,POST,PATCH,PUT,DELETE,OPTIONS';
+
+/**
+ * Builds the gateway's CORS middleware. Only ever allows an origin present
+ * in `corsOrigins` — every other origin gets no Access-Control-Allow-Origin
+ * header at all, so the browser enforces same-origin as normal.
+ *
+ * On an OPTIONS preflight, echoes back what the browser actually asked for
+ * (Access-Control-Request-Method/-Headers) rather than a fixed list — a
+ * non-simple request (JSON body, custom headers like x-request-id) is
+ * otherwise blocked client-side even though the real request would have
+ * succeeded. Falls back to DEFAULT_ALLOWED_METHODS/HEADERS when the browser
+ * didn't send its own request-method/request-headers value, since every
+ * real call through this gateway is an authenticated JSON request that
+ * needs at least Authorization/Content-Type allowed.
+ */
+export function buildCorsMiddleware(corsOrigins: readonly string[]) {
+  return function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const origin = req.header('origin');
+    if (origin && corsOrigins.includes(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
+    if (req.method === 'OPTIONS') {
+      res.setHeader(
+        'Access-Control-Allow-Methods',
+        req.header('access-control-request-method') ?? DEFAULT_ALLOWED_METHODS,
+      );
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        req.header('access-control-request-headers') ?? DEFAULT_ALLOWED_HEADERS,
+      );
+      res.setHeader('Access-Control-Max-Age', '86400');
+      res.sendStatus(204);
+      return;
+    }
+    next();
+  };
+}

--- a/apps/api-gateway/src/cors/cors-middleware.ts
+++ b/apps/api-gateway/src/cors/cors-middleware.ts
@@ -25,12 +25,25 @@ const DEFAULT_ALLOWED_METHODS = 'GET,POST,PATCH,PUT,DELETE,OPTIONS';
  */
 export function buildCorsMiddleware(corsOrigins: readonly string[]) {
   return function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
+    // Access-Control-Allow-Origin is echoed conditionally per request (it
+    // varies by the Origin header), so any cache sitting in front of this
+    // gateway (CDN, reverse proxy) must key on Origin too — otherwise a
+    // response computed for one origin could be served to a different one.
+    res.setHeader('Vary', 'Origin');
+
     const origin = req.header('origin');
     if (origin && corsOrigins.includes(origin)) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Access-Control-Allow-Credentials', 'true');
     }
     if (req.method === 'OPTIONS') {
+      // Same reasoning as above: Allow-Methods/-Headers are echoed from the
+      // preflight's own Access-Control-Request-* headers, so a cache must
+      // key on those too, not just Origin.
+      res.setHeader(
+        'Vary',
+        'Origin, Access-Control-Request-Method, Access-Control-Request-Headers',
+      );
       res.setHeader(
         'Access-Control-Allow-Methods',
         req.header('access-control-request-method') ?? DEFAULT_ALLOWED_METHODS,

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -410,6 +410,34 @@ describe('BeneficiaryService', () => {
       expect(call.sakhiId).toBe('sakhi-1');
     });
 
+    it('never calls getSakhiName for a SAKHI caller — every row is already their own case', async () => {
+      // Regression test: GET /sakhis/:sakhiId (which getSakhiName calls) is
+      // SUPERVISOR/MANAGER/ADMIN-only in auth-service — a SAKHI's own token
+      // gets 403'd there, which getSakhiName turns into a 502. Every row a
+      // SAKHI sees is already forced to their own sakhiId, so there is
+      // nothing to look up.
+      repository.findMany.mockResolvedValue({
+        items: [
+          {
+            id: 'x',
+            sakhiId: 'sakhi-1',
+            projectId: 'project-1',
+            pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe'), villageId: null },
+          },
+        ] as never,
+        nextCursor: null,
+      });
+
+      const result = await service.list(
+        { limit: 50 },
+        caller({ id: 'sakhi-1', roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(getSakhiNameMock).not.toHaveBeenCalled();
+      expect(result.items[0]).toMatchObject({ sakhiName: null });
+    });
+
     it('SUPERVISOR caller sees only their own Sakhis, resolved via the Sakhi lookup', async () => {
       repository.findMany.mockResolvedValue({ items: [], nextCursor: null });
       listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -127,6 +127,7 @@ async function enrichListPage(
   items: Record<string, unknown>[],
   authorizationHeader: string,
   supervisorRoster?: Map<string, string>,
+  skipSakhiNameLookup = false,
 ): Promise<Record<string, unknown>[]> {
   if (items.length === 0) return [];
 
@@ -135,9 +136,16 @@ async function enrichListPage(
   const villageIdOf = (item: Record<string, unknown>) =>
     (item.pii as { villageId: string | null }).villageId;
 
-  const uncoveredSakhiIds = [
-    ...new Set(items.map(sakhiIdOf).filter((id) => !supervisorRoster?.has(id))),
-  ];
+  // A SAKHI caller only ever sees their own cases (list() forces
+  // filters.sakhiId = caller.id), so every row's sakhiId is the caller's
+  // own id — falling through to the per-id fallback below would call
+  // GET /sakhis/:sakhiId, which is SUPERVISOR/MANAGER/ADMIN-only and 403s a
+  // SAKHI's own token, turning into a 502 for every SAKHI caller. Skip the
+  // lookup entirely for this caller instead of trying to resolve a name
+  // they already know is their own.
+  const uncoveredSakhiIds = skipSakhiNameLookup
+    ? []
+    : [...new Set(items.map(sakhiIdOf).filter((id) => !supervisorRoster?.has(id)))];
 
   const [projectNames, villageNames, fallbackSakhiNames] = await Promise.all([
     resolveProjectNames(authorizationHeader),
@@ -271,7 +279,12 @@ export class BeneficiaryService {
       supervisorProjectId && supervisorId
         ? await listSakhiNamesForSupervisor(supervisorProjectId, supervisorId, authorizationHeader)
         : undefined;
-    const enriched = await enrichListPage(decrypted, authorizationHeader, supervisorRoster);
+    const enriched = await enrichListPage(
+      decrypted,
+      authorizationHeader,
+      supervisorRoster,
+      caller.roles.includes('SAKHI'),
+    );
     return { items: enriched, nextCursor: page.nextCursor };
   }
 


### PR DESCRIPTION
## Summary
- **api-gateway**: CORS preflight responses only ever sent a bare 204 with no `Access-Control-Allow-Methods`/`-Headers`, so browsers rejected any non-simple authenticated request (JSON body, `Authorization`, `x-request-id`) from an otherwise-allowed origin before it ever reached the API. `buildCorsMiddleware` now echoes back the browser's requested method/headers (or a sane default) and adds `Access-Control-Max-Age`.
- **beneficiary-service**: `GET /beneficiaries` 502'd for every SAKHI caller. `enrichListPage`'s per-id name fallback called `GET /sakhis/:sakhiId` (SUPERVISOR/MANAGER/ADMIN-only) for any id not already in the supervisor roster — which for a SAKHI's own list is always their own id, since `list()` forces `filters.sakhiId = caller.id`. The 403 from that scoped route surfaced as a 502 to the SAKHI. `list()` now skips the fallback lookup entirely when the caller is a SAKHI.

## Test plan
- [x] `npx nx affected --target=lint --base=origin/develop`
- [x] `npx nx affected --target=test --base=origin/develop` (191 tests passed across api-gateway and beneficiary-service)
- [ ] Manually verify a SAKHI token can call `GET /beneficiaries` without a 502
- [ ] Manually verify an authenticated JSON request (Authorization + Content-Type) from an allowed web origin now completes without a CORS preflight failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)