### PR TITLE
feat(rules-service): Implement ESCALATION GoRules decision graph

### DIFF
--- a/apps/rules-service/prisma/seed.ts
+++ b/apps/rules-service/prisma/seed.ts
@@ -7,6 +7,7 @@ import { incRulesJson } from '../src/rules/scheduling/inc.rulesJson';
 import { ccvRulesJson } from '../src/rules/scheduling/ccv.rulesJson';
 import { hrRulesJson } from '../src/rules/scheduling/hr.rulesJson';
 import { deliveryRulesJson } from '../src/rules/scheduling/delivery.rulesJson';
+import { escalationRulesJson } from '../src/rules/scheduling/escalation.rulesJson';
 
 const prisma = new PrismaClient();
 
@@ -102,6 +103,50 @@ async function seedSchedulingRulePacks(): Promise<void> {
   }
 }
 
+// Fixed UUID pair for the first (and currently only) ESCALATION rule pack
+// (SRS §3A.2.7 FR-S-7.1) — a distinct prefix ('44444444...') from the
+// SCHEDULE packs' '33333333...' family, since this is a different
+// RuleCategory, not another scheduling journey. Same upsert-once pattern:
+// `update: {}` on both upserts means this only ever creates the rows on a
+// fresh environment.
+const ESCALATION_RULE_PACKS = [
+  {
+    ruleSetId: '44444444-4444-4444-8444-444444444441',
+    ruleVersionId: '44444444-4444-4444-8444-444444444442',
+    ruleSetName: 'Arogya Sakhi Missed-Visit Escalation',
+    rulesJson: escalationRulesJson,
+  },
+] as const;
+
+async function seedEscalationRulePacks(): Promise<void> {
+  for (const pack of ESCALATION_RULE_PACKS) {
+    await prisma.ruleSet.upsert({
+      where: { id: pack.ruleSetId },
+      create: {
+        id: pack.ruleSetId,
+        ruleCategory: 'ESCALATION',
+        ruleSetName: pack.ruleSetName,
+        status: 'ACTIVE',
+      },
+      update: {},
+    });
+
+    await prisma.ruleVersion.upsert({
+      where: { id: pack.ruleVersionId },
+      create: {
+        id: pack.ruleVersionId,
+        ruleSetId: pack.ruleSetId,
+        versionNo: 'v1',
+        rulesJson: pack.rulesJson,
+        effectiveFrom: new Date('2026-08-10'),
+        checksum: createHash('sha256').update(JSON.stringify(pack.rulesJson)).digest(),
+        status: 'PUBLISHED',
+      },
+      update: {},
+    });
+  }
+}
+
 /**
  * Seeds the SCHEDULE rule set + its v1-hardcoded published version, so
  * VisitSchedule.generatedByRuleVersionId (NOT NULL, no default) has a real
@@ -156,6 +201,9 @@ async function main(): Promise<void> {
   console.log(
     `Seeded ${SCHEDULING_RULE_PACKS.length} scheduling rule packs (ANC/PP/NN/INC/CCV/HR/DELIVERY).`,
   );
+
+  await seedEscalationRulePacks();
+  console.log(`Seeded ${ESCALATION_RULE_PACKS.length} escalation rule pack(s).`);
 }
 
 main()

--- a/apps/rules-service/src/rules/dto/evaluate-escalation.dto.ts
+++ b/apps/rules-service/src/rules/dto/evaluate-escalation.dto.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Request body for `POST /rules/:setId/evaluate-escalation`. Unlike
+ * evaluate-schedule.dto.ts's generic JSON-blob `input` (which varies per
+ * scheduleKind), ESCALATION's input shape is fixed across every visitFamily
+ * (SRS §3A.2.7 FR-S-7.1), so it gets a properly typed schema instead of a
+ * recursive JSON-value union.
+ */
+export const evaluateEscalationSchema = z
+  .object({
+    input: z
+      .object({
+        visitFamily: z.string(),
+        isHrVisit: z.boolean(),
+        consecutiveMissedCount: z.number().int().min(0),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type EvaluateEscalationInput = z.infer<typeof evaluateEscalationSchema>;

--- a/apps/rules-service/src/rules/escalationEvaluator.spec.ts
+++ b/apps/rules-service/src/rules/escalationEvaluator.spec.ts
@@ -1,0 +1,60 @@
+import { evaluateEscalationPack } from './escalationEvaluator';
+
+/**
+ * A minimal gorules decision graph whose output node passes its input
+ * unchanged (an identity graph) — good enough to exercise
+ * evaluateEscalationPack's own shape-validation logic against a real
+ * zen-engine evaluation, same technique as ruleSet.evaluator.spec.ts /
+ * scheduleEvaluator.spec.ts's IDENTITY_GRAPH.
+ */
+const IDENTITY_GRAPH = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'input', position: { x: 0, y: 0 } },
+    { id: 'output1', type: 'outputNode', name: 'output', position: { x: 0, y: 0 } },
+  ],
+  edges: [{ id: 'e1', sourceId: 'input1', targetId: 'output1', type: 'edge' }],
+};
+
+describe('evaluateEscalationPack', () => {
+  it('passes a well-formed output through unchanged', async () => {
+    const result = await evaluateEscalationPack(IDENTITY_GRAPH, {
+      shouldEscalate: true,
+      reasonCode: 'X',
+    });
+    expect(result).toEqual({ shouldEscalate: true, reasonCode: 'X' });
+  });
+
+  it('rejects an output missing shouldEscalate', async () => {
+    await expect(evaluateEscalationPack(IDENTITY_GRAPH, { reasonCode: 'X' })).rejects.toMatchObject(
+      { status: 400 },
+    );
+  });
+
+  it('rejects an output missing reasonCode', async () => {
+    await expect(
+      evaluateEscalationPack(IDENTITY_GRAPH, { shouldEscalate: true }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects an output whose shouldEscalate is not a boolean', async () => {
+    await expect(
+      evaluateEscalationPack(IDENTITY_GRAPH, { shouldEscalate: 'true', reasonCode: 'X' }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects an output whose reasonCode is not a string', async () => {
+    await expect(
+      evaluateEscalationPack(IDENTITY_GRAPH, { shouldEscalate: true, reasonCode: 123 }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('tolerates extra unexpected fields on the output (permissive, matches validateAnc etc.)', async () => {
+    const result = await evaluateEscalationPack(IDENTITY_GRAPH, {
+      shouldEscalate: false,
+      reasonCode: 'BELOW_THRESHOLD',
+      unexpectedField: 'ignored',
+    });
+    expect(result).toEqual({ shouldEscalate: false, reasonCode: 'BELOW_THRESHOLD' });
+  });
+});

--- a/apps/rules-service/src/rules/escalationEvaluator.ts
+++ b/apps/rules-service/src/rules/escalationEvaluator.ts
@@ -1,0 +1,63 @@
+import { ZenDecisionContent, ZenEngine } from '@gorules/zen-engine';
+import { badRequest } from '@armman/service-commons';
+
+/**
+ * Shape-validated result of an ESCALATION rule pack evaluation (SRS
+ * §3A.2.7 FR-S-7.1) — whether a missed-visit streak should escalate to a
+ * Supervisor, and the reasonCode explaining the decision either way.
+ */
+export interface EscalationEvaluation {
+  shouldEscalate: boolean;
+  reasonCode: string;
+}
+
+/**
+ * Runs a published ESCALATION rule version's gorules decision graph against
+ * `input` and returns its shape-validated result. Same execution pattern as
+ * scheduleEvaluator.ts's evaluateSchedulePack — fresh ZenEngine/
+ * ZenDecisionContent per call — but with a single fixed output contract
+ * (unlike SCHEDULE's per-scheduleKind shapes), since ESCALATION has exactly
+ * one input/output shape across every visitFamily.
+ *
+ * Throws badRequest() if the decision graph's output isn't
+ * `{ shouldEscalate: boolean, reasonCode: string }` — a malformed rule pack
+ * must surface as a client (400) error, not a 500 masking a config problem.
+ * Extra unexpected fields on the output are tolerated (not rejected), same
+ * permissive-on-extras convention as scheduleEvaluator.ts's validateXxx
+ * functions. A zen-engine evaluation throw (e.g. an unrecognized
+ * visitFamily) propagates as-is — this evaluator does not catch/rewrap it,
+ * matching ruleSet.evaluator.ts's documented convention that "zen-engine's
+ * own evaluation errors ... propagate as-is; the controller/service layer
+ * decides how those map to HTTP status."
+ */
+export async function evaluateEscalationPack(
+  rulesJson: unknown,
+  input: Record<string, unknown>,
+): Promise<EscalationEvaluation> {
+  const engine = new ZenEngine();
+  const content = new ZenDecisionContent(rulesJson as object);
+  const decision = engine.createDecision(content);
+  let response;
+  try {
+    response = await decision.evaluate(input);
+  } finally {
+    engine.dispose();
+  }
+
+  const result = response.result;
+  if (typeof result !== 'object' || result === null) {
+    throw badRequest(
+      "This ESCALATION rule pack's decision graph did not return a { shouldEscalate, reasonCode } object.",
+    );
+  }
+  const r = result as Record<string, unknown>;
+
+  if (typeof r.shouldEscalate !== 'boolean') {
+    throw badRequest('ESCALATION output must include a boolean shouldEscalate.');
+  }
+  if (typeof r.reasonCode !== 'string') {
+    throw badRequest('ESCALATION output must include a string reasonCode.');
+  }
+
+  return { shouldEscalate: r.shouldEscalate, reasonCode: r.reasonCode };
+}

--- a/apps/rules-service/src/rules/ruleVersion.controller.ts
+++ b/apps/rules-service/src/rules/ruleVersion.controller.ts
@@ -28,5 +28,9 @@ export function createRuleVersionController(service: RuleVersionService) {
     evaluateSchedule: asyncHandler(async (req, res) => {
       res.json(ok(await service.evaluateSchedule(req.params.setId, req.body)));
     }),
+
+    evaluateEscalation: asyncHandler(async (req, res) => {
+      res.json(ok(await service.evaluateEscalation(req.params.setId, req.body)));
+    }),
   };
 }

--- a/apps/rules-service/src/rules/ruleVersion.routes.ts
+++ b/apps/rules-service/src/rules/ruleVersion.routes.ts
@@ -5,6 +5,7 @@ import { createRuleVersionController } from './ruleVersion.controller';
 import { publishRuleVersionSchema } from './dto/publish-ruleVersion.dto';
 import { evaluateRuleSetSchema } from './dto/evaluate-ruleSet.dto';
 import { evaluateScheduleSchema } from './dto/evaluate-schedule.dto';
+import { evaluateEscalationSchema } from './dto/evaluate-escalation.dto';
 import { SCHEDULE_KINDS } from './scheduleEvaluator';
 import {
   requireRoles,
@@ -101,6 +102,14 @@ const evaluateResponseSchema = z.object({
     .enum(['NORMAL', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
     .openapi({ example: 'HIGH' }),
   conditions: z.array(riskEvaluationResultSchema),
+});
+
+const evaluateEscalationRequestSchema = evaluateEscalationSchema;
+
+const escalationEvaluateResponseSchema = z.object({
+  ruleVersionId: z.string().uuid(),
+  shouldEscalate: z.boolean(),
+  reasonCode: z.string().openapi({ example: 'ANC_TWO_CONSECUTIVE_MISSED' }),
 });
 
 const apiErrorSchema = z.object({
@@ -240,5 +249,36 @@ export function registerRuleVersionRoutes(doc: DocumentedRouter, service: RuleVe
     validate(setIdParamsSchema, 'params'),
     validateBody(evaluateScheduleRequestSchema),
     controller.evaluateSchedule,
+  );
+
+  doc.post(
+    '/rules/:setId/evaluate-escalation',
+    {
+      summary:
+        "Evaluate the rule set's currently-published gorules ESCALATION decision graph " +
+        '(missed-visit escalation, SRS §3A.2.7 FR-S-7.1) against caller-supplied ' +
+        'visitFamily/isHrVisit/consecutiveMissedCount. Never evaluates against a DRAFT version.',
+      tags: ['Rules'],
+      params: setIdParamsSchema,
+      responses: {
+        200: {
+          description: 'Escalation evaluation result',
+          schema: envelope(escalationEvaluateResponseSchema),
+        },
+        400: { description: 'Malformed input or decision-graph output', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+        404: {
+          description: 'Rule set not found, or it has no published version',
+          schema: apiErrorSchema,
+        },
+        500: { description: 'Server error', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validate(setIdParamsSchema, 'params'),
+    validateBody(evaluateEscalationRequestSchema),
+    controller.evaluateEscalation,
   );
 }

--- a/apps/rules-service/src/rules/ruleVersion.service.spec.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.spec.ts
@@ -2,9 +2,11 @@ import { RuleVersionService } from './ruleVersion.service';
 import type { RuleVersionRepository } from './ruleVersion.repository';
 import { evaluateRulePack } from './ruleSet.evaluator';
 import { evaluateSchedulePack } from './scheduleEvaluator';
+import { evaluateEscalationPack } from './escalationEvaluator';
 
 jest.mock('./ruleSet.evaluator');
 jest.mock('./scheduleEvaluator');
+jest.mock('./escalationEvaluator');
 
 describe('RuleVersionService', () => {
   const repository = {
@@ -16,6 +18,7 @@ describe('RuleVersionService', () => {
   let service: RuleVersionService;
   const evaluateRulePackMock = jest.mocked(evaluateRulePack);
   const evaluateSchedulePackMock = jest.mocked(evaluateSchedulePack);
+  const evaluateEscalationPackMock = jest.mocked(evaluateEscalationPack);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -295,6 +298,74 @@ describe('RuleVersionService', () => {
         message: 'No published rule pack version found for this rule set.',
       });
       expect(evaluateSchedulePackMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('evaluateEscalation', () => {
+    it('evaluates against the published version and returns ruleVersionId alongside the results', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'ESCALATION' } as never);
+      repository.findPublishedBySetId.mockResolvedValue({
+        id: 'ver-1',
+        ruleSetId: setId,
+        rulesJson: { rules: [] },
+      } as never);
+      evaluateEscalationPackMock.mockResolvedValue({
+        shouldEscalate: true,
+        reasonCode: 'ANC_TWO_CONSECUTIVE_MISSED',
+      });
+
+      const result = await service.evaluateEscalation(setId, {
+        input: { visitFamily: 'ANC', isHrVisit: false, consecutiveMissedCount: 2 },
+      });
+
+      expect(evaluateEscalationPackMock).toHaveBeenCalledWith(
+        { rules: [] },
+        { visitFamily: 'ANC', isHrVisit: false, consecutiveMissedCount: 2 },
+      );
+      expect(result).toEqual({
+        ruleVersionId: 'ver-1',
+        shouldEscalate: true,
+        reasonCode: 'ANC_TWO_CONSECUTIVE_MISSED',
+      });
+    });
+
+    it('400s when the rule set is not ESCALATION category, never evaluating', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'SCHEDULE' } as never);
+
+      await expect(
+        service.evaluateEscalation(setId, {
+          input: { visitFamily: 'ANC', isHrVisit: false, consecutiveMissedCount: 1 },
+        }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(repository.findPublishedBySetId).not.toHaveBeenCalled();
+      expect(evaluateEscalationPackMock).not.toHaveBeenCalled();
+    });
+
+    it('404s when the rule set itself does not exist, never checking for a published version', async () => {
+      repository.findSetById.mockResolvedValue(null);
+
+      await expect(
+        service.evaluateEscalation(setId, {
+          input: { visitFamily: 'ANC', isHrVisit: false, consecutiveMissedCount: 1 },
+        }),
+      ).rejects.toMatchObject({ status: 404, message: 'Rule set not found.' });
+      expect(repository.findPublishedBySetId).not.toHaveBeenCalled();
+      expect(evaluateEscalationPackMock).not.toHaveBeenCalled();
+    });
+
+    it('404s when the rule set exists but has no published version, never evaluating', async () => {
+      repository.findSetById.mockResolvedValue({ id: setId, ruleCategory: 'ESCALATION' } as never);
+      repository.findPublishedBySetId.mockResolvedValue(null);
+
+      await expect(
+        service.evaluateEscalation(setId, {
+          input: { visitFamily: 'ANC', isHrVisit: false, consecutiveMissedCount: 1 },
+        }),
+      ).rejects.toMatchObject({
+        status: 404,
+        message: 'No published rule pack version found for this rule set.',
+      });
+      expect(evaluateEscalationPackMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/rules-service/src/rules/ruleVersion.service.ts
+++ b/apps/rules-service/src/rules/ruleVersion.service.ts
@@ -4,8 +4,10 @@ import type { RuleVersionRepository } from './ruleVersion.repository';
 import type { PublishRuleVersionInput } from './dto/publish-ruleVersion.dto';
 import type { EvaluateRuleSetInput } from './dto/evaluate-ruleSet.dto';
 import type { EvaluateScheduleInput } from './dto/evaluate-schedule.dto';
+import type { EvaluateEscalationInput } from './dto/evaluate-escalation.dto';
 import { evaluateRulePack } from './ruleSet.evaluator';
 import { evaluateSchedulePack } from './scheduleEvaluator';
+import { evaluateEscalationPack } from './escalationEvaluator';
 
 /** Prisma unique-constraint violation code (ruleSetId + versionNo). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
@@ -120,6 +122,32 @@ export class RuleVersionService {
     }
 
     const evaluation = await evaluateSchedulePack(dto.scheduleKind, version.rulesJson, dto.input);
+    return { ruleVersionId: version.id, ...evaluation };
+  }
+
+  /**
+   * Executes the rule set's currently-published gorules decision graph as an
+   * ESCALATION-category pack (SRS §3A.2.7 FR-S-7.1) — same 404-on-missing-
+   * set/missing-published-version guard as evaluate()/evaluateSchedule(),
+   * but validates the output against escalationEvaluator.ts's single fixed
+   * `{ shouldEscalate, reasonCode }` contract rather than a per-scheduleKind
+   * shape.
+   */
+  async evaluateEscalation(ruleSetId: string, dto: EvaluateEscalationInput) {
+    const set = await this.repository.findSetById(ruleSetId);
+    if (!set) throw notFound('Rule set not found.');
+    if (set.ruleCategory !== 'ESCALATION') {
+      throw badRequest(
+        `This rule set is ${set.ruleCategory}, not ESCALATION — cannot evaluate it here.`,
+      );
+    }
+
+    const version = await this.repository.findPublishedBySetId(ruleSetId);
+    if (!version) {
+      throw notFound('No published rule pack version found for this rule set.');
+    }
+
+    const evaluation = await evaluateEscalationPack(version.rulesJson, dto.input);
     return { ruleVersionId: version.id, ...evaluation };
   }
 

--- a/apps/rules-service/src/rules/scheduling/escalation.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/escalation.rulesJson.spec.ts
@@ -1,0 +1,141 @@
+import { evaluateEscalationPack } from '../escalationEvaluator';
+import { escalationRulesJson } from './escalation.rulesJson';
+
+describe('escalationRulesJson (via evaluateEscalationPack)', () => {
+  describe('ANC', () => {
+    it('escalates at the two-consecutive-miss threshold (FR-S-3.5/FR-S-7.1)', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'ANC',
+        isHrVisit: false,
+        consecutiveMissedCount: 2,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'ANC_TWO_CONSECUTIVE_MISSED' });
+    });
+
+    it('does not escalate below the threshold (count=1)', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'ANC',
+        isHrVisit: false,
+        consecutiveMissedCount: 1,
+      });
+      expect(result.shouldEscalate).toBe(false);
+    });
+
+    it('escalates above the threshold (count=3)', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'ANC',
+        isHrVisit: false,
+        consecutiveMissedCount: 3,
+      });
+      expect(result.shouldEscalate).toBe(true);
+    });
+
+    it('HR overrides the family threshold: escalates on the first miss (FR-S-3.6)', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'ANC',
+        isHrVisit: true,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'HR_VISIT_MISSED' });
+    });
+  });
+
+  describe('HR override across other families', () => {
+    it('INC, HR visit missed: escalates on the first miss', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'INC',
+        isHrVisit: true,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'HR_VISIT_MISSED' });
+    });
+
+    it('CCV, HR visit missed: escalates on the first miss', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'CCV',
+        isHrVisit: true,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'HR_VISIT_MISSED' });
+    });
+  });
+
+  describe('INC', () => {
+    it('escalates at the two-consecutive-miss threshold (FR-S-7.1)', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'INC',
+        isHrVisit: false,
+        consecutiveMissedCount: 2,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'INC_TWO_CONSECUTIVE_MISSED' });
+    });
+
+    it('does not escalate below the threshold (count=1)', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'INC',
+        isHrVisit: false,
+        consecutiveMissedCount: 1,
+      });
+      expect(result.shouldEscalate).toBe(false);
+    });
+  });
+
+  describe('single-miss families (ANC_POST_EDD/PP/NN/CCV)', () => {
+    it('PP escalates on the first miss', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'PP',
+        isHrVisit: false,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'SINGLE_VISIT_MISSED' });
+    });
+
+    it('NN escalates on the first miss', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'NN',
+        isHrVisit: false,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'SINGLE_VISIT_MISSED' });
+    });
+
+    it('CCV escalates on the first miss', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'CCV',
+        isHrVisit: false,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'SINGLE_VISIT_MISSED' });
+    });
+
+    it('ANC_POST_EDD escalates on the first miss', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'ANC_POST_EDD',
+        isHrVisit: false,
+        consecutiveMissedCount: 1,
+      });
+      expect(result).toEqual({ shouldEscalate: true, reasonCode: 'SINGLE_VISIT_MISSED' });
+    });
+
+    it('PP with zero misses does not escalate', async () => {
+      const result = await evaluateEscalationPack(escalationRulesJson, {
+        visitFamily: 'PP',
+        isHrVisit: false,
+        consecutiveMissedCount: 0,
+      });
+      expect(result.shouldEscalate).toBe(false);
+    });
+  });
+
+  describe('validation errors', () => {
+    it('rejects an unrecognized visitFamily', async () => {
+      await expect(
+        evaluateEscalationPack(escalationRulesJson, {
+          visitFamily: 'BOGUS',
+          isHrVisit: false,
+          consecutiveMissedCount: 1,
+        }),
+      ).rejects.toBeTruthy();
+    });
+  });
+});

