### PR TITLE
feat(beneficiary-service): Populate riskConditionSummaries from enrollment health-history answers

### DIFF
--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -496,7 +496,7 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
           description: 'Risk condition summary upserted',
           schema: envelope(riskConditionSummarySchema),
         },
-        400: errorResponse(400, { message: 'gradeRank: Required' }),
+        400: errorResponse(400, { message: 'riskConditionId: Invalid uuid' }),
         401: errorResponse(401),
         403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
         404: errorResponse(404, { message: 'Beneficiary case not found.' }),

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -209,8 +209,7 @@ export class BeneficiaryRepository {
     // rule-engine evaluation — always at-risk (a reported condition is
     // inherently a risk signal) and never grade-ranked against the existing
     // row, since there is no rank to compare.
-    const isEverAtRisk =
-      data.grade === null || data.grade !== 'NORMAL' || (existing?.everAtRiskFlag ?? false);
+    const isEverAtRisk = data.grade !== 'NORMAL' || (existing?.everAtRiskFlag ?? false);
     const outranksEverHighest =
       data.gradeRank !== null &&
       (existing?.everHighestGradeRank == null || data.gradeRank > existing.everHighestGradeRank);

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -204,9 +204,16 @@ export class BeneficiaryRepository {
       },
     });
 
-    const isEverAtRisk = data.grade !== 'NORMAL' || (existing?.everAtRiskFlag ?? false);
+    // A null grade means this is a self-reported, ungraded entry (e.g.
+    // enrollment-time diagnosed conditions/sickle cell status) rather than a
+    // rule-engine evaluation — always at-risk (a reported condition is
+    // inherently a risk signal) and never grade-ranked against the existing
+    // row, since there is no rank to compare.
+    const isEverAtRisk =
+      data.grade === null || data.grade !== 'NORMAL' || (existing?.everAtRiskFlag ?? false);
     const outranksEverHighest =
