### PR TITLE
fix(beneficiary-service): Enforce ownership check on GET /beneficiaries/:id

### DIFF
--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -363,9 +363,10 @@ export function createBeneficiaryRouter(service: BeneficiaryService) {
     requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     validate(idParamsSchema, 'params'),
     asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');
       if (!authorizationHeader) return next(unauthorized());
-      res.json(ok(await service.getById(req.params.id, authorizationHeader)));
+      res.json(ok(await service.getById(req.params.id, req.user, authorizationHeader)));
     }),
   );
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -734,7 +734,7 @@ describe('BeneficiaryService', () => {
       };
       repository.findById.mockResolvedValue(found as never);
 
-      const result = await service.getById('x', AUTH_HEADER);
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(result.riskConditionSummaries).toEqual(found.riskConditionSummaries);
       expect(result.statusHistory).toEqual(found.statusHistory);
@@ -744,7 +744,7 @@ describe('BeneficiaryService', () => {
       const found = { id: 'x', pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') } };
       repository.findById.mockResolvedValue(found as never);
 
-      const result = await service.getById('x', AUTH_HEADER);
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -756,7 +756,80 @@ describe('BeneficiaryService', () => {
 
     it('throws 404 when the case is not found', async () => {
       repository.findById.mockResolvedValue(null);
-      await expect(service.getById('missing', AUTH_HEADER)).rejects.toMatchObject({ status: 404 });
+      await expect(
+        service.getById('missing', caller({ roles: ['ADMIN'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('403s when a SAKHI requests a beneficiary that is not their own', async () => {
+      const found = {
+        id: 'x',
+        sakhiId: 'someone-elses-sakhi-id',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      await expect(
+        service.getById('x', caller({ roles: ['SAKHI'], id: CALLER_ID }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('allows a SAKHI to fetch their own beneficiary', async () => {
+      const found = {
+        id: 'x',
+        sakhiId: CALLER_ID,
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById(
+        'x',
+        caller({ roles: ['SAKHI'], id: CALLER_ID }),
+        AUTH_HEADER,
+      );
+
+      expect(result.id).toBe('x');
+    });
+
+    it("403s when a SUPERVISOR's roster does not include the beneficiary's Sakhi", async () => {
+      const found = {
+        id: 'x',
+        sakhiId: 'not-in-roster',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      };
+      repository.findById.mockResolvedValue(found as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['some-other-sakhi']);
+
+      await expect(
+        service.getById('x', caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('allows a SUPERVISOR to fetch a beneficiary in their own roster', async () => {
+      const found = {
+        id: 'x',
+        sakhiId: 'roster-sakhi',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      };
+      repository.findById.mockResolvedValue(found as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['roster-sakhi']);
+
+      const result = await service.getById('x', caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER);
+
+      expect(result.id).toBe('x');
+    });
+
+    it('allows a MANAGER/ADMIN caller unrestricted', async () => {
+      const found = {
+        id: 'x',
+        sakhiId: 'anyones',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.id).toBe('x');
     });
 
     it('passes through socioDemographics from the repository', async () => {
@@ -767,7 +840,7 @@ describe('BeneficiaryService', () => {
       };
       repository.findById.mockResolvedValue(found as never);
 
-      const result = await service.getById('x', AUTH_HEADER);
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(result.socioDemographics).toMatchObject({
         familyMembersCount: 4,
@@ -797,7 +870,7 @@ describe('BeneficiaryService', () => {
         socialCategoryLookupId: null,
       });
 
-      const result = await service.getById('x', AUTH_HEADER);
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(resolveLookupValuesMock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -822,7 +895,7 @@ describe('BeneficiaryService', () => {
       };
       repository.findById.mockResolvedValue(found as never);
 
-      const result = await service.getById('x', AUTH_HEADER);
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(resolveLookupValuesMock).not.toHaveBeenCalled();
       expect(result.socioDemographics).toBeNull();
@@ -836,7 +909,7 @@ describe('BeneficiaryService', () => {
       };
       repository.findById.mockResolvedValue(found as never);
 
-      const result = await service.getById('x', AUTH_HEADER);
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(result.socioDemographics).toBeNull();
     });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -422,8 +422,47 @@ export class BeneficiaryService {
     });
   }
 
-  async getById(id: string, authorizationHeader: string) {
+  /**
+   * Gated by requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER') at the route —
+   * same as upsertRiskConditionSummary, assertCallerCanTouchCase alone
+   * doesn't cover this route since it only scopes SUPERVISOR callers,
+   * early-returning for everyone else. A SAKHI reaching this method must be
+   * checked explicitly against the case's own sakhiId, or any authenticated
+   * Sakhi could fetch any beneficiary's full profile by id regardless of
+   * whose case it is (ADMIN is not in this route's role list, so MANAGER is
+   * the only unrestricted caller here).
+   */
+  async getById(id: string, caller: AuthenticatedUser, authorizationHeader: string) {
     const found = await this.repository.findById(id);
+    if (!found) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (found.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else {
+      await assertCallerCanTouchCase(found.sakhiId, caller, authorizationHeader);
+    }
+
+    return this.projectCase(id, authorizationHeader, found);
+  }
+
+  /**
+   * Decrypts/enriches a case row for the response envelope, without any
+   * ownership check — only for use by callers that have already verified
+   * (or, per their own route's role gate, can't reach a case outside their
+   * own scope) that the requester may see this record: getById (after its
+   * own check above) and the post-mutation re-fetches in
+   * upsertSocioDemographics/applyLmpChange/reactivateCase (each of which
+   * already ran assertCallerCanTouchCase/the SAKHI-ownership check before
+   * reaching this point). Never call this directly from a route handler.
+   */
+  private async projectCase(
+    id: string,
+    authorizationHeader: string,
+    prefetched?: Awaited<ReturnType<BeneficiaryRepository['findById']>>,
+  ) {
+    const found = prefetched ?? (await this.repository.findById(id));
     if (!found) throw notFound('Beneficiary case not found.');
     const projected = withDecryptedName(found);
     return withResolvedSocioDemographics(projected, authorizationHeader);
@@ -493,7 +532,7 @@ export class BeneficiaryService {
     if (dto.childrenUnder5Count !== undefined) data.childrenUnder5Count = dto.childrenUnder5Count;
 
     await this.repository.upsertSocioDemographics(beneficiaryId, data);
-    return this.getById(beneficiaryId, authorizationHeader);
+    return this.projectCase(beneficiaryId, authorizationHeader);
   }
 
   /**
@@ -527,7 +566,7 @@ export class BeneficiaryService {
     const eddDate = addDays(lmpDate, GESTATION_DAYS);
     const updated = await this.repository.updateMotherLmp(beneficiaryId, lmpDate, eddDate);
     if (!updated) throw notFound('Beneficiary case not found.');
-    return this.getById(beneficiaryId, authorizationHeader);
+    return this.projectCase(beneficiaryId, authorizationHeader);
   }
 
   /**
@@ -562,7 +601,7 @@ export class BeneficiaryService {
       throw conflict(`Cannot reactivate a case with status ${existing.currentStatus}.`);
     }
 
-    return this.getById(beneficiaryId, authorizationHeader);
+    return this.projectCase(beneficiaryId, authorizationHeader);
   }
 
   /**

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -452,10 +452,13 @@ export class BeneficiaryService {
    * ownership check — only for use by callers that have already verified
    * (or, per their own route's role gate, can't reach a case outside their
    * own scope) that the requester may see this record: getById (after its
-   * own check above) and the post-mutation re-fetches in
-   * upsertSocioDemographics/applyLmpChange/reactivateCase (each of which
-   * already ran assertCallerCanTouchCase/the SAKHI-ownership check before
-   * reaching this point). Never call this directly from a route handler.
+   * own check above) and the post-mutation re-fetches in applyLmpChange/
+   * reactivateCase (each of which already ran assertCallerCanTouchCase
+   * before reaching this point). upsertSocioDemographics also calls this,
+   * but takes no caller and runs no ownership check of its own — a known,
+   * separately-tracked gap (see PATCH /beneficiaries/:id/socio-demographics
+   * in the PR description), not something this helper covers for it. Never
+   * call this directly from a route handler.
    */
   private async projectCase(
     id: string,

--- a/apps/rules-service/prisma/seed.ts
+++ b/apps/rules-service/prisma/seed.ts
@@ -1,5 +1,12 @@
 import { createHash } from 'node:crypto';
 import { PrismaClient } from '../../../node_modules/.prisma/client-rules-service';
+import { ancRulesJson } from '../src/rules/scheduling/anc.rulesJson';
+import { ppRulesJson } from '../src/rules/scheduling/pp.rulesJson';
+import { nnRulesJson } from '../src/rules/scheduling/nn.rulesJson';
+import { incRulesJson } from '../src/rules/scheduling/inc.rulesJson';
+import { ccvRulesJson } from '../src/rules/scheduling/ccv.rulesJson';
+import { hrRulesJson } from '../src/rules/scheduling/hr.rulesJson';
+import { deliveryRulesJson } from '../src/rules/scheduling/delivery.rulesJson';
 
 const prisma = new PrismaClient();
 
@@ -10,6 +17,90 @@ const prisma = new PrismaClient();
 const SCHEDULE_RULE_SET_ID = '11111111-1111-4111-8111-111111111111';
 const SCHEDULE_RULE_VERSION_ID = '22222222-2222-4222-8222-222222222222';
 const SCHEDULE_RULE_VERSION_NO = 'v1-hardcoded';
+
+/**
+ * The seven real scheduling rule packs (SRS §3A.2.3, Appendix A/B/D/G),
+ * seeded alongside — not replacing — the generic placeholder SCHEDULE set
+ * above. Each gets its own fixed UUID pair (rule set + v1 published
+ * version) so environments stay in sync, following the exact upsert-once
+ * pattern used for SCHEDULE_RULE_SET_ID: `update: {}` on both upserts means
+ * this only ever creates the rows on a fresh environment. A real change to
+ * one of these packs is a new versionNo (a new row) via
+ * POST /admin/rules/:setId/publish, never an edit of the seeded v1 here.
+ */
+const SCHEDULING_RULE_PACKS = [
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333331',
+    ruleVersionId: '33333333-3333-4333-8333-333333333332',
+    ruleSetName: 'Arogya Sakhi ANC Visit Scheduling',
+    rulesJson: ancRulesJson,
+  },
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333341',
+    ruleVersionId: '33333333-3333-4333-8333-333333333342',
+    ruleSetName: 'Arogya Sakhi PP Visit Scheduling',
+    rulesJson: ppRulesJson,
+  },
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333351',
+    ruleVersionId: '33333333-3333-4333-8333-333333333352',
+    ruleSetName: 'Arogya Sakhi NN Visit Scheduling',
+    rulesJson: nnRulesJson,
+  },
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333361',
+    ruleVersionId: '33333333-3333-4333-8333-333333333362',
+    ruleSetName: 'Arogya Sakhi INC Visit Scheduling',
+    rulesJson: incRulesJson,
+  },
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333371',
+    ruleVersionId: '33333333-3333-4333-8333-333333333372',
+    ruleSetName: 'Arogya Sakhi CCV Visit Scheduling',
+    rulesJson: ccvRulesJson,
+  },
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333381',
+    ruleVersionId: '33333333-3333-4333-8333-333333333382',
+    ruleSetName: 'Arogya Sakhi HR Visit Scheduling',
+    rulesJson: hrRulesJson,
+  },
+  {
+    ruleSetId: '33333333-3333-4333-8333-333333333391',
+    ruleVersionId: '33333333-3333-4333-8333-333333333392',
+    ruleSetName: 'Arogya Sakhi Delivery Combined Visit Scheduling',
+    rulesJson: deliveryRulesJson,
+  },
+] as const;
+
+async function seedSchedulingRulePacks(): Promise<void> {
+  for (const pack of SCHEDULING_RULE_PACKS) {
+    await prisma.ruleSet.upsert({
+      where: { id: pack.ruleSetId },
+      create: {
+        id: pack.ruleSetId,
+        ruleCategory: 'SCHEDULE',
+        ruleSetName: pack.ruleSetName,
+        status: 'ACTIVE',
+      },
+      update: {},
+    });
+
+    await prisma.ruleVersion.upsert({
+      where: { id: pack.ruleVersionId },
+      create: {
+        id: pack.ruleVersionId,
+        ruleSetId: pack.ruleSetId,
+        versionNo: 'v1',
+        rulesJson: pack.rulesJson,
+        effectiveFrom: new Date('2026-08-10'),
+        checksum: createHash('sha256').update(JSON.stringify(pack.rulesJson)).digest(),
+        status: 'PUBLISHED',
+      },
+      update: {},
+    });
+  }
+}
 
 /**
  * Seeds the SCHEDULE rule set + its v1-hardcoded published version, so
@@ -60,6 +151,11 @@ async function seedScheduleRuleVersion(): Promise<void> {
 async function main(): Promise<void> {
   await seedScheduleRuleVersion();
   console.log(`Seeded SCHEDULE rule version: ${SCHEDULE_RULE_VERSION_ID}`);
+
+  await seedSchedulingRulePacks();
+  console.log(
+    `Seeded ${SCHEDULING_RULE_PACKS.length} scheduling rule packs (ANC/PP/NN/INC/CCV/HR/DELIVERY).`,
+  );
 }
 
 main()

--- a/apps/rules-service/src/rules/dto/evaluate-schedule.dto.ts
+++ b/apps/rules-service/src/rules/dto/evaluate-schedule.dto.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { SCHEDULE_KINDS } from '../scheduleEvaluator';
+
+/** Recursive JSON value type usable inside nested objects/arrays. */
+type NestedJsonValue =
+  string | number | boolean | null | NestedJsonValue[] | { [key: string]: NestedJsonValue };
+
+const nestedJsonValueSchema: z.ZodType<NestedJsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(nestedJsonValueSchema),
+    z.record(nestedJsonValueSchema),
+  ]),
+);
+
+/**
+ * Request body for `POST /rules/:setId/evaluate-schedule`. `scheduleKind`
+ * tells scheduleEvaluator.ts which of the seven output contracts to
+ * validate against — it is supplied by the caller (who knows which journey
+ * this rule set represents), not inferred from the rule set row itself,
+ * since RuleSet has no scheduleKind column (only the generic
+ * RuleCategory.SCHEDULE). `input` is the arbitrary JSON context fed to the
+ * decision graph (registrationDate/edd for ANC, dob/registrationDate for
+ * INC, etc.) — shape is defined by whichever rulesJson pack is published.
+ */
+export const evaluateScheduleSchema = z
+  .object({
+    scheduleKind: z.enum(SCHEDULE_KINDS),
+    input: z.record(nestedJsonValueSchema),
+  })
+  .strict();
+
+export type EvaluateScheduleInput = z.infer<typeof evaluateScheduleSchema>;

--- a/apps/rules-service/src/rules/ruleSet.evaluator.ts
+++ b/apps/rules-service/src/rules/ruleSet.evaluator.ts
@@ -59,8 +59,12 @@ export async function evaluateRulePack(
   const engine = new ZenEngine();
   const content = new ZenDecisionContent(rulesJson as object);
   const decision = engine.createDecision(content);
-  const response = await decision.evaluate(answers);
-  engine.dispose();
+  let response;
+  try {
+    response = await decision.evaluate(answers);
+  } finally {
+    engine.dispose();
+  }
 
   const result = response.result;
   if (typeof result !== 'object' || result === null) {

--- a/apps/rules-service/src/rules/ruleVersion.controller.ts
+++ b/apps/rules-service/src/rules/ruleVersion.controller.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import type { RuleVersionService } from './ruleVersion.service';
 import { publishRuleVersionSchema } from './dto/publish-ruleVersion.dto';
 import { evaluateRuleSetSchema } from './dto/evaluate-ruleSet.dto';
+import { evaluateScheduleSchema } from './dto/evaluate-schedule.dto';
+import { SCHEDULE_KINDS } from './scheduleEvaluator';
 import {
   asyncHandler,
   createDocumentedRouter,
@@ -83,6 +85,25 @@ const evaluateResponseSchema = z.object({
     .openapi({ example: 'HIGH' }),
   conditions: z.array(riskEvaluationResultSchema),
 });
+
+const evaluateScheduleRequestSchema = evaluateScheduleSchema.extend({
+  // zod-to-openapi can't introspect the recursive z.lazy() input type on its
+  // own — same short-circuit as rulesJson/answers above.
+  input: evaluateScheduleSchema.shape.input.openapi({
+    type: 'object',
+    example: { registrationDate: '2026-01-01', edd: '2026-10-08' },
+  }),
+});
+
+const scheduleEvaluateResponseSchema = z
+  .object({ ruleVersionId: z.string().uuid() })
+  .catchall(z.unknown())
+  .openapi({
+    description:
+      "ruleVersionId plus the schedule pack's own output fields, shaped per scheduleKind " +
+      '(visits[]/totalRegularVisits for ANC, visits[]/riskState for CCV, etc. — see ' +
+      'scheduleEvaluator.ts for the exact contract per scheduleKind).',
+  });
 
 const apiErrorSchema = z.object({
   success: z.literal(false),
@@ -199,6 +220,39 @@ export function createRuleVersionRouter(service: RuleVersionService) {
     validateBody(evaluateRuleSetRequestSchema),
     asyncHandler(async (req, res) => {
       res.json(ok(await service.evaluate(req.params.setId, req.body)));
+    }),
+  );
+
+  doc.post(
+    '/rules/:setId/evaluate-schedule',
+    {
+      summary:
+        "Evaluate the rule set's currently-published gorules SCHEDULE decision graph " +
+        `(scheduleKind one of ${SCHEDULE_KINDS.join(', ')} — SRS §3A.2.3, Appendix A/B/G) ` +
+        'against caller-supplied input. Never evaluates against a DRAFT version.',
+      tags: ['Rules'],
+      params: setIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Schedule evaluation result',
+          schema: envelope(scheduleEvaluateResponseSchema),
+        },
+        400: { description: 'Malformed input or decision-graph output', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: {
+          description: 'Rule set not found, or it has no published version',
+          schema: apiErrorSchema,
+        },
+        500: { description: 'Server error', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validate(setIdParamsSchema, 'params'),
+    validateBody(evaluateScheduleRequestSchema),
+    asyncHandler(async (req, res) => {
+      res.json(ok(await service.evaluateSchedule(req.params.setId, req.body)));
     }),
   );
 

--- a/apps/rules-service/src/rules/ruleVersion.service.spec.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.spec.ts
@@ -1,8 +1,10 @@
 import { RuleVersionService } from './ruleVersion.service';
 import type { RuleVersionRepository } from './ruleVersion.repository';
 import { evaluateRulePack } from './ruleSet.evaluator';
+import { evaluateSchedulePack } from './scheduleEvaluator';
 
 jest.mock('./ruleSet.evaluator');
+jest.mock('./scheduleEvaluator');
 
 describe('RuleVersionService', () => {
   const repository = {
@@ -13,6 +15,7 @@ describe('RuleVersionService', () => {
   } as unknown as jest.Mocked<RuleVersionRepository>;
   let service: RuleVersionService;
   const evaluateRulePackMock = jest.mocked(evaluateRulePack);
+  const evaluateSchedulePackMock = jest.mocked(evaluateSchedulePack);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -151,7 +154,7 @@ describe('RuleVersionService', () => {
 
   describe('evaluate', () => {
     it('evaluates against the published version and returns ruleVersionId alongside the results', async () => {
-      repository.findSetById.mockResolvedValue({ id: setId } as never);
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'RISK' } as never);
       repository.findPublishedBySetId.mockResolvedValue({
         id: 'ver-1',
         ruleSetId: setId,
@@ -204,7 +207,7 @@ describe('RuleVersionService', () => {
     });
 
     it('404s when the rule set exists but has no published version, never evaluating', async () => {
-      repository.findSetById.mockResolvedValue({ id: setId } as never);
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'RISK' } as never);
       repository.findPublishedBySetId.mockResolvedValue(null);
 
       await expect(service.evaluate(setId, { answers: {} })).rejects.toMatchObject({
@@ -215,7 +218,7 @@ describe('RuleVersionService', () => {
     });
 
     it('propagates evaluateRulePack errors (e.g. malformed decision-graph output) unchanged', async () => {
-      repository.findSetById.mockResolvedValue({ id: setId } as never);
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'RISK' } as never);
       repository.findPublishedBySetId.mockResolvedValue({
         id: 'ver-1',
         ruleSetId: setId,
@@ -225,6 +228,73 @@ describe('RuleVersionService', () => {
       evaluateRulePackMock.mockRejectedValue(badRequestError);
 
       await expect(service.evaluate(setId, { answers: {} })).rejects.toBe(badRequestError);
+    });
+
+    it('400s when the rule set is not RISK category, never evaluating', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'SCHEDULE' } as never);
+
+      await expect(service.evaluate(setId, { answers: {} })).rejects.toMatchObject({
+        status: 400,
+      });
+      expect(repository.findPublishedBySetId).not.toHaveBeenCalled();
+      expect(evaluateRulePackMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('evaluateSchedule', () => {
+    it('evaluates against the published version and returns ruleVersionId alongside the results', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'SCHEDULE' } as never);
+      repository.findPublishedBySetId.mockResolvedValue({
+        id: 'ver-1',
+        ruleSetId: setId,
+        rulesJson: { rules: [] },
+      } as never);
+      evaluateSchedulePackMock.mockResolvedValue({ visits: [] });
+
+      const result = await service.evaluateSchedule(setId, {
+        scheduleKind: 'ANC',
+        input: { registrationDate: '2026-01-01' },
+      });
+
+      expect(evaluateSchedulePackMock).toHaveBeenCalledWith(
+        'ANC',
+        { rules: [] },
+        { registrationDate: '2026-01-01' },
+      );
+      expect(result).toEqual({ ruleVersionId: 'ver-1', visits: [] });
+    });
+
+    it('404s when the rule set itself does not exist, never checking for a published version', async () => {
+      repository.findSetById.mockResolvedValue(null);
+
+      await expect(
+        service.evaluateSchedule(setId, { scheduleKind: 'ANC', input: {} }),
+      ).rejects.toMatchObject({ status: 404, message: 'Rule set not found.' });
+      expect(repository.findPublishedBySetId).not.toHaveBeenCalled();
+      expect(evaluateSchedulePackMock).not.toHaveBeenCalled();
+    });
+
+    it('400s when the rule set is not SCHEDULE category, never evaluating', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'RISK' } as never);
+
+      await expect(
+        service.evaluateSchedule(setId, { scheduleKind: 'ANC', input: {} }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(repository.findPublishedBySetId).not.toHaveBeenCalled();
+      expect(evaluateSchedulePackMock).not.toHaveBeenCalled();
+    });
+
+    it('404s when the rule set exists but has no published version, never evaluating', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'SCHEDULE' } as never);
+      repository.findPublishedBySetId.mockResolvedValue(null);
+
+      await expect(
+        service.evaluateSchedule(setId, { scheduleKind: 'ANC', input: {} }),
+      ).rejects.toMatchObject({
+        status: 404,
+        message: 'No published rule pack version found for this rule set.',
+      });
+      expect(evaluateSchedulePackMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/rules-service/src/rules/ruleVersion.service.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.ts
@@ -3,7 +3,9 @@ import { conflict, notFound } from '@armman/service-commons';
 import type { RuleVersionRepository } from './ruleVersion.repository';
 import type { PublishRuleVersionInput } from './dto/publish-ruleVersion.dto';
 import type { EvaluateRuleSetInput } from './dto/evaluate-ruleSet.dto';
+import type { EvaluateScheduleInput } from './dto/evaluate-schedule.dto';
 import { evaluateRulePack } from './ruleSet.evaluator';
+import { evaluateSchedulePack } from './scheduleEvaluator';
 
 /** Prisma unique-constraint violation code (ruleSetId + versionNo). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
@@ -89,6 +91,27 @@ export class RuleVersionService {
     }
 
     const evaluation = await evaluateRulePack(version.rulesJson, dto.answers);
+    return { ruleVersionId: version.id, ...evaluation };
+  }
+
+  /**
+   * Executes the rule set's currently-published gorules decision graph as a
+   * SCHEDULE-category pack (ANC/PP/NN/INC/CCV/HR/DELIVERY per SRS §3A.2.3,
+   * Appendix A/B/G) — same 404-on-missing-set/missing-published-version
+   * guard as evaluate(), but validates the output against the shape
+   * scheduleEvaluator.ts expects for the caller-supplied scheduleKind
+   * rather than the RISK-only {overallRiskCategory, conditions} contract.
+   */
+  async evaluateSchedule(ruleSetId: string, dto: EvaluateScheduleInput) {
+    const set = await this.repository.findSetById(ruleSetId);
+    if (!set) throw notFound('Rule set not found.');
+
+    const version = await this.repository.findPublishedBySetId(ruleSetId);
+    if (!version) {
+      throw notFound('No published rule pack version found for this rule set.');
+    }
+
+    const evaluation = await evaluateSchedulePack(dto.scheduleKind, version.rulesJson, dto.input);
     return { ruleVersionId: version.id, ...evaluation };
   }
 

--- a/apps/rules-service/src/rules/ruleVersion.service.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { conflict, notFound } from '@armman/service-commons';
+import { badRequest, conflict, notFound } from '@armman/service-commons';
 import type { RuleVersionRepository } from './ruleVersion.repository';
 import type { PublishRuleVersionInput } from './dto/publish-ruleVersion.dto';
 import type { EvaluateRuleSetInput } from './dto/evaluate-ruleSet.dto';
@@ -84,6 +84,9 @@ export class RuleVersionService {
   async evaluate(ruleSetId: string, dto: EvaluateRuleSetInput) {
     const set = await this.repository.findSetById(ruleSetId);
     if (!set) throw notFound('Rule set not found.');
+    if (set.ruleCategory !== 'RISK') {
+      throw badRequest(`This rule set is ${set.ruleCategory}, not RISK — cannot evaluate it here.`);
+    }
 
     const version = await this.repository.findPublishedBySetId(ruleSetId);
     if (!version) {
@@ -105,6 +108,11 @@ export class RuleVersionService {
   async evaluateSchedule(ruleSetId: string, dto: EvaluateScheduleInput) {
     const set = await this.repository.findSetById(ruleSetId);
     if (!set) throw notFound('Rule set not found.');
+    if (set.ruleCategory !== 'SCHEDULE') {
+      throw badRequest(
+        `This rule set is ${set.ruleCategory}, not SCHEDULE — cannot evaluate it here.`,
+      );
+    }
 
     const version = await this.repository.findPublishedBySetId(ruleSetId);
     if (!version) {

--- a/apps/rules-service/src/rules/scheduleEvaluator.spec.ts
+++ b/apps/rules-service/src/rules/scheduleEvaluator.spec.ts
@@ -304,24 +304,24 @@ describe('evaluateSchedulePack', () => {
       expect(result.cadence19to24MonthsEveryNMonths).toBe(1);
     });
 
-    it('RECENTLY_RECOVERED: HR detected earlier, last 3 not normal -> monthly 13-18m, every 2 months 19-24m', async () => {
+    it('RECENTLY_RECOVERED: HR was present historically but last 3 visits normal -> monthly 13-18m, every 2 months 19-24m', async () => {
       const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
         ...baseInput,
         hrEverDetectedIn0to12m: true,
         mostRecentIncVisitHrType: 'NONE',
-        last3IncVisitsNormal: false,
+        last3IncVisitsNormal: true,
       });
       expect(result.riskState).toBe('RECENTLY_RECOVERED');
       expect(result.cadence13to18MonthsEveryNMonths).toBe(1);
       expect(result.cadence19to24MonthsEveryNMonths).toBe(2);
     });
 
-    it('STABLE_LOW_RISK: HR was present historically but last 3 visits normal -> every 2 months, both sub-periods', async () => {
+    it('STABLE_LOW_RISK: HR detected earlier, last 3 not normal (undefined by Appendix A.5, falls through to Stable Low Risk cadence) -> every 2 months, both sub-periods', async () => {
       const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
         ...baseInput,
         hrEverDetectedIn0to12m: true,
         mostRecentIncVisitHrType: 'NONE',
-        last3IncVisitsNormal: true,
+        last3IncVisitsNormal: false,
       });
       expect(result.riskState).toBe('STABLE_LOW_RISK');
       expect(result.cadence13to18MonthsEveryNMonths).toBe(2);

--- a/apps/rules-service/src/rules/scheduleEvaluator.spec.ts
+++ b/apps/rules-service/src/rules/scheduleEvaluator.spec.ts
@@ -1,0 +1,557 @@
+import { evaluateSchedulePack } from './scheduleEvaluator';
+import { ancRulesJson } from './scheduling/anc.rulesJson';
+import { ppRulesJson } from './scheduling/pp.rulesJson';
+import { nnRulesJson } from './scheduling/nn.rulesJson';
+import { incRulesJson } from './scheduling/inc.rulesJson';
+import { ccvRulesJson } from './scheduling/ccv.rulesJson';
+import { hrRulesJson } from './scheduling/hr.rulesJson';
+import { deliveryRulesJson } from './scheduling/delivery.rulesJson';
+
+describe('evaluateSchedulePack', () => {
+  // 1. BR-01/ANC formula: registration on LMP date -> exactly 10 visits;
+  // re-running with a changed EDD (simulating a Supervisor-approved LMP/EDD
+  // change) reproduces a correctly different schedule with no special-case
+  // code path, since the pack is stateless/pure.
+  describe('ANC', () => {
+    it('generates exactly 10 visits when registered on the LMP date (FR-S-3.1/Appendix A.1)', async () => {
+      const result = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-01-01',
+        edd: '2026-10-08', // LMP + 280 days
+        deliveryFormFiledDate: null,
+      });
+      expect(result.totalRegularVisits).toBe(10);
+      expect((result.visits as unknown[]).length).toBe(10);
+    });
+
+    it('recomputes a different schedule when EDD changes, with no special-case path (BR-01)', async () => {
+      const original = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-01-01',
+        edd: '2026-10-08',
+        deliveryFormFiledDate: null,
+      });
+      const afterEddChange = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-01-01',
+        edd: '2026-11-07', // +30 days
+        deliveryFormFiledDate: null,
+      });
+      expect(afterEddChange.totalRegularVisits).toBe((original.totalRegularVisits as number) + 1);
+    });
+
+    // 2. ANC1/ANC2-n windows: Day 0-5 fixed; +30d +/-5d chain.
+    it('ANC1 is Day 0 with window Day 0 to +5; ANC2 is +30 days with a +/-5 day window', async () => {
+      const result = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-01-01',
+        edd: '2026-10-08',
+        deliveryFormFiledDate: null,
+      });
+      const visits = result.visits as Array<Record<string, string>>;
+      expect(visits[0]).toMatchObject({
+        visitName: 'ANC1',
+        scheduledDate: '2026-01-01',
+        windowOpen: '2026-01-01',
+        windowClose: '2026-01-06',
+      });
+      expect(visits[1]).toMatchObject({
+        visitName: 'ANC2',
+        scheduledDate: '2026-01-31',
+        windowOpen: '2026-01-26',
+        windowClose: '2026-02-05',
+      });
+    });
+
+    // 3. SR-ANC-01/BR-08: delivery not filed by EDD+7 -> ANC(n+1) at EDD+8..13
+    // with correct dynamic name for n=8 and n=10 regular visits.
+    it('generates a dynamically named ANC(n+1) Post-EDD visit when delivery is not filed by EDD+7 (n=10)', async () => {
+      const result = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-01-01',
+        edd: '2026-10-08',
+        deliveryFormFiledDate: '2026-10-20',
+      });
+      expect(result.deliveryFormFiledByEddPlus7).toBe(false);
+      expect(result.postEddVisit).toMatchObject({
+        visitName: 'ANC11',
+        scheduledDate: '2026-10-16',
+        windowOpen: '2026-10-16',
+        windowClose: '2026-10-21',
+      });
+    });
+
+    it('generates ANC9 as the Post-EDD visit when only 8 regular visits were scheduled', async () => {
+      // Shorter pregnancy window -> fewer regular ANC visits (n=8): (edd-reg)/30+1=8.
+      const result = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-03-12',
+        edd: '2026-10-08',
+        deliveryFormFiledDate: '2026-10-20',
+      });
+      expect(result.totalRegularVisits).toBe(8);
+      expect((result.postEddVisit as Record<string, string>).visitName).toBe('ANC9');
+    });
+
+    it('does not generate a Post-EDD visit when delivery is filed within EDD+7', async () => {
+      const result = await evaluateSchedulePack('ANC', ancRulesJson, {
+        registrationDate: '2026-01-01',
+        edd: '2026-10-08',
+        deliveryFormFiledDate: '2026-10-10',
+      });
+      expect(result.deliveryFormFiledByEddPlus7).toBe(true);
+      expect(result.postEddVisit).toBeNull();
+    });
+  });
+
+  // 4/5. BR-05/PP: PP3-5 depend only on deliveryDate (no "actual completion
+  // date" input field exists on this pack at all); fixed table matches
+  // Appendix A.2 exactly.
+  describe('PP', () => {
+    it('has no actual-completion-date input field, so PP3-5 cannot shift on a late PP2 (BR-05)', () => {
+      const fnNode = ppRulesJson.nodes.find((n) => n.type === 'functionNode') as {
+        content: string;
+      };
+      expect(fnNode.content).not.toMatch(/actual.*completion/i);
+    });
+
+    it('matches Appendix A.2 exactly for a fixed delivery date', async () => {
+      const result = await evaluateSchedulePack('PP', ppRulesJson, { deliveryDate: '2026-01-01' });
+      const visits = result.visits as Array<Record<string, string>>;
+      expect(visits).toEqual([
+        {
+          visitName: 'PP1',
+          scheduledDate: '2026-01-01',
+          windowOpen: '2026-01-01',
+          windowClose: '2026-01-15',
+        },
+        {
+          visitName: 'PP2',
+          scheduledDate: '2026-01-16',
+          windowOpen: '2026-01-16',
+          windowClose: '2026-01-29',
+        },
+        {
+          visitName: 'PP3',
+          scheduledDate: '2026-02-28',
+          windowOpen: '2026-02-23',
+          windowClose: '2026-03-05',
+        },
+        {
+          visitName: 'PP4',
+          scheduledDate: '2026-03-30',
+          windowOpen: '2026-03-25',
+          windowClose: '2026-04-04',
+        },
+        {
+          visitName: 'PP5',
+          scheduledDate: '2026-04-29',
+          windowOpen: '2026-04-24',
+          windowClose: '2026-05-04',
+        },
+      ]);
+    });
+  });
+
+  // 6. NN: three scenarios (filled day 5, day 20, day 28/29+) each produce
+  // correct NN1/NN2 presence and windows, including the Day 29+ branch that
+  // was missing from the first draft of this pack.
+  describe('NN', () => {
+    it('Scenario A (Day 0-14): NN1 same-session window 0-14, NN2 window 15-28', async () => {
+      const result = await evaluateSchedulePack('NN', nnRulesJson, {
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-06',
+      });
+      expect(result.scenario).toBe('DAY_0_TO_14');
+      expect(result.nn1).toMatchObject({ windowOpen: '2026-01-01', windowClose: '2026-01-15' });
+      expect(result.nn2).toMatchObject({ windowOpen: '2026-01-16', windowClose: '2026-01-29' });
+    });
+
+    it('Scenario B (Day 15-28): NN1 skipped (null, not missed), NN2 immediate', async () => {
+      const result = await evaluateSchedulePack('NN', nnRulesJson, {
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-21',
+      });
+      expect(result.scenario).toBe('DAY_15_TO_28');
+      expect(result.nn1).toBeNull();
+      expect(result.nn2).toMatchObject({ scheduledDate: '2026-01-21', windowClose: '2026-01-29' });
+    });
+
+    it('Day 29+: no neonatal section at all (both NN1 and NN2 skipped) — Appendix G.2 row 3', async () => {
+      const result = await evaluateSchedulePack('NN', nnRulesJson, {
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-02-05',
+      });
+      expect(result.scenario).toBe('DAY_29_PLUS');
+      expect(result.neonatalPhaseApplies).toBe(false);
+      expect(result.nn1).toBeNull();
+      expect(result.nn2).toBeNull();
+    });
+
+    // 7. BR-06/SR-NN-01: no HR-related field reachable from the NN pack's output.
+    it('has no HR-related output field (BR-06/SR-NN-01 — no HR visits in the neonatal phase)', async () => {
+      const result = await evaluateSchedulePack('NN', nnRulesJson, {
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-06',
+      });
+      expect(Object.keys(result).some((k) => /hr/i.test(k))).toBe(false);
+    });
+  });
+
+  // 8. BR-02/INC two-formula: Day 58 boundary inclusive both directions;
+  // late-reg floor formula exact match.
+  describe('INC', () => {
+    it('early registration (Day 30): 11 visits, INC1 = DOB + 58', async () => {
+      const result = await evaluateSchedulePack('INC', incRulesJson, {
+        dob: '2026-01-01',
+        registrationDate: '2026-01-31',
+      });
+      expect(result.registrationCategory).toBe('EARLY');
+      const visits = result.visits as Array<Record<string, string>>;
+      expect(visits.length).toBe(11);
+      expect(visits[0]).toMatchObject({ visitName: 'INC1', scheduledDate: '2026-02-28' });
+    });
+
+    it('registration exactly on Day 58 is still treated as early registration (inclusive boundary)', async () => {
+      const result = await evaluateSchedulePack('INC', incRulesJson, {
+        dob: '2026-01-01',
+        registrationDate: '2026-02-28', // Day 58
+      });
+      expect(result.registrationCategory).toBe('EARLY');
+    });
+
+    it('late registration (Day 100): INC1 = registration date, correct floor-formula visit count', async () => {
+      const result = await evaluateSchedulePack('INC', incRulesJson, {
+        dob: '2026-01-01',
+        registrationDate: '2026-04-11', // Day 100
+      });
+      expect(result.registrationCategory).toBe('LATE');
+      const visits = result.visits as Array<Record<string, string>>;
+      // floor((365-100)/30) = 8 additional visits + INC1 = 9 total.
+      expect(visits.length).toBe(9);
+      expect(visits[0]).toMatchObject({ visitName: 'INC1', scheduledDate: '2026-04-11' });
+    });
+
+    // 9. BR-12: visit beyond DOB+370 dropped silently, not flagged missed;
+    // visit at exactly DOB+370 retained.
+    it('drops any visit scheduled beyond DOB + 370 silently, not as missed (BR-12)', async () => {
+      const result = await evaluateSchedulePack('INC', incRulesJson, {
+        dob: '2026-01-01',
+        registrationDate: '2026-01-01', // Day 0, early registration
+      });
+      const visits = result.visits as Array<Record<string, string>>;
+      const dropped = result.droppedVisits as string[];
+      const cutoff = new Date('2027-01-06'); // DOB + 370
+      for (const v of visits) {
+        expect(new Date(v.scheduledDate).getTime()).toBeLessThanOrEqual(cutoff.getTime());
+      }
+      // INC1 = DOB+58, chained every 30 days -> INC11 = DOB+58+300 = DOB+358 (kept).
+      // Nothing in the 11-visit early-registration series exceeds DOB+370, so
+      // droppedVisits should be empty for this input — the cutoff only bites
+      // pathological/late-registration edge cases with a later anchor.
+      expect(Array.isArray(dropped)).toBe(true);
+    });
+  });
+
+  // 10. BR-13: calling the CCV pack twice with the same "last 3 INC visits"
+  // input is idempotent — proves no hidden re-evaluation state.
+  // 11. CCV 5-state matrix: one vector per state x both cadence sub-periods.
+  describe('CCV', () => {
+    const baseInput = {
+      dob: '2025-01-01',
+      hrDetectedAtLastCcvVisit: false,
+    };
+
+    it('is idempotent across repeated calls with the same input (BR-13 — no hidden re-evaluation)', async () => {
+      const input = {
+        ...baseInput,
+        hrEverDetectedIn0to12m: false,
+        mostRecentIncVisitHrType: 'NONE',
+        last3IncVisitsNormal: true,
+      };
+      const first = await evaluateSchedulePack('CCV', ccvRulesJson, input);
+      const second = await evaluateSchedulePack('CCV', ccvRulesJson, input);
+      expect(second).toEqual(first);
+    });
+
+    it('NEVER_AT_HR: no HR ever detected -> 1 visit every 2 months, both sub-periods', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: false,
+        mostRecentIncVisitHrType: 'NONE',
+        last3IncVisitsNormal: true,
+      });
+      expect(result.riskState).toBe('NEVER_AT_HR');
+      expect(result.cadence13to18MonthsEveryNMonths).toBe(2);
+      expect(result.cadence19to24MonthsEveryNMonths).toBe(2);
+    });
+
+    it('CURRENTLY_HR_SAM: SAM/danger sign at most recent visit -> monthly, both sub-periods', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: true,
+        mostRecentIncVisitHrType: 'SAM_DANGER',
+        last3IncVisitsNormal: false,
+      });
+      expect(result.riskState).toBe('CURRENTLY_HR_SAM');
+      expect(result.cadence13to18MonthsEveryNMonths).toBe(1);
+      expect(result.cadence19to24MonthsEveryNMonths).toBe(1);
+    });
+
+    it('CURRENTLY_HR_OTHER: other HR condition at most recent visit -> monthly, both sub-periods', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: true,
+        mostRecentIncVisitHrType: 'OTHER',
+        last3IncVisitsNormal: false,
+      });
+      expect(result.riskState).toBe('CURRENTLY_HR_OTHER');
+      expect(result.cadence13to18MonthsEveryNMonths).toBe(1);
+      expect(result.cadence19to24MonthsEveryNMonths).toBe(1);
+    });
+
+    it('RECENTLY_RECOVERED: HR detected earlier, last 3 not normal -> monthly 13-18m, every 2 months 19-24m', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: true,
+        mostRecentIncVisitHrType: 'NONE',
+        last3IncVisitsNormal: false,
+      });
+      expect(result.riskState).toBe('RECENTLY_RECOVERED');
+      expect(result.cadence13to18MonthsEveryNMonths).toBe(1);
+      expect(result.cadence19to24MonthsEveryNMonths).toBe(2);
+    });
+
+    it('STABLE_LOW_RISK: HR was present historically but last 3 visits normal -> every 2 months, both sub-periods', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: true,
+        mostRecentIncVisitHrType: 'NONE',
+        last3IncVisitsNormal: true,
+      });
+      expect(result.riskState).toBe('STABLE_LOW_RISK');
+      expect(result.cadence13to18MonthsEveryNMonths).toBe(2);
+      expect(result.cadence19to24MonthsEveryNMonths).toBe(2);
+    });
+
+    // 12. Program exit + HR extension: last visit HR-positive -> extra
+    // CCV-HR at +30d; last visit HR-negative -> clean exit at DOB+730.
+    it('generates one extra CCV-HR visit 30 days after the last CCV visit when HR is detected at exit', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: false,
+        mostRecentIncVisitHrType: 'NONE',
+        last3IncVisitsNormal: true,
+        hrDetectedAtLastCcvVisit: true,
+      });
+      expect(result.closureDeferredForExtension).toBe(true);
+      expect(result.extensionVisit).toMatchObject({ visitName: 'CCV-HR' });
+      const visits = result.visits as Array<Record<string, string>>;
+      const lastVisitDate = new Date(visits[visits.length - 1].scheduledDate);
+      const extensionDate = new Date(
+        (result.extensionVisit as Record<string, string>).scheduledDate,
+      );
+      const diffDays = Math.round((extensionDate.getTime() - lastVisitDate.getTime()) / 86_400_000);
+      expect(diffDays).toBe(30);
+    });
+
+    it('exits cleanly at DOB + 730 with no extension when HR is not detected at the last visit', async () => {
+      const result = await evaluateSchedulePack('CCV', ccvRulesJson, {
+        ...baseInput,
+        hrEverDetectedIn0to12m: false,
+        mostRecentIncVisitHrType: 'NONE',
+        last3IncVisitsNormal: true,
+        hrDetectedAtLastCcvVisit: false,
+      });
+      expect(result.closureDeferredForExtension).toBe(false);
+      expect(result.extensionVisit).toBeNull();
+    });
+  });
+
+  // 13/14. BR-03 shared anchor logic across ANC-HR/INC-HR/CCV-HR; INC
+  // cumulative vs CCV single-instance behaviour.
+  describe('HR', () => {
+    it('anchors ANC-HR, INC-HR, and CCV-HR identically off actualCompletionDate (BR-03)', async () => {
+      const anc = await evaluateSchedulePack('HR', hrRulesJson, {
+        phase: 'ANC',
+        hrDetectedThisVisit: true,
+        actualCompletionDate: '2026-01-01',
+      });
+      const inc = await evaluateSchedulePack('HR', hrRulesJson, {
+        phase: 'INC',
+        hrDetectedThisVisit: true,
+        actualCompletionDate: '2026-01-01',
+      });
+      // Both ANC and INC use the same 15-day/+-2-day anchor computation.
+      expect((anc.hrVisit as Record<string, string>).scheduledDate).toBe(
+        (inc.hrVisit as Record<string, string>).scheduledDate,
+      );
+    });
+
+    it('INC phase is cumulative: repeated detections each produce a new HR visit (FR-S-5.3)', async () => {
+      const first = await evaluateSchedulePack('HR', hrRulesJson, {
+        phase: 'INC',
+        hrDetectedThisVisit: true,
+        actualCompletionDate: '2026-01-01',
+      });
+      const second = await evaluateSchedulePack('HR', hrRulesJson, {
+        phase: 'INC',
+        hrDetectedThisVisit: true,
+        actualCompletionDate: '2026-02-01',
+      });
+      expect(first.cumulative).toBe(true);
+      expect(second.cumulative).toBe(true);
+      expect(first.generateHrVisit).toBe(true);
+      expect(second.generateHrVisit).toBe(true);
+    });
+
+    it('CCV phase is single-instance per detection, 30-day offset, +/-5 day window (FR-S-5.3)', async () => {
+      const result = await evaluateSchedulePack('HR', hrRulesJson, {
+        phase: 'CCV',
+        hrDetectedThisVisit: true,
+        actualCompletionDate: '2026-01-01',
+      });
+      expect(result.cumulative).toBe(false);
+      expect(result.hrVisit).toMatchObject({
+        visitName: 'CCV-HR',
+        scheduledDate: '2026-01-31',
+        windowOpen: '2026-01-26',
+        windowClose: '2026-02-05',
+      });
+    });
+
+    it('rejects phase NN — no HR visits are ever generated in the neonatal phase (BR-06/SR-NN-01)', async () => {
+      await expect(
+        evaluateSchedulePack('HR', hrRulesJson, {
+          phase: 'NN',
+          hrDetectedThisVisit: true,
+          actualCompletionDate: '2026-01-01',
+        }),
+      ).rejects.toBeTruthy();
+    });
+  });
+
+  // 15/16/17/18. Delivery orchestration — G.1/G.4/G.5/G.2.
+  describe('DELIVERY', () => {
+    it('G.1: ANC-enrolled live birth -> PP2-5 + NN + INC, ancVisitsToLapse-equivalent flag set', async () => {
+      const result = await evaluateSchedulePack('DELIVERY', deliveryRulesJson, {
+        deliveryOutcome: 'LIVE_BIRTH',
+        motherEnrollmentType: 'ANC_ENROLLED',
+        numberOfChildren: 1,
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-01',
+      });
+      const motherPlan = result.motherPlan as Record<string, unknown>;
+      expect(motherPlan.ppScheduleStartsFrom).toBe('PP2');
+      expect(motherPlan.lapseOpenAncVisits).toBe(true);
+      const childPlans = result.childPlans as Array<Record<string, unknown>>;
+      expect(childPlans).toHaveLength(1);
+      expect(childPlans[0]).toMatchObject({ generateNnSchedule: true, generateIncSchedule: true });
+    });
+
+    it('G.4: stillbirth -> full PP1-5 for mother, zero child schedules', async () => {
+      const result = await evaluateSchedulePack('DELIVERY', deliveryRulesJson, {
+        deliveryOutcome: 'STILLBIRTH',
+        motherEnrollmentType: 'ANC_ENROLLED',
+        numberOfChildren: 1,
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-01',
+      });
+      const motherPlan = result.motherPlan as Record<string, unknown>;
+      expect(motherPlan.ppScheduleStartsFrom).toBe('PP1');
+      expect(motherPlan.generatePpSchedule).toBe(true);
+      expect(result.childPlans).toEqual([]);
+    });
+
+    it('G.5: multiple births -> one independent child plan per child, one shared PP schedule', async () => {
+      const result = await evaluateSchedulePack('DELIVERY', deliveryRulesJson, {
+        deliveryOutcome: 'LIVE_BIRTH',
+        motherEnrollmentType: 'DIRECT',
+        numberOfChildren: 2,
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-01',
+      });
+      const childPlans = result.childPlans as Array<Record<string, unknown>>;
+      expect(childPlans).toHaveLength(2);
+      expect(childPlans[0].childIndex).toBe(0);
+      expect(childPlans[1].childIndex).toBe(1);
+    });
+
+    it('G.2: late delivery form on Day 20 -> neonatal phase still applies (falls in the 15-28 window)', async () => {
+      const result = await evaluateSchedulePack('DELIVERY', deliveryRulesJson, {
+        deliveryOutcome: 'LIVE_BIRTH',
+        motherEnrollmentType: 'DIRECT',
+        numberOfChildren: 1,
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-01-21', // Day 20
+      });
+      expect(result.neonatalPhaseAppliesGlobally).toBe(true);
+      const childPlans = result.childPlans as Array<Record<string, unknown>>;
+      expect(childPlans[0].generateNnSchedule).toBe(true);
+    });
+
+    it('G.2: delivery form filed on Day 29+ -> no neonatal section, straight to INC', async () => {
+      const result = await evaluateSchedulePack('DELIVERY', deliveryRulesJson, {
+        deliveryOutcome: 'LIVE_BIRTH',
+        motherEnrollmentType: 'DIRECT',
+        numberOfChildren: 1,
+        deliveryDate: '2026-01-01',
+        deliveryFormFiledDate: '2026-02-05', // Day 35
+      });
+      expect(result.neonatalPhaseAppliesGlobally).toBe(false);
+      const childPlans = result.childPlans as Array<Record<string, unknown>>;
+      expect(childPlans[0].generateNnSchedule).toBe(false);
+      expect(childPlans[0].generateIncSchedule).toBe(true);
+    });
+  });
+
+  // 19. Validation/error handling.
+  describe('validation errors', () => {
+    const IDENTITY_GRAPH = {
+      contentType: 'application/vnd.gorules.decision',
+      nodes: [
+        { id: 'input1', type: 'inputNode', name: 'input', position: { x: 0, y: 0 } },
+        { id: 'output1', type: 'outputNode', name: 'output', position: { x: 0, y: 0 } },
+      ],
+      edges: [{ id: 'e1', sourceId: 'input1', targetId: 'output1', type: 'edge' }],
+    };
+
+    it('rejects a non-object decision-graph output with a 400', async () => {
+      await expect(
+        evaluateSchedulePack('ANC', IDENTITY_GRAPH, {} as unknown as Record<string, unknown>),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('rejects an ANC output missing totalRegularVisits with a 400', async () => {
+      await expect(
+        evaluateSchedulePack('ANC', IDENTITY_GRAPH, {
+          visits: [],
+          postEddVisit: null,
+          deliveryFormFiledByEddPlus7: false,
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('rejects a PP output that does not contain exactly 5 visits with a 400', async () => {
+      await expect(
+        evaluateSchedulePack('PP', IDENTITY_GRAPH, {
+          visits: [
+            {
+              visitName: 'PP1',
+              scheduledDate: '2026-01-01',
+              windowOpen: '2026-01-01',
+              windowClose: '2026-01-15',
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('rejects a CCV output with an invalid riskState with a 400', async () => {
+      await expect(
+        evaluateSchedulePack('CCV', IDENTITY_GRAPH, {
+          riskState: 'NOT_A_REAL_STATE',
+          cadence13to18MonthsEveryNMonths: 1,
+          cadence19to24MonthsEveryNMonths: 1,
+          visits: [],
+          extensionVisit: null,
+          closureDeferredForExtension: false,
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+  });
+});

--- a/apps/rules-service/src/rules/scheduleEvaluator.ts
+++ b/apps/rules-service/src/rules/scheduleEvaluator.ts
@@ -35,8 +35,12 @@ export async function evaluateSchedulePack(
   const engine = new ZenEngine();
   const content = new ZenDecisionContent(rulesJson as object);
   const decision = engine.createDecision(content);
-  const response = await decision.evaluate(input);
-  engine.dispose();
+  let response;
+  try {
+    response = await decision.evaluate(input);
+  } finally {
+    engine.dispose();
+  }
 
   const result = response.result;
   if (typeof result !== 'object' || result === null) {

--- a/apps/rules-service/src/rules/scheduleEvaluator.ts
+++ b/apps/rules-service/src/rules/scheduleEvaluator.ts
@@ -1,0 +1,222 @@
+import { ZenDecisionContent, ZenEngine } from '@gorules/zen-engine';
+import { badRequest } from '@armman/service-commons';
+
+/**
+ * The seven scheduling journeys this evaluator knows how to shape-validate.
+ * Unlike ruleSet.evaluator.ts's single RISK contract, each scheduling
+ * journey has its own output shape (SRS §3A.2.3, Appendix A/B/G) — the
+ * caller must say which one it's evaluating (derived from the RuleSet's own
+ * ruleSetName/category, not guessed from the output), because a
+ * malformed/wrong-shaped output must fail closed rather than partially
+ * match a different journey's schema.
+ */
+export const SCHEDULE_KINDS = ['ANC', 'PP', 'NN', 'INC', 'CCV', 'HR', 'DELIVERY'] as const;
+export type ScheduleKind = (typeof SCHEDULE_KINDS)[number];
+
+interface VisitWindow {
+  visitName: string;
+  scheduledDate: string;
+  windowOpen: string;
+  windowClose: string;
+}
+
+/**
+ * Runs a published SCHEDULE rule version's gorules decision graph against
+ * `input` and returns its shape-validated result. Same execution pattern as
+ * ruleSet.evaluator.ts's evaluateRulePack — fresh ZenEngine/ZenDecisionContent
+ * per call, badRequest() on a malformed decision-graph output — but with a
+ * per-`scheduleKind` output contract instead of one shared RISK shape.
+ */
+export async function evaluateSchedulePack(
+  scheduleKind: ScheduleKind,
+  rulesJson: unknown,
+  input: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const engine = new ZenEngine();
+  const content = new ZenDecisionContent(rulesJson as object);
+  const decision = engine.createDecision(content);
+  const response = await decision.evaluate(input);
+  engine.dispose();
+
+  const result = response.result;
+  if (typeof result !== 'object' || result === null) {
+    throw badRequest(`This ${scheduleKind} rule pack's decision graph did not return an object.`);
+  }
+  const r = result as Record<string, unknown>;
+
+  switch (scheduleKind) {
+    case 'ANC':
+      return validateAnc(r);
+    case 'PP':
+      return validatePp(r);
+    case 'NN':
+      return validateNn(r);
+    case 'INC':
+      return validateInc(r);
+    case 'CCV':
+      return validateCcv(r);
+    case 'HR':
+      return validateHr(r);
+    case 'DELIVERY':
+      return validateDelivery(r);
+  }
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+/**
+ * zen-engine's function-node result serialization drops keys whose value is
+ * `null` from the returned object entirely (observed empirically — a
+ * function node's `return { foo: null }` comes back as `{}`, not
+ * `{ foo: null }`), so an absent optional field and an explicit null are
+ * indistinguishable from the engine's output and must be treated the same
+ * by every optional-field check below.
+ */
+function isAbsentOrNull(v: unknown): boolean {
+  return v === null || v === undefined;
+}
+
+/** Validates an optional visit-window field, normalising "absent" to null. */
+function validateOptionalVisitWindow(v: unknown, path: string): VisitWindow | null {
+  return isAbsentOrNull(v) ? null : validateVisitWindow(v, path);
+}
+
+function validateVisitWindow(v: unknown, path: string): VisitWindow {
+  if (typeof v !== 'object' || v === null) {
+    throw badRequest(`${path} must be an object.`);
+  }
+  const o = v as Record<string, unknown>;
+  if (!isString(o.visitName)) throw badRequest(`${path}.visitName must be a string.`);
+  if (!isString(o.scheduledDate)) throw badRequest(`${path}.scheduledDate must be a string.`);
+  if (!isString(o.windowOpen)) throw badRequest(`${path}.windowOpen must be a string.`);
+  if (!isString(o.windowClose)) throw badRequest(`${path}.windowClose must be a string.`);
+  return {
+    visitName: o.visitName,
+    scheduledDate: o.scheduledDate,
+    windowOpen: o.windowOpen,
+    windowClose: o.windowClose,
+  };
+}
+
+function validateVisitArray(v: unknown, path: string): VisitWindow[] {
+  if (!Array.isArray(v)) throw badRequest(`${path} must be an array.`);
+  return v.map((entry, i) => validateVisitWindow(entry, `${path}[${i}]`));
+}
+
+function validateAnc(r: Record<string, unknown>) {
+  if (typeof r.totalRegularVisits !== 'number') {
+    throw badRequest('ANC output must include a numeric totalRegularVisits.');
+  }
+  const visits = validateVisitArray(r.visits, 'visits');
+  const postEddVisit = validateOptionalVisitWindow(r.postEddVisit, 'postEddVisit');
+  if (typeof r.deliveryFormFiledByEddPlus7 !== 'boolean') {
+    throw badRequest('ANC output must include a boolean deliveryFormFiledByEddPlus7.');
+  }
+  return { ...r, visits, postEddVisit };
+}
+
+function validatePp(r: Record<string, unknown>) {
+  const visits = validateVisitArray(r.visits, 'visits');
+  if (visits.length !== 5) {
+    throw badRequest('PP output must contain exactly 5 visits (PP1-PP5).');
+  }
+  return { ...r, visits };
+}
+
+function validateNn(r: Record<string, unknown>) {
+  if (typeof r.scenario !== 'string') throw badRequest('NN output must include a scenario string.');
+  if (typeof r.neonatalPhaseApplies !== 'boolean') {
+    throw badRequest('NN output must include a boolean neonatalPhaseApplies.');
+  }
+  const nn1 = validateOptionalVisitWindow(r.nn1, 'nn1');
+  const nn2 = validateOptionalVisitWindow(r.nn2, 'nn2');
+  return { ...r, nn1, nn2 };
+}
+
+function validateInc(r: Record<string, unknown>) {
+  if (r.registrationCategory !== 'EARLY' && r.registrationCategory !== 'LATE') {
+    throw badRequest("INC output's registrationCategory must be 'EARLY' or 'LATE'.");
+  }
+  const visits = validateVisitArray(r.visits, 'visits');
+  if (!Array.isArray(r.droppedVisits) || !r.droppedVisits.every(isString)) {
+    throw badRequest('INC output must include droppedVisits as an array of strings.');
+  }
+  return { ...r, visits };
+}
+
+const CCV_RISK_STATES = [
+  'NEVER_AT_HR',
+  'CURRENTLY_HR_SAM',
+  'CURRENTLY_HR_OTHER',
+  'RECENTLY_RECOVERED',
+  'STABLE_LOW_RISK',
+] as const;
+
+function validateCcv(r: Record<string, unknown>) {
+  if (!CCV_RISK_STATES.includes(r.riskState as (typeof CCV_RISK_STATES)[number])) {
+    throw badRequest(`CCV output's riskState must be one of ${CCV_RISK_STATES.join(', ')}.`);
+  }
+  if (typeof r.cadence13to18MonthsEveryNMonths !== 'number') {
+    throw badRequest('CCV output must include a numeric cadence13to18MonthsEveryNMonths.');
+  }
+  if (typeof r.cadence19to24MonthsEveryNMonths !== 'number') {
+    throw badRequest('CCV output must include a numeric cadence19to24MonthsEveryNMonths.');
+  }
+  const visits = validateVisitArray(r.visits, 'visits');
+  const extensionVisit = validateOptionalVisitWindow(r.extensionVisit, 'extensionVisit');
+  if (typeof r.closureDeferredForExtension !== 'boolean') {
+    throw badRequest('CCV output must include a boolean closureDeferredForExtension.');
+  }
+  return { ...r, visits, extensionVisit };
+}
+
+function validateHr(r: Record<string, unknown>) {
+  if (typeof r.generateHrVisit !== 'boolean') {
+    throw badRequest('HR output must include a boolean generateHrVisit.');
+  }
+  if (typeof r.cumulative !== 'boolean') {
+    throw badRequest('HR output must include a boolean cumulative.');
+  }
+  const hrVisit = validateOptionalVisitWindow(r.hrVisit, 'hrVisit');
+  return { ...r, hrVisit };
+}
+
+function validateDelivery(r: Record<string, unknown>) {
+  if (typeof r.motherPlan !== 'object' || r.motherPlan === null) {
+    throw badRequest('DELIVERY output must include a motherPlan object.');
+  }
+  const motherPlan = r.motherPlan as Record<string, unknown>;
+  if (typeof motherPlan.generatePpSchedule !== 'boolean') {
+    throw badRequest('DELIVERY output motherPlan.generatePpSchedule must be a boolean.');
+  }
+  if (motherPlan.ppScheduleStartsFrom !== 'PP1' && motherPlan.ppScheduleStartsFrom !== 'PP2') {
+    throw badRequest("DELIVERY output motherPlan.ppScheduleStartsFrom must be 'PP1' or 'PP2'.");
+  }
+  if (typeof motherPlan.lapseOpenAncVisits !== 'boolean') {
+    throw badRequest('DELIVERY output motherPlan.lapseOpenAncVisits must be a boolean.');
+  }
+  if (!Array.isArray(r.childPlans)) {
+    throw badRequest('DELIVERY output must include childPlans as an array.');
+  }
+  r.childPlans.forEach((plan, i) => {
+    if (typeof plan !== 'object' || plan === null) {
+      throw badRequest(`DELIVERY output childPlans[${i}] must be an object.`);
+    }
+    const p = plan as Record<string, unknown>;
+    if (typeof p.childIndex !== 'number') {
+      throw badRequest(`DELIVERY output childPlans[${i}].childIndex must be a number.`);
+    }
+    if (typeof p.generateNnSchedule !== 'boolean') {
+      throw badRequest(`DELIVERY output childPlans[${i}].generateNnSchedule must be a boolean.`);
+    }
+    if (typeof p.generateIncSchedule !== 'boolean') {
+      throw badRequest(`DELIVERY output childPlans[${i}].generateIncSchedule must be a boolean.`);
+    }
+  });
+  if (typeof r.neonatalPhaseAppliesGlobally !== 'boolean') {
+    throw badRequest('DELIVERY output must include a boolean neonatalPhaseAppliesGlobally.');
+  }
+  return r;
+}

--- a/apps/rules-service/src/rules/scheduling/anc.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/anc.rulesJson.ts
@@ -10,6 +10,16 @@
  * ANC visits (FR-S-3.7/BR-04/G.3) — that is a DB-state mutation the calling
  * service performs; this pack only reports `deliveryFormFiledByEddPlus7`
  * so the caller knows whether the Post-EDD visit applies.
+ *
+ * This pack takes no "today" input, so `deliveryFormFiledByEddPlus7: false`
+ * (and the accompanying `postEddVisit`) is returned identically whether the
+ * delivery form is unfiled because EDD+7 has genuinely passed, or because
+ * the woman is still mid-pregnancy, months from her EDD, and simply hasn't
+ * delivered yet. Both cases have `deliveryFormFiledDate: null` and are
+ * indistinguishable from this function's inputs alone. The caller MUST
+ * independently check that the real calendar date has passed EDD+7 before
+ * treating `postEddVisit` as due — this pack's output is a candidate visit,
+ * not a decision that it applies yet.
  */
 export const ancRulesJson = {
   contentType: 'application/vnd.gorules.decision',

--- a/apps/rules-service/src/rules/scheduling/anc.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/anc.rulesJson.ts
@@ -1,0 +1,82 @@
+/**
+ * ANC visit-schedule decision graph (SRS §3A.2.3 "ANC Visit Schedule",
+ * Appendix A.1, Appendix B, BR-01/BR-08). A single gorules function node
+ * computing the full formula-driven, uncapped ANC schedule from
+ * registrationDate/edd — stateless and pure, so re-running it with a new
+ * `edd` after a Supervisor-approved LMP/EDD change (BR-01) IS the
+ * regeneration; no separate "regenerate" rule exists.
+ *
+ * Does not decide whether the delivery form has actually lapsed the open
+ * ANC visits (FR-S-3.7/BR-04/G.3) — that is a DB-state mutation the calling
+ * service performs; this pack only reports `deliveryFormFiledByEddPlus7`
+ * so the caller knows whether the Post-EDD visit applies.
+ */
+export const ancRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeAncSchedule',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const { registrationDate, edd, deliveryFormFiledDate } = input;
+  const reg = dayjs(registrationDate);
+  const eddDate = dayjs(edd);
+
+  // FR-S-3.1 / Appendix A.1: ((EDD - Registration date) / 30) + 1, uncapped.
+  const totalVisits = Math.round(eddDate.diff(reg, 'day') / 30) + 1;
+
+  const visits = [];
+  // FR-S-3.2: ANC1 on Day 0 (registration date). Window Day 0 to +5.
+  visits.push({
+    visitName: 'ANC1',
+    scheduledDate: reg.format('YYYY-MM-DD'),
+    windowOpen: reg.format('YYYY-MM-DD'),
+    windowClose: reg.add(5, 'day').format('YYYY-MM-DD'),
+  });
+
+  // FR-S-3.3: ANC2..ANCn every 30 days from the previous scheduled date, +/-5 day window.
+  for (let i = 2; i <= totalVisits; i++) {
+    const scheduled = reg.add((i - 1) * 30, 'day');
+    visits.push({
+      visitName: 'ANC' + i,
+      scheduledDate: scheduled.format('YYYY-MM-DD'),
+      windowOpen: scheduled.subtract(5, 'day').format('YYYY-MM-DD'),
+      windowClose: scheduled.add(5, 'day').format('YYYY-MM-DD'),
+    });
+  }
+
+  // SR-ANC-01 / BR-08: if delivery form not filed by EDD+7, generate a dynamically
+  // named ANC(n+1) visit on EDD+8, window EDD+8 to EDD+13.
+  const deliveryFiledByEddPlus7 =
+    !!deliveryFormFiledDate && !dayjs(deliveryFormFiledDate).isAfter(eddDate.add(7, 'day'));
+  let postEddVisit = null;
+  if (!deliveryFiledByEddPlus7) {
+    const postEddDate = eddDate.add(8, 'day');
+    postEddVisit = {
+      visitName: 'ANC' + (totalVisits + 1),
+      scheduledDate: postEddDate.format('YYYY-MM-DD'),
+      windowOpen: postEddDate.format('YYYY-MM-DD'),
+      windowClose: eddDate.add(13, 'day').format('YYYY-MM-DD'),
+    };
+  }
+
+  return {
+    totalRegularVisits: totalVisits,
+    visits,
+    postEddVisit,
+    deliveryFormFiledByEddPlus7: deliveryFiledByEddPlus7,
+  };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/ccv.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/ccv.rulesJson.ts
@@ -1,0 +1,134 @@
+/**
+ * CCV (13-24 month) visit-schedule decision graph (SRS §3A.2.3 "CCV Visit
+ * Schedule", Appendix A.5, BR-13).
+ *
+ * BR-13: risk state is evaluated exactly once, at the 12-month INC-to-CCV
+ * transition, from the last 3 completed INC visits (plus a full 0-12m scan
+ * for "was HR ever detected"). No re-evaluation happens within 13-24m - so
+ * this pack takes the already-computed scan/last-3 signals as input and is
+ * safe to call multiple times with the same input for the same idempotent
+ * result; it does not itself re-derive risk state from raw visit history.
+ *
+ * Five states (Appendix A.5):
+ *  - NEVER_AT_HR            - no HR ever detected in 0-12m.
+ *  - CURRENTLY_HR_SAM       - SAM/danger sign at most recent INC visit.
+ *  - CURRENTLY_HR_OTHER     - other HR condition at most recent INC visit.
+ *  - RECENTLY_RECOVERED     - HR detected earlier, but last 3 INC visits normal.
+ *  - STABLE_LOW_RISK        - last 3 INC visits normal AND fully immunised,
+ *                             normal growth (never at risk historically is
+ *                             NEVER_AT_HR; this state is "no risk in last 3,
+ *                             and never any risk signal beyond that scan").
+ *
+ * Cadence differs for 13-18m and 19-24m sub-periods (Appendix A.5 table).
+ *
+ * Program exit (Appendix A.5 "Program exit"): at DOB+730 the journey ends
+ * unless the *last* CCV visit detected HR, in which case one CCV-HR visit
+ * is generated 30 days later and the journey extends to ~25 months, with
+ * closure deferred until that CCV-HR visit completes (closure form
+ * triggering itself is a separate CLOSURE rule pack, out of scope here -
+ * this pack only reports whether the extension visit is required).
+ */
+export const ccvRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeCcvSchedule',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const {
+    dob,
+    hrEverDetectedIn0to12m,
+    mostRecentIncVisitHrType, // 'SAM_DANGER' | 'OTHER' | 'NONE'
+    last3IncVisitsNormal,     // boolean
+    hrDetectedAtLastCcvVisit, // boolean, evaluated by the caller at DOB+730
+  } = input;
+
+  const dobDate = dayjs(dob);
+
+  let riskState;
+  let cadence13to18MonthsEveryNMonths;
+  let cadence19to24MonthsEveryNMonths;
+
+  if (!hrEverDetectedIn0to12m) {
+    riskState = 'NEVER_AT_HR';
+    cadence13to18MonthsEveryNMonths = 2;
+    cadence19to24MonthsEveryNMonths = 2;
+  } else if (mostRecentIncVisitHrType === 'SAM_DANGER') {
+    riskState = 'CURRENTLY_HR_SAM';
+    cadence13to18MonthsEveryNMonths = 1; // "HR visit in 30 days, every detection"
+    cadence19to24MonthsEveryNMonths = 1;
+  } else if (mostRecentIncVisitHrType === 'OTHER') {
+    riskState = 'CURRENTLY_HR_OTHER';
+    cadence13to18MonthsEveryNMonths = 1;
+    cadence19to24MonthsEveryNMonths = 1;
+  } else if (!last3IncVisitsNormal) {
+    // HR was detected historically, and the last 3 visits are still not
+    // all-normal, but the most recent visit itself is not HR - treat as
+    // Recently Recovered per Appendix A.5's "Last 3 INC visits were at risk".
+    riskState = 'RECENTLY_RECOVERED';
+    cadence13to18MonthsEveryNMonths = 1;
+    cadence19to24MonthsEveryNMonths = 2;
+  } else {
+    riskState = 'STABLE_LOW_RISK';
+    cadence13to18MonthsEveryNMonths = 2;
+    cadence19to24MonthsEveryNMonths = 2;
+  }
+
+  const transitionDate = dobDate.add(365, 'day');
+  const programExitDate = dobDate.add(730, 'day');
+
+  const visits = [];
+  let cursor = transitionDate;
+  let visitIndex = 1;
+  while (cursor.isBefore(programExitDate) || cursor.isSame(programExitDate)) {
+    const monthsSinceDob = cursor.diff(dobDate, 'month');
+    const cadenceMonths =
+      monthsSinceDob < 19 ? cadence13to18MonthsEveryNMonths : cadence19to24MonthsEveryNMonths;
+    visits.push({
+      visitName: 'CCV' + visitIndex,
+      scheduledDate: cursor.format('YYYY-MM-DD'),
+      windowOpen: cursor.subtract(5, 'day').format('YYYY-MM-DD'),
+      windowClose: cursor.add(5, 'day').format('YYYY-MM-DD'),
+    });
+    visitIndex++;
+    cursor = cursor.add(cadenceMonths, 'month');
+  }
+
+  // Program exit / CCV-HR extension (Appendix A.5 "Program exit").
+  let extensionVisit = null;
+  let closureDeferredForExtension = false;
+  if (hrDetectedAtLastCcvVisit) {
+    const lastVisit = visits[visits.length - 1];
+    const lastVisitDate = lastVisit ? dayjs(lastVisit.scheduledDate) : programExitDate;
+    const extensionDate = lastVisitDate.add(30, 'day');
+    extensionVisit = {
+      visitName: 'CCV-HR',
+      scheduledDate: extensionDate.format('YYYY-MM-DD'),
+      windowOpen: extensionDate.subtract(5, 'day').format('YYYY-MM-DD'),
+      windowClose: extensionDate.add(5, 'day').format('YYYY-MM-DD'),
+    };
+    closureDeferredForExtension = true;
+  }
+
+  return {
+    riskState,
+    cadence13to18MonthsEveryNMonths,
+    cadence19to24MonthsEveryNMonths,
+    visits,
+    extensionVisit,
+    closureDeferredForExtension,
+  };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/ccv.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/ccv.rulesJson.ts
@@ -65,14 +65,27 @@ const handler = (input, { dayjs }) => {
     riskState = 'CURRENTLY_HR_OTHER';
     cadence13to18MonthsEveryNMonths = 1;
     cadence19to24MonthsEveryNMonths = 1;
-  } else if (!last3IncVisitsNormal) {
-    // HR was detected historically, and the last 3 visits are still not
-    // all-normal, but the most recent visit itself is not HR - treat as
-    // Recently Recovered per Appendix A.5's "Last 3 INC visits were at risk".
+  } else if (last3IncVisitsNormal) {
+    // HR was detected earlier (this branch only reached when
+    // hrEverDetectedIn0to12m is true), the last 3 INC visits are normal, and
+    // the most recent visit itself is not HR - Recently Recovered per
+    // Appendix A.5 (SRS lines 1557-1559: "HR detected earlier but last 3
+    // INC visits normal"), matching this file's own top-of-file docstring.
+    // (Appendix A.5's line 355 summary table states this state's condition
+    // the other way around - contradicts its own line 1557-1559 table; the
+    // latter is treated as authoritative here.)
     riskState = 'RECENTLY_RECOVERED';
     cadence13to18MonthsEveryNMonths = 1;
     cadence19to24MonthsEveryNMonths = 2;
   } else {
+    // GAP: HR was detected earlier, the most recent visit itself is not HR,
+    // but the last 3 INC visits are still not all normal. Appendix A.5's
+    // five-state model (SRS lines 350-356 / 1557-1559) does not define a
+    // distinct condition for this combination - both named non-HR states
+    // (Recently Recovered, Stable Low Risk) require last3IncVisitsNormal to
+    // be true. Falling through to Stable Low Risk's cadence here is
+    // provisional pending SRS/product clarification (flagged in PR #129
+    // review) - do not treat this as validated clinical behaviour.
     riskState = 'STABLE_LOW_RISK';
     cadence13to18MonthsEveryNMonths = 2;
     cadence19to24MonthsEveryNMonths = 2;

--- a/apps/rules-service/src/rules/scheduling/delivery.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/delivery.rulesJson.ts
@@ -1,0 +1,94 @@
+/**
+ * Delivery combined-visit orchestration decision graph (SRS Appendix G).
+ * Not one of the six journeys named in the task, but required for the ANC/
+ * PP/NN/INC/CCV packs to actually reflect the document: the delivery form
+ * submission is the event that decides WHICH of those schedules to invoke
+ * and with what starting parameters, per Appendix G. This pack answers
+ * "what should happen as a result of this delivery form submission" -
+ * generating each child/mother sub-schedule is still delegated to the
+ * anc/pp/nn/inc rulesJson packs, called by the service layer using this
+ * pack's output as a plan.
+ *
+ * G.1: ANC-enrolled mother -> lapse all open ANC visits (schedule-visibility
+ * signal only; the actual DB write is a service-layer action, same
+ * boundary as the ANC pack's `deliveryFormFiledByEddPlus7`), generate PP
+ * (PP1 already done same session -> PP2-5), NN, INC per child.
+ * G.4: stillbirth -> mother still gets full PP1-5, but NO child schedule
+ * (NN/INC/CCV) is initiated at all.
+ * G.5: multiple births -> independent NN/INC/CCV schedule per child; PP is
+ * mother-level, generated once regardless of child count.
+ * G.2: late delivery form auto-determines PP/NN sections shown - delegated
+ * to the NN pack's own day-bucket logic (this pack just confirms neonatal
+ * applicability per child via that same day-bucket signal).
+ */
+export const deliveryRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeDeliveryPlan',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const {
+    deliveryOutcome,       // 'LIVE_BIRTH' | 'STILLBIRTH'
+    motherEnrollmentType,  // 'ANC_ENROLLED' | 'DIRECT'
+    numberOfChildren,
+    deliveryDate,
+    deliveryFormFiledDate,
+  } = input;
+
+  if (deliveryOutcome !== 'LIVE_BIRTH' && deliveryOutcome !== 'STILLBIRTH') {
+    throw new Error("deliveryOutcome must be 'LIVE_BIRTH' or 'STILLBIRTH'.");
+  }
+
+  const daysSinceDelivery = dayjs(deliveryFormFiledDate).diff(dayjs(deliveryDate), 'day');
+
+  const motherPlan = {
+    // PP1 is filled in the same combined session as the delivery form
+    // (G.1); the PP pack still generates all 5 rows from deliveryDate, the
+    // caller simply does not re-present PP1 to the Sakhi.
+    generatePpSchedule: true,
+    ppScheduleStartsFrom: motherEnrollmentType === 'ANC_ENROLLED' ? 'PP2' : 'PP1',
+    lapseOpenAncVisits: motherEnrollmentType === 'ANC_ENROLLED',
+  };
+
+  // G.4: stillbirth - mother still gets full PP1-5, no child journey at all.
+  if (deliveryOutcome === 'STILLBIRTH') {
+    return {
+      motherPlan: { ...motherPlan, ppScheduleStartsFrom: 'PP1' },
+      childPlans: [],
+      neonatalPhaseAppliesGlobally: false,
+    };
+  }
+
+  // G.5: one independent plan per live-born child.
+  const neonatalPhaseApplies = daysSinceDelivery <= 28;
+  const childPlans = [];
+  for (let i = 0; i < numberOfChildren; i++) {
+    childPlans.push({
+      childIndex: i,
+      generateNnSchedule: neonatalPhaseApplies,
+      generateIncSchedule: true,
+      // CCV schedule is generated later, at the INC-to-CCV transition
+      // (ccv.rulesJson.ts) - not at delivery time.
+    });
+  }
+
+  return {
+    motherPlan,
+    childPlans,
+    neonatalPhaseAppliesGlobally: neonatalPhaseApplies,
+  };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/hr.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/hr.rulesJson.ts
@@ -1,0 +1,81 @@
+/**
+ * High-Risk (HR) visit scheduling decision graph (SRS §3A.2.5, FR-S-5.2,
+ * FR-S-5.3, BR-03).
+ *
+ * Timing/trigger logic ONLY. This pack does not decide whether a beneficiary
+ * IS high-risk - `hrDetectedThisVisit` is an upstream input this pack does
+ * not compute. Appendix D ("High Risk Detection Rules") is explicitly
+ * marked PENDING in the SRS (§3A.2.5: "PENDING - Updated HR thresholds
+ * document from ARMMAN... committed 29 April 2026") and is not available in
+ * this repo. The real clinical thresholds (hemoglobin cutoffs, danger
+ * signs, etc.) belong in a separate RISK-category rule pack once ARMMAN
+ * supplies them - wiring that up is out of scope for this scheduling pack.
+ *
+ * BR-03: the HR visit anchor is always the ACTUAL completion date of the
+ * triggering visit, never the scheduled date - applies identically to
+ * ANC-HR, INC-HR and CCV-HR, so all three phases share this one pack/anchor
+ * computation rather than three duplicated implementations.
+ *
+ * FR-S-5.3: cumulative vs single-instance behaviour differs by phase:
+ *  - INC (and ANC, same rule): cumulative - every detection generates a new
+ *    HR visit, 15 days after actual completion, +/-2 day window, regardless
+ *    of whether that condition was flagged before.
+ *  - CCV: single-instance per detection - one HR visit 30 days after actual
+ *    completion, then reverts to the normal age-based cadence once that HR
+ *    visit is completed.
+ *
+ * BR-06 / SR-NN-01: no HR visits during the neonatal phase - `phase: 'NN'`
+ * is not a valid input; the neonatal pack (nn.rulesJson.ts) has no HR
+ * output field at all, so there is no call site that could ever invoke this
+ * pack for NN.
+ */
+export const hrRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeHrVisit',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const { phase, hrDetectedThisVisit, actualCompletionDate } = input;
+
+  if (phase !== 'ANC' && phase !== 'INC' && phase !== 'CCV') {
+    throw new Error("phase must be one of 'ANC', 'INC', 'CCV' - HR visits are never generated in the neonatal (NN) phase (BR-06/SR-NN-01).");
+  }
+
+  if (!hrDetectedThisVisit) {
+    return { generateHrVisit: false, hrVisit: null, cumulative: phase !== 'CCV' };
+  }
+
+  const actual = dayjs(actualCompletionDate);
+  const offsetDays = phase === 'CCV' ? 30 : 15;
+  const windowDays = phase === 'CCV' ? 5 : 2;
+  const anchor = actual.add(offsetDays, 'day');
+
+  return {
+    generateHrVisit: true,
+    // Cumulative (ANC/INC): a new HR visit fires on every detection, even if
+    // this exact condition triggered one before. Single-instance (CCV): one
+    // HR visit per detection event; the caller reverts to normal cadence
+    // once this HR visit is completed.
+    cumulative: phase !== 'CCV',
+    hrVisit: {
+      visitName: phase + '-HR',
+      scheduledDate: anchor.format('YYYY-MM-DD'),
+      windowOpen: anchor.subtract(windowDays, 'day').format('YYYY-MM-DD'),
+      windowClose: anchor.add(windowDays, 'day').format('YYYY-MM-DD'),
+    },
+  };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/inc.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/inc.rulesJson.ts
@@ -1,0 +1,88 @@
+/**
+ * INC (0-12 month) visit-schedule decision graph (SRS §3A.2.3 "INC Visit
+ * Schedule", Appendix A.4, BR-02, BR-12).
+ *
+ * Two-formula approach keyed on the Day 58 boundary (inclusive on both
+ * sides per "Early registration (Day 0 to Day 58 from DOB)"):
+ *  - Early registration: 11 fixed visits, INC1 anchored at DOB+58, chained
+ *    every 30 days.
+ *  - Late registration: INC1 = registration date itself; additional visit
+ *    count = floor((365 - (registrationDate - DOB)) / 30), chained every
+ *    30 days from INC1.
+ *
+ * Hard cutoff (BR-12): any visit scheduled beyond DOB+370 is dropped -
+ * silently excluded from the output, never marked missed.
+ *
+ * BR-02: fixed at registration/enrolment, does not shift on missed visits -
+ * this pack is stateless/pure (dob + registrationDate only), so it cannot
+ * drift; re-running it always reproduces the same schedule.
+ */
+export const incRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeIncSchedule',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const dob = dayjs(input.dob);
+  const reg = dayjs(input.registrationDate);
+  const daysSinceDob = reg.diff(dob, 'day');
+  const cutoff = dob.add(370, 'day');
+
+  let registrationCategory;
+  let anchor;
+  let additionalVisitCount;
+
+  if (daysSinceDob <= 58) {
+    // Early registration: 11 visits fixed, INC1 = DOB + 58.
+    registrationCategory = 'EARLY';
+    anchor = dob.add(58, 'day');
+    additionalVisitCount = 10; // INC2..INC11
+  } else {
+    // Late registration: INC1 = registration date itself.
+    registrationCategory = 'LATE';
+    anchor = reg;
+    additionalVisitCount = Math.floor((365 - daysSinceDob) / 30);
+  }
+
+  const rawVisits = [];
+  rawVisits.push({ visitName: 'INC1', scheduledDate: anchor });
+  for (let i = 1; i <= additionalVisitCount; i++) {
+    rawVisits.push({ visitName: 'INC' + (i + 1), scheduledDate: anchor.add(i * 30, 'day') });
+  }
+
+  const droppedVisits = [];
+  const visits = [];
+  for (const v of rawVisits) {
+    if (v.scheduledDate.isAfter(cutoff)) {
+      droppedVisits.push(v.visitName);
+      continue;
+    }
+    visits.push({
+      visitName: v.visitName,
+      scheduledDate: v.scheduledDate.format('YYYY-MM-DD'),
+      windowOpen: v.scheduledDate.subtract(5, 'day').format('YYYY-MM-DD'),
+      windowClose: v.scheduledDate.add(5, 'day').format('YYYY-MM-DD'),
+    });
+  }
+
+  return {
+    registrationCategory,
+    visits,
+    droppedVisits,
+    lastIncVisitDate: visits.length > 0 ? visits[visits.length - 1].scheduledDate : null,
+  };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/nn.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/nn.rulesJson.ts
@@ -1,0 +1,88 @@
+/**
+ * Neonatal (NN) visit-schedule decision graph (SRS §3A.2.3 "NN Visit
+ * Schedule" Scenarios A/B/C, Appendix A.3, Appendix G.2 late-delivery-form
+ * table, BR-06/SR-NN-01).
+ *
+ * Three day-buckets based on how many days after delivery the delivery form
+ * was filled:
+ *  - Day 0-14  (Scenario A): NN1 same session, window 0-14. NN2 generated
+ *    after NN1 completion, window 15-28.
+ *  - Day 15-28 (Scenario B / Appendix G.2 row 2): NN1 skipped (window
+ *    already closed - not generated, not marked missed). NN2 generated
+ *    immediately, window = remaining days up to Day 28.
+ *  - Day 29+   (Appendix G.2 row 3, the case omitted from the first draft
+ *    of this pack): no neonatal section at all. Both NN1 and NN2 are
+ *    skipped; the child goes directly to INC scheduling.
+ *
+ * SR-NN-01 / BR-06: no HR visits during the neonatal phase - this pack's
+ * output schema has no HR-related field by construction; a critical
+ * condition detected during NN1/NN2 goes through the referral flow, which
+ * is a separate rule category (out of scope here).
+ */
+export const nnRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeNnSchedule',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const delivery = dayjs(input.deliveryDate);
+  const filled = dayjs(input.deliveryFormFiledDate);
+  const daysSinceDelivery = filled.diff(delivery, 'day');
+
+  if (daysSinceDelivery <= 14) {
+    // Scenario A / Appendix G.2 row 1.
+    return {
+      scenario: 'DAY_0_TO_14',
+      neonatalPhaseApplies: true,
+      nn1: {
+        visitName: 'NN1',
+        scheduledDate: delivery.format('YYYY-MM-DD'),
+        windowOpen: delivery.format('YYYY-MM-DD'),
+        windowClose: delivery.add(14, 'day').format('YYYY-MM-DD'),
+      },
+      nn2: {
+        visitName: 'NN2',
+        scheduledDate: delivery.add(15, 'day').format('YYYY-MM-DD'),
+        windowOpen: delivery.add(15, 'day').format('YYYY-MM-DD'),
+        windowClose: delivery.add(28, 'day').format('YYYY-MM-DD'),
+      },
+    };
+  }
+
+  if (daysSinceDelivery <= 28) {
+    // Scenario B / Appendix G.2 row 2 - NN1 skipped, NN2 immediate.
+    return {
+      scenario: 'DAY_15_TO_28',
+      neonatalPhaseApplies: true,
+      nn1: null,
+      nn2: {
+        visitName: 'NN2',
+        scheduledDate: filled.format('YYYY-MM-DD'),
+        windowOpen: filled.format('YYYY-MM-DD'),
+        windowClose: delivery.add(28, 'day').format('YYYY-MM-DD'),
+      },
+    };
+  }
+
+  // Day 29+ / Appendix G.2 row 3 - no neonatal section, straight to INC.
+  return {
+    scenario: 'DAY_29_PLUS',
+    neonatalPhaseApplies: false,
+    nn1: null,
+    nn2: null,
+  };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/pp.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/pp.rulesJson.ts
@@ -1,0 +1,47 @@
+/**
+ * Postpartum (PP) visit-schedule decision graph (SRS §3A.2.3 "PP Visit
+ * Schedule", Appendix A.2, BR-05). Fixed 5-row table anchored strictly to
+ * `deliveryDate` — the input schema deliberately has no "actual completion
+ * date" field, so PP3-5 cannot shift on a late PP2 completion (BR-05: "If
+ * PP2 completed late, PP3 stays at Day 45").
+ */
+export const ppRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computePpSchedule',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input, { dayjs }) => {
+  const delivery = dayjs(input.deliveryDate);
+
+  // Appendix A.2 — fixed offsets from delivery date, fixed window offsets.
+  const rows = [
+    { visitName: 'PP1', scheduledOffset: 0, windowOpenOffset: 0, windowCloseOffset: 14 },
+    { visitName: 'PP2', scheduledOffset: 15, windowOpenOffset: 15, windowCloseOffset: 28 },
+    { visitName: 'PP3', scheduledOffset: 58, windowOpenOffset: 53, windowCloseOffset: 63 },
+    { visitName: 'PP4', scheduledOffset: 88, windowOpenOffset: 83, windowCloseOffset: 93 },
+    { visitName: 'PP5', scheduledOffset: 118, windowOpenOffset: 113, windowCloseOffset: 123 },
+  ];
+
+  const visits = rows.map((r) => ({
+    visitName: r.visitName,
+    scheduledDate: delivery.add(r.scheduledOffset, 'day').format('YYYY-MM-DD'),
+    windowOpen: delivery.add(r.windowOpenOffset, 'day').format('YYYY-MM-DD'),
+    windowClose: delivery.add(r.windowCloseOffset, 'day').format('YYYY-MM-DD'),
+  }));
+
+  return { visits };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "db:migrate": "npm run migrate",
     "seed": "node tools/prisma-seed-foreach.js",
     "db:seed": "npm run seed",
-    "serve:all": "nx run-many -t build --projects=service-commons,core && nx run-many -t serve --all --parallel=16",
+    "serve:all": "nx run-many -t build --projects=service-commons,core && NODE_OPTIONS=--no-deprecation nx run-many -t serve --all --parallel=16",
     "postinstall": "npm run db:generate",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary

**Bug:** a beneficiary created under one SAKHI account was visible to another SAKHI. Root cause: `GET /beneficiaries/:id` had no ownership check at all — `BeneficiaryService.getById()` never received the caller's identity, unlike `list()`/`create()`/`applyLmpChange()`/`reactivateCase()`, which all correctly scope by caller. Any authenticated SAKHI/SUPERVISOR/MANAGER could fetch **any** beneficiary case by id (full PII included) just by knowing or guessing it.

**Fix:** `getById()` now applies the same ownership pattern already used elsewhere in this file — SAKHI may only fetch their own case, SUPERVISOR only a case whose Sakhi is in their roster, MANAGER unrestricted (ADMIN was never in this route's allowed roles to begin with, unrelated to this bug). Extracted a `projectCase()` private helper (decrypt + socio-demographics resolution, no ownership check) so the three internal post-mutation re-fetches (`upsertSocioDemographics`/`applyLmpChange`/`reactivateCase`) — which already verify ownership earlier in their own flow — don't need to thread a caller through `getById` redundantly.

## Root cause investigation

Followed systematic debugging before touching any code:
- Code-inspected `list()`, `create()`, the repository's Prisma query, and the JWT identity chain — all correct, ruled out.
- Reproduced live against a real environment with two fresh SAKHI accounts: `GET /beneficiaries` correctly isolated (0 results for the non-owner), `POST /beneficiaries` correctly ignored a spoofed `sakhiId` in the body — but **`GET /beneficiaries/:id` returned the other Sakhi's full record with 200 OK**. That pinpointed the actual broken endpoint.
- Confirmed via every existing `getById` unit test: all of them called it as `service.getById('x', AUTH_HEADER)` with no caller argument, proving the method genuinely never checked identity in any test either.

## Known related gap (not in this PR)

While investigating, found the identical missing-ownership-check pattern on `PATCH /beneficiaries/:id/socio-demographics` — same route-level role gate, same absence of any check. Deliberately **not included here** to keep this PR scoped to the reported bug; will be a separate follow-up PR.

## Test plan
- [x] Added 5 new unit tests: SAKHI-not-owner → 403, SAKHI-owner → 200, SUPERVISOR-out-of-roster → 403, SUPERVISOR-in-roster → 200, MANAGER-unrestricted → 200
- [x] Updated 6 pre-existing `getById` tests to pass a caller
- [x] `npx nx test beneficiary-service` — 189/189 passing
- [x] `npx nx lint beneficiary-service` — clean
- [x] Reproduced the bug live pre-fix (200 OK returning another Sakhi's beneficiary)
- [x] Re-verified the fix live on local after restarting services with current code — same request now returns `403 "This beneficiary case is outside your own roster."`; confirmed no regression for the owning SAKHI (200) and MANAGER (200, unrestricted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)