--- a/apps/rules-service/src/rules/scheduling/escalation.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/escalation.rulesJson.ts
@@ -1,0 +1,98 @@
+/**
+ * Missed-visit escalation decision graph (SRS §3A.2.7 FR-S-7.1, FR-S-3.5,
+ * FR-S-3.6).
+ *
+ * Decides whether a missed-visit streak should escalate to a Supervisor,
+ * given the visit family the missed visit belongs to, whether it was an HR
+ * (high-risk) visit, and how many consecutive visits in that family have
+ * been missed. This pack does NOT decide what happens after escalation
+ * (notification, task creation, etc.) — that is downstream of this rule
+ * pack's `shouldEscalate`/`reasonCode` output, same separation-of-concerns
+ * as hr.rulesJson.ts only computing the HR visit anchor, not the clinical
+ * HR-detection itself.
+ *
+ * FR-S-7.1 escalation table (verified thresholds — do not alter):
+ *  - HR visit missed (`isHrVisit === true`): escalate on the very first miss
+ *    (`consecutiveMissedCount >= 1`), regardless of visitFamily — an HR visit
+ *    carries its own urgency that overrides the family's normal threshold.
+ *    reasonCode: 'HR_VISIT_MISSED'.
+ *  - ANC (FR-S-3.5) and INC, non-HR: escalate only after two consecutive
+ *    misses (`consecutiveMissedCount >= 2`). reasonCode:
+ *    'ANC_TWO_CONSECUTIVE_MISSED' / 'INC_TWO_CONSECUTIVE_MISSED'.
+ *  - ANC_POST_EDD, PP, NN, CCV, non-HR: escalate on a single miss
+ *    (`consecutiveMissedCount >= 1`). reasonCode: 'SINGLE_VISIT_MISSED'.
+ *  - FR-S-3.6 (ANC-HR): an ANC visit flagged HR is handled by the
+ *    `isHrVisit === true` branch above, not the ANC branch — the two-miss
+ *    ANC threshold only ever applies to non-HR ANC visits.
+ *  - Any other visitFamily is a caller/config error, not a business
+ *    scenario this pack has an answer for — the handler throws rather than
+ *    silently defaulting to "don't escalate", so a bad upstream mapping
+ *    fails loudly instead of quietly dropping missed-visit escalations.
+ *
+ * When NOT escalating, the pack still returns a reasonCode explaining why
+ * ('BELOW_THRESHOLD') rather than an empty/undefined value, so callers never
+ * have to special-case a missing reasonCode on the false path.
+ */
+export const escalationRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeEscalation',
+      position: { x: 200, y: 0 },
+      content: `
+const handler = (input) => {
+  const { visitFamily, isHrVisit, consecutiveMissedCount } = input;
+
+  // FR-S-7.1: an HR visit miss escalates on the very first miss, regardless
+  // of visitFamily - this check takes priority over every family-specific
+  // threshold below (including ANC-HR, FR-S-3.6).
+  if (isHrVisit === true) {
+    return {
+      shouldEscalate: consecutiveMissedCount >= 1,
+      reasonCode: consecutiveMissedCount >= 1 ? 'HR_VISIT_MISSED' : 'BELOW_THRESHOLD',
+    };
+  }
+
+  // FR-S-3.5/FR-S-7.1: ANC (non-HR) escalates after two consecutive misses.
+  if (visitFamily === 'ANC') {
+    return {
+      shouldEscalate: consecutiveMissedCount >= 2,
+      reasonCode: consecutiveMissedCount >= 2 ? 'ANC_TWO_CONSECUTIVE_MISSED' : 'BELOW_THRESHOLD',
+    };
+  }
+
+  // FR-S-7.1: INC (non-HR) escalates after two consecutive misses.
+  if (visitFamily === 'INC') {
+    return {
+      shouldEscalate: consecutiveMissedCount >= 2,
+      reasonCode: consecutiveMissedCount >= 2 ? 'INC_TWO_CONSECUTIVE_MISSED' : 'BELOW_THRESHOLD',
+    };
+  }
+
+  // FR-S-7.1: single-visit-family journeys escalate on the very first miss.
+  if (
+    visitFamily === 'ANC_POST_EDD' ||
+    visitFamily === 'PP' ||
+    visitFamily === 'NN' ||
+    visitFamily === 'CCV'
+  ) {
+    return {
+      shouldEscalate: consecutiveMissedCount >= 1,
+      reasonCode: consecutiveMissedCount >= 1 ? 'SINGLE_VISIT_MISSED' : 'BELOW_THRESHOLD',
+    };
+  }
+
+  throw new Error('Unknown visitFamily: ' + input.visitFamily);
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};


### PR DESCRIPTION
Closes #154

## Summary
- Adds the missed-visit escalation rule pack (SRS §3A.2.7 FR-S-7.1) as a GoRules decision graph — the ESCALATION rule category, completing the set alongside the existing SCHEDULE/RISK packs.
- Escalation thresholds implemented (verified against the SRS, do not alter without a spec change):
  - HR (high-risk) visit missed → escalate on the very first miss, regardless of visit family — overrides every family-specific threshold below, including ANC-HR (FR-S-3.6).
  - ANC / INC (non-HR) → escalate after two consecutive misses (FR-S-3.5).
  - ANC_POST_EDD / PP / NN / CCV (non-HR) → escalate on a single miss.
  - Any other `visitFamily` is a caller/config error — the handler throws rather than silently defaulting to "don't escalate".
- New `POST /rules/:setId/evaluate-escalation` endpoint, wired through the current `ruleVersion.routes.ts` / `ruleVersion.controller.ts` / `ruleVersion.service.ts` split (rebased onto develop's post-#144 routes-split architecture and post-#146 Node 24.18.0 pin).
- Seeded as a fixed-UUID `ESCALATION` category rule pack (`prisma/seed.ts`), following the same upsert-once pattern as the SCHEDULE packs.

## Test plan
- [x] `npx nx test rules-service` — 95/95 passing, including full per-family threshold coverage (ANC/INC two-miss, HR-override across ANC/INC/CCV, single-miss families PP/NN/CCV/ANC_POST_EDD, below-threshold non-escalation, unrecognized-`visitFamily` rejection).
- [x] `npx nx lint rules-service` — clean.
- [x] `npx tsc --noEmit` (app + spec tsconfigs) — clean.
- [x] Diff against `develop` confirmed purely additive (0 deletions across 10 files) and correctly integrated into the current routes-split controller pattern, not the pre-#144 monolithic controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)