-      existing?.everHighestGradeRank == null || data.gradeRank > existing.everHighestGradeRank;
+      data.gradeRank !== null &&
+      (existing?.everHighestGradeRank == null || data.gradeRank > existing.everHighestGradeRank);
 
     return this.prisma.beneficiaryRiskConditionSummary.upsert({
       where: {
@@ -233,7 +240,7 @@ export class BeneficiaryRepository {
         everHighestVisitId: data.visitId,
         everHighestSubmissionId: data.submissionId,
         everHighestAssessedAt: data.assessedAt,
-        everAtRiskFlag: data.grade !== 'NORMAL',
+        everAtRiskFlag: isEverAtRisk,
         currentReferralTriggerFlag: data.isReferralTrigger,
         currentHrVisitTriggerFlag: data.isHrVisitTrigger,
         sourceRuleVersionId: data.ruleVersionId,

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.types.ts
@@ -123,8 +123,8 @@ export interface SocioDemographicsCreateData {
 export interface UpsertRiskConditionSummaryData {
   riskConditionId: string;
   phase: string;
-  grade: string;
-  gradeRank: number;
+  grade: string | null;
+  gradeRank: number | null;
   observedValueJson: Prisma.InputJsonValue | null;
   visitId: string | null;
   submissionId: string | null;

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -1413,5 +1413,32 @@ describe('BeneficiaryService', () => {
         }),
       );
     });
+
+    it('passes through null grade/gradeRank unchanged for an ungraded, self-reported entry', async () => {
+      repository.findById.mockResolvedValue({ id: 'ben-1', sakhiId: CALLER_ID } as never);
+      repository.upsertRiskConditionSummary.mockResolvedValue({} as never);
+
+      await service.upsertRiskConditionSummary(
+        'ben-1',
+        {
+          riskConditionId: RISK_CONDITION_ID,
+          phase: 'REGISTRATION',
+          assessedAt: new Date('2026-01-01'),
+          isReferralTrigger: false,
+          isHrVisitTrigger: false,
+        },
+        caller({ id: CALLER_ID, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.upsertRiskConditionSummary).toHaveBeenCalledWith(
+        'ben-1',
+        expect.objectContaining({
+          riskConditionId: RISK_CONDITION_ID,
+          grade: null,
+          gradeRank: null,
+        }),
+      );
+    });
   });
 });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -407,8 +407,8 @@ export class BeneficiaryService {
     return this.repository.upsertRiskConditionSummary(beneficiaryId, {
       riskConditionId: dto.riskConditionId,
       phase: dto.phase,
-      grade: dto.grade,
-      gradeRank: dto.gradeRank,
+      grade: dto.grade ?? null,
+      gradeRank: dto.gradeRank ?? null,
       // Untyped external JSON crossing into Prisma's InputJsonValue at this
       // one boundary — the zod schema (z.record) already guarantees a plain
       // JSON-serializable object.

--- a/apps/beneficiary-service/src/beneficiary/dto/upsert-risk-condition-summary.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/upsert-risk-condition-summary.dto.spec.ts
@@ -1,0 +1,40 @@
+import { upsertRiskConditionSummarySchema } from './upsert-risk-condition-summary.dto';
+
+const RISK_CONDITION_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const baseInput = {
+  riskConditionId: RISK_CONDITION_ID,
+  phase: 'REGISTRATION' as const,
+  assessedAt: new Date('2026-01-01').toISOString(),
+  isReferralTrigger: false,
+  isHrVisitTrigger: false,
+};
+
+describe('upsertRiskConditionSummarySchema', () => {
+  it('accepts a payload with grade and gradeRank omitted', () => {
+    const result = upsertRiskConditionSummarySchema.safeParse(baseInput);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a payload with grade and gradeRank present', () => {
+    const result = upsertRiskConditionSummarySchema.safeParse({
+      ...baseInput,
+      grade: 'HIGH',
+      gradeRank: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty-string grade when provided', () => {
+    const result = upsertRiskConditionSummarySchema.safeParse({ ...baseInput, grade: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown fields', () => {
+    const result = upsertRiskConditionSummarySchema.safeParse({
+      ...baseInput,
+      unexpectedField: 'nope',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/beneficiary-service/src/beneficiary/dto/upsert-risk-condition-summary.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/upsert-risk-condition-summary.dto.ts
@@ -9,13 +9,18 @@ import { SUMMARY_PHASES } from '../beneficiary.constants';
  * forklift rule), so `gradeRank` is supplied pre-computed by the caller, who
  * does own that table and its per-condition gradeScale — see the
  * `latestGradeRank` schema comment on BeneficiaryRiskConditionSummary.
+ *
+ * `grade`/`gradeRank` are optional/nullable to also accept self-reported,
+ * ungraded entries — e.g. a mother's enrollment-time diagnosed conditions or
+ * sickle cell status, pushed by visit-form-service after a MOTHER_REGISTRATION
+ * submission, which has no rule-engine grade to compute.
  */
 export const upsertRiskConditionSummarySchema = z
   .object({
     riskConditionId: z.string().uuid(),
     phase: z.enum(SUMMARY_PHASES),
-    grade: z.string().min(1).max(50),
-    gradeRank: z.number().int(),
+    grade: z.string().min(1).max(50).nullable().optional(),
+    gradeRank: z.number().int().nullable().optional(),
     observedValueJson: z.record(z.string(), z.unknown()).nullable().optional(),
     visitId: z.string().uuid().nullable().optional(),
     submissionId: z.string().uuid().nullable().optional(),

--- a/apps/risk-referral-service/package.json
+++ b/apps/risk-referral-service/package.json
@@ -3,7 +3,14 @@
   "version": "0.1.0",
   "description": "Risk assessments, flags, referrals and follow-ups.",
   "private": true,
-  "scripts": { "prisma:generate": "prisma generate", "prisma:migrate": "prisma migrate deploy" },
+  "scripts": {
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"commonjs\",\"resolveJsonModule\":true} prisma/seed.ts"
+  },
   "dependencies": {
     "@armman/core": "*",
     "@armman/service-commons": "*",
@@ -14,5 +21,9 @@
     "pino-http": "^10.2.0",
     "zod": "^3.23.8"
   },
-  "devDependencies": { "@types/express": "^4.17.21", "prisma": "^5.18.0" }
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "prisma": "^5.18.0",
+    "ts-node": "^10.9.2"
+  }
 }

--- a/apps/risk-referral-service/prisma/seed-data/self-reported-conditions.json
+++ b/apps/risk-referral-service/prisma/seed-data/self-reported-conditions.json
@@ -1,0 +1,31 @@
+[
+  { "conditionCode": "HYPERTENSION_HIGH_BP", "conditionName": "Hypertension (High BP)" },
+  {
+    "conditionCode": "DIABETES_PRE_GESTATIONAL",
+    "conditionName": "Diabetes (Pre-gestational / diagnosed before pregnancy)"
+  },
+  {
+    "conditionCode": "GESTATIONAL_DIABETES",
+    "conditionName": "Gestational diabetes (in previous pregnancy)"
+  },
+  { "conditionCode": "THYROID_DISORDER", "conditionName": "Thyroid disorder" },
+  { "conditionCode": "HEART_DISEASE", "conditionName": "Heart disease" },
+  { "conditionCode": "EPILEPSY_SEIZURE_DISORDER", "conditionName": "Epilepsy / Seizure disorder" },
+  {
+    "conditionCode": "ASTHMA_CHRONIC_RESPIRATORY",
+    "conditionName": "Asthma / Chronic respiratory disease"
+  },
+  { "conditionCode": "KIDNEY_DISEASE", "conditionName": "Kidney disease" },
+  { "conditionCode": "THALASSEMIA", "conditionName": "Thalassemia" },
+  { "conditionCode": "LIVER_DISEASE", "conditionName": "Liver disease" },
+  { "conditionCode": "ANEMIA_SEVERE_RECURRENT", "conditionName": "Anemia (severe / recurrent)" },
+  { "conditionCode": "TUBERCULOSIS", "conditionName": "Tuberculosis (current or past)" },
+  { "conditionCode": "HIV_AIDS", "conditionName": "HIV / AIDS" },
+  { "conditionCode": "HEPATITIS_B", "conditionName": "Hepatitis B" },
+  {
+    "conditionCode": "MENTAL_HEALTH_CONDITION",
+    "conditionName": "Mental health condition (e.g., depression, anxiety)"
+  },
+  { "conditionCode": "SICKLE_CELL_DISEASE", "conditionName": "Sickle Cell Disease (SCD)" },
+  { "conditionCode": "SICKLE_CELL_TRAIT", "conditionName": "Sickle Cell Trait (SCT)/Carrier" }
+]

--- a/apps/risk-referral-service/prisma/seed.ts
+++ b/apps/risk-referral-service/prisma/seed.ts
@@ -1,0 +1,78 @@
+import { PrismaClient } from '../../../node_modules/.prisma/client-risk-referral-service';
+import selfReportedConditions from './seed-data/self-reported-conditions.json';
+
+const prisma = new PrismaClient();
+
+interface SeedResult {
+  step: string;
+  created: boolean;
+  message: string;
+}
+
+interface SelfReportedConditionSeed {
+  conditionCode: string;
+  conditionName: string;
+}
+
+/**
+ * Master data for the self-reported medical conditions and sickle cell
+ * statuses captured at enrollment (MOTHER_REGISTRATION Q58/Q60) — these have
+ * no grading rule set (gradeScale BINARY, referral/education defaults false)
+ * since they're history reported by the mother, not an evaluated risk.
+ * Content lives in ./seed-data/self-reported-conditions.json, transcribed
+ * from the MOTHER_REGISTRATION form's Q58/Q60 positive answer codes (see
+ * apps/visit-form-service/prisma/seed-data/mother-registration.json).
+ */
+async function seedSelfReportedConditions(): Promise<SeedResult> {
+  let createdCount = 0;
+
+  for (const condition of selfReportedConditions as SelfReportedConditionSeed[]) {
+    const existing = await prisma.riskCondition.findUnique({
+      where: { conditionCode: condition.conditionCode },
+    });
+    if (existing) continue;
+
+    await prisma.riskCondition.create({
+      data: {
+        conditionCode: condition.conditionCode,
+        conditionName: condition.conditionName,
+        entityType: 'MOTHER',
+        phase: 'REGISTRATION',
+        gradeScale: 'BINARY',
+        referralRequiredDefault: false,
+        educationRequiredDefault: false,
+        status: 'ACTIVE',
+      },
+    });
+    createdCount += 1;
+  }
+
+  if (createdCount === 0) {
+    return {
+      step: 'self-reported-conditions',
+      created: false,
+      message: 'All self-reported condition rows already present — skipped.',
+    };
+  }
+  return {
+    step: 'self-reported-conditions',
+    created: true,
+    message: `Seeded ${createdCount} self-reported condition row(s).`,
+  };
+}
+
+async function main(): Promise<void> {
+  const results = [await seedSelfReportedConditions()];
+
+  console.log('\nSeed summary:');
+  for (const r of results) {
+    console.log(`  [${r.created ? 'created' : 'skipped'}] ${r.step}: ${r.message}`);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/risk-referral-service/src/app.module.ts
+++ b/apps/risk-referral-service/src/app.module.ts
@@ -13,6 +13,7 @@ import { PrismaService } from './prisma/prisma.service';
 import { createHealthRouter } from './health/health.controller';
 import { createReferralModule } from './referrals/referral.module';
 import { createRiskAssessmentModule } from './risk-assessments/riskAssessment.module';
+import { createRiskConditionModule } from './risk-conditions/riskCondition.module';
 import { buildRiskReferralServiceOpenApiDocument } from './docs/openapi';
 
 // Re-export shared HTTP helpers so feature routers can import from a single place.
@@ -54,6 +55,7 @@ export function createApp(prisma: PrismaService): Application {
 
   const referralModule = createReferralModule(prisma);
   const riskAssessmentModule = createRiskAssessmentModule(prisma);
+  const riskConditionModule = createRiskConditionModule(prisma);
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();
@@ -66,11 +68,13 @@ export function createApp(prisma: PrismaService): Application {
       buildRiskReferralServiceOpenApiDocument(
         referralModule.registry,
         riskAssessmentModule.registry,
+        riskConditionModule.registry,
       ),
     ),
   );
   api.use(referralModule.router);
   api.use(riskAssessmentModule.router);
+  api.use(riskConditionModule.router);
   app.use('/api/v1', api);
 
   app.use(notFoundHandler);

--- a/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.spec.ts
+++ b/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.spec.ts
@@ -1,0 +1,41 @@
+import { listRiskConditionsQuerySchema } from './list-risk-conditions.dto';
+
+describe('listRiskConditionsQuerySchema', () => {
+  it('accepts a single condition code', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({
+      conditionCode: 'HYPERTENSION_HIGH_BP',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a comma-separated batch of condition codes', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({
+      conditionCode: 'HYPERTENSION_HIGH_BP,SICKLE_CELL_TRAIT',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing conditionCode', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty conditionCode', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({ conditionCode: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a batch larger than the max', () => {
+    const codes = Array.from({ length: 101 }, (_, i) => `CODE_${i}`).join(',');
+    const result = listRiskConditionsQuerySchema.safeParse({ conditionCode: codes });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown fields', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({
+      conditionCode: 'HYPERTENSION_HIGH_BP',
+      extra: 'nope',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.ts
+++ b/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/** Caps a single lookup batch — matches call-sheet-stats.dto.ts's own cap. */
+export const MAX_BATCH_CONDITION_CODES = 100;
+
+/**
+ * Query schema for `GET /risk-conditions?conditionCode=...` — a comma
+ * separated batch of condition codes to resolve to riskConditionIds in one
+ * round trip. Kept as a plain string + `.refine()` (not `z.coerce.*`),
+ * matching list-call-sheet-stats-batch.dto.ts's own note on why —
+ * zod-to-openapi cannot introspect a `ZodEffects`-wrapped transform and
+ * crashes OpenAPI doc generation at startup.
+ */
+export const listRiskConditionsQuerySchema = z
+  .object({
+    conditionCode: z
+      .string()
+      .trim()
+      .min(1)
+      .refine((v) => v.split(',').length <= MAX_BATCH_CONDITION_CODES, {
+        message: `conditionCode: must be a comma-separated list of at most ${MAX_BATCH_CONDITION_CODES} codes`,
+      }),
+  })
+  .strict();
+
+export type ListRiskConditionsQuery = z.infer<typeof listRiskConditionsQuerySchema>;

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.ts
@@ -1,0 +1,70 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import type { RiskConditionService } from './riskCondition.service';
+import { listRiskConditionsQuerySchema } from './dto/list-risk-conditions.dto';
+import {
+  asyncHandler,
+  createDocumentedRouter,
+  ok,
+  trustGatewayIdentity,
+  validate,
+} from '../app.module';
+
+extendZodWithOpenApi(z);
+
+const riskConditionLookupSchema = z.object({
+  conditionCode: z.string(),
+  riskConditionId: z.string().uuid(),
+});
+
+const apiErrorSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+  errorCode: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+  details: z.record(z.unknown()).optional(),
+});
+
+function envelope<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ success: z.literal(true), message: z.string(), data });
+}
+
+/**
+ * Risk condition reference-data routes. Mounted under the global `api/v1`
+ * prefix. Read-only lookup so callers outside this service (e.g.
+ * visit-form-service resolving a self-reported condition's stable code to a
+ * riskConditionId before pushing a BeneficiaryRiskConditionSummary row) never
+ * need a direct query against risk_conditions (forklift rule).
+ */
+export function createRiskConditionRouter(service: RiskConditionService) {
+  const doc = createDocumentedRouter();
+
+  doc.get(
+    '/risk-conditions',
+    {
+      summary:
+        'Resolve a comma-separated batch of condition codes to their riskConditionId. ' +
+        'Codes with no matching ACTIVE row are omitted from the response rather than ' +
+        'failing the whole batch.',
+      tags: ['Risk Conditions'],
+      responses: {
+        200: {
+          description: 'Resolved condition lookups (may be a subset of the requested codes)',
+          schema: envelope(z.array(riskConditionLookupSchema)),
+        },
+        400: { description: 'Missing/malformed conditionCode query param', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    validate(listRiskConditionsQuerySchema, 'query'),
+    asyncHandler(async (req, res) => {
+      const codes = String(req.query.conditionCode)
+        .split(',')
+        .map((c) => c.trim());
+      const found = await service.listByConditionCodes(codes);
+      res.json(ok(found));
+    }),
+  );
+
+  return doc;
+}

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.module.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.module.ts
@@ -1,0 +1,15 @@
+import type { DocumentedRouter } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { RiskConditionRepository } from './riskCondition.repository';
+import { RiskConditionService } from './riskCondition.service';
+import { createRiskConditionRouter } from './riskCondition.controller';
+
+/**
+ * Composition root for the risk-conditions feature: wires repository →
+ * service → router.
+ */
+export function createRiskConditionModule(prisma: PrismaService): DocumentedRouter {
+  const repository = new RiskConditionRepository(prisma);
+  const service = new RiskConditionService(repository);
+  return createRiskConditionRouter(service);
+}

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.repository.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.repository.ts
@@ -1,0 +1,14 @@
+import type { PrismaService } from '../prisma/prisma.service';
+
+/** Data access for risk_conditions reference data. Read-only from this feature. */
+export class RiskConditionRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Active, non-deleted RiskCondition rows matching any of the given codes. */
+  findByConditionCodes(conditionCodes: string[]) {
+    return this.prisma.riskCondition.findMany({
+      where: { conditionCode: { in: conditionCodes }, status: 'ACTIVE', isDeleted: false },
+      select: { id: true, conditionCode: true },
+    });
+  }
+}

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.service.spec.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.service.spec.ts
@@ -1,0 +1,51 @@
+import { RiskConditionService } from './riskCondition.service';
+import type { RiskConditionRepository } from './riskCondition.repository';
+
+describe('RiskConditionService', () => {
+  const repository = {
+    findByConditionCodes: jest.fn(),
+  } as unknown as jest.Mocked<RiskConditionRepository>;
+  let service: RiskConditionService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new RiskConditionService(repository);
+  });
+
+  describe('listByConditionCodes', () => {
+    it('returns riskConditionId for each resolved condition code', async () => {
+      repository.findByConditionCodes.mockResolvedValue([
+        { id: 'rc-1', conditionCode: 'HYPERTENSION_HIGH_BP' },
+        { id: 'rc-2', conditionCode: 'SICKLE_CELL_TRAIT' },
+      ] as never);
+
+      const result = await service.listByConditionCodes([
+        'HYPERTENSION_HIGH_BP',
+        'SICKLE_CELL_TRAIT',
+      ]);
+
+      expect(result).toEqual([
+        { conditionCode: 'HYPERTENSION_HIGH_BP', riskConditionId: 'rc-1' },
+        { conditionCode: 'SICKLE_CELL_TRAIT', riskConditionId: 'rc-2' },
+      ]);
+    });
+
+    it('omits codes the repository did not resolve, without throwing', async () => {
+      repository.findByConditionCodes.mockResolvedValue([
+        { id: 'rc-1', conditionCode: 'HYPERTENSION_HIGH_BP' },
+      ] as never);
+
+      const result = await service.listByConditionCodes(['HYPERTENSION_HIGH_BP', 'UNSEEDED_CODE']);
+
+      expect(result).toEqual([{ conditionCode: 'HYPERTENSION_HIGH_BP', riskConditionId: 'rc-1' }]);
+    });
+
+    it('returns an empty array when no codes resolve', async () => {
+      repository.findByConditionCodes.mockResolvedValue([]);
+
+      const result = await service.listByConditionCodes(['UNKNOWN']);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.service.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.service.ts
@@ -1,0 +1,23 @@
+import type { RiskConditionRepository } from './riskCondition.repository';
+
+/**
+ * Business logic for resolving risk_conditions reference data. Read-only
+ * lookup, used by other services to resolve a stable conditionCode (e.g.
+ * "HYPERTENSION_HIGH_BP") to the riskConditionId a BeneficiaryRiskConditionSummary
+ * row needs — this service owns risk_conditions, so no other service may
+ * query it directly (forklift rule, no cross-service joins).
+ */
+export class RiskConditionService {
+  constructor(private readonly repository: RiskConditionRepository) {}
+
+  /**
+   * Resolves each of the given condition codes to its riskConditionId.
+   * Codes with no matching ACTIVE row are silently omitted from the result —
+   * the caller decides what to do with an unresolved code (e.g. skip it)
+   * rather than the whole batch failing for one unseeded/retired code.
+   */
+  async listByConditionCodes(conditionCodes: string[]) {
+    const found = await this.repository.findByConditionCodes(conditionCodes);
+    return found.map((c) => ({ conditionCode: c.conditionCode, riskConditionId: c.id }));
+  }
+}

--- a/apps/visit-form-service/src/beneficiaries/health-history.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/health-history.client.spec.ts
@@ -1,0 +1,222 @@
+import { extractSelfReportedConditionCodes, syncHealthHistory } from './health-history.client';
+
+const Q58 =
+  'have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions';
+const Q60 = 'have_you_been_detected_with_sickle_cell_disease_or_sickle_cell_trait_sct';
+
+describe('extractSelfReportedConditionCodes', () => {
+  it('maps a single Q58 positive code to its risk condition code', () => {
+    expect(extractSelfReportedConditionCodes({ [Q58]: ['hypertension_high_bp'] })).toEqual([
+      'HYPERTENSION_HIGH_BP',
+    ]);
+  });
+
+  it('maps multiple Q58 positive codes', () => {
+    expect(
+      extractSelfReportedConditionCodes({
+        [Q58]: ['hypertension_high_bp', 'hiv_aids', 'tuberculosis_current_or_past'],
+      }),
+    ).toEqual(['HYPERTENSION_HIGH_BP', 'HIV_AIDS', 'TUBERCULOSIS']);
+  });
+
+  it('excludes "no known medical condition"', () => {
+    expect(extractSelfReportedConditionCodes({ [Q58]: ['no_known_medical_condition'] })).toEqual(
+      [],
+    );
+  });
+
+  it('excludes "don\'t know" for Q58', () => {
+    expect(extractSelfReportedConditionCodes({ [Q58]: ['don_t_know'] })).toEqual([]);
+  });
+
+  it('maps Q60 "Sickle Cell Disease (SCD)"', () => {
+    expect(extractSelfReportedConditionCodes({ [Q60]: 'sickle_cell_disease_scd' })).toEqual([
+      'SICKLE_CELL_DISEASE',
+    ]);
+  });
+
+  it('maps Q60 "Sickle Cell Trait (SCT)/Carrier"', () => {
+    expect(extractSelfReportedConditionCodes({ [Q60]: 'sickle_cell_trait_sct_carrier' })).toEqual([
+      'SICKLE_CELL_TRAIT',
+    ]);
+  });
+
+  it.each([
+    'tested_and_result_is_normal',
+    'not_tested_yet',
+    'don_t_know_not_aware',
+    'tested_earlier_but_result_not_available',
+  ])('excludes Q60 negative code %s', (code) => {
+    expect(extractSelfReportedConditionCodes({ [Q60]: code })).toEqual([]);
+  });
+
+  it('combines Q58 and Q60 positives with no duplicates', () => {
+    expect(
+      extractSelfReportedConditionCodes({
+        [Q58]: ['hypertension_high_bp', 'thyroid_disorder'],
+        [Q60]: 'sickle_cell_trait_sct_carrier',
+      }),
+    ).toEqual(['HYPERTENSION_HIGH_BP', 'THYROID_DISORDER', 'SICKLE_CELL_TRAIT']);
+  });
+
+  it('returns an empty array when neither question was answered', () => {
+    expect(extractSelfReportedConditionCodes({})).toEqual([]);
+    expect(extractSelfReportedConditionCodes({ trimester_of_preganancy: '1' })).toEqual([]);
+  });
+
+  it('ignores unrelated formData keys without throwing', () => {
+    expect(
+      extractSelfReportedConditionCodes({ trimester_of_preganancy: '1', remarks: 'a note' }),
+    ).toEqual([]);
+  });
+});
+
+describe('syncHealthHistory', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('makes no fetch calls when nothing was extracted', async () => {
+    await syncHealthHistory('b1', {}, 'Bearer test-token');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves one condition and PATCHes a single ungraded summary row', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ conditionCode: 'HYPERTENSION_HIGH_BP', riskConditionId: 'rc-1' }],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await syncHealthHistory('b1', { [Q58]: ['hypertension_high_bp'] }, 'Bearer test-token');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('/risk-conditions?conditionCode=HYPERTENSION_HIGH_BP'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('/beneficiaries/b1/risk-condition-summary'),
+      expect.objectContaining({
+        method: 'PATCH',
+        body: expect.stringContaining('"riskConditionId":"rc-1"'),
+      }),
+    );
+    const secondCallBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(secondCallBody).toMatchObject({
+      riskConditionId: 'rc-1',
+      phase: 'REGISTRATION',
+      isReferralTrigger: false,
+      isHrVisitTrigger: false,
+    });
+    expect(secondCallBody.grade).toBeUndefined();
+    expect(secondCallBody.gradeRank).toBeUndefined();
+  });
+
+  it('sends one PATCH per resolved condition for multiple positives', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { conditionCode: 'HYPERTENSION_HIGH_BP', riskConditionId: 'rc-1' },
+            { conditionCode: 'SICKLE_CELL_TRAIT', riskConditionId: 'rc-2' },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await syncHealthHistory(
+      'b1',
+      { [Q58]: ['hypertension_high_bp'], [Q60]: 'sickle_cell_trait_sct_carrier' },
+      'Bearer test-token',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips a condition code the lookup did not resolve, without throwing', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ conditionCode: 'HYPERTENSION_HIGH_BP', riskConditionId: 'rc-1' }],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await syncHealthHistory(
+      'b1',
+      { [Q58]: ['hypertension_high_bp', 'hiv_aids'] },
+      'Bearer test-token',
+    );
+
+    // Lookup returned only one of the two requested codes — only one PATCH follows.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows a non-ok lookup response and makes no PATCH calls', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await expect(
+      syncHealthHistory('b1', { [Q58]: ['hypertension_high_bp'] }, 'Bearer test-token'),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows a lookup network failure and makes no PATCH calls', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(
+      syncHealthHistory('b1', { [Q58]: ['hypertension_high_bp'] }, 'Bearer test-token'),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows a PATCH failure for one condition and still attempts the remaining ones', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { conditionCode: 'HYPERTENSION_HIGH_BP', riskConditionId: 'rc-1' },
+            { conditionCode: 'SICKLE_CELL_TRAIT', riskConditionId: 'rc-2' },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    await syncHealthHistory(
+      'b1',
+      { [Q58]: ['hypertension_high_bp'], [Q60]: 'sickle_cell_trait_sct_carrier' },
+      'Bearer test-token',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/visit-form-service/src/beneficiaries/health-history.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/health-history.client.ts
@@ -1,0 +1,146 @@
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — matches geography.client.ts's/
+// socio-demographics.client.ts's stance.
+const API_GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+/**
+ * Q58's positive (diagnosed/treated) answer codes, mapped to the stable
+ * risk_conditions.conditionCode seeded for each — negative/unknown codes
+ * ("no_known_medical_condition", "don_t_know") are intentionally absent so
+ * they never resolve to a condition.
+ */
+const DIAGNOSED_CONDITION_CODE_TO_RISK_CONDITION_CODE: Record<string, string> = {
+  hypertension_high_bp: 'HYPERTENSION_HIGH_BP',
+  diabetes_pre_gestational_diagnosed_before_pregnancy: 'DIABETES_PRE_GESTATIONAL',
+  gestational_diabetes_in_previous_pregnancy: 'GESTATIONAL_DIABETES',
+  thyroid_disorder: 'THYROID_DISORDER',
+  heart_disease: 'HEART_DISEASE',
+  epilepsy_seizure_disorder: 'EPILEPSY_SEIZURE_DISORDER',
+  asthma_chronic_respiratory_disease: 'ASTHMA_CHRONIC_RESPIRATORY',
+  kidney_disease: 'KIDNEY_DISEASE',
+  thalassemia: 'THALASSEMIA',
+  liver_disease: 'LIVER_DISEASE',
+  anemia_severe_recurrent: 'ANEMIA_SEVERE_RECURRENT',
+  tuberculosis_current_or_past: 'TUBERCULOSIS',
+  hiv_aids: 'HIV_AIDS',
+  hepatitis_b: 'HEPATITIS_B',
+  mental_health_condition_e_g_depression_anxiety: 'MENTAL_HEALTH_CONDITION',
+};
+
+/** Q60's two positive (detected) answer codes, mapped the same way. */
+const SICKLE_CELL_STATUS_CODE_TO_RISK_CONDITION_CODE: Record<string, string> = {
+  sickle_cell_disease_scd: 'SICKLE_CELL_DISEASE',
+  sickle_cell_trait_sct_carrier: 'SICKLE_CELL_TRAIT',
+};
+
+const Q58_QUESTION_CODE =
+  'have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions';
+const Q60_QUESTION_CODE =
+  'have_you_been_detected_with_sickle_cell_disease_or_sickle_cell_trait_sct';
+
+/**
+ * Extracts the risk_conditions.conditionCodes implied by a MOTHER_REGISTRATION
+ * submission's Q58 (multiselect diagnosed/treated conditions) and Q60
+ * (single-select sickle cell status) answers. Returns an empty array when
+ * neither question was answered with a positive code — nothing to sync.
+ */
+export function extractSelfReportedConditionCodes(formData: Record<string, unknown>): string[] {
+  const codes: string[] = [];
+
+  const q58 = formData[Q58_QUESTION_CODE];
+  const q58Answers = Array.isArray(q58) ? q58 : typeof q58 === 'string' ? [q58] : [];
+  for (const answer of q58Answers) {
+    if (typeof answer !== 'string') continue;
+    const mapped = DIAGNOSED_CONDITION_CODE_TO_RISK_CONDITION_CODE[answer];
+    if (mapped) codes.push(mapped);
+  }
+
+  const q60 = formData[Q60_QUESTION_CODE];
+  if (typeof q60 === 'string') {
+    const mapped = SICKLE_CELL_STATUS_CODE_TO_RISK_CONDITION_CODE[q60];
+    if (mapped) codes.push(mapped);
+  }
+
+  return [...new Set(codes)];
+}
+
+/**
+ * Pushes a MOTHER_REGISTRATION submission's self-reported diagnosed
+ * conditions and sickle cell status to beneficiary-service as
+ * BeneficiaryRiskConditionSummary rows, resolving each conditionCode to its
+ * riskConditionId via risk-referral-service first (this service owns neither
+ * table — no cross-service joins per the forklift rule).
+ *
+ * Best-effort by design, matching syncSocioDemographics's stance: the
+ * submission itself is already durably saved by the time this runs, and
+ * form_submissions.form_data_json keeps every answer verbatim regardless. A
+ * failure here is logged and swallowed rather than failing the Sakhi's
+ * submission.
+ */
+export async function syncHealthHistory(
+  beneficiaryId: string,
+  formData: Record<string, unknown>,
+  authorizationHeader: string,
+): Promise<void> {
+  const conditionCodes = extractSelfReportedConditionCodes(formData);
+  if (conditionCodes.length === 0) return;
+
+  let resolved: { conditionCode: string; riskConditionId: string }[];
+  try {
+    const res = await fetch(
+      `${API_GATEWAY_BASE_URL}/api/v1/risk-conditions?conditionCode=${conditionCodes.join(',')}`,
+      { headers: { Authorization: authorizationHeader } },
+    );
+    if (!res.ok) {
+      console.warn(
+        `Failed to resolve self-reported condition codes for beneficiary ${beneficiaryId} ` +
+          `(risk-referral-service returned ${res.status}); the submission itself was still saved.`,
+      );
+      return;
+    }
+    const body = (await res.json()) as {
+      data: { conditionCode: string; riskConditionId: string }[];
+    };
+    resolved = body.data;
+  } catch (err) {
+    console.warn(
+      `Unable to reach risk-referral-service to resolve self-reported condition codes for ` +
+        `beneficiary ${beneficiaryId}; the submission itself was still saved. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  const assessedAt = new Date().toISOString();
+  for (const { riskConditionId } of resolved) {
+    try {
+      const res = await fetch(
+        `${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/risk-condition-summary`,
+        {
+          method: 'PATCH',
+          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            riskConditionId,
+            phase: 'REGISTRATION',
+            assessedAt,
+            isReferralTrigger: false,
+            isHrVisitTrigger: false,
+          }),
+        },
+      );
+      if (!res.ok) {
+        console.warn(
+          `Failed to sync health history for beneficiary ${beneficiaryId}, condition ` +
+            `${riskConditionId} (beneficiary-service returned ${res.status}); the submission ` +
+            'itself was still saved.',
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `Unable to reach beneficiary-service to sync health history for beneficiary ` +
+          `${beneficiaryId}, condition ${riskConditionId}; the submission itself was still ` +
+          `saved. ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -2,9 +2,11 @@ import { FormService } from './form.service';
 import type { FormRepository } from './form.repository';
 import * as geographyClient from '../geography/geography.client';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
+import { syncHealthHistory } from '../beneficiaries/health-history.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
+jest.mock('../beneficiaries/health-history.client');
 
 describe('FormService', () => {
   const repository = {
@@ -589,6 +591,89 @@ describe('FormService', () => {
       );
 
       expect(jest.mocked(syncSocioDemographics)).not.toHaveBeenCalled();
+    });
+
+    it('syncs self-reported health history to beneficiary-service for MOTHER_REGISTRATION', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue(publishedVersion as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+      const formData = {
+        phone_owner: 'SELF',
+        have_you_ever_been_diagnosed_with_or_treated_for_any_of_the_following_medical_conditions: [
+          'hypertension_high_bp',
+        ],
+      };
+
+      await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData,
+        },
+        'u1',
+        'Bearer test-token',
+      );
+
+      expect(jest.mocked(syncHealthHistory)).toHaveBeenCalledWith(
+        'b1',
+        formData,
+        'Bearer test-token',
+      );
+    });
+
+    it('does not sync health history for a non-MOTHER_REGISTRATION form', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue({
+        ...publishedVersion,
+        formDefinition: { formCode: 'CHILD_REGISTRATION' },
+      } as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+      await service.createSubmission(
+        'CHILD_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData: { phone_owner: 'SELF' },
+        },
+        'u1',
+        'Bearer test-token',
+      );
+
+      expect(jest.mocked(syncHealthHistory)).not.toHaveBeenCalled();
+    });
+
+    it('syncs both socio-demographics and health history for the same MOTHER_REGISTRATION submission', async () => {
+      repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+      repository.findVersionById.mockResolvedValue(publishedVersion as never);
+      repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+      const formData = { phone_owner: 'SELF', what_is_your_religion: 'hindu' };
+
+      await service.createSubmission(
+        'MOTHER_REGISTRATION',
+        {
+          formVersionId: 'version-1',
+          beneficiaryId: 'b1',
+          localSubmissionUuid: 'uuid-1',
+          formData,
+        },
+        'u1',
+        'Bearer test-token',
+      );
+
+      expect(jest.mocked(syncSocioDemographics)).toHaveBeenCalledWith(
+        'b1',
+        formData,
+        'Bearer test-token',
+      );
+      expect(jest.mocked(syncHealthHistory)).toHaveBeenCalledWith(
+        'b1',
+        formData,
+        'Bearer test-token',
+      );
     });
 
     it('decomposes formData into typed form_answers and passes them to the repository', () => {

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -12,6 +12,7 @@ import {
 } from './form.mapper';
 import { validateSubmission } from './form-validation';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
+import { syncHealthHistory } from '../beneficiaries/health-history.client';
 import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
@@ -193,6 +194,7 @@ export class FormService {
     // after the submission is durably saved — see syncSocioDemographics.
     if (formCode === 'MOTHER_REGISTRATION') {
       await syncSocioDemographics(dto.beneficiaryId, dto.formData, authorizationHeader);
+      await syncHealthHistory(dto.beneficiaryId, dto.formData, authorizationHeader);
     }
 
     // Triggers the risk-grading pipeline for every visit-linked submission

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,7 +249,51 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
-        "prisma": "^5.18.0"
+        "prisma": "^5.18.0",
+        "ts-node": "^10.9.2"
+      }
+    },
+    "apps/risk-referral-service/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "apps/rules-service": {


### PR DESCRIPTION
## Summary
- `GET /beneficiaries/:id` always returned an empty `riskConditionSummaries` for a mother's Q58 (diagnosed conditions) and Q60 (sickle cell status) enrollment answers — the app only showed them correctly when reading the same device's local cache. This never populated for a supervisor, a different device, or after a reinstall.
- `beneficiary-service`'s `create()` has no access to these answers (they live only in `visit-form-service`'s MOTHER_REGISTRATION submission), and `BeneficiaryRiskConditionSummary` is a graded clinical-risk rollup, not a flat conditions list — so instead of wiring `create()`, this pushes the resolved conditions right after MOTHER_REGISTRATION is submitted, mirroring the existing socio-demographics sync pattern.
- Adds `GET /risk-conditions?conditionCode=...` on risk-referral-service to resolve condition codes to `riskConditionId`s, seeds 17 ungraded `RiskCondition` rows (15 Q58 conditions + SCD/SCT), relaxes `grade`/`gradeRank` to nullable on beneficiary-service's upsert DTO for these self-reported entries, and adds `health-history.client.ts` in visit-form-service to extract + sync them.

## Test plan
- [x] `npx nx affected --target=lint,test --base=origin/develop` — 3 affected projects (beneficiary-service, risk-referral-service, visit-form-service), all lint clean, 494 tests passing, 0 failures
- [x] Verified the existing graded risk-assessment pipeline (risk-referral-service → beneficiary-service) is behaviorally unchanged for non-null grade/gradeRank — the new null-handling logic in `upsertRiskConditionSummary` algebraically reduces to the old formula for any non-null input
- [x] Confirmed no other consumer reads `latestGrade`/`everHighestGrade`/`everAtRiskFlag` assuming always-non-null (the one aggregation that reads them, `countByRiskGrade`, already handles null via `?? 'UNGRADED'`)
- [ ] Seed must be run in each target environment (`npm run seed` at repo root) before self-reported conditions can resolve via the new lookup endpoint

## Follow-ups / known limitations
- `everAtRiskFlag=true` is set unconditionally for these self-reported rows (a reported condition is treated as inherently a risk signal) — worth confirming downstream UI/reports that filter on this flag are fine mixing self-reported entries alongside rule-graded ones.
- No new Prisma migration needed — only new seed data and DTO relaxation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)