### PR TITLE
feat: Risk-grading write pipeline, visit summary/update, and beneficiary summary widgets

### DIFF
--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -76,6 +76,10 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
   // from /rules, so it needs its own gateway entry (mirrors /admin/forms).
   { prefix: '/admin/rules', target: appConfig.RULES_SERVICE_URL, requiresAuth: true },
   { prefix: '/referrals', target: appConfig.RISK_REFERRAL_SERVICE_URL, requiresAuth: true },
+  // Internal-use endpoint, not part of a human-facing surface —
+  // visit-form-service calls it through the gateway after persisting a
+  // visit-linked submission, to trigger the risk-grading pipeline.
+  { prefix: '/risk-assessments', target: appConfig.RISK_REFERRAL_SERVICE_URL, requiresAuth: true },
   { prefix: '/closures', target: appConfig.CLOSURE_REOPEN_SERVICE_URL, requiresAuth: true },
   // Internal-use decision endpoint, not part of the public Quick Response
   // surface — approval-service calls it through the gateway (rather than

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -821,6 +821,70 @@ describe('AuthService', () => {
           ).rejects.toMatchObject({ status: 400 });
           expect(repository.updateUserTransaction).not.toHaveBeenCalled();
         });
+
+        it("creates the profile using this same request's projectId, when roleCode SAKHI and projectId are both set in one call", async () => {
+          // Regression test: previously, assigning a SAKHI's projectId and
+          // creating their Sakhi profile (supervisorId/phoneNumber) in the
+          // same PATCH failed with "SAKHI role has no project assigned" —
+          // the profile-creation check read findActiveUserRole's
+          // *pre-update* row instead of this same request's input.projectId.
+          repository.findSakhiProfileByUserId.mockResolvedValue(null);
+          repository.findActiveUserRole.mockImplementation(((_userId: string, roleCode: string) =>
+            Promise.resolve(
+              roleCode === 'SAKHI' ? { id: 'user-role-1', projectId: null } : null,
+            )) as never);
+          repository.findProjectById.mockResolvedValue({ projectId: 'project-new' } as never);
+          repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+          await service.updateUser('user-1', {
+            roleCode: 'SAKHI',
+            projectId: 'project-new',
+            supervisorId: 'supervisor-1',
+            phoneNumber: '+919876544139',
+          });
+
+          expect(repository.updateUserTransaction).toHaveBeenCalledWith(
+            'user-1',
+            expect.objectContaining({
+              userRole: { id: 'user-role-1', data: { projectId: 'project-new' } },
+              sakhiProfile: {
+                create: {
+                  userId: 'user-1',
+                  primaryProjectId: 'project-new',
+                  phoneNumber: '+919876544139',
+                  activeFrom: expect.any(Date),
+                },
+                data: { supervisorId: 'supervisor-1', phoneNumber: '+919876544139' },
+              },
+            }),
+          );
+        });
+
+        it('still throws 400 when projectId is set for a DIFFERENT roleCode than SAKHI', async () => {
+          // input.projectId should only be trusted as the effective project
+          // when this same request's roleCode update targets SAKHI itself —
+          // a MANAGER role's projectId update must not leak into an
+          // unrelated Sakhi-profile creation.
+          repository.findSakhiProfileByUserId.mockResolvedValue(null);
+          repository.findActiveUserRole.mockImplementation(((_userId: string, roleCode: string) =>
+            Promise.resolve(
+              roleCode === 'MANAGER'
+                ? { id: 'manager-role-1', projectId: 'manager-project-1' }
+                : roleCode === 'SAKHI'
+                  ? { id: 'sakhi-role-1', projectId: null }
+                  : null,
+            )) as never);
+          repository.findProjectById.mockResolvedValue({ projectId: 'manager-project-1' } as never);
+
+          await expect(
+            service.updateUser('user-1', {
+              roleCode: 'MANAGER',
+              projectId: 'manager-project-1',
+              phoneNumber: '+919876544139',
+            }),
+          ).rejects.toMatchObject({ status: 400 });
+          expect(repository.updateUserTransaction).not.toHaveBeenCalled();
+        });
       });
 
       it('maps a duplicate employeeCode to a 409 conflict', async () => {

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -200,7 +200,17 @@ export class AuthService {
             'User does not hold an active SAKHI role; cannot create a Sakhi profile.',
           );
         }
-        if (!sakhiRole.projectId) {
+        // This read reflects the DB *before* the transaction below applies
+        // input.projectId — a caller assigning a project and a Sakhi profile
+        // in the same PATCH (roleCode: 'SAKHI', projectId, supervisorId/etc.)
+        // must not be told "no project assigned" just because the write
+        // hasn't happened yet. Only trust input.projectId here when this
+        // same request's roleCode update targets the SAKHI role itself.
+        const effectiveProjectId =
+          input.roleCode === 'SAKHI' && input.projectId !== undefined
+            ? input.projectId
+            : sakhiRole.projectId;
+        if (!effectiveProjectId) {
           throw badRequest(
             "User's SAKHI role has no project assigned; cannot create a Sakhi profile.",
           );
@@ -210,7 +220,7 @@ export class AuthService {
         }
         sakhiProfileCreate = {
           userId: id,
-          primaryProjectId: sakhiRole.projectId,
+          primaryProjectId: effectiveProjectId,
           phoneNumber: input.phoneNumber,
           activeFrom: input.activeFrom ? new Date(input.activeFrom) : new Date(),
         };

--- a/apps/beneficiary-service/prisma/migrations/20260808000000_add_risk_condition_summary_grade_rank/migration.sql
+++ b/apps/beneficiary-service/prisma/migrations/20260808000000_add_risk_condition_summary_grade_rank/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Beneficiary_risk_condition_summary" ADD COLUMN "latest_grade_rank" INTEGER;
+ALTER TABLE "Beneficiary_risk_condition_summary" ADD COLUMN "ever_highest_grade_rank" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Beneficiary_risk_condition_summary_beneficiary_id_risk_condition_id_key" ON "Beneficiary_risk_condition_summary"("beneficiary_id", "risk_condition_id");

--- a/apps/beneficiary-service/prisma/schema.prisma
+++ b/apps/beneficiary-service/prisma/schema.prisma
@@ -348,6 +348,13 @@ model BeneficiaryRiskConditionSummary {
   baselineSubmissionId         String?      @map("baseline_submission_id")
   baselineAssessedAt           DateTime?    @map("baseline_assessed_at")
   latestGrade                  String?      @map("latest_grade") @db.VarChar(50)
+  // Severity rank of latestGrade within its own risk_condition's gradeScale
+  // (BINARY / NORMAL_MILD_MODERATE_SEVERE / NORMAL_LOW_MEDIUM_HIGH per the
+  // ERD) — this service doesn't own risk_conditions and can't rank a grade
+  // string itself (no cross-service joins), so risk-referral-service
+  // computes and pushes the rank alongside the grade. Used only to decide
+  // whether an incoming grade should replace everHighestGrade below.
+  latestGradeRank               Int?         @map("latest_grade_rank")
   latestObservedValueJson      Json?        @map("latest_observed_value_json")
   // visit_instances.visit_id — owned by another service.
   latestVisitId                String?      @map("latest_visit_id")
@@ -355,6 +362,9 @@ model BeneficiaryRiskConditionSummary {
   latestSubmissionId           String?      @map("latest_submission_id")
   latestAssessedAt             DateTime?    @map("latest_assessed_at")
   everHighestGrade             String?      @map("ever_highest_grade") @db.VarChar(50)
+  // See latestGradeRank — the highest rank ever recorded, so a later lower
+  // grade can be recognized as lower without re-deriving rank from a string.
+  everHighestGradeRank          Int?         @map("ever_highest_grade_rank")
   everHighestObservedValueJson Json?        @map("ever_highest_observed_value_json")
   // visit_instances.visit_id — owned by another service.
   everHighestVisitId           String?      @map("ever_highest_visit_id")
@@ -370,6 +380,10 @@ model BeneficiaryRiskConditionSummary {
 
   beneficiaryCase BeneficiaryCase @relation(fields: [beneficiaryId], references: [id])
 
+  // One row per beneficiary+condition (per the ERD's derivation note) — lets
+  // PATCH /beneficiaries/:id/risk-condition-summary use a real upsert instead
+  // of a racy find-then-write.
+  @@unique([beneficiaryId, riskConditionId])
   @@map("Beneficiary_risk_condition_summary")
 }
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -10,8 +10,16 @@ import {
   SUMMARY_PHASES,
 } from './beneficiary.constants';
 import { createBeneficiarySchema } from './dto/create-beneficiary.dto';
-import { listBeneficiariesQuerySchema } from './dto/list-beneficiaries.dto';
+import {
+  listBeneficiariesQuerySchema,
+  normalizeRegisteredDateAliases,
+} from './dto/list-beneficiaries.dto';
+import {
+  summaryQuerySchema,
+  normalizeRegisteredDateAliases as normalizeSummaryDateAliases,
+} from './dto/summary-query.dto';
 import { upsertSocioDemographicsSchema } from './dto/upsert-socio-demographics.dto';
+import { upsertRiskConditionSummarySchema } from './dto/upsert-risk-condition-summary.dto';
 import { applyLmpChangeSchema } from './dto/apply-lmp-change.dto';
 import {
   asyncHandler,
@@ -199,6 +207,19 @@ const beneficiaryListPageSchema = z.object({
   }),
 });
 
+const registrationSummarySchema = z.object({
+  total: z.number().int(),
+  motherCount: z.number().int(),
+  childCount: z.number().int(),
+});
+
+const riskSummarySchema = z.object({
+  total: z.number().int(),
+  byGrade: z.record(z.string(), z.number().int()),
+  everAtRiskCount: z.number().int(),
+  referralTriggerCount: z.number().int(),
+});
+
 function envelope<T extends z.ZodTypeAny>(data: T) {
   return z.object({ success: z.literal(true), message: z.string(), data });
 }
@@ -252,8 +273,72 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
       if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');
       if (!authorizationHeader) return next(unauthorized());
-      const query = req.query as unknown as z.infer<typeof listBeneficiariesQuerySchema>;
+      const query = normalizeRegisteredDateAliases(
+        req.query as unknown as z.infer<typeof listBeneficiariesQuerySchema>,
+      );
       res.json(ok(await service.list(query, req.user, authorizationHeader)));
+    }),
+  );
+
+  doc.get(
+    '/beneficiaries/registration-summary',
+    {
+      summary:
+        'Registration Summary widget — total/mother/child counts of in-scope beneficiary ' +
+        'cases. Same role-scoping (sakhiId) and registrationDate range (fromDate/toDate) as ' +
+        'GET /beneficiaries, minus pagination/search.',
+      tags: ['Beneficiaries'],
+      responses: {
+        200: { description: 'Registration counts', schema: envelope(registrationSummarySchema) },
+        400: errorResponse(400, { message: 'fromDate must be on or before toDate.' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: "sakhiId is not in this Supervisor's roster." }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(summaryQuerySchema, 'query'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const query = normalizeSummaryDateAliases(
+        req.query as unknown as z.infer<typeof summaryQuerySchema>,
+      );
+      res.json(ok(await service.getRegistrationSummary(query, req.user, authorizationHeader)));
+    }),
+  );
+
+  doc.get(
+    '/beneficiaries/risk-summary',
+    {
+      summary:
+        "Risk Summary widget — counts of in-scope beneficiaries' risk condition summaries " +
+        'grouped by latestGrade, plus everAtRiskCount/referralTriggerCount. Same role-scoping ' +
+        '(sakhiId) and registrationDate range (fromDate/toDate) as GET /beneficiaries. Counts ' +
+        'per condition (a beneficiary with 2 HIGH conditions contributes 2 to byGrade.HIGH), ' +
+        'not collapsed to one grade per beneficiary.',
+      tags: ['Beneficiaries'],
+      responses: {
+        200: { description: 'Risk grade counts', schema: envelope(riskSummarySchema) },
+        400: errorResponse(400, { message: 'fromDate must be on or before toDate.' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: "sakhiId is not in this Supervisor's roster." }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(summaryQuerySchema, 'query'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const query = normalizeSummaryDateAliases(
+        req.query as unknown as z.infer<typeof summaryQuerySchema>,
+      );
+      res.json(ok(await service.getRiskSummary(query, req.user, authorizationHeader)));
     }),
   );
 
@@ -387,6 +472,48 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
       const updated = await service.applyLmpChange(
         req.params.id,
         req.body.lmpDate,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
+    }),
+  );
+
+  doc.patch(
+    '/beneficiaries/:id/risk-condition-summary',
+    {
+      summary:
+        "Upsert a beneficiary's per-condition risk rollup (Beneficiary_risk_condition_summary) " +
+        "— gated by requireRoles('SAKHI') since this codebase has no machine/service-account " +
+        "identity: the call chain originates from a SAKHI's form submission (visit-form-service " +
+        "-> risk-referral-service -> here), forwarding the SAKHI's own token at each hop. Not the " +
+        "source of truth — risk-referral-service's risk_assessments/risk_flags tables are; this " +
+        'is a derived rollup updated after every applicable visit/risk evaluation.',
+      tags: ['Beneficiaries'],
+      params: idParamsSchema,
+      responses: {
+        200: {
+          description: 'Risk condition summary upserted',
+          schema: envelope(riskConditionSummarySchema),
+        },
+        400: errorResponse(400, { message: 'gradeRank: Required' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validate(idParamsSchema, 'params'),
+    validateBody(upsertRiskConditionSummarySchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.upsertRiskConditionSummary(
+        req.params.id,
+        req.body,
         req.user,
         authorizationHeader,
       );

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -239,6 +239,7 @@ export class BeneficiaryRepository {
         sourceRuleVersionId: data.ruleVersionId,
       },
       update: {
+        phase: data.phase as never,
         latestGrade: data.grade,
         latestGradeRank: data.gradeRank,
         latestObservedValueJson: data.observedValueJson ?? undefined,

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -1,8 +1,10 @@
 import type { PrismaService } from '../prisma/prisma.service';
 import type {
   BeneficiaryListFilters,
+  BeneficiarySummaryFilters,
   CreateEnrollmentInput,
   DuplicateSearchTokens,
+  UpsertRiskConditionSummaryData,
 } from './beneficiary.repository.types';
 
 // Re-exported so existing importers of `./beneficiary.repository` keep working;
@@ -111,6 +113,154 @@ export class BeneficiaryRepository {
     const items = hasMore ? rows.slice(0, filters.limit) : rows;
     const lastItem = items[items.length - 1];
     return { items, nextCursor: hasMore && lastItem ? encodeCursor(lastItem) : null };
+  }
+
+  /**
+   * Counts in-scope beneficiary cases by caseType for the Registration
+   * Summary widget — same role-scoping/date-range semantics as findMany's
+   * `sakhiId`/`sakhiIds`/`fromDate`/`toDate` filters, just no pagination or
+   * detail rows since this is a count-only aggregate.
+   */
+  async countByCaseType(filters: BeneficiarySummaryFilters) {
+    const where: NonNullable<Parameters<typeof this.prisma.beneficiaryCase.groupBy>[0]>['where'] = {
+      isDeleted: false,
+    };
+    if (filters.sakhiId) where.sakhiId = filters.sakhiId;
+    if (filters.sakhiIds) where.sakhiId = { in: filters.sakhiIds };
+    if (filters.fromDate || filters.toDate) {
+      where.registrationDate = {
+        ...(filters.fromDate ? { gte: new Date(`${filters.fromDate}T00:00:00.000Z`) } : {}),
+        ...(filters.toDate ? { lte: new Date(`${filters.toDate}T23:59:59.999Z`) } : {}),
+      };
+    }
+
+    const grouped = await this.prisma.beneficiaryCase.groupBy({
+      by: ['caseType'],
+      where,
+      _count: { _all: true },
+    });
+
+    const motherCount = grouped.find((g) => g.caseType === 'MOTHER')?._count._all ?? 0;
+    const childCount = grouped.find((g) => g.caseType === 'CHILD')?._count._all ?? 0;
+    return { total: motherCount + childCount, motherCount, childCount };
+  }
+
+  /**
+   * Counts in-scope beneficiaries' latest risk grade per condition for the
+   * Risk Summary widget. Counts per-condition (one BeneficiaryRiskConditionSummary
+   * row per beneficiary+condition), not collapsed to one grade per beneficiary
+   * — matches the table's own grain.
+   */
+  async countByRiskGrade(filters: BeneficiarySummaryFilters) {
+    const caseWhere: NonNullable<
+      Parameters<typeof this.prisma.beneficiaryCase.findMany>[0]
+    >['where'] = { isDeleted: false };
+    if (filters.sakhiId) caseWhere.sakhiId = filters.sakhiId;
+    if (filters.sakhiIds) caseWhere.sakhiId = { in: filters.sakhiIds };
+    if (filters.fromDate || filters.toDate) {
+      caseWhere.registrationDate = {
+        ...(filters.fromDate ? { gte: new Date(`${filters.fromDate}T00:00:00.000Z`) } : {}),
+        ...(filters.toDate ? { lte: new Date(`${filters.toDate}T23:59:59.999Z`) } : {}),
+      };
+    }
+
+    const summaries = await this.prisma.beneficiaryRiskConditionSummary.findMany({
+      where: { beneficiaryCase: caseWhere },
+      select: { latestGrade: true, everAtRiskFlag: true, currentReferralTriggerFlag: true },
+    });
+
+    const byGrade: Record<string, number> = {};
+    let everAtRiskCount = 0;
+    let referralTriggerCount = 0;
+    for (const summary of summaries) {
+      const grade = summary.latestGrade ?? 'UNGRADED';
+      byGrade[grade] = (byGrade[grade] ?? 0) + 1;
+      if (summary.everAtRiskFlag) everAtRiskCount++;
+      if (summary.currentReferralTriggerFlag) referralTriggerCount++;
+    }
+
+    return { total: summaries.length, byGrade, everAtRiskCount, referralTriggerCount };
+  }
+
+  /**
+   * Upserts the per-condition risk rollup pushed by risk-referral-service
+   * after it evaluates a submission (see the ERD's derivation note on
+   * Beneficiary_risk_condition_summary: "not the source of truth... updated
+   * after every applicable visit/risk evaluation"). `latest*` always
+   * updates; `baseline*` is set only on first insert (never overwritten —
+   * baseline is a point-in-time snapshot); `everHighest*`/`everAtRiskFlag`
+   * only move toward "more severe," never back down, once any non-NORMAL
+   * grade has ever been recorded. `currentReferralTriggerFlag`/
+   * `currentHrVisitTriggerFlag` always reflect only the latest push, not an
+   * "ever" history.
+   *
+   * Uses the (beneficiaryId, riskConditionId) unique constraint for a real
+   * upsert — no separate find-then-write race window.
+   */
+  async upsertRiskConditionSummary(beneficiaryId: string, data: UpsertRiskConditionSummaryData) {
+    const existing = await this.prisma.beneficiaryRiskConditionSummary.findUnique({
+      where: {
+        beneficiaryId_riskConditionId: { beneficiaryId, riskConditionId: data.riskConditionId },
+      },
+    });
+
+    const isEverAtRisk = data.grade !== 'NORMAL' || (existing?.everAtRiskFlag ?? false);
+    const outranksEverHighest =
+      existing?.everHighestGradeRank == null || data.gradeRank > existing.everHighestGradeRank;
+
+    return this.prisma.beneficiaryRiskConditionSummary.upsert({
+      where: {
+        beneficiaryId_riskConditionId: { beneficiaryId, riskConditionId: data.riskConditionId },
+      },
+      create: {
+        beneficiaryId,
+        riskConditionId: data.riskConditionId,
+        phase: data.phase as never,
+        baselineGrade: data.grade,
+        baselineObservedValueJson: data.observedValueJson ?? undefined,
+        baselineVisitId: data.visitId,
+        baselineSubmissionId: data.submissionId,
+        baselineAssessedAt: data.assessedAt,
+        latestGrade: data.grade,
+        latestGradeRank: data.gradeRank,
+        latestObservedValueJson: data.observedValueJson ?? undefined,
+        latestVisitId: data.visitId,
+        latestSubmissionId: data.submissionId,
+        latestAssessedAt: data.assessedAt,
+        everHighestGrade: data.grade,
+        everHighestGradeRank: data.gradeRank,
+        everHighestObservedValueJson: data.observedValueJson ?? undefined,
+        everHighestVisitId: data.visitId,
+        everHighestSubmissionId: data.submissionId,
+        everHighestAssessedAt: data.assessedAt,
+        everAtRiskFlag: data.grade !== 'NORMAL',
+        currentReferralTriggerFlag: data.isReferralTrigger,
+        currentHrVisitTriggerFlag: data.isHrVisitTrigger,
+        sourceRuleVersionId: data.ruleVersionId,
+      },
+      update: {
+        latestGrade: data.grade,
+        latestGradeRank: data.gradeRank,
+        latestObservedValueJson: data.observedValueJson ?? undefined,
+        latestVisitId: data.visitId,
+        latestSubmissionId: data.submissionId,
+        latestAssessedAt: data.assessedAt,
+        everAtRiskFlag: isEverAtRisk,
+        ...(outranksEverHighest
+          ? {
+              everHighestGrade: data.grade,
+              everHighestGradeRank: data.gradeRank,
+              everHighestObservedValueJson: data.observedValueJson ?? undefined,
+              everHighestVisitId: data.visitId,
+              everHighestSubmissionId: data.submissionId,
+              everHighestAssessedAt: data.assessedAt,
+            }
+          : {}),
+        currentReferralTriggerFlag: data.isReferralTrigger,
+        currentHrVisitTriggerFlag: data.isHrVisitTrigger,
+        sourceRuleVersionId: data.ruleVersionId,
+      },
+    });
   }
 
   findById(id: string) {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '../../../../node_modules/.prisma/client-beneficiary-service';
 import type { BeneficiaryStatus, CasePhase, CaseType, Sex } from './beneficiary.constants';
 
 export interface BeneficiaryListFilters {
@@ -31,6 +32,14 @@ export interface BeneficiaryListFilters {
 export interface BeneficiaryListPage<T> {
   items: T[];
   nextCursor: string | null;
+}
+
+/** Same role-scoping shape as BeneficiaryListFilters, for the count-only summary widgets. */
+export interface BeneficiarySummaryFilters {
+  sakhiId?: string;
+  sakhiIds?: string[];
+  fromDate?: string;
+  toDate?: string;
 }
 
 export interface DuplicateSearchTokens {
@@ -109,6 +118,20 @@ export interface SocioDemographicsCreateData {
   socialCategoryLookupId: string | null;
   familyMembersCount: number | null;
   childrenUnder5Count: number | null;
+}
+
+export interface UpsertRiskConditionSummaryData {
+  riskConditionId: string;
+  phase: string;
+  grade: string;
+  gradeRank: number;
+  observedValueJson: Prisma.InputJsonValue | null;
+  visitId: string | null;
+  submissionId: string | null;
+  assessedAt: Date;
+  isReferralTrigger: boolean;
+  isHrVisitTrigger: boolean;
+  ruleVersionId: string | null;
 }
 
 export interface CreateEnrollmentInput {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -27,6 +27,9 @@ describe('BeneficiaryService', () => {
     createEnrollment: jest.fn(),
     updateMotherLmp: jest.fn(),
     reactivateCase: jest.fn(),
+    countByCaseType: jest.fn(),
+    countByRiskGrade: jest.fn(),
+    upsertRiskConditionSummary: jest.fn(),
   } as unknown as jest.Mocked<BeneficiaryRepository>;
   let service: BeneficiaryService;
 
@@ -1209,5 +1212,206 @@ describe('BeneficiaryService', () => {
     await expect(service.create(baseMotherInput, CALLER_ID, AUTH_HEADER)).rejects.toThrow(
       'db down',
     );
+  });
+
+  describe('getRegistrationSummary', () => {
+    it('scopes a SAKHI caller to their own cases', async () => {
+      repository.countByCaseType.mockResolvedValue({ total: 5, motherCount: 3, childCount: 2 });
+
+      const result = await service.getRegistrationSummary({}, caller(), AUTH_HEADER);
+
+      expect(repository.countByCaseType).toHaveBeenCalledWith(
+        expect.objectContaining({ sakhiId: CALLER_ID }),
+      );
+      expect(result).toEqual({ total: 5, motherCount: 3, childCount: 2 });
+    });
+
+    it('scopes a SUPERVISOR caller to their roster', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
+      repository.countByCaseType.mockResolvedValue({ total: 0, motherCount: 0, childCount: 0 });
+
+      await service.getRegistrationSummary({}, caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER);
+
+      expect(repository.countByCaseType).toHaveBeenCalledWith(
+        expect.objectContaining({ sakhiIds: ['sakhi-a', 'sakhi-b'] }),
+      );
+    });
+
+    it('rejects a SUPERVISOR sakhiId outside their roster', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+
+      await expect(
+        service.getRegistrationSummary(
+          { sakhiId: 'sakhi-outside' },
+          caller({ roles: ['SUPERVISOR'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow("sakhiId is not in this Supervisor's roster.");
+    });
+
+    it('leaves a MANAGER/ADMIN caller unscoped with no sakhiId filter', async () => {
+      repository.countByCaseType.mockResolvedValue({ total: 10, motherCount: 6, childCount: 4 });
+
+      await service.getRegistrationSummary({}, caller({ roles: ['MANAGER'] }), AUTH_HEADER);
+
+      expect(repository.countByCaseType).toHaveBeenCalledWith(
+        expect.not.objectContaining({ sakhiId: expect.anything() }),
+      );
+    });
+
+    it('rejects fromDate after toDate', async () => {
+      await expect(
+        service.getRegistrationSummary(
+          { fromDate: '2026-02-01', toDate: '2026-01-01' },
+          caller(),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('fromDate must be on or before toDate.');
+    });
+
+    it('rejects a SUPERVISOR caller with no project scope', async () => {
+      await expect(
+        service.getRegistrationSummary(
+          {},
+          caller({ roles: ['SUPERVISOR'], projectId: null }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('Supervisor caller has no project scope.');
+    });
+  });
+
+  describe('getRiskSummary', () => {
+    it('returns counts grouped by grade, scoped to the caller', async () => {
+      repository.countByRiskGrade.mockResolvedValue({
+        total: 3,
+        byGrade: { HIGH: 2, NORMAL: 1 },
+        everAtRiskCount: 2,
+        referralTriggerCount: 1,
+      });
+
+      const result = await service.getRiskSummary({}, caller(), AUTH_HEADER);
+
+      expect(repository.countByRiskGrade).toHaveBeenCalledWith(
+        expect.objectContaining({ sakhiId: CALLER_ID }),
+      );
+      expect(result.byGrade).toEqual({ HIGH: 2, NORMAL: 1 });
+    });
+
+    it('rejects fromDate after toDate', async () => {
+      await expect(
+        service.getRiskSummary(
+          { fromDate: '2026-02-01', toDate: '2026-01-01' },
+          caller(),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('fromDate must be on or before toDate.');
+    });
+  });
+
+  describe('upsertRiskConditionSummary', () => {
+    const RISK_CONDITION_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const dto = {
+      riskConditionId: RISK_CONDITION_ID,
+      phase: 'ANC' as const,
+      grade: 'HIGH',
+      gradeRank: 3,
+      assessedAt: new Date('2026-01-01'),
+      isReferralTrigger: true,
+      isHrVisitTrigger: false,
+    };
+
+    it('404s when the beneficiary case does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.upsertRiskConditionSummary('unknown-id', dto, caller(), AUTH_HEADER),
+      ).rejects.toThrow('Beneficiary case not found.');
+    });
+
+    it('403s when a SAKHI targets a beneficiary that is not their own', async () => {
+      repository.findById.mockResolvedValue({ id: 'ben-1', sakhiId: 'someone-else' } as never);
+
+      await expect(
+        service.upsertRiskConditionSummary(
+          'ben-1',
+          dto,
+          caller({ id: CALLER_ID, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('This beneficiary case is outside your own roster.');
+      expect(repository.upsertRiskConditionSummary).not.toHaveBeenCalled();
+    });
+
+    it('allows a SAKHI to upsert their own beneficiary', async () => {
+      repository.findById.mockResolvedValue({ id: 'ben-1', sakhiId: CALLER_ID } as never);
+      repository.upsertRiskConditionSummary.mockResolvedValue({} as never);
+
+      await service.upsertRiskConditionSummary(
+        'ben-1',
+        dto,
+        caller({ id: CALLER_ID, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.upsertRiskConditionSummary).toHaveBeenCalled();
+    });
+
+    it("403s when a SUPERVISOR's roster does not include the beneficiary's Sakhi", async () => {
+      repository.findById.mockResolvedValue({ id: 'ben-1', sakhiId: 'sakhi-outside' } as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-inside']);
+
+      await expect(
+        service.upsertRiskConditionSummary(
+          'ben-1',
+          dto,
+          caller({ roles: ['SUPERVISOR'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow("This beneficiary case is outside this Supervisor's roster.");
+      expect(repository.upsertRiskConditionSummary).not.toHaveBeenCalled();
+    });
+
+    it('allows a MANAGER/ADMIN caller unrestricted', async () => {
+      repository.findById.mockResolvedValue({ id: 'ben-1', sakhiId: 'any-sakhi' } as never);
+      repository.upsertRiskConditionSummary.mockResolvedValue({} as never);
+
+      await service.upsertRiskConditionSummary(
+        'ben-1',
+        dto,
+        caller({ roles: ['MANAGER'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.upsertRiskConditionSummary).toHaveBeenCalled();
+    });
+
+    it('passes through all fields to the repository upsert', async () => {
+      repository.findById.mockResolvedValue({ id: 'ben-1', sakhiId: CALLER_ID } as never);
+      repository.upsertRiskConditionSummary.mockResolvedValue({} as never);
+
+      await service.upsertRiskConditionSummary(
+        'ben-1',
+        {
+          ...dto,
+          observedValueJson: { systolicBp: 145 },
+          visitId: 'visit-1',
+          submissionId: 'submission-1',
+          ruleVersionId: 'rule-version-1',
+        },
+        caller({ id: CALLER_ID, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.upsertRiskConditionSummary).toHaveBeenCalledWith(
+        'ben-1',
+        expect.objectContaining({
+          riskConditionId: RISK_CONDITION_ID,
+          grade: 'HIGH',
+          gradeRank: 3,
+          isReferralTrigger: true,
+          isHrVisitTrigger: false,
+        }),
+      );
+    });
   });
 });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -13,12 +13,15 @@ import {
 import type {
   BeneficiaryRiskConditionSummary,
   BeneficiaryStatusHistory,
+  Prisma,
 } from '../../../../node_modules/.prisma/client-beneficiary-service';
 import type { BeneficiaryStatus, CaseType } from './beneficiary.constants';
 import { buildSearchTokens, evaluateDuplicateMatch } from './beneficiary.duplicate-detection';
 import { computeBmi, withDecryptedName } from './beneficiary.mapper';
 import type { BeneficiaryListFilters, BeneficiaryRepository } from './beneficiary.repository';
 import type { CreateBeneficiaryInput } from './dto/create-beneficiary.dto';
+import type { UpsertRiskConditionSummaryInput } from './dto/upsert-risk-condition-summary.dto';
+import type { SummaryQueryInput } from './dto/summary-query.dto';
 import type { UpsertSocioDemographicsInput } from './dto/upsert-socio-demographics.dto';
 import { resolveHealthBlockIdFromPhc, resolveVillageNames } from '../geography/geography.client';
 import { resolveLookupIdsByValueCode, resolveLookupValues } from '../lookups/lookup.client';
@@ -186,6 +189,43 @@ export interface ListBeneficiariesQuery {
   limit: number;
 }
 
+/**
+ * Resolves the sakhiId/sakhiIds scoping filters shared by `list()` and the
+ * count-only summary endpoints: a SAKHI only ever sees their own cases, a
+ * SUPERVISOR is scoped to their own roster (optionally narrowed to one
+ * in-roster sakhiId), and MANAGER/ADMIN are unscoped unless they pass an
+ * explicit sakhiId. Throws forbidden() for an out-of-roster sakhiId or a
+ * SUPERVISOR with no project claim — same guards `list()` already enforced
+ * inline before this was extracted for reuse by the summary endpoints.
+ */
+async function resolveSakhiScoping(
+  querySakhiId: string | undefined,
+  caller: AuthenticatedUser,
+  authorizationHeader: string,
+): Promise<{ sakhiId?: string; sakhiIds?: string[] }> {
+  if (caller.roles.includes('SAKHI')) {
+    return { sakhiId: caller.id };
+  }
+  if (caller.roles.includes('SUPERVISOR')) {
+    if (!caller.projectId) {
+      throw forbidden('Supervisor caller has no project scope.');
+    }
+    const roster = await listSakhiIdsForSupervisor(
+      caller.projectId,
+      caller.id,
+      authorizationHeader,
+    );
+    if (querySakhiId) {
+      if (!roster.includes(querySakhiId)) {
+        throw forbidden("sakhiId is not in this Supervisor's roster.");
+      }
+      return { sakhiId: querySakhiId };
+    }
+    return { sakhiIds: roster };
+  }
+  return querySakhiId ? { sakhiId: querySakhiId } : {};
+}
+
 /** Business logic for the beneficiary enrollment lifecycle. */
 export class BeneficiaryService {
   constructor(private readonly repository: BeneficiaryRepository) {}
@@ -286,6 +326,100 @@ export class BeneficiaryService {
       caller.roles.includes('SAKHI'),
     );
     return { items: enriched, nextCursor: page.nextCursor };
+  }
+
+  /**
+   * Registration Summary widget — total/mother/child counts of in-scope
+   * beneficiary cases, same role-scoping and optional fromDate/toDate range
+   * as `list()`.
+   */
+  async getRegistrationSummary(
+    query: SummaryQueryInput,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    if (query.fromDate && query.toDate && query.fromDate > query.toDate) {
+      throw badRequest('fromDate must be on or before toDate.');
+    }
+    const scoping = await resolveSakhiScoping(query.sakhiId, caller, authorizationHeader);
+    return this.repository.countByCaseType({
+      ...scoping,
+      fromDate: query.fromDate,
+      toDate: query.toDate,
+    });
+  }
+
+  /**
+   * Risk Summary widget — counts of in-scope beneficiaries' risk condition
+   * summaries grouped by latestGrade, same role-scoping/date-range as
+   * `list()`/getRegistrationSummary. Counts per-condition, not collapsed to
+   * one grade per beneficiary (see BeneficiaryRepository.countByRiskGrade).
+   */
+  async getRiskSummary(
+    query: SummaryQueryInput,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    if (query.fromDate && query.toDate && query.fromDate > query.toDate) {
+      throw badRequest('fromDate must be on or before toDate.');
+    }
+    const scoping = await resolveSakhiScoping(query.sakhiId, caller, authorizationHeader);
+    return this.repository.countByRiskGrade({
+      ...scoping,
+      fromDate: query.fromDate,
+      toDate: query.toDate,
+    });
+  }
+
+  /**
+   * Upserts a beneficiary's per-condition risk rollup — called
+   * server-to-server by risk-referral-service after it evaluates a
+   * submission and writes its own RiskAssessment/RiskFlag source-of-truth
+   * rows (see BeneficiaryRepository.upsertRiskConditionSummary for the
+   * baseline/latest/everHighest semantics).
+   *
+   * Gated by requireRoles('SAKHI') at the route (this codebase has no
+   * machine/service-account identity — the call chain forwards the
+   * originating SAKHI's own token through visit-form-service and
+   * risk-referral-service). assertCallerCanTouchCase alone doesn't cover
+   * this route: it only scopes SUPERVISOR callers, early-returning for
+   * everyone else — so a SAKHI reaching this method must be checked
+   * explicitly, or any authenticated Sakhi could upsert any beneficiary's
+   * risk rollup regardless of whose case it is.
+   */
+  async upsertRiskConditionSummary(
+    beneficiaryId: string,
+    dto: UpsertRiskConditionSummaryInput,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const found = await this.repository.findById(beneficiaryId);
+    if (!found) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (found.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else {
+      await assertCallerCanTouchCase(found.sakhiId, caller, authorizationHeader);
+    }
+
+    return this.repository.upsertRiskConditionSummary(beneficiaryId, {
+      riskConditionId: dto.riskConditionId,
+      phase: dto.phase,
+      grade: dto.grade,
+      gradeRank: dto.gradeRank,
+      // Untyped external JSON crossing into Prisma's InputJsonValue at this
+      // one boundary — the zod schema (z.record) already guarantees a plain
+      // JSON-serializable object.
+      observedValueJson: (dto.observedValueJson as Prisma.InputJsonValue | undefined) ?? null,
+      visitId: dto.visitId ?? null,
+      submissionId: dto.submissionId ?? null,
+      assessedAt: dto.assessedAt,
+      isReferralTrigger: dto.isReferralTrigger,
+      isHrVisitTrigger: dto.isHrVisitTrigger,
+      ruleVersionId: dto.ruleVersionId ?? null,
+    });
   }
 
   async getById(id: string, authorizationHeader: string) {

--- a/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/list-beneficiaries.dto.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { BENEFICIARY_STATUSES, CASE_TYPES } from '../beneficiary.constants';
 
+const dateOnlySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)');
+
 /**
  * Query params for `GET /beneficiaries`, per SRS FR-S-9.2 ("Search by name
  * and mobile number. Filter by pada (multi-select) and risk level
@@ -12,17 +16,23 @@ import { BENEFICIARY_STATUSES, CASE_TYPES } from '../beneficiary.constants';
  * `sakhiId` lets a SUPERVISOR/MANAGER/ADMIN caller scope the list to one
  * Sakhi's roster (a SAKHI caller's own id always wins regardless of this
  * param — see BeneficiaryService.list). `fromDate`/`toDate` range-filter on
- * registrationDate. `cursor`/`limit` are the HLD-mandated cursor pagination —
- * `cursor` is opaque, returned as `nextCursor` in the response and passed
- * back unchanged for the next page.
+ * registrationDate; `registeredFrom`/`registeredTo` are accepted as
+ * equivalent aliases (the milestone's requested param names) — both pairs
+ * are normalized onto `fromDate`/`toDate` before the service layer sees the
+ * query, so BeneficiaryService/BeneficiaryRepository need no changes.
+ * `cursor`/`limit` are the HLD-mandated cursor pagination — `cursor` is
+ * opaque, returned as `nextCursor` in the response and passed back unchanged
+ * for the next page.
  */
 // Deliberately a plain z.object (AnyZodObject), not wrapped in .refine() —
 // createDocumentedRouter() auto-infers this schema as the route's OpenAPI
 // query parameters straight from the `validate(schema, 'query')` middleware,
-// and zod-to-openapi cannot introspect a ZodEffects (what .refine() produces)
-// as a parameter object; it throws MissingParameterDataError at service
-// startup, not a per-request error. The fromDate<=toDate cross-field check
-// lives in beneficiary.service.ts instead — see assertValidDateRange().
+// and zod-to-openapi cannot introspect a ZodEffects (what .refine()/.transform()
+// produces) as a parameter object; it throws MissingParameterDataError at
+// service startup, not a per-request error. So alias normalization can't
+// live in this schema either — it happens in beneficiary.controller.ts,
+// right after validate() parses the query, alongside the existing
+// fromDate<=toDate cross-field check (in beneficiary.service.ts).
 export const listBeneficiariesQuerySchema = z
   .object({
     projectId: z.string().uuid().optional(),
@@ -35,14 +45,11 @@ export const listBeneficiariesQuerySchema = z
     name: z.string().trim().min(1).max(200).optional(),
     mobileNumber: z.string().trim().min(1).max(20).optional(),
     // Range filter on registrationDate — date-only strings (@db.Date column).
-    fromDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)')
-      .optional(),
-    toDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)')
-      .optional(),
+    fromDate: dateOnlySchema.optional(),
+    toDate: dateOnlySchema.optional(),
+    // Aliases for fromDate/toDate — see this schema's doc comment.
+    registeredFrom: dateOnlySchema.optional(),
+    registeredTo: dateOnlySchema.optional(),
     // Opaque, base64-encoded cursor — see beneficiary.repository.ts's encode/decodeCursor.
     cursor: z.string().trim().min(1).optional(),
     limit: z.coerce.number().int().min(1).max(100).default(50),
@@ -50,3 +57,18 @@ export const listBeneficiariesQuerySchema = z
   .strict();
 
 export type ListBeneficiariesQueryInput = z.infer<typeof listBeneficiariesQuerySchema>;
+
+/**
+ * Normalizes `registeredFrom`/`registeredTo` onto `fromDate`/`toDate` — an
+ * explicit `fromDate`/`toDate` wins if a caller (incorrectly) sends both
+ * forms for the same bound, rather than silently picking one.
+ */
+export function normalizeRegisteredDateAliases(
+  query: ListBeneficiariesQueryInput,
+): ListBeneficiariesQueryInput {
+  return {
+    ...query,
+    fromDate: query.fromDate ?? query.registeredFrom,
+    toDate: query.toDate ?? query.registeredTo,
+  };
+}

--- a/apps/beneficiary-service/src/beneficiary/dto/summary-query.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/summary-query.dto.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+const dateOnlySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)');
+
+/**
+ * Shared query params for the registration-summary and risk-summary widgets —
+ * same role-scoping/date-range filters as `GET /beneficiaries`
+ * (listBeneficiariesQuerySchema), minus the fields a count-only aggregate has
+ * no use for (pagination, name/mobile search, geography narrowing).
+ * `registeredFrom`/`registeredTo` are accepted as aliases for `fromDate`/
+ * `toDate` — see normalizeRegisteredDateAliases.
+ */
+export const summaryQuerySchema = z
+  .object({
+    sakhiId: z.string().uuid().optional(),
+    fromDate: dateOnlySchema.optional(),
+    toDate: dateOnlySchema.optional(),
+    registeredFrom: dateOnlySchema.optional(),
+    registeredTo: dateOnlySchema.optional(),
+  })
+  .strict();
+
+export type SummaryQueryInput = z.infer<typeof summaryQuerySchema>;
+
+/**
+ * Normalizes `registeredFrom`/`registeredTo` onto `fromDate`/`toDate` — an
+ * explicit `fromDate`/`toDate` wins if a caller sends both forms for the
+ * same bound. Mirrors list-beneficiaries.dto.ts's alias for GET /beneficiaries.
+ */
+export function normalizeRegisteredDateAliases(query: SummaryQueryInput): SummaryQueryInput {
+  return {
+    ...query,
+    fromDate: query.fromDate ?? query.registeredFrom,
+    toDate: query.toDate ?? query.registeredTo,
+  };
+}

--- a/apps/beneficiary-service/src/beneficiary/dto/upsert-risk-condition-summary.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/upsert-risk-condition-summary.dto.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+import { SUMMARY_PHASES } from '../beneficiary.constants';
+
+/**
+ * Request body for `PATCH /beneficiaries/:id/risk-condition-summary` — pushed
+ * server-to-server by risk-referral-service after it evaluates a submission
+ * and writes its own RiskAssessment/RiskFlag source-of-truth rows. This
+ * service doesn't own risk_conditions (no cross-service joins per the
+ * forklift rule), so `gradeRank` is supplied pre-computed by the caller, who
+ * does own that table and its per-condition gradeScale — see the
+ * `latestGradeRank` schema comment on BeneficiaryRiskConditionSummary.
+ */
+export const upsertRiskConditionSummarySchema = z
+  .object({
+    riskConditionId: z.string().uuid(),
+    phase: z.enum(SUMMARY_PHASES),
+    grade: z.string().min(1).max(50),
+    gradeRank: z.number().int(),
+    observedValueJson: z.record(z.string(), z.unknown()).nullable().optional(),
+    visitId: z.string().uuid().nullable().optional(),
+    submissionId: z.string().uuid().nullable().optional(),
+    assessedAt: z.coerce.date(),
+    isReferralTrigger: z.boolean(),
+    isHrVisitTrigger: z.boolean(),
+    ruleVersionId: z.string().uuid().nullable().optional(),
+  })
+  .strict();
+
+export type UpsertRiskConditionSummaryInput = z.infer<typeof upsertRiskConditionSummarySchema>;

--- a/apps/risk-referral-service/prisma/migrations/20260808000000_add_risk_assessment_submission_unique/migration.sql
+++ b/apps/risk-referral-service/prisma/migrations/20260808000000_add_risk_assessment_submission_unique/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "risk_assessments_submission_id_key" ON "risk_assessments"("submission_id");

--- a/apps/risk-referral-service/prisma/schema.prisma
+++ b/apps/risk-referral-service/prisma/schema.prisma
@@ -165,6 +165,10 @@ model RiskAssessment {
 
   riskFlags RiskFlag[]
 
+  // A retried POST /risk-assessments call (dropped-connection retry from
+  // visit-form-service) must not double-write — same idempotency pattern as
+  // form_submissions.localSubmissionUuid/beneficiary_cases.localCaseUuid.
+  @@unique([submissionId])
   @@map("risk_assessments")
 }
 

--- a/apps/risk-referral-service/src/app.module.ts
+++ b/apps/risk-referral-service/src/app.module.ts
@@ -12,6 +12,7 @@ import { appConfig } from './config/app-config';
 import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createReferralModule } from './referrals/referral.module';
+import { createRiskAssessmentModule } from './risk-assessments/riskAssessment.module';
 import { buildRiskReferralServiceOpenApiDocument } from './docs/openapi';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
@@ -52,15 +53,24 @@ export function createApp(prisma: PrismaService): Application {
   app.use(requestId);
 
   const referralModule = createReferralModule(prisma);
+  const riskAssessmentModule = createRiskAssessmentModule(prisma);
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();
   api.use(createHealthRouter(prisma));
-  // Built from referralModule.registry — every route registered via
+  // Built from every feature module's registry — every route registered via
   // createDocumentedRouter() above is already in the spec, so this can never
   // drift from what's actually mounted.
-  api.use(createSwaggerRouter(buildRiskReferralServiceOpenApiDocument(referralModule.registry)));
+  api.use(
+    createSwaggerRouter(
+      buildRiskReferralServiceOpenApiDocument(
+        referralModule.registry,
+        riskAssessmentModule.registry,
+      ),
+    ),
+  );
   api.use(referralModule.router);
+  api.use(riskAssessmentModule.router);
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/risk-referral-service/src/docs/openapi.ts
+++ b/apps/risk-referral-service/src/docs/openapi.ts
@@ -1,15 +1,16 @@
-import type { OpenAPIRegistry } from '@armman/service-commons';
-import { buildServiceOpenApiDocument } from '@armman/service-commons';
+import { OpenAPIRegistry, buildServiceOpenApiDocument } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
 /**
- * Builds the risk-referral-service OpenAPI document from the registry that
- * `createReferralRouter` (via `createDocumentedRouter()`) already populated as
- * each route was defined — there is no separate, hand-maintained route list
- * to keep in sync here.
+ * Builds the risk-referral-service OpenAPI document from every feature
+ * router's registry — each `createDocumentedRouter()` call creates its own
+ * registry, so referrals/risk-assessments routes are merged here (via the
+ * registry's `parents` constructor param) rather than one router's routes
+ * silently missing from the combined doc.
  */
-export function buildRiskReferralServiceOpenApiDocument(registry: OpenAPIRegistry) {
-  return buildServiceOpenApiDocument(registry, {
+export function buildRiskReferralServiceOpenApiDocument(...registries: OpenAPIRegistry[]) {
+  const merged = new OpenAPIRegistry(registries);
+  return buildServiceOpenApiDocument(merged, {
     title: 'Arogya Sakhi — Risk Referral Service API',
     description: 'Risk assessments, flags, referrals, and follow-ups.',
     port: appConfig.PORT,

--- a/apps/risk-referral-service/src/risk-assessments/beneficiaryRiskSummary.client.ts
+++ b/apps/risk-referral-service/src/risk-assessments/beneficiaryRiskSummary.client.ts
@@ -1,0 +1,50 @@
+/**
+ * Pushes one condition's rollup to beneficiary-service's
+ * `PATCH /beneficiaries/:id/risk-condition-summary` through the gateway,
+ * forwarding the caller's own Authorization header. Deliberately does not
+ * throw on failure — this push is best-effort enrichment of a derived,
+ * non-source-of-truth table (see the ERD's derivation note); a failure here
+ * must never roll back or fail the RiskAssessment/RiskFlag write that
+ * already committed. The caller logs the outcome and moves on — no
+ * retry/reconciliation exists in this codebase (confirmed: zero event/queue
+ * infrastructure anywhere), an accepted known gap for this milestone.
+ */
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+export interface RiskConditionSummaryPush {
+  riskConditionId: string;
+  phase: string;
+  grade: string;
+  gradeRank: number;
+  observedValueJson: Record<string, unknown> | null;
+  visitId: string | null;
+  submissionId: string | null;
+  assessedAt: string;
+  isReferralTrigger: boolean;
+  isHrVisitTrigger: boolean;
+  ruleVersionId: string | null;
+}
+
+export async function pushRiskConditionSummary(
+  beneficiaryId: string,
+  data: RiskConditionSummaryPush,
+  authorizationHeader: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(
+      `${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/risk-condition-summary`,
+      {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      },
+    );
+    if (!res.ok) {
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      return { ok: false, error: body?.message ?? `beneficiary-service returned ${res.status}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'unknown error' };
+  }
+}

--- a/apps/risk-referral-service/src/risk-assessments/dto/create-riskAssessment.dto.ts
+++ b/apps/risk-referral-service/src/risk-assessments/dto/create-riskAssessment.dto.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/** Recursive JSON value type usable inside nested objects/arrays. */
+type NestedJsonValue =
+  string | number | boolean | null | NestedJsonValue[] | { [key: string]: NestedJsonValue };
+
+const nestedJsonValueSchema: z.ZodType<NestedJsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(nestedJsonValueSchema),
+    z.record(nestedJsonValueSchema),
+  ]),
+);
+
+/**
+ * Request body for `POST /risk-assessments` — called by visit-form-service
+ * after persisting a visit-linked, VALID form submission. `ruleSetId` is
+ * read by the caller from its own FormDefinition.riskRuleSetId (see that
+ * column's schema comment) — this service has no form/entity knowledge of
+ * its own to derive it. `visitId` is nullable since a submission need not
+ * always be visit-linked (mirrors form_submissions.visitId).
+ */
+export const createRiskAssessmentSchema = z
+  .object({
+    beneficiaryId: z.string().uuid(),
+    visitId: z.string().uuid().nullable(),
+    submissionId: z.string().uuid(),
+    ruleSetId: z.string().uuid(),
+    answers: z.record(nestedJsonValueSchema),
+  })
+  .strict();
+
+export type CreateRiskAssessmentInput = z.infer<typeof createRiskAssessmentSchema>;

--- a/apps/risk-referral-service/src/risk-assessments/lookup.client.ts
+++ b/apps/risk-referral-service/src/risk-assessments/lookup.client.ts
@@ -1,0 +1,48 @@
+import { badGateway } from '@armman/service-commons';
+
+// Read directly (not via appConfig) — see beneficiary.client.ts in this
+// service for why.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+interface LookupValue {
+  id: string;
+  valueCode: string;
+}
+
+interface LookupCategory {
+  categoryCode: string;
+  values: LookupValue[];
+}
+
+/**
+ * Resolves a RISK_GRADE valueCode (NORMAL/MILD/MODERATE/SEVERE/HIGH/CRITICAL,
+ * per auth-service's seed-data.ts) to its lookup_values id — RiskFlag stores
+ * `riskGradeLookupValueId`, not the bare grade string, since RISK_GRADE is
+ * owned by auth-service (no cross-service relation). Mirrors
+ * beneficiary-service's lookup.client.ts fetchLookupCategory pattern.
+ * Throws unprocessable-mapped badGateway on network/5xx; returns null for an
+ * unrecognized grade so the caller can turn that into a clean 400 (a rule
+ * pack that outputs a grade string not seeded in RISK_GRADE is a
+ * config/authoring problem, not a crash).
+ */
+export async function resolveRiskGradeLookupId(
+  grade: string,
+  authorizationHeader: string,
+): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/lookups/RISK_GRADE`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve risk grade — auth-service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve risk grade — auth-service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: LookupCategory };
+  const match = body.data.values.find((v) => v.valueCode === grade);
+  return match?.id ?? null;
+}

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.controller.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.controller.ts
@@ -71,10 +71,14 @@ function envelope<T extends z.ZodTypeAny>(data: T) {
  *
  * Called server-to-server by visit-form-service after it persists a
  * visit-linked, VALID form submission — see riskAssessment.service.ts for
- * the full evaluate -> persist -> push pipeline. Gated by
- * requireRoles('SAKHI') since this codebase has no machine/service-account
- * identity: the call chain forwards the SAKHI's own token from the
- * originating submission.
+ * the full evaluate -> persist -> push pipeline. The originating call is
+ * always a forwarded SAKHI token (this codebase has no machine/
+ * service-account identity), but SUPERVISOR/MANAGER/ADMIN are also allowed
+ * to match the service's own full authorization matrix (a SAKHI may only
+ * act on her own beneficiary, a SUPERVISOR only on a beneficiary whose
+ * Sakhi is in her roster, MANAGER/ADMIN unrestricted) — e.g. an admin tool
+ * manually re-triggering grading for a beneficiary outside the normal
+ * submission flow.
  */
 export function createRiskAssessmentRouter(service: RiskAssessmentService) {
   const doc = createDocumentedRouter();
@@ -89,9 +93,10 @@ export function createRiskAssessmentRouter(service: RiskAssessmentService) {
         'original assessment rather than re-evaluating.',
       tags: ['Risk Assessments'],
       responses: {
-        201: { description: 'Risk assessment created', schema: envelope(riskAssessmentSchema) },
-        200: {
-          description: 'Existing risk assessment for this submissionId returned as-is',
+        201: {
+          description:
+            'Risk assessment created (or, for a retried submissionId, the original ' +
+            'assessment returned as-is)',
           schema: envelope(riskAssessmentSchema),
         },
         400: {
@@ -103,19 +108,18 @@ export function createRiskAssessmentRouter(service: RiskAssessmentService) {
           description: "Caller role not permitted, or beneficiary outside caller's own roster",
           schema: apiErrorSchema,
         },
-        404: { description: 'Beneficiary case not found', schema: apiErrorSchema },
-        422: {
-          description: 'No published rule pack version found for the given ruleSetId',
+        404: {
+          description: 'Beneficiary case not found, or the rule set has no published version',
           schema: apiErrorSchema,
         },
         502: {
-          description: 'rules-service or beneficiary-service unreachable',
+          description: 'rules-service unreachable',
           schema: apiErrorSchema,
         },
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI'),
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
     validateBody(createRiskAssessmentRequestSchema),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.controller.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.controller.ts
@@ -1,0 +1,130 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { RiskAssessmentService } from './riskAssessment.service';
+import { createRiskAssessmentSchema } from './dto/create-riskAssessment.dto';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  requireRoles,
+  trustGatewayIdentity,
+  unauthorized,
+  validateBody,
+  ok,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const createRiskAssessmentRequestSchema = createRiskAssessmentSchema.extend({
+  beneficiaryId: createRiskAssessmentSchema.shape.beneficiaryId.openapi({
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  }),
+  submissionId: createRiskAssessmentSchema.shape.submissionId.openapi({
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  }),
+  ruleSetId: createRiskAssessmentSchema.shape.ruleSetId.openapi({
+    example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  }),
+  // zod-to-openapi can't introspect the recursive z.lazy() answers type on
+  // its own — same short-circuit as evaluate-ruleSet.dto.ts's answers field.
+  answers: createRiskAssessmentSchema.shape.answers.openapi({
+    type: 'object',
+    example: { systolicBp: 145, hemoglobin: 9.2 },
+  }),
+});
+
+const riskFlagSchema = z.object({
+  id: z.string().uuid(),
+  riskConditionId: z.string().uuid(),
+  riskGradeLookupValueId: z.string().uuid(),
+  observedValueJson: z.record(z.unknown()).nullable(),
+  isReferralTrigger: z.boolean(),
+  isEducationTrigger: z.boolean(),
+  isHrVisitTrigger: z.boolean(),
+});
+
+const riskAssessmentSchema = z.object({
+  id: z.string().uuid(),
+  beneficiaryId: z.string().uuid(),
+  visitId: z.string().uuid().nullable(),
+  submissionId: z.string().uuid(),
+  ruleVersionId: z.string().uuid(),
+  evaluatedAt: z.string().datetime(),
+  overallRiskCategory: z.enum(['NORMAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']),
+  overallHighRiskFlag: z.boolean(),
+  hrDetectedFlag: z.boolean(),
+  riskFlags: z.array(riskFlagSchema),
+});
+
+const apiErrorSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+  errorCode: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+  details: z.record(z.unknown()).optional(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Risk assessment HTTP routes. Mounted under the global `api/v1` prefix.
+ *
+ * Called server-to-server by visit-form-service after it persists a
+ * visit-linked, VALID form submission — see riskAssessment.service.ts for
+ * the full evaluate -> persist -> push pipeline. Gated by
+ * requireRoles('SAKHI') since this codebase has no machine/service-account
+ * identity: the call chain forwards the SAKHI's own token from the
+ * originating submission.
+ */
+export function createRiskAssessmentRouter(service: RiskAssessmentService) {
+  const doc = createDocumentedRouter();
+
+  doc.post(
+    '/risk-assessments',
+    {
+      summary:
+        "Evaluate a submission against its form's rule set and persist the resulting " +
+        'RiskAssessment/RiskFlag rows, then push the per-condition rollup to ' +
+        'beneficiary-service. Idempotent by submissionId — a retried call returns the ' +
+        'original assessment rather than re-evaluating.',
+      tags: ['Risk Assessments'],
+      responses: {
+        201: { description: 'Risk assessment created', schema: envelope(riskAssessmentSchema) },
+        200: {
+          description: 'Existing risk assessment for this submissionId returned as-is',
+          schema: envelope(riskAssessmentSchema),
+        },
+        400: {
+          description: 'Malformed answers, or the rule pack returned an unrecognized grade',
+          schema: apiErrorSchema,
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: {
+          description: "Caller role not permitted, or beneficiary outside caller's own roster",
+          schema: apiErrorSchema,
+        },
+        404: { description: 'Beneficiary case not found', schema: apiErrorSchema },
+        422: {
+          description: 'No published rule pack version found for the given ruleSetId',
+          schema: apiErrorSchema,
+        },
+        502: {
+          description: 'rules-service or beneficiary-service unreachable',
+          schema: apiErrorSchema,
+        },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validateBody(createRiskAssessmentRequestSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const created = await service.create(req.body, req.user, authorizationHeader);
+      res.status(201).json(ok(created));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.module.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.module.ts
@@ -1,0 +1,15 @@
+import type { DocumentedRouter } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { RiskAssessmentRepository } from './riskAssessment.repository';
+import { RiskAssessmentService } from './riskAssessment.service';
+import { createRiskAssessmentRouter } from './riskAssessment.controller';
+
+/**
+ * Composition root for the risk-assessments feature: wires repository →
+ * service → router.
+ */
+export function createRiskAssessmentModule(prisma: PrismaService): DocumentedRouter {
+  const repository = new RiskAssessmentRepository(prisma);
+  const service = new RiskAssessmentService(repository);
+  return createRiskAssessmentRouter(service);
+}

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
@@ -1,0 +1,90 @@
+import type { Prisma } from '../../../../node_modules/.prisma/client-risk-referral-service';
+import type { PrismaService } from '../prisma/prisma.service';
+
+export interface RiskFlagCreateData {
+  riskConditionId: string;
+  riskGradeLookupValueId: string;
+  observedValueJson: Prisma.InputJsonValue | null;
+  isReferralTrigger: boolean;
+  isEducationTrigger: boolean;
+  isHrVisitTrigger: boolean;
+}
+
+export interface RiskAssessmentCreateData {
+  beneficiaryId: string;
+  visitId: string | null;
+  submissionId: string;
+  ruleVersionId: string;
+  evaluatedAt: Date;
+  overallRiskCategory: 'NORMAL' | 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+  overallHighRiskFlag: boolean;
+  hrDetectedFlag: boolean;
+  flags: RiskFlagCreateData[];
+}
+
+/** Data access for risk assessments/flags. Owns only this service's `risk_*` tables. */
+export class RiskAssessmentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * The `phase` for each of the given risk_conditions ids, keyed by id —
+   * needed to push the correct SummaryPhase-equivalent to beneficiary-service
+   * (see riskAssessment.service.ts's RISK_PHASE_TO_SUMMARY_PHASE mapping).
+   */
+  async findPhasesByConditionIds(riskConditionIds: string[]): Promise<Map<string, string>> {
+    const conditions = await this.prisma.riskCondition.findMany({
+      where: { id: { in: riskConditionIds } },
+      select: { id: true, phase: true },
+    });
+    return new Map(conditions.map((c) => [c.id, c.phase]));
+  }
+
+  /** Existing assessment for a submissionId, or null — used for idempotent replay. */
+  findBySubmissionId(submissionId: string) {
+    return this.prisma.riskAssessment.findFirst({
+      where: { submissionId, isDeleted: false },
+      include: { riskFlags: true },
+    });
+  }
+
+  /**
+   * Creates one RiskAssessment and its RiskFlag rows in a single
+   * transaction — the two must never exist independently (a RiskAssessment
+   * with zero flags, or flags with no parent assessment, are both
+   * inconsistent states per the ERD's condition-level/visit-level summary
+   * split).
+   */
+  create(data: RiskAssessmentCreateData) {
+    return this.prisma.$transaction(async (tx) => {
+      const assessment = await tx.riskAssessment.create({
+        data: {
+          beneficiaryId: data.beneficiaryId,
+          visitId: data.visitId,
+          submissionId: data.submissionId,
+          ruleVersionId: data.ruleVersionId,
+          evaluatedAt: data.evaluatedAt,
+          overallRiskCategory: data.overallRiskCategory,
+          overallHighRiskFlag: data.overallHighRiskFlag,
+          hrDetectedFlag: data.hrDetectedFlag,
+        },
+      });
+
+      await tx.riskFlag.createMany({
+        data: data.flags.map((flag) => ({
+          riskAssessmentId: assessment.id,
+          riskConditionId: flag.riskConditionId,
+          riskGradeLookupValueId: flag.riskGradeLookupValueId,
+          observedValueJson: flag.observedValueJson ?? undefined,
+          isReferralTrigger: flag.isReferralTrigger,
+          isEducationTrigger: flag.isEducationTrigger,
+          isHrVisitTrigger: flag.isHrVisitTrigger,
+        })),
+      });
+
+      return tx.riskAssessment.findUniqueOrThrow({
+        where: { id: assessment.id },
+        include: { riskFlags: true },
+      });
+    });
+  }
+}

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.spec.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.spec.ts
@@ -1,0 +1,324 @@
+import type { AuthenticatedUser } from '@armman/service-commons';
+import { RiskAssessmentService } from './riskAssessment.service';
+import type { RiskAssessmentRepository } from './riskAssessment.repository';
+import type { CreateRiskAssessmentInput } from './dto/create-riskAssessment.dto';
+import { evaluateRuleSet } from './ruleSet.client';
+import { resolveRiskGradeLookupId } from './lookup.client';
+import { pushRiskConditionSummary } from './beneficiaryRiskSummary.client';
+import { BeneficiaryClient } from '../referrals/beneficiary.client';
+import { listSakhiIdsForSupervisor } from '../referrals/sakhi.client';
+
+jest.mock('./ruleSet.client');
+jest.mock('./lookup.client');
+jest.mock('./beneficiaryRiskSummary.client');
+jest.mock('../referrals/sakhi.client');
+
+describe('RiskAssessmentService', () => {
+  const repository = {
+    findBySubmissionId: jest.fn(),
+    create: jest.fn(),
+    findPhasesByConditionIds: jest.fn(),
+  } as unknown as jest.Mocked<RiskAssessmentRepository>;
+  const beneficiaryClient = {
+    getById: jest.fn(),
+  } as unknown as jest.Mocked<BeneficiaryClient>;
+  let service: RiskAssessmentService;
+
+  const AUTH_HEADER = 'Bearer test-token';
+  const evaluateRuleSetMock = jest.mocked(evaluateRuleSet);
+  const resolveRiskGradeLookupIdMock = jest.mocked(resolveRiskGradeLookupId);
+  const pushRiskConditionSummaryMock = jest.mocked(pushRiskConditionSummary);
+  const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
+
+  const CALLER_ID = '99999999-9999-9999-9999-999999999999';
+  const BENEFICIARY_ID = '11111111-1111-1111-1111-111111111111';
+
+  const dto: CreateRiskAssessmentInput = {
+    beneficiaryId: BENEFICIARY_ID,
+    visitId: '22222222-2222-2222-2222-222222222222',
+    submissionId: '33333333-3333-3333-3333-333333333333',
+    ruleSetId: '44444444-4444-4444-4444-444444444444',
+    answers: { systolicBp: 145 },
+  };
+
+  function caller(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
+    return {
+      id: CALLER_ID,
+      roles: ['SAKHI'],
+      projectId: null,
+      geographyUnitId: null,
+      ...overrides,
+    };
+  }
+
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    consoleErrorSpy.mockClear();
+    service = new RiskAssessmentService(repository, beneficiaryClient);
+    beneficiaryClient.getById.mockResolvedValue({ id: BENEFICIARY_ID, sakhiId: CALLER_ID });
+    repository.findPhasesByConditionIds.mockResolvedValue(new Map([['cond-1', 'ANC']]));
+    resolveRiskGradeLookupIdMock.mockResolvedValue('grade-lookup-id-1');
+    pushRiskConditionSummaryMock.mockResolvedValue({ ok: true });
+  });
+
+  describe('IDOR guard', () => {
+    it('404s when the beneficiary case does not exist', async () => {
+      beneficiaryClient.getById.mockResolvedValue(null);
+
+      await expect(service.create(dto, caller(), AUTH_HEADER)).rejects.toMatchObject({
+        status: 404,
+      });
+      expect(evaluateRuleSetMock).not.toHaveBeenCalled();
+    });
+
+    it('403s when a SAKHI targets a beneficiary that is not their own', async () => {
+      beneficiaryClient.getById.mockResolvedValue({
+        id: BENEFICIARY_ID,
+        sakhiId: 'someone-else',
+      });
+
+      await expect(
+        service.create(dto, caller({ id: CALLER_ID, roles: ['SAKHI'] }), AUTH_HEADER),
+      ).rejects.toThrow('This beneficiary case is outside your own roster.');
+      expect(evaluateRuleSetMock).not.toHaveBeenCalled();
+    });
+
+    it("403s when a SUPERVISOR's roster does not include the beneficiary's Sakhi", async () => {
+      beneficiaryClient.getById.mockResolvedValue({
+        id: BENEFICIARY_ID,
+        sakhiId: 'sakhi-outside',
+      });
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-inside']);
+
+      await expect(
+        service.create(dto, caller({ roles: ['SUPERVISOR'], projectId: 'project-1' }), AUTH_HEADER),
+      ).rejects.toThrow("This beneficiary case is outside this Supervisor's roster.");
+      expect(evaluateRuleSetMock).not.toHaveBeenCalled();
+    });
+
+    it('403s when a SUPERVISOR caller has no project scope', async () => {
+      await expect(
+        service.create(dto, caller({ roles: ['SUPERVISOR'], projectId: null }), AUTH_HEADER),
+      ).rejects.toThrow('Supervisor caller has no project scope.');
+      expect(evaluateRuleSetMock).not.toHaveBeenCalled();
+    });
+
+    it('allows a MANAGER/ADMIN caller unrestricted, with no roster lookup', async () => {
+      beneficiaryClient.getById.mockResolvedValue({
+        id: BENEFICIARY_ID,
+        sakhiId: 'any-sakhi',
+      });
+      evaluateRuleSetMock.mockResolvedValue({
+        ruleVersionId: 'rule-version-1',
+        overallRiskCategory: 'NORMAL',
+        conditions: [],
+      });
+      repository.create.mockResolvedValue({ id: 'assessment-1' } as never);
+
+      await service.create(dto, caller({ roles: ['MANAGER'] }), AUTH_HEADER);
+
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+      expect(evaluateRuleSetMock).toHaveBeenCalled();
+    });
+  });
+
+  it('returns the existing assessment unchanged on a replayed submissionId, without re-evaluating', async () => {
+    const existing = { id: 'assessment-1' };
+    repository.findBySubmissionId.mockResolvedValue(existing as never);
+
+    await expect(service.create(dto, caller(), AUTH_HEADER)).resolves.toBe(existing);
+    expect(evaluateRuleSetMock).not.toHaveBeenCalled();
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('evaluates, resolves grade lookups, and persists RiskAssessment + RiskFlag rows', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    evaluateRuleSetMock.mockResolvedValue({
+      ruleVersionId: 'rule-version-1',
+      overallRiskCategory: 'HIGH',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'HIGH',
+          gradeRank: 3,
+          isReferralTrigger: true,
+          isEducationTrigger: false,
+          isHrVisitTrigger: true,
+          observedValueJson: { systolicBp: 145 },
+        },
+      ],
+    });
+    repository.create.mockResolvedValue({ id: 'assessment-1' } as never);
+
+    await service.create(dto, caller(), AUTH_HEADER);
+
+    expect(evaluateRuleSetMock).toHaveBeenCalledWith(dto.ruleSetId, dto.answers, AUTH_HEADER);
+    expect(resolveRiskGradeLookupIdMock).toHaveBeenCalledWith('HIGH', AUTH_HEADER);
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beneficiaryId: dto.beneficiaryId,
+        visitId: dto.visitId,
+        submissionId: dto.submissionId,
+        ruleVersionId: 'rule-version-1',
+        overallRiskCategory: 'HIGH',
+        overallHighRiskFlag: true,
+        hrDetectedFlag: true,
+        flags: [
+          expect.objectContaining({
+            riskConditionId: 'cond-1',
+            riskGradeLookupValueId: 'grade-lookup-id-1',
+            isReferralTrigger: true,
+            isHrVisitTrigger: true,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('sets overallHighRiskFlag/hrDetectedFlag false for a NORMAL, non-triggering evaluation', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    evaluateRuleSetMock.mockResolvedValue({
+      ruleVersionId: 'rule-version-1',
+      overallRiskCategory: 'NORMAL',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'NORMAL',
+          gradeRank: 0,
+          isReferralTrigger: false,
+          isEducationTrigger: false,
+          isHrVisitTrigger: false,
+          observedValueJson: null,
+        },
+      ],
+    });
+    repository.create.mockResolvedValue({ id: 'assessment-1' } as never);
+
+    await service.create(dto, caller(), AUTH_HEADER);
+
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ overallHighRiskFlag: false, hrDetectedFlag: false }),
+    );
+  });
+
+  it('400s when the rule pack returns a grade not recognized by RISK_GRADE', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    evaluateRuleSetMock.mockResolvedValue({
+      ruleVersionId: 'rule-version-1',
+      overallRiskCategory: 'HIGH',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'SUPER_HIGH',
+          gradeRank: 9,
+          isReferralTrigger: false,
+          isEducationTrigger: false,
+          isHrVisitTrigger: false,
+          observedValueJson: null,
+        },
+      ],
+    });
+    resolveRiskGradeLookupIdMock.mockResolvedValue(null);
+
+    await expect(service.create(dto, caller(), AUTH_HEADER)).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('pushes the rollup to beneficiary-service once per distinct condition, mapping RiskPhase to SummaryPhase', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    repository.findPhasesByConditionIds.mockResolvedValue(new Map([['cond-1', 'INC']]));
+    evaluateRuleSetMock.mockResolvedValue({
+      ruleVersionId: 'rule-version-1',
+      overallRiskCategory: 'HIGH',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'HIGH',
+          gradeRank: 3,
+          isReferralTrigger: true,
+          isEducationTrigger: false,
+          isHrVisitTrigger: true,
+          observedValueJson: { systolicBp: 145 },
+        },
+      ],
+    });
+    repository.create.mockResolvedValue({ id: 'assessment-1' } as never);
+
+    await service.create(dto, caller(), AUTH_HEADER);
+
+    expect(pushRiskConditionSummaryMock).toHaveBeenCalledWith(
+      dto.beneficiaryId,
+      expect.objectContaining({
+        riskConditionId: 'cond-1',
+        phase: 'INFANT_FOLLOWUP', // INC -> INFANT_FOLLOWUP mapping
+        grade: 'HIGH',
+        gradeRank: 3,
+      }),
+      AUTH_HEADER,
+    );
+  });
+
+  it('does not fail the whole request when the beneficiary-service push fails — logs and continues', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    evaluateRuleSetMock.mockResolvedValue({
+      ruleVersionId: 'rule-version-1',
+      overallRiskCategory: 'HIGH',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'HIGH',
+          gradeRank: 3,
+          isReferralTrigger: true,
+          isEducationTrigger: false,
+          isHrVisitTrigger: true,
+          observedValueJson: null,
+        },
+      ],
+    });
+    const assessment = { id: 'assessment-1' };
+    repository.create.mockResolvedValue(assessment as never);
+    pushRiskConditionSummaryMock.mockResolvedValue({ ok: false, error: 'network blip' });
+
+    await expect(service.create(dto, caller(), AUTH_HEADER)).resolves.toBe(assessment);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('skips the push (and logs) for a condition with no resolvable phase', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    repository.findPhasesByConditionIds.mockResolvedValue(new Map());
+    evaluateRuleSetMock.mockResolvedValue({
+      ruleVersionId: 'rule-version-1',
+      overallRiskCategory: 'NORMAL',
+      conditions: [
+        {
+          riskConditionId: 'cond-unknown',
+          grade: 'NORMAL',
+          gradeRank: 0,
+          isReferralTrigger: false,
+          isEducationTrigger: false,
+          isHrVisitTrigger: false,
+          observedValueJson: null,
+        },
+      ],
+    });
+    repository.create.mockResolvedValue({ id: 'assessment-1' } as never);
+
+    await service.create(dto, caller(), AUTH_HEADER);
+
+    expect(pushRiskConditionSummaryMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('propagates rules-service evaluation failures (e.g. 422 no published version)', async () => {
+    repository.findBySubmissionId.mockResolvedValue(null);
+    const evalError = { status: 422, message: 'No published rule pack version found.' };
+    evaluateRuleSetMock.mockRejectedValue(evalError);
+
+    await expect(service.create(dto, caller(), AUTH_HEADER)).rejects.toBe(evalError);
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
@@ -1,0 +1,185 @@
+import { badRequest, forbidden, notFound, type AuthenticatedUser } from '@armman/service-commons';
+import type { Prisma } from '../../../../node_modules/.prisma/client-risk-referral-service';
+import type { RiskAssessmentRepository, RiskFlagCreateData } from './riskAssessment.repository';
+import type { CreateRiskAssessmentInput } from './dto/create-riskAssessment.dto';
+import { evaluateRuleSet } from './ruleSet.client';
+import { resolveRiskGradeLookupId } from './lookup.client';
+import { pushRiskConditionSummary } from './beneficiaryRiskSummary.client';
+import { BeneficiaryClient } from '../referrals/beneficiary.client';
+import { listSakhiIdsForSupervisor } from '../referrals/sakhi.client';
+
+/**
+ * Maps RiskCondition.phase (this service's own RiskPhase enum) to
+ * beneficiary-service's SummaryPhase enum — the two aren't 1:1: RiskPhase
+ * has INC/CCV where SummaryPhase groups the same infant-tracking period as
+ * INFANT_FOLLOWUP/CLOSURE (matching CasePhase's own NN/INC/CCV naming
+ * elsewhere in the SRS's case-phase model).
+ */
+const RISK_PHASE_TO_SUMMARY_PHASE: Record<string, string> = {
+  REGISTRATION: 'REGISTRATION',
+  ANC: 'ANC',
+  DELIVERY: 'DELIVERY',
+  PP: 'PP',
+  NN: 'NN',
+  INC: 'INFANT_FOLLOWUP',
+  CCV: 'CLOSURE',
+};
+
+/**
+ * Orchestrates the risk-grading write pipeline: evaluate the submission's
+ * answers against the form's rule set (rules-service), persist the
+ * RiskAssessment/RiskFlag source-of-truth rows (this service's own tables),
+ * then push the derived per-condition rollup to beneficiary-service. Called
+ * server-to-server by visit-form-service after it persists a visit-linked,
+ * VALID form submission.
+ */
+export class RiskAssessmentService {
+  constructor(
+    private readonly repository: RiskAssessmentRepository,
+    private readonly beneficiaryClient: BeneficiaryClient = new BeneficiaryClient(),
+  ) {}
+
+  /**
+   * Idempotent by submissionId (@unique on risk_assessments) — a retried
+   * visit-form-service call (dropped connection) returns the original
+   * assessment instead of re-evaluating and double-writing, mirroring
+   * beneficiary_cases.localCaseUuid/form_submissions.localSubmissionUuid.
+   *
+   * The rules-service evaluate call and the RiskAssessment/RiskFlag write
+   * happen together, or not at all — a rules-service failure never leaves a
+   * partial write (see riskAssessment.repository.ts's single transaction).
+   * The follow-up push to beneficiary-service happens only after that write
+   * has already committed, and its failure never rolls anything back — it
+   * is a best-effort push of a derived, non-source-of-truth rollup (see
+   * beneficiaryRiskSummary.client.ts).
+   *
+   * IDOR guard: this route is gated by requireRoles('SAKHI') (this codebase
+   * has no machine/service-account identity — the call forwards the
+   * originating SAKHI's own token), but dto.beneficiaryId is caller-supplied
+   * and was previously never checked against the caller's own identity —
+   * any authenticated SAKHI could evaluate/write a risk assessment for any
+   * beneficiary. Mirrors ReferralService.decide's ownership check exactly:
+   * a SAKHI may only act on her own beneficiary, a SUPERVISOR only on a
+   * beneficiary whose Sakhi is in her roster, MANAGER/ADMIN unrestricted.
+   */
+  async create(
+    dto: CreateRiskAssessmentInput,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const beneficiary = await this.beneficiaryClient.getById(
+      dto.beneficiaryId,
+      authorizationHeader,
+    );
+    if (!beneficiary) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (beneficiary.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else if (caller.roles.includes('SUPERVISOR')) {
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
+      const roster = await listSakhiIdsForSupervisor(
+        caller.projectId,
+        caller.id,
+        authorizationHeader,
+      );
+      if (!roster.includes(beneficiary.sakhiId)) {
+        throw forbidden("This beneficiary case is outside this Supervisor's roster.");
+      }
+    }
+
+    const existing = await this.repository.findBySubmissionId(dto.submissionId);
+    if (existing) return existing;
+
+    const evaluation = await evaluateRuleSet(dto.ruleSetId, dto.answers, authorizationHeader);
+
+    const flags: RiskFlagCreateData[] = [];
+    for (const condition of evaluation.conditions) {
+      const riskGradeLookupValueId = await resolveRiskGradeLookupId(
+        condition.grade,
+        authorizationHeader,
+      );
+      if (!riskGradeLookupValueId) {
+        throw badRequest(
+          `The rule pack returned grade "${condition.grade}" for risk condition ` +
+            `${condition.riskConditionId}, which is not a recognized RISK_GRADE value.`,
+        );
+      }
+      flags.push({
+        riskConditionId: condition.riskConditionId,
+        riskGradeLookupValueId,
+        // Untyped external JSON (from rules-service's evaluate response)
+        // crossing into Prisma's InputJsonValue at this one boundary.
+        observedValueJson: condition.observedValueJson as Prisma.InputJsonValue | null,
+        isReferralTrigger: condition.isReferralTrigger,
+        isEducationTrigger: condition.isEducationTrigger,
+        isHrVisitTrigger: condition.isHrVisitTrigger,
+      });
+    }
+
+    const evaluatedAt = new Date();
+    const hrDetectedFlag = evaluation.conditions.some((c) => c.isHrVisitTrigger);
+    const overallHighRiskFlag = ['HIGH', 'CRITICAL'].includes(evaluation.overallRiskCategory);
+
+    const assessment = await this.repository.create({
+      beneficiaryId: dto.beneficiaryId,
+      visitId: dto.visitId,
+      submissionId: dto.submissionId,
+      ruleVersionId: evaluation.ruleVersionId,
+      evaluatedAt,
+      overallRiskCategory: evaluation.overallRiskCategory,
+      overallHighRiskFlag,
+      hrDetectedFlag,
+      flags,
+    });
+
+    // Best-effort push per distinct condition — failures are logged and
+    // swallowed (see beneficiaryRiskSummary.client.ts's doc comment); the
+    // RiskAssessment/RiskFlag write above has already committed regardless.
+    const phaseByConditionId = await this.repository.findPhasesByConditionIds(
+      evaluation.conditions.map((c) => c.riskConditionId),
+    );
+    for (const condition of evaluation.conditions) {
+      const riskPhase = phaseByConditionId.get(condition.riskConditionId);
+      const summaryPhase = riskPhase ? RISK_PHASE_TO_SUMMARY_PHASE[riskPhase] : undefined;
+      if (!summaryPhase) {
+        console.error(
+          `Risk condition ${condition.riskConditionId} has no resolvable phase — skipping ` +
+            `risk-condition-summary push for beneficiary ${dto.beneficiaryId}.`,
+        );
+        continue;
+      }
+      const result = await pushRiskConditionSummary(
+        dto.beneficiaryId,
+        {
+          riskConditionId: condition.riskConditionId,
+          phase: summaryPhase,
+          grade: condition.grade,
+          gradeRank: condition.gradeRank,
+          observedValueJson: condition.observedValueJson,
+          visitId: dto.visitId,
+          submissionId: dto.submissionId,
+          assessedAt: evaluatedAt.toISOString(),
+          isReferralTrigger: condition.isReferralTrigger,
+          isHrVisitTrigger: condition.isHrVisitTrigger,
+          ruleVersionId: evaluation.ruleVersionId,
+        },
+        authorizationHeader,
+      );
+      if (!result.ok) {
+        // Matches closure.service.ts's console.error precedent for a
+        // best-effort side-call failure — no shared structured logger is
+        // threaded into this service layer today.
+        console.error(
+          `Failed to push risk-condition-summary for beneficiary ${dto.beneficiaryId}, ` +
+            `condition ${condition.riskConditionId}: ${result.error}`,
+        );
+      }
+    }
+
+    return assessment;
+  }
+}

--- a/apps/risk-referral-service/src/risk-assessments/ruleSet.client.ts
+++ b/apps/risk-referral-service/src/risk-assessments/ruleSet.client.ts
@@ -1,4 +1,4 @@
-import { badGateway, unprocessable, HttpError } from '@armman/service-commons';
+import { badGateway, notFound, HttpError } from '@armman/service-commons';
 
 const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
 
@@ -22,9 +22,10 @@ interface EvaluateResponse {
  * Calls rules-service's `POST /rules/:setId/evaluate` through the gateway,
  * forwarding the caller's own Authorization header (this codebase has no
  * machine/service-account identity — see that endpoint's doc comment).
- * 422 (no published version for this rule set) is re-thrown as-is so the
- * caller can decide how to surface "this form's ruleSetId has nothing
- * published yet" — not swallowed into a generic 502.
+ * 404 (rule set not found, or found but has no published version) is
+ * re-thrown as-is so the caller can decide how to surface "this form's
+ * ruleSetId is unconfigured/has nothing published yet" — not swallowed into
+ * a generic 502.
  */
 export async function evaluateRuleSet(
   ruleSetId: string,
@@ -42,9 +43,9 @@ export async function evaluateRuleSet(
     throw badGateway('Unable to evaluate the rule set — rules-service is unreachable.');
   }
 
-  if (res.status === 422) {
+  if (res.status === 404) {
     const body = (await res.json().catch(() => null)) as { message?: string } | null;
-    throw unprocessable(body?.message ?? 'No published rule pack version found for this rule set.');
+    throw notFound(body?.message ?? 'No published rule pack version found for this rule set.');
   }
   if (!res.ok) {
     if (res.status >= 400 && res.status < 500) {

--- a/apps/risk-referral-service/src/risk-assessments/ruleSet.client.ts
+++ b/apps/risk-referral-service/src/risk-assessments/ruleSet.client.ts
@@ -1,0 +1,59 @@
+import { badGateway, unprocessable, HttpError } from '@armman/service-commons';
+
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+export interface RiskEvaluationResult {
+  riskConditionId: string;
+  grade: string;
+  gradeRank: number;
+  isReferralTrigger: boolean;
+  isEducationTrigger: boolean;
+  isHrVisitTrigger: boolean;
+  observedValueJson: Record<string, unknown> | null;
+}
+
+interface EvaluateResponse {
+  ruleVersionId: string;
+  overallRiskCategory: 'NORMAL' | 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+  conditions: RiskEvaluationResult[];
+}
+
+/**
+ * Calls rules-service's `POST /rules/:setId/evaluate` through the gateway,
+ * forwarding the caller's own Authorization header (this codebase has no
+ * machine/service-account identity — see that endpoint's doc comment).
+ * 422 (no published version for this rule set) is re-thrown as-is so the
+ * caller can decide how to surface "this form's ruleSetId has nothing
+ * published yet" — not swallowed into a generic 502.
+ */
+export async function evaluateRuleSet(
+  ruleSetId: string,
+  answers: Record<string, unknown>,
+  authorizationHeader: string,
+): Promise<EvaluateResponse> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/rules/${ruleSetId}/evaluate`, {
+      method: 'POST',
+      headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answers }),
+    });
+  } catch {
+    throw badGateway('Unable to evaluate the rule set — rules-service is unreachable.');
+  }
+
+  if (res.status === 422) {
+    const body = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw unprocessable(body?.message ?? 'No published rule pack version found for this rule set.');
+  }
+  if (!res.ok) {
+    if (res.status >= 400 && res.status < 500) {
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      throw new HttpError(res.status, body?.message ?? 'Unable to evaluate the rule set.');
+    }
+    throw badGateway('Unable to evaluate the rule set — rules-service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: EvaluateResponse };
+  return body.data;
+}

--- a/apps/rules-service/package.json
+++ b/apps/rules-service/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "description": "Central GoRules execution and versioned rule packs.",
   "private": true,
-  "scripts": { "prisma:generate": "prisma generate", "prisma:migrate": "prisma migrate deploy" },
+  "scripts": {
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy"
+  },
   "dependencies": {
     "@armman/core": "*",
     "@armman/service-commons": "*",
+    "@gorules/zen-engine": "0.54.0",
     "@prisma/client": "^5.18.0",
     "express": "^4.19.2",
     "helmet": "^7.1.0",
@@ -14,5 +18,8 @@
     "pino-http": "^10.2.0",
     "zod": "^3.23.8"
   },
-  "devDependencies": { "@types/express": "^4.17.21", "prisma": "^5.18.0" }
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "prisma": "^5.18.0"
+  }
 }

--- a/apps/rules-service/src/rules/dto/evaluate-ruleSet.dto.ts
+++ b/apps/rules-service/src/rules/dto/evaluate-ruleSet.dto.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+/** Recursive JSON value type usable inside nested objects/arrays. */
+type NestedJsonValue =
+  string | number | boolean | null | NestedJsonValue[] | { [key: string]: NestedJsonValue };
+
+const nestedJsonValueSchema: z.ZodType<NestedJsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(nestedJsonValueSchema),
+    z.record(nestedJsonValueSchema),
+  ]),
+);
+
+/**
+ * Request body for `POST /rules/:setId/evaluate` — an arbitrary JSON object
+ * of answers/observed values, fed to the published rule version's gorules
+ * decision graph as its evaluation context. Shape is defined by whatever the
+ * decision graph itself expects; this service is a generic GoRules executor,
+ * not risk-domain-aware.
+ */
+export const evaluateRuleSetSchema = z
+  .object({
+    answers: z.record(nestedJsonValueSchema),
+  })
+  .strict();
+
+export type EvaluateRuleSetInput = z.infer<typeof evaluateRuleSetSchema>;

--- a/apps/rules-service/src/rules/ruleSet.evaluator.spec.ts
+++ b/apps/rules-service/src/rules/ruleSet.evaluator.spec.ts
@@ -1,0 +1,126 @@
+import { evaluateRulePack } from './ruleSet.evaluator';
+
+/**
+ * A minimal gorules decision graph whose output node passes its input
+ * through unchanged (an identity graph) — good enough to exercise
+ * evaluateRulePack's own shape-validation logic against a real zen-engine
+ * evaluation, without needing a hand-authored real risk-grading rule pack.
+ */
+const IDENTITY_GRAPH = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'input', position: { x: 0, y: 0 } },
+    { id: 'output1', type: 'outputNode', name: 'output', position: { x: 0, y: 0 } },
+  ],
+  edges: [{ id: 'e1', sourceId: 'input1', targetId: 'output1', type: 'edge' }],
+};
+
+describe('evaluateRulePack', () => {
+  it('evaluates a well-formed decision graph and returns the parsed output', async () => {
+    const result = await evaluateRulePack(IDENTITY_GRAPH, {
+      overallRiskCategory: 'HIGH',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'HIGH',
+          gradeRank: 3,
+          isReferralTrigger: true,
+          isEducationTrigger: false,
+          isHrVisitTrigger: true,
+          observedValueJson: { systolicBp: 145 },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      overallRiskCategory: 'HIGH',
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'HIGH',
+          gradeRank: 3,
+          isReferralTrigger: true,
+          isEducationTrigger: false,
+          isHrVisitTrigger: true,
+          observedValueJson: { systolicBp: 145 },
+        },
+      ],
+    });
+  });
+
+  it('defaults missing boolean triggers to false and observedValueJson to null', async () => {
+    const result = await evaluateRulePack(IDENTITY_GRAPH, {
+      overallRiskCategory: 'NORMAL',
+      conditions: [{ riskConditionId: 'cond-1', grade: 'NORMAL', gradeRank: 0 }],
+    });
+
+    expect(result.conditions[0]).toEqual({
+      riskConditionId: 'cond-1',
+      grade: 'NORMAL',
+      gradeRank: 0,
+      isReferralTrigger: false,
+      isEducationTrigger: false,
+      isHrVisitTrigger: false,
+      observedValueJson: null,
+    });
+  });
+
+  it('rejects an output that is not an object', async () => {
+    // The identity graph reflects whatever `answers` is back as the raw
+    // evaluation result — passing a non-object here is the simplest way to
+    // make zen-engine's real `result` a non-object, exercising
+    // evaluateRulePack's own runtime shape guard (the DTO's z.record type
+    // wouldn't allow this at the HTTP boundary; this tests defense-in-depth
+    // for whatever a rule pack's decision graph can actually emit).
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, 'not-an-object' as unknown as Record<string, unknown>),
+    ).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('rejects an output missing overallRiskCategory', async () => {
+    await expect(evaluateRulePack(IDENTITY_GRAPH, { conditions: [] })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('rejects an output with an invalid overallRiskCategory value', async () => {
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, { overallRiskCategory: 'WORST', conditions: [] }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects an output whose conditions is not an array', async () => {
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, { overallRiskCategory: 'NORMAL', conditions: {} }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a condition entry missing riskConditionId', async () => {
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, {
+        overallRiskCategory: 'NORMAL',
+        conditions: [{ grade: 'NORMAL', gradeRank: 0 }],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a condition entry missing grade', async () => {
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, {
+        overallRiskCategory: 'NORMAL',
+        conditions: [{ riskConditionId: 'cond-1', gradeRank: 0 }],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a condition entry with a non-numeric gradeRank', async () => {
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, {
+        overallRiskCategory: 'NORMAL',
+        conditions: [{ riskConditionId: 'cond-1', grade: 'NORMAL', gradeRank: 'zero' }],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/rules-service/src/rules/ruleSet.evaluator.spec.ts
+++ b/apps/rules-service/src/rules/ruleSet.evaluator.spec.ts
@@ -48,10 +48,19 @@ describe('evaluateRulePack', () => {
     });
   });
 
-  it('defaults missing boolean triggers to false and observedValueJson to null', async () => {
+  it('defaults observedValueJson to null when omitted', async () => {
     const result = await evaluateRulePack(IDENTITY_GRAPH, {
       overallRiskCategory: 'NORMAL',
-      conditions: [{ riskConditionId: 'cond-1', grade: 'NORMAL', gradeRank: 0 }],
+      conditions: [
+        {
+          riskConditionId: 'cond-1',
+          grade: 'NORMAL',
+          gradeRank: 0,
+          isReferralTrigger: false,
+          isEducationTrigger: false,
+          isHrVisitTrigger: false,
+        },
+      ],
     });
 
     expect(result.conditions[0]).toEqual({
@@ -63,6 +72,36 @@ describe('evaluateRulePack', () => {
       isHrVisitTrigger: false,
       observedValueJson: null,
     });
+  });
+
+  it('rejects a condition entry with a missing (non-boolean) trigger field, rather than silently defaulting to false', async () => {
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, {
+        overallRiskCategory: 'NORMAL',
+        conditions: [{ riskConditionId: 'cond-1', grade: 'NORMAL', gradeRank: 0 }],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects a condition entry whose trigger field is the string "false", rather than coercing it truthy', async () => {
+    // Regression test: Boolean("false") === true — a decision graph authored
+    // visually (not in code) that happens to emit the literal string "false"
+    // for a trigger column must be rejected, not silently flip the trigger on.
+    await expect(
+      evaluateRulePack(IDENTITY_GRAPH, {
+        overallRiskCategory: 'NORMAL',
+        conditions: [
+          {
+            riskConditionId: 'cond-1',
+            grade: 'NORMAL',
+            gradeRank: 0,
+            isReferralTrigger: 'false',
+            isEducationTrigger: false,
+            isHrVisitTrigger: false,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
   });
 
   it('rejects an output that is not an object', async () => {

--- a/apps/rules-service/src/rules/ruleSet.evaluator.ts
+++ b/apps/rules-service/src/rules/ruleSet.evaluator.ts
@@ -1,0 +1,109 @@
+import { ZenDecisionContent, ZenEngine } from '@gorules/zen-engine';
+import { badRequest } from '@armman/service-commons';
+
+const OVERALL_RISK_CATEGORIES = ['NORMAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] as const;
+type OverallRiskCategory = (typeof OVERALL_RISK_CATEGORIES)[number];
+
+/**
+ * Per-condition evaluation result the decision graph is expected to output —
+ * risk-referral-service's contract for POST /risk-assessments. This service
+ * doesn't validate the *content* of the output beyond structural shape — it
+ * has no domain knowledge of what a valid grade/riskConditionId looks like,
+ * only that the decision graph returned something risk-referral-service can
+ * consume.
+ */
+export interface RiskEvaluationResult {
+  riskConditionId: string;
+  grade: string;
+  gradeRank: number;
+  isReferralTrigger: boolean;
+  isEducationTrigger: boolean;
+  isHrVisitTrigger: boolean;
+  observedValueJson: Record<string, unknown> | null;
+}
+
+export interface RulePackEvaluation {
+  /**
+   * The visit-level rollup category — deliberately computed by the rule
+   * pack itself (the business-rule author), not derived here: there is no
+   * existing cross-condition comparison rule to roll up multiple
+   * independent gradeScale results (BINARY / NORMAL_MILD_MODERATE_SEVERE /
+   * NORMAL_LOW_MEDIUM_HIGH per the ERD) into one overall category, and
+   * inventing one in this generic executor would bake an unreviewed
+   * business decision into infrastructure code.
+   */
+  overallRiskCategory: OverallRiskCategory;
+  conditions: RiskEvaluationResult[];
+}
+
+/**
+ * Runs a published rule version's gorules decision graph against `answers`
+ * and returns the visit-level category plus per-condition results. Wraps
+ * zen-engine's ZenEngine/ZenDecisionContent — a fresh instance per call
+ * rather than a cached/pooled engine, since evaluate() is called relatively
+ * infrequently (once per visit-linked form submission) and correctness
+ * (always evaluating the exact rulesJson passed in) matters more here than
+ * shaving engine-construction overhead.
+ *
+ * Throws badRequest() if the decision graph's output isn't the expected
+ * shape — a malformed/mismatched rule pack must surface as a client (400)
+ * error to whoever published it, not a 500 masking a config problem.
+ * zen-engine's own evaluation errors (malformed rulesJson, missing fields
+ * the graph requires) propagate as-is; the controller/service layer decides
+ * how those map to HTTP status.
+ */
+export async function evaluateRulePack(
+  rulesJson: unknown,
+  answers: Record<string, unknown>,
+): Promise<RulePackEvaluation> {
+  const engine = new ZenEngine();
+  const content = new ZenDecisionContent(rulesJson as object);
+  const decision = engine.createDecision(content);
+  const response = await decision.evaluate(answers);
+  engine.dispose();
+
+  const result = response.result;
+  if (typeof result !== 'object' || result === null) {
+    throw badRequest(
+      "This rule pack's decision graph did not return an { overallRiskCategory, conditions } object.",
+    );
+  }
+  const r = result as Record<string, unknown>;
+
+  if (!OVERALL_RISK_CATEGORIES.includes(r.overallRiskCategory as OverallRiskCategory)) {
+    throw badRequest(`overallRiskCategory must be one of ${OVERALL_RISK_CATEGORIES.join(', ')}.`);
+  }
+  if (!Array.isArray(r.conditions)) {
+    throw badRequest('conditions must be an array of per-condition results.');
+  }
+
+  return {
+    overallRiskCategory: r.overallRiskCategory as OverallRiskCategory,
+    conditions: r.conditions.map((entry, index) => validateResultEntry(entry, index)),
+  };
+}
+
+function validateResultEntry(entry: unknown, index: number): RiskEvaluationResult {
+  if (typeof entry !== 'object' || entry === null) {
+    throw badRequest(`conditions[${index}] from the decision graph is not an object.`);
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.riskConditionId !== 'string') {
+    throw badRequest(`conditions[${index}].riskConditionId must be a string.`);
+  }
+  if (typeof e.grade !== 'string') {
+    throw badRequest(`conditions[${index}].grade must be a string.`);
+  }
+  if (typeof e.gradeRank !== 'number') {
+    throw badRequest(`conditions[${index}].gradeRank must be a number.`);
+  }
+  return {
+    riskConditionId: e.riskConditionId,
+    grade: e.grade,
+    gradeRank: e.gradeRank,
+    isReferralTrigger: Boolean(e.isReferralTrigger),
+    isEducationTrigger: Boolean(e.isEducationTrigger),
+    isHrVisitTrigger: Boolean(e.isHrVisitTrigger),
+    observedValueJson: (e.observedValueJson as Record<string, unknown> | undefined) ?? null,
+  };
+}

--- a/apps/rules-service/src/rules/ruleSet.evaluator.ts
+++ b/apps/rules-service/src/rules/ruleSet.evaluator.ts
@@ -97,13 +97,22 @@ function validateResultEntry(entry: unknown, index: number): RiskEvaluationResul
   if (typeof e.gradeRank !== 'number') {
     throw badRequest(`conditions[${index}].gradeRank must be a number.`);
   }
+  if (typeof e.isReferralTrigger !== 'boolean') {
+    throw badRequest(`conditions[${index}].isReferralTrigger must be a boolean.`);
+  }
+  if (typeof e.isEducationTrigger !== 'boolean') {
+    throw badRequest(`conditions[${index}].isEducationTrigger must be a boolean.`);
+  }
+  if (typeof e.isHrVisitTrigger !== 'boolean') {
+    throw badRequest(`conditions[${index}].isHrVisitTrigger must be a boolean.`);
+  }
   return {
     riskConditionId: e.riskConditionId,
     grade: e.grade,
     gradeRank: e.gradeRank,
-    isReferralTrigger: Boolean(e.isReferralTrigger),
-    isEducationTrigger: Boolean(e.isEducationTrigger),
-    isHrVisitTrigger: Boolean(e.isHrVisitTrigger),
+    isReferralTrigger: e.isReferralTrigger,
+    isEducationTrigger: e.isEducationTrigger,
+    isHrVisitTrigger: e.isHrVisitTrigger,
     observedValueJson: (e.observedValueJson as Record<string, unknown> | undefined) ?? null,
   };
 }

--- a/apps/rules-service/src/rules/ruleVersion.controller.ts
+++ b/apps/rules-service/src/rules/ruleVersion.controller.ts
@@ -2,6 +2,7 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { RuleVersionService } from './ruleVersion.service';
 import { publishRuleVersionSchema } from './dto/publish-ruleVersion.dto';
+import { evaluateRuleSetSchema } from './dto/evaluate-ruleSet.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -54,6 +55,33 @@ const ruleVersionSummarySchema = z.object({
   id: z.string().uuid(),
   ruleSetId: z.string().uuid(),
   status: z.enum(['DRAFT', 'PUBLISHED', 'RETIRED']).openapi({ example: 'PUBLISHED' }),
+});
+
+const evaluateRuleSetRequestSchema = evaluateRuleSetSchema.extend({
+  // zod-to-openapi can't introspect the recursive z.lazy() answers type on
+  // its own — same short-circuit as rulesJson above.
+  answers: evaluateRuleSetSchema.shape.answers.openapi({
+    type: 'object',
+    example: { systolicBp: 145, hemoglobin: 9.2 },
+  }),
+});
+
+const riskEvaluationResultSchema = z.object({
+  riskConditionId: z.string().uuid(),
+  grade: z.string().openapi({ example: 'HIGH' }),
+  gradeRank: z.number().int(),
+  isReferralTrigger: z.boolean(),
+  isEducationTrigger: z.boolean(),
+  isHrVisitTrigger: z.boolean(),
+  observedValueJson: z.record(z.unknown()).nullable(),
+});
+
+const evaluateResponseSchema = z.object({
+  ruleVersionId: z.string().uuid(),
+  overallRiskCategory: z
+    .enum(['NORMAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
+    .openapi({ example: 'HIGH' }),
+  conditions: z.array(riskEvaluationResultSchema),
 });
 
 const apiErrorSchema = z.object({
@@ -139,6 +167,38 @@ export function createRuleVersionRouter(service: RuleVersionService) {
       if (!req.user) return next(unauthorized());
       const published = await service.publish(req.params.setId, req.body, req.user.id);
       res.status(201).json(ok(published));
+    }),
+  );
+
+  doc.post(
+    '/rules/:setId/evaluate',
+    {
+      summary:
+        "Evaluate the rule set's currently-published gorules decision graph against caller-" +
+        "supplied answers. Gated by requireRoles('SAKHI') — this codebase has no machine/" +
+        'service-account identity, so "server-to-server" here just means the SAKHI\'s own ' +
+        'forwarded token from the originating form-submission call chain (visit-form-service ' +
+        '-> risk-referral-service -> here). Never evaluates against a DRAFT version.',
+      tags: ['Rules'],
+      params: setIdParamsSchema,
+      responses: {
+        200: { description: 'Evaluation results', schema: envelope(evaluateResponseSchema) },
+        400: { description: 'Malformed answers or decision-graph output', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        422: {
+          description: 'No published rule pack version found for this rule set',
+          schema: apiErrorSchema,
+        },
+        500: { description: 'Server error', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validate(setIdParamsSchema, 'params'),
+    validateBody(evaluateRuleSetRequestSchema),
+    asyncHandler(async (req, res) => {
+      res.json(ok(await service.evaluate(req.params.setId, req.body)));
     }),
   );
 

--- a/apps/rules-service/src/rules/ruleVersion.controller.ts
+++ b/apps/rules-service/src/rules/ruleVersion.controller.ts
@@ -186,8 +186,8 @@ export function createRuleVersionRouter(service: RuleVersionService) {
         400: { description: 'Malformed answers or decision-graph output', schema: apiErrorSchema },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
         403: { description: 'Caller role not permitted', schema: apiErrorSchema },
-        422: {
-          description: 'No published rule pack version found for this rule set',
+        404: {
+          description: 'Rule set not found, or it has no published version',
           schema: apiErrorSchema,
         },
         500: { description: 'Server error', schema: apiErrorSchema },

--- a/apps/rules-service/src/rules/ruleVersion.service.spec.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.spec.ts
@@ -151,6 +151,7 @@ describe('RuleVersionService', () => {
 
   describe('evaluate', () => {
     it('evaluates against the published version and returns ruleVersionId alongside the results', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId } as never);
       repository.findPublishedBySetId.mockResolvedValue({
         id: 'ver-1',
         ruleSetId: setId,
@@ -191,16 +192,30 @@ describe('RuleVersionService', () => {
       });
     });
 
-    it('422s when the rule set has no published version, never evaluating', async () => {
+    it('404s when the rule set itself does not exist, never checking for a published version', async () => {
+      repository.findSetById.mockResolvedValue(null);
+
+      await expect(service.evaluate(setId, { answers: {} })).rejects.toMatchObject({
+        status: 404,
+        message: 'Rule set not found.',
+      });
+      expect(repository.findPublishedBySetId).not.toHaveBeenCalled();
+      expect(evaluateRulePackMock).not.toHaveBeenCalled();
+    });
+
+    it('404s when the rule set exists but has no published version, never evaluating', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId } as never);
       repository.findPublishedBySetId.mockResolvedValue(null);
 
       await expect(service.evaluate(setId, { answers: {} })).rejects.toMatchObject({
-        status: 422,
+        status: 404,
+        message: 'No published rule pack version found for this rule set.',
       });
       expect(evaluateRulePackMock).not.toHaveBeenCalled();
     });
 
     it('propagates evaluateRulePack errors (e.g. malformed decision-graph output) unchanged', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId } as never);
       repository.findPublishedBySetId.mockResolvedValue({
         id: 'ver-1',
         ruleSetId: setId,

--- a/apps/rules-service/src/rules/ruleVersion.service.spec.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.spec.ts
@@ -1,5 +1,8 @@
 import { RuleVersionService } from './ruleVersion.service';
 import type { RuleVersionRepository } from './ruleVersion.repository';
+import { evaluateRulePack } from './ruleSet.evaluator';
+
+jest.mock('./ruleSet.evaluator');
 
 describe('RuleVersionService', () => {
   const repository = {
@@ -9,6 +12,7 @@ describe('RuleVersionService', () => {
     publishNewVersion: jest.fn(),
   } as unknown as jest.Mocked<RuleVersionRepository>;
   let service: RuleVersionService;
+  const evaluateRulePackMock = jest.mocked(evaluateRulePack);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -142,6 +146,70 @@ describe('RuleVersionService', () => {
       repository.publishNewVersion.mockRejectedValue(dbError);
 
       await expect(service.publish(setId, { rulesJson: {} }, 'admin-1')).rejects.toBe(dbError);
+    });
+  });
+
+  describe('evaluate', () => {
+    it('evaluates against the published version and returns ruleVersionId alongside the results', async () => {
+      repository.findPublishedBySetId.mockResolvedValue({
+        id: 'ver-1',
+        ruleSetId: setId,
+        rulesJson: { rules: [] },
+      } as never);
+      evaluateRulePackMock.mockResolvedValue({
+        overallRiskCategory: 'HIGH',
+        conditions: [
+          {
+            riskConditionId: 'cond-1',
+            grade: 'HIGH',
+            gradeRank: 3,
+            isReferralTrigger: true,
+            isEducationTrigger: false,
+            isHrVisitTrigger: true,
+            observedValueJson: { systolicBp: 145 },
+          },
+        ],
+      });
+
+      const result = await service.evaluate(setId, { answers: { systolicBp: 145 } });
+
+      expect(evaluateRulePackMock).toHaveBeenCalledWith({ rules: [] }, { systolicBp: 145 });
+      expect(result).toEqual({
+        ruleVersionId: 'ver-1',
+        overallRiskCategory: 'HIGH',
+        conditions: [
+          {
+            riskConditionId: 'cond-1',
+            grade: 'HIGH',
+            gradeRank: 3,
+            isReferralTrigger: true,
+            isEducationTrigger: false,
+            isHrVisitTrigger: true,
+            observedValueJson: { systolicBp: 145 },
+          },
+        ],
+      });
+    });
+
+    it('422s when the rule set has no published version, never evaluating', async () => {
+      repository.findPublishedBySetId.mockResolvedValue(null);
+
+      await expect(service.evaluate(setId, { answers: {} })).rejects.toMatchObject({
+        status: 422,
+      });
+      expect(evaluateRulePackMock).not.toHaveBeenCalled();
+    });
+
+    it('propagates evaluateRulePack errors (e.g. malformed decision-graph output) unchanged', async () => {
+      repository.findPublishedBySetId.mockResolvedValue({
+        id: 'ver-1',
+        ruleSetId: setId,
+        rulesJson: {},
+      } as never);
+      const badRequestError = { status: 400, message: 'bad output' };
+      evaluateRulePackMock.mockRejectedValue(badRequestError);
+
+      await expect(service.evaluate(setId, { answers: {} })).rejects.toBe(badRequestError);
     });
   });
 });

--- a/apps/rules-service/src/rules/ruleVersion.service.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { conflict, notFound, unprocessable } from '@armman/service-commons';
+import { conflict, notFound } from '@armman/service-commons';
 import type { RuleVersionRepository } from './ruleVersion.repository';
 import type { PublishRuleVersionInput } from './dto/publish-ruleVersion.dto';
 import type { EvaluateRuleSetInput } from './dto/evaluate-ruleSet.dto';
@@ -70,16 +70,22 @@ export class RuleVersionService {
    * describes, previously unimplemented (this service only stored rule
    * packs opaquely; nothing interpreted rulesJson until now).
    *
-   * 404 if the set has no published version — never silently evaluates
-   * against a DRAFT (an unreviewed rule pack must not affect real risk
-   * grading). Returns the published version's own id as `ruleVersionId`
-   * alongside the results, so the caller (risk-referral-service) can record
-   * which rule version produced a given RiskAssessment.
+   * 404 if the set doesn't exist, and a separate 404 if it exists but has no
+   * published version — same two-step check as getPublished() just above,
+   * so a stale/typo'd ruleSetId is distinguishable from a real set that
+   * simply hasn't been published yet. Never silently evaluates against a
+   * DRAFT (an unreviewed rule pack must not affect real risk grading).
+   * Returns the published version's own id as `ruleVersionId` alongside the
+   * results, so the caller (risk-referral-service) can record which rule
+   * version produced a given RiskAssessment.
    */
   async evaluate(ruleSetId: string, dto: EvaluateRuleSetInput) {
+    const set = await this.repository.findSetById(ruleSetId);
+    if (!set) throw notFound('Rule set not found.');
+
     const version = await this.repository.findPublishedBySetId(ruleSetId);
     if (!version) {
-      throw unprocessable('No published rule pack version found for this rule set.');
+      throw notFound('No published rule pack version found for this rule set.');
     }
 
     const evaluation = await evaluateRulePack(version.rulesJson, dto.answers);

--- a/apps/rules-service/src/rules/ruleVersion.service.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.ts
@@ -1,7 +1,9 @@
 import { createHash } from 'node:crypto';
-import { conflict, notFound } from '@armman/service-commons';
+import { conflict, notFound, unprocessable } from '@armman/service-commons';
 import type { RuleVersionRepository } from './ruleVersion.repository';
 import type { PublishRuleVersionInput } from './dto/publish-ruleVersion.dto';
+import type { EvaluateRuleSetInput } from './dto/evaluate-ruleSet.dto';
+import { evaluateRulePack } from './ruleSet.evaluator';
 
 /** Prisma unique-constraint violation code (ruleSetId + versionNo). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
@@ -59,6 +61,29 @@ export class RuleVersionService {
     const version = await this.repository.findPublishedBySetId(ruleSetId);
     if (!version) throw notFound('No published rule pack version found for this rule set.');
     return toApiRuleVersion(version as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Executes the rule set's currently-published gorules decision graph
+   * against the caller-supplied answers — the "Central GoRules execution"
+   * this service's own purpose statement (package.json/.claude/CLAUDE.md)
+   * describes, previously unimplemented (this service only stored rule
+   * packs opaquely; nothing interpreted rulesJson until now).
+   *
+   * 404 if the set has no published version — never silently evaluates
+   * against a DRAFT (an unreviewed rule pack must not affect real risk
+   * grading). Returns the published version's own id as `ruleVersionId`
+   * alongside the results, so the caller (risk-referral-service) can record
+   * which rule version produced a given RiskAssessment.
+   */
+  async evaluate(ruleSetId: string, dto: EvaluateRuleSetInput) {
+    const version = await this.repository.findPublishedBySetId(ruleSetId);
+    if (!version) {
+      throw unprocessable('No published rule pack version found for this rule set.');
+    }
+
+    const evaluation = await evaluateRulePack(version.rulesJson, dto.answers);
+    return { ruleVersionId: version.id, ...evaluation };
   }
 
   /**

--- a/apps/visit-form-service/prisma/migrations/20260808000001_add_form_definition_risk_rule_set_id/migration.sql
+++ b/apps/visit-form-service/prisma/migrations/20260808000001_add_form_definition_risk_rule_set_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "form_definitions" ADD COLUMN "risk_rule_set_id" TEXT;

--- a/apps/visit-form-service/prisma/schema.prisma
+++ b/apps/visit-form-service/prisma/schema.prisma
@@ -193,6 +193,13 @@ model FormDefinition {
   formName        String               @map("form_name") @db.VarChar(80)
   entityType      FormEntityType       @map("entity_type")
   status          FormDefinitionStatus
+  // rule_sets.rule_set_id — owned by rules-service, no cross-service
+  // relation. Null for a form with no risk-relevant fields (e.g. SUPERVISOR/
+  // SYSTEM entityType forms) — such a form simply skips risk evaluation on
+  // submission. Set once per form by an ADMIN; there is no admin endpoint to
+  // manage this yet (seeded/updated directly) — a known gap, not in scope
+  // for this milestone.
+  riskRuleSetId   String?              @map("risk_rule_set_id")
   createdAt       DateTime             @default(now()) @map("created_at")
   createdByUserId String?              @map("created_by_user_id")
   updatedAt       DateTime             @updatedAt @map("updated_at")

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -13,6 +13,7 @@ import {
 import { validateSubmission } from './form-validation';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
 import { getAncestorChain } from '../geography/geography.client';
+import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
 /**
  * Business logic for the dynamic-forms feature: fetching the active version,
@@ -192,6 +193,24 @@ export class FormService {
     // after the submission is durably saved — see syncSocioDemographics.
     if (formCode === 'MOTHER_REGISTRATION') {
       await syncSocioDemographics(dto.beneficiaryId, dto.formData, authorizationHeader);
+    }
+
+    // Triggers the risk-grading pipeline for every visit-linked submission
+    // whose form has a risk_rule_set_id configured (see FormDefinition's
+    // schema comment) — a form with no ruleSetId set (e.g. SUPERVISOR/SYSTEM
+    // entityType forms) simply has nothing to evaluate. Best-effort, same
+    // stance as syncSocioDemographics above.
+    if (dto.visitId && version.formDefinition.riskRuleSetId) {
+      await triggerRiskAssessment(
+        {
+          beneficiaryId: dto.beneficiaryId,
+          visitId: dto.visitId,
+          submissionId: created.id,
+          ruleSetId: version.formDefinition.riskRuleSetId,
+          answers: dto.formData,
+        },
+        authorizationHeader,
+      );
     }
 
     return toApiFormSubmission(created);

--- a/apps/visit-form-service/src/lookups/lookup.client.ts
+++ b/apps/visit-form-service/src/lookups/lookup.client.ts
@@ -1,0 +1,67 @@
+import { badGateway } from '@armman/service-commons';
+
+// Read directly (not via appConfig) — see geography.client.ts (beneficiary-service)
+// for why. Despite the name, this is the gateway's own base URL.
+const GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+interface LookupValue {
+  id: string;
+  valueCode: string;
+  valueLabel: string;
+}
+
+interface LookupCategory {
+  categoryCode: string;
+  values: LookupValue[];
+}
+
+/**
+ * Fetches the full VISIT_STATUS category (STARTED/PENDING/MISSED/COMPLETED/
+ * DISCARDED, per auth-service's seed-data.ts), keyed by lookup_value_id —
+ * needed because a raw lookup_value_id UUID is opaque and not portable
+ * across environments; callers need the semantic valueCode. Mirrors
+ * beneficiary-service's lookup.client.ts fetchLookupCategory.
+ */
+async function fetchVisitStatusCategory(authorizationHeader: string): Promise<Map<string, string>> {
+  let res: Response;
+  try {
+    res = await fetch(`${GATEWAY_BASE_URL}/api/v1/lookups/VISIT_STATUS`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve visit status — auth-service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve visit status — auth-service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: LookupCategory };
+  return new Map(body.data.values.map((v) => [v.id, v.valueCode]));
+}
+
+/**
+ * Resolves a single VISIT_STATUS lookup_value_id to its stable valueCode —
+ * needed because visitInstance.service.ts must know the *semantic* status
+ * (is this transition to COMPLETED? is the visit already COMPLETED?).
+ * Returns null if the id doesn't resolve to a known value — the caller
+ * treats that as "unrecognized status", not a crash.
+ */
+export async function resolveVisitStatusCode(
+  lookupValueId: string,
+  authorizationHeader: string,
+): Promise<string | null> {
+  const byId = await fetchVisitStatusCategory(authorizationHeader);
+  return byId.get(lookupValueId) ?? null;
+}
+
+/**
+ * Resolves every VISIT_STATUS lookup_value_id in one call — used by
+ * getVisitSummary to translate a page of visits' raw statusLookupValueId
+ * into human-readable byStatus counts without a per-row lookup.
+ */
+export async function resolveVisitStatusCodes(
+  authorizationHeader: string,
+): Promise<Map<string, string>> {
+  return fetchVisitStatusCategory(authorizationHeader);
+}

--- a/apps/visit-form-service/src/risk-assessments/riskAssessment.client.ts
+++ b/apps/visit-form-service/src/risk-assessments/riskAssessment.client.ts
@@ -1,0 +1,46 @@
+// Read directly (not via appConfig) — matches geography.client.ts/
+// socio-demographics.client.ts's stance in this service.
+const API_GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+/**
+ * Triggers risk evaluation for a visit-linked, VALID submission by calling
+ * risk-referral-service's `POST /risk-assessments`, which evaluates the
+ * submission's answers against the form's rule set, persists
+ * RiskAssessment/RiskFlag, and pushes the rollup to beneficiary-service.
+ *
+ * Best-effort by design, matching syncSocioDemographics's stance: the
+ * submission itself is already durably saved by the time this runs, and
+ * losing a risk-grading pass is recoverable (the next visit/submission for
+ * this beneficiary+condition re-evaluates) — rejecting a completed
+ * submission in the field over a downstream evaluation failure is not
+ * acceptable.
+ */
+export async function triggerRiskAssessment(
+  input: {
+    beneficiaryId: string;
+    visitId: string | null;
+    submissionId: string;
+    ruleSetId: string;
+    answers: Record<string, unknown>;
+  },
+  authorizationHeader: string,
+): Promise<void> {
+  try {
+    const res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/risk-assessments`, {
+      method: 'POST',
+      headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!res.ok) {
+      console.warn(
+        `Failed to trigger risk assessment for submission ${input.submissionId} ` +
+          `(risk-referral-service returned ${res.status}); the submission itself was still saved.`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Unable to reach risk-referral-service to evaluate submission ${input.submissionId}; ` +
+        `the submission itself was still saved. ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/sakhis/sakhi.client.ts
+++ b/apps/visit-form-service/src/sakhis/sakhi.client.ts
@@ -40,3 +40,31 @@ export async function findSakhiById(
   const body = (await res.json()) as { data: Sakhi };
   return body.data;
 }
+
+/**
+ * Resolves the Sakhi ids reporting to a given Supervisor, via auth-service's
+ * existing `GET /projects/:projectId/sakhis` — mirrors beneficiary-service's
+ * sakhi.client.ts's listSakhiIdsForSupervisor exactly. Used to scope
+ * `GET /visits/visit-summary` to a Supervisor's own Sakhis' visits.
+ */
+export async function listSakhiIdsForSupervisor(
+  projectId: string,
+  supervisorId: string,
+  authorizationHeader: string,
+): Promise<string[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${GATEWAY_BASE_URL}/api/v1/projects/${projectId}/sakhis`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve Sakhis — the auth service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve Sakhis — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: Sakhi[] };
+  return body.data.filter((sakhi) => sakhi.supervisorId === supervisorId).map((s) => s.sakhiId);
+}

--- a/apps/visit-form-service/src/visits/dto/update-visitInstance.dto.ts
+++ b/apps/visit-form-service/src/visits/dto/update-visitInstance.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for `PATCH /visits/:id` — lets a visit actually reach a
+ * terminal status (COMPLETED/MISSED/etc.) after `POST /visits` created it.
+ * `statusLookupValueId` is a plain scalar lookup_values id, same as
+ * create-visitInstance.dto.ts — not cross-validated against auth-service's
+ * VISIT_STATUS category here either, matching that existing precedent.
+ */
+export const updateVisitInstanceSchema = z
+  .object({
+    statusLookupValueId: z.string().uuid(),
+    actualVisitDate: z.coerce.date().optional(),
+    meetBeneficiaryFlag: z.boolean().optional(),
+    notMetReason: z.string().trim().min(1).max(255).optional(),
+  })
+  .strict();
+
+export type UpdateVisitInstanceInput = z.infer<typeof updateVisitInstanceSchema>;

--- a/apps/visit-form-service/src/visits/dto/visit-summary-query.dto.ts
+++ b/apps/visit-form-service/src/visits/dto/visit-summary-query.dto.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+/**
+ * Query params for `GET /visits/visit-summary` — same role-scoping
+ * (sakhiId) and date-range shape as beneficiary-service's summary
+ * endpoints, filtered on VisitSchedule.scheduledDate (when the visit was
+ * due), not actualVisitDate — see visitInstance.repository.ts's
+ * countByStatus doc comment.
+ */
+export const visitSummaryQuerySchema = z
+  .object({
+    sakhiId: z.string().uuid().optional(),
+    fromDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)')
+      .optional(),
+    toDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)')
+      .optional(),
+  })
+  .strict();
+
+export type VisitSummaryQueryInput = z.infer<typeof visitSummaryQuerySchema>;

--- a/apps/visit-form-service/src/visits/visitInstance.controller.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.controller.ts
@@ -2,6 +2,8 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import type { VisitInstanceService } from './visitInstance.service';
 import { createVisitInstanceSchema } from './dto/create-visitInstance.dto';
+import { updateVisitInstanceSchema } from './dto/update-visitInstance.dto';
+import { visitSummaryQuerySchema } from './dto/visit-summary-query.dto';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -9,10 +11,14 @@ import {
   ok,
   requireRoles,
   trustGatewayIdentity,
+  unauthorized,
+  validate,
   validateBody,
 } from '../app.module';
 
 extendZodWithOpenApi(z);
+
+const idParamsSchema = z.object({ id: z.string().uuid() }).strict();
 
 // Request DTO annotated with examples for Swagger UI; validation behavior is
 // unchanged (`.openapi()` only attaches documentation metadata).
@@ -63,6 +69,11 @@ const visitInstanceSchema = z.object({
   updatedAt: z.string().datetime().openapi({ example: '2026-07-20T10:15:00.000Z' }),
 });
 
+const visitSummarySchema = z.object({
+  total: z.number().int(),
+  byStatus: z.record(z.string(), z.number().int()),
+});
+
 function envelope<T extends z.ZodTypeAny>(data: T) {
   return z.object({ success: z.literal(true), message: z.string(), data });
 }
@@ -97,6 +108,35 @@ export function createVisitInstanceRouter(service: VisitInstanceService) {
     }),
   );
 
+  doc.get(
+    '/visits/visit-summary',
+    {
+      summary:
+        'Visit Summary widget — counts of in-scope visits grouped by status, filtered by ' +
+        'VisitSchedule.scheduledDate (when due, not when it happened). Same role-scoping as ' +
+        'PATCH /visits/:id: SAKHI sees own visits, SUPERVISOR sees roster visits, ' +
+        'MANAGER/ADMIN unscoped.',
+      tags: ['Visits'],
+      responses: {
+        200: { description: 'Visit status counts', schema: envelope(visitSummarySchema) },
+        400: errorResponse(400, { message: 'fromDate must be on or before toDate.' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: "sakhiId is not in this Supervisor's roster." }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    validate(visitSummaryQuerySchema, 'query'),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const query = req.query as unknown as z.infer<typeof visitSummaryQuerySchema>;
+      res.json(ok(await service.getVisitSummary(query, req.user, authorizationHeader)));
+    }),
+  );
+
   doc.post(
     '/visits',
     {
@@ -119,6 +159,44 @@ export function createVisitInstanceRouter(service: VisitInstanceService) {
     asyncHandler(async (req, res) => {
       const created = await service.create(req.body);
       res.status(201).json(ok(created));
+    }),
+  );
+
+  doc.patch(
+    '/visits/:id',
+    {
+      summary:
+        "Update a visit instance's status (e.g. to COMPLETED/MISSED). A SAKHI may only " +
+        'update her own visit; a SUPERVISOR only a visit whose Sakhi is assigned to her; ' +
+        'MANAGER/ADMIN unrestricted. completedAt is set automatically when the new status ' +
+        'resolves to COMPLETED, left null otherwise.',
+      tags: ['Visits'],
+      params: idParamsSchema,
+      responses: {
+        200: { description: 'Visit instance updated', schema: envelope(visitInstanceSchema) },
+        400: errorResponse(400, { message: 'statusLookupValueId: Invalid uuid' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'You do not have access to this visit.' }),
+        404: errorResponse(404, { message: 'Visit instance not found.' }),
+        409: errorResponse(409, { message: 'This visit is already COMPLETED.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    validate(idParamsSchema, 'params'),
+    validateBody(updateVisitInstanceSchema),
+    asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.updateStatus(
+        req.params.id,
+        req.body,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
     }),
   );
 

--- a/apps/visit-form-service/src/visits/visitInstance.controller.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.controller.ts
@@ -126,7 +126,7 @@ export function createVisitInstanceRouter(service: VisitInstanceService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(visitSummaryQuerySchema, 'query'),
     asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
@@ -183,7 +183,7 @@ export function createVisitInstanceRouter(service: VisitInstanceService) {
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(idParamsSchema, 'params'),
     validateBody(updateVisitInstanceSchema),
     asyncHandler(async (req, res, next) => {

--- a/apps/visit-form-service/src/visits/visitInstance.repository.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.repository.ts
@@ -1,5 +1,6 @@
 import type { PrismaService } from '../prisma/prisma.service';
 import type { CreateVisitInstanceInput } from './dto/create-visitInstance.dto';
+import type { UpdateVisitInstanceInput } from './dto/update-visitInstance.dto';
 
 /** Data access for visit instances. Owns only this service's `visit_instances` table. */
 export class VisitInstanceRepository {
@@ -13,6 +14,45 @@ export class VisitInstanceRepository {
     return this.prisma.visitInstance.findUnique({ where: { localVisitUuid } });
   }
 
+  findById(id: string) {
+    return this.prisma.visitInstance.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  /**
+   * Counts in-scope visits by their raw statusLookupValueId, filtered by
+   * VisitSchedule.scheduledDate — the date the visit was DUE, not
+   * actualVisitDate (when/if it happened), per the visit-summary widget's
+   * confirmed semantics: a MISSED visit has no actualVisitDate but must
+   * still be countable within the period it was due in. The service layer
+   * resolves each statusLookupValueId to its human-readable valueCode.
+   */
+  async countByStatus(filters: {
+    sakhiId?: string;
+    sakhiIds?: string[];
+    fromDate?: string;
+    toDate?: string;
+  }) {
+    const where: NonNullable<Parameters<typeof this.prisma.visitInstance.groupBy>[0]>['where'] = {
+      isDeleted: false,
+    };
+    if (filters.sakhiId) where.sakhiId = filters.sakhiId;
+    if (filters.sakhiIds) where.sakhiId = { in: filters.sakhiIds };
+    if (filters.fromDate || filters.toDate) {
+      where.schedule = {
+        scheduledDate: {
+          ...(filters.fromDate ? { gte: new Date(`${filters.fromDate}T00:00:00.000Z`) } : {}),
+          ...(filters.toDate ? { lte: new Date(`${filters.toDate}T23:59:59.999Z`) } : {}),
+        },
+      };
+    }
+
+    return this.prisma.visitInstance.groupBy({
+      by: ['statusLookupValueId'],
+      where,
+      _count: { _all: true },
+    });
+  }
+
   findScheduleById(scheduleId: string) {
     return this.prisma.visitSchedule.findFirst({
       where: { id: scheduleId, isDeleted: false },
@@ -21,5 +61,46 @@ export class VisitInstanceRepository {
 
   create(data: CreateVisitInstanceInput) {
     return this.prisma.visitInstance.create({ data });
+  }
+
+  /**
+   * Applies a status transition, in one transaction with the
+   * VisitStatusHistory row that records it. Only updates a row still at
+   * `existing.statusLookupValueId` — the same optimistic-concurrency guard
+   * `beneficiary.repository.ts`'s `reactivateCase` uses: if the visit's
+   * status already changed between the caller's findById and this call,
+   * `count` comes back 0 and the service turns that into a 409 instead of
+   * silently overwriting a since-changed visit.
+   */
+  async updateStatus(
+    id: string,
+    fromStatusLookupValueId: string | null,
+    data: UpdateVisitInstanceInput & { completedAt: Date | null },
+    changedByUserId: string,
+  ): Promise<boolean> {
+    return this.prisma.$transaction(async (tx) => {
+      const result = await tx.visitInstance.updateMany({
+        where: { id, isDeleted: false, statusLookupValueId: fromStatusLookupValueId },
+        data: {
+          statusLookupValueId: data.statusLookupValueId,
+          actualVisitDate: data.actualVisitDate,
+          meetBeneficiaryFlag: data.meetBeneficiaryFlag,
+          notMetReason: data.notMetReason,
+          completedAt: data.completedAt,
+        },
+      });
+      if (result.count === 0) return false;
+
+      await tx.visitStatusHistory.create({
+        data: {
+          visitId: id,
+          fromStatusLookupValueId,
+          toStatusLookupValueId: data.statusLookupValueId,
+          changedByUserId,
+          changedAt: new Date(),
+        },
+      });
+      return true;
+    });
   }
 }

--- a/apps/visit-form-service/src/visits/visitInstance.service.spec.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.service.spec.ts
@@ -1,15 +1,34 @@
 import { VisitInstanceService } from './visitInstance.service';
 import type { VisitInstanceRepository } from './visitInstance.repository';
 import type { CreateVisitInstanceInput } from './dto/create-visitInstance.dto';
+import { findSakhiById, listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
+import { resolveVisitStatusCode, resolveVisitStatusCodes } from '../lookups/lookup.client';
+
+jest.mock('../sakhis/sakhi.client');
+jest.mock('../lookups/lookup.client');
 
 describe('VisitInstanceService', () => {
   const repository = {
     findMany: jest.fn(),
+    findById: jest.fn(),
     findByLocalVisitUuid: jest.fn(),
     findScheduleById: jest.fn(),
     create: jest.fn(),
+    updateStatus: jest.fn(),
+    countByStatus: jest.fn(),
   } as unknown as jest.Mocked<VisitInstanceRepository>;
   let service: VisitInstanceService;
+
+  const AUTH_HEADER = 'Bearer test-token';
+  const findSakhiByIdMock = jest.mocked(findSakhiById);
+  const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
+  const resolveVisitStatusCodeMock = jest.mocked(resolveVisitStatusCode);
+  const resolveVisitStatusCodesMock = jest.mocked(resolveVisitStatusCodes);
+
+  // Distinct from sampleRow.statusLookupValueId ('aaaaaaaa-...') below, so
+  // "transitioning to COMPLETED" tests aren't accidentally a no-op re-completion.
+  const COMPLETED_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  const MISSED_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -92,5 +111,252 @@ describe('VisitInstanceService', () => {
     repository.create.mockRejectedValue(new Error('db down'));
 
     await expect(service.create(dto)).rejects.toThrow('db down');
+  });
+
+  describe('updateStatus', () => {
+    const SAKHI_ID = sampleRow.sakhiId;
+
+    it('404s when the visit does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.updateStatus(
+          'unknown-id',
+          { statusLookupValueId: COMPLETED_ID },
+          { id: SAKHI_ID, roles: ['SAKHI'] },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('Visit instance not found.');
+    });
+
+    it('403s when a SAKHI targets a visit that is not their own', async () => {
+      repository.findById.mockResolvedValue(sampleRow);
+
+      await expect(
+        service.updateStatus(
+          sampleRow.id,
+          { statusLookupValueId: COMPLETED_ID },
+          { id: 'someone-else', roles: ['SAKHI'] },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('You do not have access to this visit.');
+    });
+
+    it('403s when a SUPERVISOR targets a visit whose Sakhi is not assigned to them', async () => {
+      repository.findById.mockResolvedValue(sampleRow);
+      findSakhiByIdMock.mockResolvedValue({
+        sakhiId: SAKHI_ID,
+        supervisorId: 'someone-else',
+        primaryProjectId: 'p1',
+      });
+
+      await expect(
+        service.updateStatus(
+          sampleRow.id,
+          { statusLookupValueId: COMPLETED_ID },
+          { id: 'supervisor-1', roles: ['SUPERVISOR'] },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('You do not have access to this visit.');
+    });
+
+    it('allows a SUPERVISOR to update a visit whose Sakhi is assigned to them', async () => {
+      repository.findById.mockResolvedValue(sampleRow);
+      findSakhiByIdMock.mockResolvedValue({
+        sakhiId: SAKHI_ID,
+        supervisorId: 'supervisor-1',
+        primaryProjectId: 'p1',
+      });
+      // sampleRow's existing status (a different id) resolves to a code
+      // distinct from COMPLETED so this isn't misread as a re-completion.
+      resolveVisitStatusCodeMock.mockImplementation((id) =>
+        Promise.resolve(id === COMPLETED_ID ? 'COMPLETED' : 'PENDING'),
+      );
+      repository.updateStatus.mockResolvedValue(true);
+
+      await service.updateStatus(
+        sampleRow.id,
+        { statusLookupValueId: COMPLETED_ID },
+        { id: 'supervisor-1', roles: ['SUPERVISOR'] },
+        AUTH_HEADER,
+      );
+
+      expect(repository.updateStatus).toHaveBeenCalled();
+    });
+
+    it('sets completedAt when the new status resolves to COMPLETED', async () => {
+      repository.findById.mockResolvedValueOnce(sampleRow).mockResolvedValueOnce(sampleRow);
+      resolveVisitStatusCodeMock.mockImplementation((id) =>
+        Promise.resolve(id === COMPLETED_ID ? 'COMPLETED' : 'PENDING'),
+      );
+      repository.updateStatus.mockResolvedValue(true);
+
+      await service.updateStatus(
+        sampleRow.id,
+        { statusLookupValueId: COMPLETED_ID },
+        { id: SAKHI_ID, roles: ['SAKHI'] },
+        AUTH_HEADER,
+      );
+
+      expect(repository.updateStatus).toHaveBeenCalledWith(
+        sampleRow.id,
+        sampleRow.statusLookupValueId,
+        expect.objectContaining({ completedAt: expect.any(Date) }),
+        SAKHI_ID,
+      );
+    });
+
+    it('leaves completedAt null when the new status resolves to MISSED', async () => {
+      repository.findById.mockResolvedValue(sampleRow);
+      resolveVisitStatusCodeMock.mockResolvedValue('MISSED');
+      repository.updateStatus.mockResolvedValue(true);
+
+      await service.updateStatus(
+        sampleRow.id,
+        { statusLookupValueId: MISSED_ID },
+        { id: SAKHI_ID, roles: ['SAKHI'] },
+        AUTH_HEADER,
+      );
+
+      expect(repository.updateStatus).toHaveBeenCalledWith(
+        sampleRow.id,
+        sampleRow.statusLookupValueId,
+        expect.objectContaining({ completedAt: null }),
+        SAKHI_ID,
+      );
+    });
+
+    it('409s when re-completing an already-COMPLETED visit', async () => {
+      const completedRow = { ...sampleRow, statusLookupValueId: COMPLETED_ID };
+      repository.findById.mockResolvedValue(completedRow);
+      resolveVisitStatusCodeMock.mockResolvedValue('COMPLETED');
+
+      await expect(
+        service.updateStatus(
+          sampleRow.id,
+          { statusLookupValueId: COMPLETED_ID },
+          { id: SAKHI_ID, roles: ['SAKHI'] },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('This visit is already COMPLETED.');
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('409s when the conditional update races with a concurrent status change', async () => {
+      repository.findById.mockResolvedValue(sampleRow);
+      resolveVisitStatusCodeMock.mockImplementation((id) =>
+        Promise.resolve(id === COMPLETED_ID ? 'COMPLETED' : 'PENDING'),
+      );
+      repository.updateStatus.mockResolvedValue(false);
+
+      await expect(
+        service.updateStatus(
+          sampleRow.id,
+          { statusLookupValueId: COMPLETED_ID },
+          { id: SAKHI_ID, roles: ['SAKHI'] },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('This visit was already updated by another request.');
+    });
+
+    it('MANAGER/ADMIN callers bypass the ownership check entirely', async () => {
+      repository.findById.mockResolvedValue(sampleRow);
+      resolveVisitStatusCodeMock.mockImplementation((id) =>
+        Promise.resolve(id === COMPLETED_ID ? 'COMPLETED' : 'PENDING'),
+      );
+      repository.updateStatus.mockResolvedValue(true);
+
+      await service.updateStatus(
+        sampleRow.id,
+        { statusLookupValueId: COMPLETED_ID },
+        { id: 'manager-1', roles: ['MANAGER'] },
+        AUTH_HEADER,
+      );
+
+      expect(findSakhiByIdMock).not.toHaveBeenCalled();
+      expect(repository.updateStatus).toHaveBeenCalled();
+    });
+  });
+
+  describe('getVisitSummary', () => {
+    const SAKHI_ID = 'sakhi-1';
+
+    it('scopes a SAKHI caller to their own visits', async () => {
+      repository.countByStatus.mockResolvedValue([
+        { statusLookupValueId: COMPLETED_ID, _count: { _all: 3 } },
+      ]);
+      resolveVisitStatusCodesMock.mockResolvedValue(new Map([[COMPLETED_ID, 'COMPLETED']]));
+
+      const result = await service.getVisitSummary(
+        {},
+        { id: SAKHI_ID, roles: ['SAKHI'] },
+        AUTH_HEADER,
+      );
+
+      expect(repository.countByStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ sakhiId: SAKHI_ID }),
+      );
+      expect(result).toEqual({ total: 3, byStatus: { COMPLETED: 3 } });
+    });
+
+    it('scopes a SUPERVISOR caller to their roster', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
+      repository.countByStatus.mockResolvedValue([]);
+      resolveVisitStatusCodesMock.mockResolvedValue(new Map());
+
+      await service.getVisitSummary(
+        {},
+        { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: 'p1' },
+        AUTH_HEADER,
+      );
+
+      expect(repository.countByStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ sakhiIds: ['sakhi-a', 'sakhi-b'] }),
+      );
+    });
+
+    it('rejects a SUPERVISOR caller with no project scope', async () => {
+      await expect(
+        service.getVisitSummary(
+          {},
+          { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: null },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('Supervisor caller has no project scope.');
+    });
+
+    it('leaves a MANAGER caller unscoped', async () => {
+      repository.countByStatus.mockResolvedValue([]);
+      resolveVisitStatusCodesMock.mockResolvedValue(new Map());
+
+      await service.getVisitSummary({}, { id: 'manager-1', roles: ['MANAGER'] }, AUTH_HEADER);
+
+      expect(repository.countByStatus).toHaveBeenCalledWith(
+        expect.not.objectContaining({ sakhiId: expect.anything() }),
+      );
+    });
+
+    it('rejects fromDate after toDate', async () => {
+      await expect(
+        service.getVisitSummary(
+          { fromDate: '2026-02-01', toDate: '2026-01-01' },
+          { id: SAKHI_ID, roles: ['SAKHI'] },
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('fromDate must be on or before toDate.');
+    });
+
+    it('returns all-zero counts when no visits are in scope', async () => {
+      repository.countByStatus.mockResolvedValue([]);
+      resolveVisitStatusCodesMock.mockResolvedValue(new Map());
+
+      const result = await service.getVisitSummary(
+        {},
+        { id: SAKHI_ID, roles: ['SAKHI'] },
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual({ total: 0, byStatus: {} });
+    });
   });
 });

--- a/apps/visit-form-service/src/visits/visitInstance.service.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.service.ts
@@ -1,6 +1,22 @@
-import { unprocessable } from '@armman/service-commons';
+import { badRequest, conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
 import type { VisitInstanceRepository } from './visitInstance.repository';
 import type { CreateVisitInstanceInput } from './dto/create-visitInstance.dto';
+import type { UpdateVisitInstanceInput } from './dto/update-visitInstance.dto';
+import type { VisitSummaryQueryInput } from './dto/visit-summary-query.dto';
+import { findSakhiById, listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
+import { resolveVisitStatusCode, resolveVisitStatusCodes } from '../lookups/lookup.client';
+
+/** The calling principal's own identity, as carried on their trusted-identity headers. */
+export interface CallerIdentity {
+  readonly id: string;
+  readonly roles: readonly string[];
+  readonly projectId?: string | null;
+}
+
+/** MANAGER and ADMIN are unrestricted — same convention as every other service. */
+function isPrivileged(caller: CallerIdentity): boolean {
+  return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
+}
 
 /** Visit instance domain logic. Data access is delegated to the repository. */
 export class VisitInstanceService {
@@ -33,5 +49,139 @@ export class VisitInstanceService {
     }
 
     return this.repository.create(dto);
+  }
+
+  /**
+   * Transitions a visit's status (per SRS — lets a visit actually reach
+   * COMPLETED/MISSED after POST /visits created it). `completedAt` is set
+   * only when the new status resolves to COMPLETED — it represents when the
+   * visit was actually conducted, so a MISSED visit (never conducted) leaves
+   * it null; VisitStatusHistory is the record of when the MISSED transition
+   * itself happened. Re-completing an already-COMPLETED visit is rejected
+   * with 409, mirroring beneficiary.service.ts's reactivateCase pattern —
+   * a completed visit is a terminal state change, not silently idempotent.
+   *
+   * IDOR scoping mirrors visitSchedule.service.ts: SAKHI may only touch her
+   * own visit (visit.sakhiId === caller.id); SUPERVISOR only a visit whose
+   * Sakhi is assigned to her (resolved via sakhi.client.ts, since this
+   * service doesn't own sakhi_profiles); MANAGER/ADMIN unrestricted.
+   */
+  async updateStatus(
+    id: string,
+    dto: UpdateVisitInstanceInput,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(id);
+    if (!existing) throw notFound('Visit instance not found.');
+
+    if (!isPrivileged(caller)) {
+      if (caller.roles.includes('SAKHI')) {
+        if (existing.sakhiId !== caller.id) {
+          throw forbidden('You do not have access to this visit.');
+        }
+      } else {
+        const sakhi = await findSakhiById(existing.sakhiId, authorizationHeader);
+        if (!sakhi || sakhi.supervisorId !== caller.id) {
+          throw forbidden('You do not have access to this visit.');
+        }
+      }
+    }
+
+    const [fromStatusCode, toStatusCode] = await Promise.all([
+      existing.statusLookupValueId
+        ? resolveVisitStatusCode(existing.statusLookupValueId, authorizationHeader)
+        : Promise.resolve(null),
+      resolveVisitStatusCode(dto.statusLookupValueId, authorizationHeader),
+    ]);
+
+    if (fromStatusCode === 'COMPLETED' && toStatusCode === 'COMPLETED') {
+      throw conflict('This visit is already COMPLETED.');
+    }
+
+    const updated = await this.repository.updateStatus(
+      id,
+      existing.statusLookupValueId,
+      { ...dto, completedAt: toStatusCode === 'COMPLETED' ? new Date() : null },
+      caller.id,
+    );
+    if (!updated) {
+      // Raced with another status change between the read above and the
+      // conditional update — same outcome as the check above, just caught a
+      // beat later instead of trusting a stale read (mirrors reactivateCase).
+      throw conflict('This visit was already updated by another request.');
+    }
+
+    return this.repository.findById(id);
+  }
+
+  /**
+   * Visit Summary widget — counts of in-scope visits grouped by status
+   * valueCode, same role-scoping as updateStatus (SAKHI own visits,
+   * SUPERVISOR roster via auth-service, MANAGER/ADMIN unscoped) and the
+   * same fromDate/toDate cross-field check as beneficiary-service's summary
+   * endpoints.
+   */
+  async getVisitSummary(
+    query: VisitSummaryQueryInput,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    if (query.fromDate && query.toDate && query.fromDate > query.toDate) {
+      throw badRequest('fromDate must be on or before toDate.');
+    }
+
+    let sakhiId: string | undefined;
+    let sakhiIds: string[] | undefined;
+
+    if (caller.roles.includes('SAKHI')) {
+      sakhiId = caller.id;
+    } else if (!isPrivileged(caller)) {
+      // SUPERVISOR
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
+      if (query.sakhiId) {
+        const roster = await listSakhiIdsForSupervisor(
+          caller.projectId,
+          caller.id,
+          authorizationHeader,
+        );
+        if (!roster.includes(query.sakhiId)) {
+          throw forbidden("sakhiId is not in this Supervisor's roster.");
+        }
+        sakhiId = query.sakhiId;
+      } else {
+        sakhiIds = await listSakhiIdsForSupervisor(
+          caller.projectId,
+          caller.id,
+          authorizationHeader,
+        );
+      }
+    } else if (query.sakhiId) {
+      sakhiId = query.sakhiId;
+    }
+
+    const [grouped, statusCodes] = await Promise.all([
+      this.repository.countByStatus({
+        sakhiId,
+        sakhiIds,
+        fromDate: query.fromDate,
+        toDate: query.toDate,
+      }),
+      resolveVisitStatusCodes(authorizationHeader),
+    ]);
+
+    const byStatus: Record<string, number> = {};
+    let total = 0;
+    for (const row of grouped) {
+      const code = row.statusLookupValueId
+        ? (statusCodes.get(row.statusLookupValueId) ?? 'UNKNOWN')
+        : 'UNKNOWN';
+      byStatus[code] = (byStatus[code] ?? 0) + row._count._all;
+      total += row._count._all;
+    }
+
+    return { total, byStatus };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,6 +257,7 @@
       "dependencies": {
         "@armman/core": "*",
         "@armman/service-commons": "*",
+        "@gorules/zen-engine": "0.54.0",
         "@prisma/client": "^5.18.0",
         "express": "^4.19.2",
         "helmet": "^7.1.0",
@@ -2547,7 +2548,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -2557,7 +2558,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2566,7 +2567,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2823,6 +2824,196 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@gorules/zen-engine": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine/-/zen-engine-0.54.0.tgz",
+      "integrity": "sha512-rt8LeikbQVxDthok9KsLGQxoLVG26Hmb4QCS+CCVSaoFDVDMmo3VfhryyCVkqvY0FjIeIZTluZcPlAI8gNAkqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "optionalDependencies": {
+        "@gorules/zen-engine-darwin-arm64": "0.54.0",
+        "@gorules/zen-engine-darwin-x64": "0.54.0",
+        "@gorules/zen-engine-linux-arm64-gnu": "0.54.0",
+        "@gorules/zen-engine-linux-arm64-musl": "0.54.0",
+        "@gorules/zen-engine-linux-x64-gnu": "0.54.0",
+        "@gorules/zen-engine-linux-x64-musl": "0.54.0",
+        "@gorules/zen-engine-wasm32-wasi": "0.54.0",
+        "@gorules/zen-engine-win32-x64-msvc": "0.54.0"
+      }
+    },
+    "node_modules/@gorules/zen-engine-darwin-arm64": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-darwin-arm64/-/zen-engine-darwin-arm64-0.54.0.tgz",
+      "integrity": "sha512-FBNmqK+plKAnJvbCi26BGHdhdhRFL2IJs+jVmlzAE95Mkt0DKB6jdVRSRZS3y1hhEnIdcXEBhx6S2f/eWDLcZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-darwin-x64": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-darwin-x64/-/zen-engine-darwin-x64-0.54.0.tgz",
+      "integrity": "sha512-SL+dPc6K149fQZ/43Cuf11wUrUqmA2/Dhu2HJDnHNf9yTTs8/o2WnK5+amZ+eWTZZdbDJmYpfIDdM7YRnL5KEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-linux-arm64-gnu": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-linux-arm64-gnu/-/zen-engine-linux-arm64-gnu-0.54.0.tgz",
+      "integrity": "sha512-3bCz4p1BgTQcSWc+4AWWYcX3IPqHuct+QjxLFfQQNeuYjmkCPP44tgRltaVZsLtWIebBeOUAxuF9AHnTwrpDDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-linux-arm64-musl": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-linux-arm64-musl/-/zen-engine-linux-arm64-musl-0.54.0.tgz",
+      "integrity": "sha512-lWNthckrELOOPCyArgWKDPmE0k4tlAL8KkAW/xjjKU6mMnrQWMi6ZgQbUMF4Egp86BY8zRwZfqFGkQL7JvInbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-linux-x64-gnu": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-linux-x64-gnu/-/zen-engine-linux-x64-gnu-0.54.0.tgz",
+      "integrity": "sha512-1EW5Ri7+XuUWsp+wNfgao/RN9CO1HL1ddf9vES4VjqBe6AYL9RaqcFDa+hDUCcp5CDvC34sCf/Xnvr8BCm5DBg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-linux-x64-musl": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-linux-x64-musl/-/zen-engine-linux-x64-musl-0.54.0.tgz",
+      "integrity": "sha512-YSo2fwUw16QFBYTRsM4euhDEMDvN6UmSp6mWIxE1p/VeCGjxDTS9PJpPK114HYYmI/nSLiKP3qCe/tkA0PRSOA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@gorules/zen-engine-wasm32-wasi": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-wasm32-wasi/-/zen-engine-wasm32-wasi-0.54.0.tgz",
+      "integrity": "sha512-CGpmNAm22+iEHGGNIH/sf9dDrNzxDYeA9jAkt/vynCYRJarF55YgfbvutOZ0t8pl+8D+falA6mB9eJ6ME7wWaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@gorules/zen-engine-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@gorules/zen-engine-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@gorules/zen-engine-win32-x64-msvc": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@gorules/zen-engine-win32-x64-msvc/-/zen-engine-win32-x64-msvc-0.54.0.tgz",
+      "integrity": "sha512-bj5PytBCNFBueP+8jma0iL0MnF75c0lk147FL9CrGvZdsxuHw5v4ogvv8vQNQMKhidDyfokcfq67+dFcUP9gUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -9929,7 +10120,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -11369,23 +11559,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -11402,24 +11575,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -11432,17 +11587,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-circus/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/jest-cli": {
@@ -17505,7 +17649,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2884,9 +2884,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2902,9 +2899,6 @@
       "integrity": "sha512-lWNthckrELOOPCyArgWKDPmE0k4tlAL8KkAW/xjjKU6mMnrQWMi6ZgQbUMF4Egp86BY8zRwZfqFGkQL7JvInbg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2922,9 +2916,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2940,9 +2931,6 @@
       "integrity": "sha512-YSo2fwUw16QFBYTRsM4euhDEMDvN6UmSp6mWIxE1p/VeCGjxDTS9PJpPK114HYYmI/nSLiKP3qCe/tkA0PRSOA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10120,6 +10108,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -11559,6 +11548,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -11575,6 +11581,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -11587,6 +11611,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-circus/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jest-cli": {


### PR DESCRIPTION
## Summary

Closes the gap identified in the ngrok endpoint audit — 5 previously-missing endpoints built, 1 existing endpoint extended, plus one unrelated bugfix picked up along the way:

- **rules-service**: `POST /rules/:setId/evaluate` — first real implementation of "Central GoRules execution" (`@gorules/zen-engine`). Only ever evaluates a PUBLISHED rule pack, never DRAFT.
- **risk-referral-service**: `POST /risk-assessments` — the missing risk-grading write pipeline. Resolves the rule set, calls rules-service to evaluate, persists the `RiskAssessment` row (unique per `submissionId`), and updates the beneficiary's risk-condition-summary rollup.
- **api-gateway**: new `/risk-assessments` proxy route (internal-use, mirrors `/admin/forms`/`/admin/rules`).
- **beneficiary-service**:
  - `GET /beneficiaries/registration-summary` and `GET /beneficiaries/risk-summary` dashboard widgets.
  - `PATCH /beneficiaries/:id/risk-condition-summary` — SAKHI-only rollup upsert, called from the visit-form-service → risk-referral-service → here chain.
  - Extends `GET /beneficiaries` with `registeredFrom`/`registeredTo` as aliases for the existing `fromDate`/`toDate` filter.
- **visit-form-service**:
  - `PATCH /visits/:id` — update visit status, role-scoped (SAKHI own visit, SUPERVISOR own roster, MANAGER/ADMIN unrestricted); auto-sets `completedAt` on COMPLETED.
  - `GET /visits/visit-summary` — status-count widget, same role scoping.
  - Wires `form.service.ts` to trigger the risk-grading pipeline after a visit-linked submission is persisted, forwarding the originating SAKHI's own token (no machine identity exists in this codebase).
- **auth-service** (unrelated bugfix found and fixed alongside this work): `PATCH /users/:id` assigning a SAKHI's `projectId` and creating their Sakhi profile in the same call previously failed with "SAKHI role has no project assigned" — the profile-creation check read the pre-update row instead of this same request's `input.projectId`.

## Test plan
- [x] `npx nx affected --target=lint --base=origin/develop` — 19 projects, all clean
- [x] `npx nx test auth-service` — 66/66 passed
- [x] `npx nx test beneficiary-service` — 79/79 passed
- [x] `npx nx test risk-referral-service` — 35/35 passed
- [x] `npx nx test rules-service` — 26/26 passed
- [x] `npx nx test visit-form-service` — 243/243 passed
- [ ] Manual end-to-end: submit a visit-linked form → confirm risk-assessment is recorded and the beneficiary's risk-condition-summary rollup updates
- [ ] Manual: `PATCH /visits/:id` and both new summary widgets against a live SAKHI/SUPERVISOR/MANAGER token

## Migrations
- `beneficiary-service`: `20260808000000_add_risk_condition_summary_grade_rank`
- `risk-referral-service`: `20260808000000_add_risk_assessment_submission_unique`
- `visit-form-service`: `20260808000001_add_form_definition_risk_rule_set_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)