### PR TITLE
feat(visit-form-service): Add Delivery, Postpartum, and Neonatal visit forms

### DIFF
--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -20,6 +20,9 @@ const motherRegistration = loadSeedData('mother-registration.json');
 const childRegistration = loadSeedData('child-registration.json');
 const ancVisit = loadSeedData('anc-visit.json');
 const infantVisit = loadSeedData('infant-visit.json');
+const deliveryVisit = loadSeedData('delivery-visit.json');
+const postpartumVisit = loadSeedData('postpartum-visit.json');
+const neonatalVisit = loadSeedData('neonatal-visit.json');
 
 /**
  * Every seed-data file must round-trip through the same Zod schemas the
@@ -32,6 +35,9 @@ describe.each([
   ['child-registration.json', childRegistration],
   ['anc-visit.json', ancVisit],
   ['infant-visit.json', infantVisit],
+  ['delivery-visit.json', deliveryVisit],
+  ['postpartum-visit.json', postpartumVisit],
+  ['neonatal-visit.json', neonatalVisit],
 ])('%s', (_name, payload) => {
   it('has a schemaJson that satisfies schemaJsonSchema', () => {
     expect(() => schemaJsonSchema.parse(payload.schemaJson)).not.toThrow();
@@ -516,5 +522,274 @@ describe('infant-visit.json', () => {
 
   it('has no cross-field validation rules', () => {
     expect(infantVisit.validationJson).toEqual([]);
+  });
+});
+
+describe('delivery-visit.json', () => {
+  const fields = deliveryVisit.schemaJson;
+  const byCode = new Map(fields.map((f) => [f.question_code, f]));
+
+  it('has exactly 44 fields (13 mother-level + 3x10 child fields + remarks)', () => {
+    expect(fields).toHaveLength(44);
+  });
+
+  it('applies numericRange to every field the source doc bounds', () => {
+    const expectedRanges: Record<string, { min: number; max: number }> = {
+      number_of_babies_born: { min: 1, max: 3 },
+      child1_birth_length_cm: { min: 35, max: 60 },
+      child1_birth_weight_kg: { min: 0.5, max: 6 },
+      child2_birth_length_cm: { min: 35, max: 60 },
+      child2_birth_weight_kg: { min: 0.5, max: 6 },
+      child3_birth_length_cm: { min: 35, max: 60 },
+      child3_birth_weight_kg: { min: 0.5, max: 6 },
+    };
+    for (const [code, range] of Object.entries(expectedRanges)) {
+      expect(byCode.get(code)?.numericRange).toEqual(range);
+    }
+  });
+
+  it('gates home-delivery-only fields behind place_of_delivery=home', () => {
+    const HOME_GATE = { field: 'place_of_delivery', operator: 'eq', value: 'home' };
+    expect(byCode.get('misoprostol_tablets_taken_back')?.visibleWhen).toEqual(HOME_GATE);
+    expect(byCode.get('reason_for_home_delivery')?.visibleWhen).toEqual(HOME_GATE);
+  });
+
+  it('gates child2/child3 fields behind number_of_babies_born (row 12)', () => {
+    for (const code of [
+      'child2_delivery_outcome',
+      'child2_sex_of_baby',
+      'child2_birth_length_cm',
+      'child2_birth_weight_kg',
+    ]) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'number_of_babies_born',
+        operator: 'gte',
+        value: 2,
+      });
+    }
+    for (const code of [
+      'child3_delivery_outcome',
+      'child3_sex_of_baby',
+      'child3_birth_length_cm',
+      'child3_birth_weight_kg',
+    ]) {
+      expect(byCode.get(code)?.visibleWhen).toEqual({
+        field: 'number_of_babies_born',
+        operator: 'gte',
+        value: 3,
+      });
+    }
+  });
+
+  it('correctly defines childN_sex_of_baby as Male/Female/Intersex-Other, not cause-of-death — the source doc mislabels this row for Child3 (row 28)', () => {
+    for (const code of ['child1_sex_of_baby', 'child2_sex_of_baby', 'child3_sex_of_baby']) {
+      const field = byCode.get(code);
+      expect(field?.options?.map((o) => o.value_code)).toEqual([
+        'male',
+        'female',
+        'intersex_other',
+      ]);
+    }
+  });
+
+  it('gates each childN death-detail block behind that same child being reported not alive', () => {
+    for (const prefix of ['child1', 'child2', 'child3']) {
+      const gate = { field: `${prefix}_is_newborn_alive_now`, operator: 'eq', value: 'no' };
+      expect(byCode.get(`${prefix}_cause_of_death`)?.visibleWhen).toEqual(gate);
+      expect(byCode.get(`${prefix}_place_of_death`)?.visibleWhen).toEqual(gate);
+      expect(byCode.get(`${prefix}_date_of_death`)?.visibleWhen).toEqual(gate);
+    }
+  });
+
+  it('applies notBefore date_of_delivery to every childN_date_of_death (death cannot precede birth)', () => {
+    for (const prefix of ['child1', 'child2', 'child3']) {
+      expect(byCode.get(`${prefix}_date_of_death`)?.dateRule).toEqual({
+        notFuture: true,
+        notBefore: { field: 'date_of_delivery' },
+      });
+    }
+  });
+
+  it('has an EXCLUSIVE_OPTION rule so "None" cannot combine with a selected delivery complication', () => {
+    expect(deliveryVisit.validationJson).toContainEqual({
+      rule: 'EXCLUSIVE_OPTION',
+      field: 'did_mother_experience_complications',
+      exclusiveValues: ['none'],
+    });
+  });
+});
+
+describe('postpartum-visit.json', () => {
+  const fields = postpartumVisit.schemaJson;
+  const byCode = new Map(fields.map((f) => [f.question_code, f]));
+
+  it('has exactly 36 fields, per the Revised App Form Final Postpartum form', () => {
+    expect(fields).toHaveLength(36);
+  });
+
+  it('applies numericRange to every field the source doc bounds', () => {
+    const expectedRanges: Record<string, { min: number; max: number }> = {
+      ifa_tablets_consumed_since_last_visit: { min: 0, max: 35 },
+      current_weight_kg: { min: 25, max: 100 },
+      current_muac_cm: { min: 10, max: 40 },
+      bp_systolic: { min: 70, max: 300 },
+      bp_diastolic: { min: 40, max: 130 },
+      body_temperature_f: { min: 94, max: 105 },
+      haemoglobin_g_dl: { min: 1, max: 18 },
+      random_blood_glucose_mg_dl: { min: 40, max: 400 },
+      anc_visits_completed_before_delivery: { min: 0, max: 20 },
+    };
+    for (const [code, range] of Object.entries(expectedRanges)) {
+      expect(byCode.get(code)?.numericRange).toEqual(range);
+    }
+  });
+
+  it('short-circuits the rest of the form when the mother is not alive (row 3)', () => {
+    expect(byCode.get('is_mother_alive')?.required).toBe(true);
+    // Every subsequent mandatory field is gated behind is_mother_alive=yes,
+    // except anc_visits_completed_before_delivery, which the doc places
+    // outside the mother-status-gated flow (row 36).
+    for (const field of fields) {
+      if (
+        [
+          'actual_visit_date',
+          'visit_name',
+          'is_mother_alive',
+          'anc_visits_completed_before_delivery',
+        ].includes(field.question_code)
+      ) {
+        continue;
+      }
+      if (field.visibleWhen?.field === 'is_mother_alive') {
+        expect(field.visibleWhen).toEqual({
+          field: 'is_mother_alive',
+          operator: 'eq',
+          value: 'yes',
+        });
+      }
+    }
+  });
+
+  it('requires pads-changed-per-day only when bleeding has not stopped (row 11-12)', () => {
+    expect(byCode.get('pads_changed_per_day')?.visibleWhen).toEqual({
+      field: 'vaginal_bleeding_stopped',
+      operator: 'eq',
+      value: 'no',
+    });
+  });
+
+  it('requires breastfeeding-difficulties only when breastfeeding is uncomfortable (row 13-14)', () => {
+    expect(byCode.get('breastfeeding_difficulties')?.visibleWhen).toEqual({
+      field: 'able_to_breastfeed_comfortably',
+      operator: 'eq',
+      value: 'no',
+    });
+  });
+
+  it('requires the IFA non-consumption reason only when not taking IFA (row 18-20)', () => {
+    expect(byCode.get('reason_for_non_consumption_of_ifa')?.visibleWhen).toEqual({
+      field: 'taking_ifa_tablets',
+      operator: 'eq',
+      value: 'no',
+    });
+  });
+
+  it('requires family planning method only when using family planning (row 22-23)', () => {
+    expect(byCode.get('family_planning_methods')?.visibleWhen).toEqual({
+      field: 'using_family_planning',
+      operator: 'eq',
+      value: 'yes',
+    });
+  });
+
+  it('wires current_bmi to the BMI computed formula (row 28)', () => {
+    expect(byCode.get('current_bmi')?.computedFrom).toBe('BMI');
+  });
+
+  it('has 5 EXCLUSIVE_OPTION rules for the "none/no abnormal signs" checkbox groups', () => {
+    const exclusiveRules = postpartumVisit.validationJson.filter(
+      (r) => (r as { rule: string }).rule === 'EXCLUSIVE_OPTION',
+    );
+    expect(exclusiveRules).toHaveLength(5);
+  });
+});
+
+describe('neonatal-visit.json', () => {
+  const fields = neonatalVisit.schemaJson;
+  const byCode = new Map(fields.map((f) => [f.question_code, f]));
+
+  it('has exactly 32 fields (26 base + 4 per-vaccine date fields + 2 pre-filled delivery fields)', () => {
+    expect(fields).toHaveLength(32);
+  });
+
+  it('applies numericRange to birth/current length and weight', () => {
+    const expectedRanges: Record<string, { min: number; max: number }> = {
+      birth_weight_kg: { min: 0.5, max: 6 },
+      current_length_cm: { min: 35, max: 60 },
+      current_weight_kg: { min: 0.5, max: 6 },
+    };
+    for (const [code, range] of Object.entries(expectedRanges)) {
+      expect(byCode.get(code)?.numericRange).toEqual(range);
+    }
+  });
+
+  it('gates the death-detail block behind is_newborn_alive_now=no', () => {
+    const gate = { field: 'is_newborn_alive_now', operator: 'eq', value: 'no' };
+    expect(byCode.get('cause_of_death')?.visibleWhen).toEqual(gate);
+    expect(byCode.get('place_of_death')?.visibleWhen).toEqual(gate);
+    expect(byCode.get('date_of_death')?.visibleWhen).toEqual(gate);
+  });
+
+  it('gates the KMC block behind birth_weight_kg < 2.5 (row 11, low-birth-weight eligibility)', () => {
+    expect(byCode.get('is_kmc_practiced')?.visibleWhen).toEqual({
+      field: 'birth_weight_kg',
+      operator: 'lt',
+      value: 2.5,
+    });
+    expect(byCode.get('kmc_duration')?.visibleWhen).toEqual({
+      field: 'is_kmc_practiced',
+      operator: 'eq',
+      value: 'yes',
+    });
+    expect(byCode.get('kmc_breastfeeding_duration')?.visibleWhen).toEqual({
+      field: 'is_kmc_practiced',
+      operator: 'eq',
+      value: 'yes',
+    });
+  });
+
+  it('wires nutritional-status fields to the NUTRITIONAL_ZSCORE computed formula (rows 23-25)', () => {
+    for (const code of [
+      'nutritional_status_wasting',
+      'nutritional_status_stunting',
+      'nutritional_status_underweight',
+    ]) {
+      expect(byCode.get(code)?.computedFrom).toBe('NUTRITIONAL_ZSCORE');
+    }
+  });
+
+  it('has an EXCLUSIVE_OPTION rule so "None" cannot combine with a selected vaccine', () => {
+    expect(neonatalVisit.validationJson).toContainEqual({
+      rule: 'EXCLUSIVE_OPTION',
+      field: 'vaccination_taken_at_birth',
+      exclusiveValues: ['none'],
+    });
+  });
+
+  it('has a REQUIRED_IF_SELECTED rule so each selected vaccine requires its date', () => {
+    expect(neonatalVisit.validationJson).toContainEqual({
+      rule: 'REQUIRED_IF_SELECTED',
+      field: 'vaccination_taken_at_birth',
+      optionFieldMap: {
+        bcg: 'bcg_date',
+        opv: 'opv_date',
+        hepatitis_b: 'hepatitis_b_date',
+        vitamin_k: 'vitamin_k_date',
+      },
+    });
+  });
+
+  it('has 4 total validationJson rules (2 EXCLUSIVE_OPTION + 1 EXCLUSIVE_OPTION for feeding concerns + 1 REQUIRED_IF_SELECTED)', () => {
+    expect(neonatalVisit.validationJson).toHaveLength(4);
   });
 });

--- a/apps/visit-form-service/prisma/seed-data/delivery-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/delivery-visit.json
@@ -1,0 +1,695 @@
+{
+  "schemaJson": [
+    {
+      "label": "Delivery form filled date",
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "date",
+      "question_code": "delivery_form_filled_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Date of delivery",
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_delivery",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Time of delivery",
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "time",
+      "question_code": "time_of_delivery"
+    },
+    {
+      "label": "Date of discharge",
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_discharge",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "date_of_delivery" } }
+    },
+    {
+      "label": "Term of delivery",
+      "options": [
+        { "label": "Pre Term", "sort_order": 0, "value_code": "pre_term" },
+        { "label": "Post Term", "sort_order": 1, "value_code": "post_term" },
+        { "label": "Full Term", "sort_order": 2, "value_code": "full_term" }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "term_of_delivery"
+    },
+    {
+      "label": "Type of delivery",
+      "options": [
+        { "label": "Caesarian", "sort_order": 0, "value_code": "caesarian" },
+        { "label": "Normal", "sort_order": 1, "value_code": "normal" },
+        {
+          "label": "Assisted (Forcep/vacuum)",
+          "sort_order": 2,
+          "value_code": "assisted_forcep_vacuum"
+        }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "type_of_delivery"
+    },
+    {
+      "label": "Place of Delivery",
+      "options": [
+        {
+          "label": "District hospital (civil hospital)",
+          "sort_order": 0,
+          "value_code": "district_hospital"
+        },
+        {
+          "label": "Sub-district hospital",
+          "sort_order": 1,
+          "value_code": "sub_district_hospital"
+        },
+        { "label": "Rural Hospital", "sort_order": 2, "value_code": "rural_hospital" },
+        { "label": "PHC", "sort_order": 3, "value_code": "phc" },
+        { "label": "SC", "sort_order": 4, "value_code": "sc" },
+        { "label": "Pvt. Hospital", "sort_order": 5, "value_code": "pvt_hospital" },
+        { "label": "Home", "sort_order": 6, "value_code": "home" },
+        { "label": "Transit", "sort_order": 7, "value_code": "transit" }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "place_of_delivery"
+    },
+    {
+      "label": "Who conducted the delivery?",
+      "options": [
+        { "label": "Specialist", "sort_order": 0, "value_code": "specialist" },
+        { "label": "Medical officer", "sort_order": 1, "value_code": "medical_officer" },
+        { "label": "Staffnurse", "sort_order": 2, "value_code": "staffnurse" },
+        { "label": "ANM", "sort_order": 3, "value_code": "anm" },
+        { "label": "LHV", "sort_order": 4, "value_code": "lhv" },
+        { "label": "Dai", "sort_order": 5, "value_code": "dai" },
+        { "label": "Other-mention", "sort_order": 6, "value_code": "other" }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "who_conducted_the_delivery"
+    },
+    {
+      "label": "If home delivery, no of misoprostol tablets taken back",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "misoprostol_tablets_taken_back",
+      "visibleWhen": { "field": "place_of_delivery", "operator": "eq", "value": "home" }
+    },
+    {
+      "label": "Reason for home delivery",
+      "options": [
+        { "label": "Financial constraint", "sort_order": 0, "value_code": "financial_constraint" },
+        {
+          "label": "Long distance to health facility/poor transportation",
+          "sort_order": 1,
+          "value_code": "long_distance_poor_transportation"
+        },
+        {
+          "label": "Poor experience of health facility",
+          "sort_order": 2,
+          "value_code": "poor_experience_of_health_facility"
+        },
+        {
+          "label": "Lack of awareness/decision making constraint",
+          "sort_order": 3,
+          "value_code": "lack_of_awareness_decision_making_constraint"
+        }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "reason_for_home_delivery",
+      "visibleWhen": { "field": "place_of_delivery", "operator": "eq", "value": "home" }
+    },
+    {
+      "label": "Did the mother experience any complications during delivery?",
+      "options": [
+        { "label": "Blood transfusion", "sort_order": 0, "value_code": "blood_transfusion" },
+        { "label": "Shoulder dystocia", "sort_order": 1, "value_code": "shoulder_dystocia" },
+        {
+          "label": "Complete perineal tear",
+          "sort_order": 2,
+          "value_code": "complete_perineal_tear"
+        },
+        {
+          "label": "Severe perineal tears",
+          "sort_order": 3,
+          "value_code": "severe_perineal_tears"
+        },
+        {
+          "label": "Postpartum hemorrhage (PPH)",
+          "sort_order": 4,
+          "value_code": "postpartum_hemorrhage_pph"
+        },
+        { "label": "Eclampsia", "sort_order": 5, "value_code": "eclampsia" },
+        { "label": "Abruption", "sort_order": 6, "value_code": "abruption" },
+        { "label": "Preterm labor", "sort_order": 7, "value_code": "preterm_labor" },
+        { "label": "Prolonged labor", "sort_order": 8, "value_code": "prolonged_labor" },
+        { "label": "Obstructed labor", "sort_order": 9, "value_code": "obstructed_labor" },
+        { "label": "Uterine rupture", "sort_order": 10, "value_code": "uterine_rupture" },
+        {
+          "label": "Infections during delivery",
+          "sort_order": 11,
+          "value_code": "infections_during_delivery"
+        },
+        {
+          "label": "Infections after delivery",
+          "sort_order": 12,
+          "value_code": "infections_after_delivery"
+        },
+        { "label": "Retained placenta", "sort_order": 13, "value_code": "retained_placenta" },
+        { "label": "Other (please specify)", "sort_order": 14, "value_code": "other" },
+        { "label": "None", "sort_order": 15, "value_code": "none" }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "did_mother_experience_complications"
+    },
+    {
+      "label": "Was this a case of multiple gestation?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "was_multiple_gestation"
+    },
+    {
+      "label": "If yes for multiple gestation, number of babies born",
+      "section": "Delivery Details",
+      "required": true,
+      "input_type": "number",
+      "question_code": "number_of_babies_born",
+      "numericRange": { "min": 1, "max": 3 },
+      "visibleWhen": { "field": "was_multiple_gestation", "operator": "eq", "value": "yes" }
+    },
+
+    {
+      "label": "Child1: delivery outcome",
+      "options": [
+        { "label": "Live Birth", "sort_order": 0, "value_code": "live_birth" },
+        {
+          "label": "Antepartum Still Birth (Fresh)",
+          "sort_order": 1,
+          "value_code": "antepartum_still_birth_fresh"
+        },
+        {
+          "label": "Intrapartum still birth (Macerated)",
+          "sort_order": 2,
+          "value_code": "intrapartum_still_birth_macerated"
+        }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child1_delivery_outcome"
+    },
+    {
+      "label": "Child1: related complications during delivery?",
+      "options": [
+        { "label": "Birth asphyxia", "sort_order": 0, "value_code": "birth_asphyxia" },
+        { "label": "Fetal distress", "sort_order": 1, "value_code": "fetal_distress" },
+        { "label": "Birth trauma", "sort_order": 2, "value_code": "birth_trauma" },
+        { "label": "Neonatal infections", "sort_order": 3, "value_code": "neonatal_infections" },
+        {
+          "label": "Congenital anomalies detected",
+          "sort_order": 4,
+          "value_code": "congenital_anomalies_detected"
+        },
+        { "label": "Other (please specify)", "sort_order": 5, "value_code": "other" }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "child1_related_complications"
+    },
+    {
+      "label": "Child1: Immediate crying after birth",
+      "options": [
+        {
+          "label": "Cried immediately after birth",
+          "sort_order": 0,
+          "value_code": "cried_immediately"
+        },
+        { "label": "Delayed crying", "sort_order": 1, "value_code": "delayed_crying" },
+        { "label": "Did not cry at birth", "sort_order": 2, "value_code": "did_not_cry" }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child1_immediate_crying"
+    },
+    {
+      "label": "Child1: Sex of baby",
+      "options": [
+        { "label": "Male", "sort_order": 0, "value_code": "male" },
+        { "label": "Female", "sort_order": 1, "value_code": "female" },
+        { "label": "Intersex / Other", "sort_order": 2, "value_code": "intersex_other" }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child1_sex_of_baby"
+    },
+    {
+      "label": "Child1: Birth Length of the baby in cm",
+      "section": "Child 1",
+      "required": true,
+      "input_type": "number",
+      "question_code": "child1_birth_length_cm",
+      "numericRange": { "min": 35, "max": 60 }
+    },
+    {
+      "label": "Child1: Birth Weight of the baby in kg",
+      "section": "Child 1",
+      "required": true,
+      "input_type": "number",
+      "question_code": "child1_birth_weight_kg",
+      "numericRange": { "min": 0.5, "max": 6 }
+    },
+    {
+      "label": "Child1: Is the new born alive now?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "child1_is_newborn_alive_now"
+    },
+    {
+      "label": "Child1: If No, Cause of death",
+      "options": [
+        { "label": "Infections", "sort_order": 0, "value_code": "infections" },
+        { "label": "Diarrhea", "sort_order": 1, "value_code": "diarrhea" },
+        { "label": "Dehydration", "sort_order": 2, "value_code": "dehydration" },
+        {
+          "label": "Malnourished Children (Grade 3 and 4)",
+          "sort_order": 3,
+          "value_code": "malnourished_grade_3_4"
+        },
+        { "label": "Congenital defects", "sort_order": 4, "value_code": "congenital_defects" },
+        {
+          "label": "Birth Asphyxia and Birth Trauma",
+          "sort_order": 5,
+          "value_code": "birth_asphyxia_and_trauma"
+        },
+        { "label": "Accidental", "sort_order": 6, "value_code": "accidental" },
+        {
+          "label": "Delay in reaching the health centre",
+          "sort_order": 7,
+          "value_code": "delay_reaching_health_centre"
+        },
+        {
+          "label": "Delay in provision of services at the health centre",
+          "sort_order": 8,
+          "value_code": "delay_in_services_at_health_centre"
+        },
+        { "label": "Other (specify)", "sort_order": 9, "value_code": "other" }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "child1_cause_of_death",
+      "visibleWhen": { "field": "child1_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Child1: Place of death",
+      "options": [
+        { "label": "Home", "sort_order": 0, "value_code": "home" },
+        { "label": "Health facility", "sort_order": 1, "value_code": "health_facility" },
+        { "label": "Other", "sort_order": 2, "value_code": "other" }
+      ],
+      "section": "Child 1",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child1_place_of_death",
+      "visibleWhen": { "field": "child1_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Child1: Date of death",
+      "section": "Child 1",
+      "required": true,
+      "input_type": "date",
+      "question_code": "child1_date_of_death",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "date_of_delivery" } },
+      "visibleWhen": { "field": "child1_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+
+    {
+      "label": "Child2: delivery outcome",
+      "options": [
+        { "label": "Live Birth", "sort_order": 0, "value_code": "live_birth" },
+        {
+          "label": "Antepartum Still Birth (Fresh)",
+          "sort_order": 1,
+          "value_code": "antepartum_still_birth_fresh"
+        },
+        {
+          "label": "Intrapartum still birth (Macerated)",
+          "sort_order": 2,
+          "value_code": "intrapartum_still_birth_macerated"
+        }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child2_delivery_outcome",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: related complications during delivery?",
+      "options": [
+        { "label": "Birth asphyxia", "sort_order": 0, "value_code": "birth_asphyxia" },
+        { "label": "Fetal distress", "sort_order": 1, "value_code": "fetal_distress" },
+        { "label": "Birth trauma", "sort_order": 2, "value_code": "birth_trauma" },
+        { "label": "Neonatal infections", "sort_order": 3, "value_code": "neonatal_infections" },
+        {
+          "label": "Congenital anomalies detected",
+          "sort_order": 4,
+          "value_code": "congenital_anomalies_detected"
+        },
+        { "label": "Other (please specify)", "sort_order": 5, "value_code": "other" }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "child2_related_complications",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: Immediate crying after birth",
+      "options": [
+        {
+          "label": "Cried immediately after birth",
+          "sort_order": 0,
+          "value_code": "cried_immediately"
+        },
+        { "label": "Delayed crying", "sort_order": 1, "value_code": "delayed_crying" },
+        { "label": "Did not cry at birth", "sort_order": 2, "value_code": "did_not_cry" }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child2_immediate_crying",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: Sex of baby",
+      "options": [
+        { "label": "Male", "sort_order": 0, "value_code": "male" },
+        { "label": "Female", "sort_order": 1, "value_code": "female" },
+        { "label": "Intersex / Other", "sort_order": 2, "value_code": "intersex_other" }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child2_sex_of_baby",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: Birth Length of the baby in cm",
+      "section": "Child 2",
+      "required": true,
+      "input_type": "number",
+      "question_code": "child2_birth_length_cm",
+      "numericRange": { "min": 35, "max": 60 },
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: Birth Weight of the baby in kg",
+      "section": "Child 2",
+      "required": true,
+      "input_type": "number",
+      "question_code": "child2_birth_weight_kg",
+      "numericRange": { "min": 0.5, "max": 6 },
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: Is the new born alive now?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "child2_is_newborn_alive_now",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 2 }
+    },
+    {
+      "label": "Child2: If No, Cause of death",
+      "options": [
+        { "label": "Infections", "sort_order": 0, "value_code": "infections" },
+        { "label": "Diarrhea", "sort_order": 1, "value_code": "diarrhea" },
+        { "label": "Dehydration", "sort_order": 2, "value_code": "dehydration" },
+        {
+          "label": "Malnourished Children (Grade 3 and 4)",
+          "sort_order": 3,
+          "value_code": "malnourished_grade_3_4"
+        },
+        { "label": "Congenital defects", "sort_order": 4, "value_code": "congenital_defects" },
+        {
+          "label": "Birth Asphyxia and Birth Trauma",
+          "sort_order": 5,
+          "value_code": "birth_asphyxia_and_trauma"
+        },
+        { "label": "Accidental", "sort_order": 6, "value_code": "accidental" },
+        {
+          "label": "Delay in reaching the health centre",
+          "sort_order": 7,
+          "value_code": "delay_reaching_health_centre"
+        },
+        {
+          "label": "Delay in provision of services at the health centre",
+          "sort_order": 8,
+          "value_code": "delay_in_services_at_health_centre"
+        },
+        { "label": "Other (specify)", "sort_order": 9, "value_code": "other" }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "child2_cause_of_death",
+      "visibleWhen": { "field": "child2_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Child2: Place of death",
+      "options": [
+        { "label": "Home", "sort_order": 0, "value_code": "home" },
+        { "label": "Health facility", "sort_order": 1, "value_code": "health_facility" },
+        { "label": "Other", "sort_order": 2, "value_code": "other" }
+      ],
+      "section": "Child 2",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child2_place_of_death",
+      "visibleWhen": { "field": "child2_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Child2: Date of death",
+      "section": "Child 2",
+      "required": true,
+      "input_type": "date",
+      "question_code": "child2_date_of_death",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "date_of_delivery" } },
+      "visibleWhen": { "field": "child2_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+
+    {
+      "label": "Child3: delivery outcome",
+      "options": [
+        { "label": "Live Birth", "sort_order": 0, "value_code": "live_birth" },
+        {
+          "label": "Antepartum Still Birth (Fresh)",
+          "sort_order": 1,
+          "value_code": "antepartum_still_birth_fresh"
+        },
+        {
+          "label": "Intrapartum still birth (Macerated)",
+          "sort_order": 2,
+          "value_code": "intrapartum_still_birth_macerated"
+        }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child3_delivery_outcome",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: related complications during delivery?",
+      "options": [
+        { "label": "Birth asphyxia", "sort_order": 0, "value_code": "birth_asphyxia" },
+        { "label": "Fetal distress", "sort_order": 1, "value_code": "fetal_distress" },
+        { "label": "Birth trauma", "sort_order": 2, "value_code": "birth_trauma" },
+        { "label": "Neonatal infections", "sort_order": 3, "value_code": "neonatal_infections" },
+        {
+          "label": "Congenital anomalies detected",
+          "sort_order": 4,
+          "value_code": "congenital_anomalies_detected"
+        },
+        { "label": "Other (please specify)", "sort_order": 5, "value_code": "other" }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "child3_related_complications",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: Immediate crying after birth",
+      "options": [
+        {
+          "label": "Cried immediately after birth",
+          "sort_order": 0,
+          "value_code": "cried_immediately"
+        },
+        { "label": "Delayed crying", "sort_order": 1, "value_code": "delayed_crying" },
+        { "label": "Did not cry at birth", "sort_order": 2, "value_code": "did_not_cry" }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child3_immediate_crying",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: Sex of baby",
+      "options": [
+        { "label": "Male", "sort_order": 0, "value_code": "male" },
+        { "label": "Female", "sort_order": 1, "value_code": "female" },
+        { "label": "Intersex / Other", "sort_order": 2, "value_code": "intersex_other" }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child3_sex_of_baby",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: Birth Length of the baby in cm",
+      "section": "Child 3",
+      "required": true,
+      "input_type": "number",
+      "question_code": "child3_birth_length_cm",
+      "numericRange": { "min": 35, "max": 60 },
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: Birth Weight of the baby in kg",
+      "section": "Child 3",
+      "required": true,
+      "input_type": "number",
+      "question_code": "child3_birth_weight_kg",
+      "numericRange": { "min": 0.5, "max": 6 },
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: Is the new born alive now?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "child3_is_newborn_alive_now",
+      "visibleWhen": { "field": "number_of_babies_born", "operator": "gte", "value": 3 }
+    },
+    {
+      "label": "Child3: If No, Cause of death",
+      "options": [
+        { "label": "Infections", "sort_order": 0, "value_code": "infections" },
+        { "label": "Diarrhea", "sort_order": 1, "value_code": "diarrhea" },
+        { "label": "Dehydration", "sort_order": 2, "value_code": "dehydration" },
+        {
+          "label": "Malnourished Children (Grade 3 and 4)",
+          "sort_order": 3,
+          "value_code": "malnourished_grade_3_4"
+        },
+        { "label": "Congenital defects", "sort_order": 4, "value_code": "congenital_defects" },
+        {
+          "label": "Birth Asphyxia and Birth Trauma",
+          "sort_order": 5,
+          "value_code": "birth_asphyxia_and_trauma"
+        },
+        { "label": "Accidental", "sort_order": 6, "value_code": "accidental" },
+        {
+          "label": "Delay in reaching the health centre",
+          "sort_order": 7,
+          "value_code": "delay_reaching_health_centre"
+        },
+        {
+          "label": "Delay in provision of services at the health centre",
+          "sort_order": 8,
+          "value_code": "delay_in_services_at_health_centre"
+        },
+        { "label": "Other (specify)", "sort_order": 9, "value_code": "other" }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "child3_cause_of_death",
+      "visibleWhen": { "field": "child3_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Child3: Place of death",
+      "options": [
+        { "label": "Home", "sort_order": 0, "value_code": "home" },
+        { "label": "Health facility", "sort_order": 1, "value_code": "health_facility" },
+        { "label": "Other", "sort_order": 2, "value_code": "other" }
+      ],
+      "section": "Child 3",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "child3_place_of_death",
+      "visibleWhen": { "field": "child3_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Child3: Date of death",
+      "section": "Child 3",
+      "required": true,
+      "input_type": "date",
+      "question_code": "child3_date_of_death",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "date_of_delivery" } },
+      "visibleWhen": { "field": "child3_is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+
+    {
+      "label": "Remarks",
+      "section": "Delivery Details",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    }
+  ],
+  "validationJson": [
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "did_mother_experience_complications",
+      "exclusiveValues": ["none"]
+    }
+  ]
+}

--- a/apps/visit-form-service/prisma/seed-data/neonatal-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/neonatal-visit.json
@@ -1,0 +1,494 @@
+{
+  "schemaJson": [
+    {
+      "label": "Actual visit date",
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "date",
+      "question_code": "actual_visit_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Visit name",
+      "options": [
+        { "label": "Neo 1 (0-7 days)", "sort_order": 0, "value_code": "nn1" },
+        { "label": "Neo 2 (8-28 Days)", "sort_order": 1, "value_code": "nn2" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "visit_name"
+    },
+    {
+      "label": "Birth weight of the baby in kg (from the Delivery form, for the KMC eligibility check below)",
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "birth_weight_kg",
+      "numericRange": { "min": 0.5, "max": 6 }
+    },
+    {
+      "label": "Term of delivery (from the Delivery form, for the KMC eligibility check below)",
+      "options": [
+        { "label": "Pre Term", "sort_order": 0, "value_code": "pre_term" },
+        { "label": "Post Term", "sort_order": 1, "value_code": "post_term" },
+        { "label": "Full Term", "sort_order": 2, "value_code": "full_term" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "term_of_delivery"
+    },
+    {
+      "label": "Is the new born alive now?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "is_newborn_alive_now"
+    },
+    {
+      "label": "If No, Cause of death",
+      "options": [
+        { "label": "Infections", "sort_order": 0, "value_code": "infections" },
+        { "label": "Diarrhea", "sort_order": 1, "value_code": "diarrhea" },
+        { "label": "Dehydration", "sort_order": 2, "value_code": "dehydration" },
+        {
+          "label": "Malnourished Children (Grade 3 and 4)",
+          "sort_order": 3,
+          "value_code": "malnourished_grade_3_4"
+        },
+        { "label": "Congenital defects", "sort_order": 4, "value_code": "congenital_defects" },
+        {
+          "label": "Birth Asphyxia and Birth Trauma",
+          "sort_order": 5,
+          "value_code": "birth_asphyxia_and_trauma"
+        },
+        { "label": "Accidental", "sort_order": 6, "value_code": "accidental" },
+        {
+          "label": "Delay in reaching the health centre",
+          "sort_order": 7,
+          "value_code": "delay_reaching_health_centre"
+        },
+        {
+          "label": "Delay in provision of services at the health centre",
+          "sort_order": 8,
+          "value_code": "delay_in_services_at_health_centre"
+        },
+        { "label": "Other (specify)", "sort_order": 9, "value_code": "other" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "cause_of_death",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Place of death",
+      "options": [
+        { "label": "Home", "sort_order": 0, "value_code": "home" },
+        { "label": "Health facility", "sort_order": 1, "value_code": "health_facility" },
+        { "label": "Other", "sort_order": 2, "value_code": "other" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "place_of_death",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Date of death",
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_death",
+      "dateRule": { "notFuture": true },
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Is the neonate currently showing any danger signs?",
+      "options": [
+        { "label": "Dry cough/Wet cough/Persistent cough", "sort_order": 0, "value_code": "cough" },
+        { "label": "Chest indrawing", "sort_order": 1, "value_code": "chest_indrawing" },
+        { "label": "Fever > 37.8", "sort_order": 2, "value_code": "fever_gt_37_8" },
+        {
+          "label": "Umbilical stump Bleeding/Signs of infection",
+          "sort_order": 3,
+          "value_code": "umbilical_stump_bleeding_infection"
+        },
+        { "label": "Yellow eyes; Yellow skin", "sort_order": 4, "value_code": "yellow_eyes_skin" },
+        {
+          "label": "Presence of oedema (pitting)",
+          "sort_order": 5,
+          "value_code": "oedema_pitting"
+        },
+        { "label": "Convulsions", "sort_order": 6, "value_code": "convulsions" },
+        { "label": "Lethargic", "sort_order": 7, "value_code": "lethargic" },
+        { "label": "Reduced movement", "sort_order": 8, "value_code": "reduced_movement" },
+        {
+          "label": "Not able to drink/feed",
+          "sort_order": 9,
+          "value_code": "not_able_to_drink_feed"
+        },
+        { "label": "Vomits everything", "sort_order": 10, "value_code": "vomits_everything" },
+        { "label": "Diarrhoea", "sort_order": 11, "value_code": "diarrhoea" },
+        { "label": "Blood in stool", "sort_order": 12, "value_code": "blood_in_stool" },
+        {
+          "label": "No abnormal signs/symptoms",
+          "sort_order": 13,
+          "value_code": "no_abnormal_signs_symptoms"
+        }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "danger_signs",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "What was the child fed immediately after birth?",
+      "options": [
+        { "label": "Colostrum Given", "sort_order": 0, "value_code": "colostrum_given" },
+        {
+          "label": "Breastfed within 1 hour of birth",
+          "sort_order": 1,
+          "value_code": "breastfed_within_1_hour"
+        },
+        {
+          "label": "Breastfed within 1-24 hour of birth",
+          "sort_order": 2,
+          "value_code": "breastfed_within_1_24_hours"
+        },
+        { "label": "After 24 hour of birth", "sort_order": 3, "value_code": "after_24_hours" },
+        { "label": "Honey", "sort_order": 4, "value_code": "honey" },
+        { "label": "Top feed given after birth", "sort_order": 5, "value_code": "top_feed_given" },
+        { "label": "Other", "sort_order": 6, "value_code": "other" },
+        { "label": "Don't know/don't remember", "sort_order": 7, "value_code": "dont_know" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "fed_immediately_after_birth",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Current feeding practice",
+      "options": [
+        {
+          "label": "Exclusive breastfeeding",
+          "sort_order": 0,
+          "value_code": "exclusive_breastfeeding"
+        },
+        {
+          "label": "Top feed + breastfeed",
+          "sort_order": 1,
+          "value_code": "top_feed_and_breastfeed"
+        },
+        {
+          "label": "Only top feed (cowmilk/buffalo milk/goat milk/formula milk)",
+          "sort_order": 2,
+          "value_code": "only_top_feed"
+        },
+        { "label": "Water + breastfeed", "sort_order": 3, "value_code": "water_and_breastfeed" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "current_feeding_practice",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Feeding concerns",
+      "options": [
+        { "label": "Mother not alive", "sort_order": 0, "value_code": "mother_not_alive" },
+        {
+          "label": "Mother has cracked/inverted nipples",
+          "sort_order": 1,
+          "value_code": "cracked_inverted_nipples"
+        },
+        {
+          "label": "Baby not latching properly",
+          "sort_order": 2,
+          "value_code": "baby_not_latching_properly"
+        },
+        { "label": "Low milk supply", "sort_order": 3, "value_code": "low_milk_supply" },
+        {
+          "label": "Breast engorgement or swelling",
+          "sort_order": 4,
+          "value_code": "breast_engorgement_or_swelling"
+        },
+        {
+          "label": "Baby refusing to feed",
+          "sort_order": 5,
+          "value_code": "baby_refusing_to_feed"
+        },
+        { "label": "Other", "sort_order": 6, "value_code": "other" },
+        { "label": "No concerns", "sort_order": 7, "value_code": "no_concerns" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "feeding_concerns",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Any deformity observed in the newborn?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "deformity_observed",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Vaccination taken at birth?",
+      "options": [
+        { "label": "BCG", "sort_order": 0, "value_code": "bcg" },
+        { "label": "OPV", "sort_order": 1, "value_code": "opv" },
+        { "label": "Hepatitis B", "sort_order": 2, "value_code": "hepatitis_b" },
+        { "label": "Vitamin K", "sort_order": 3, "value_code": "vitamin_k" },
+        { "label": "None", "sort_order": 4, "value_code": "none" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "vaccination_taken_at_birth",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "BCG date",
+      "section": "Neonatal Visit",
+      "required": false,
+      "input_type": "date",
+      "question_code": "bcg_date"
+    },
+    {
+      "label": "OPV date",
+      "section": "Neonatal Visit",
+      "required": false,
+      "input_type": "date",
+      "question_code": "opv_date"
+    },
+    {
+      "label": "Hepatitis B date",
+      "section": "Neonatal Visit",
+      "required": false,
+      "input_type": "date",
+      "question_code": "hepatitis_b_date"
+    },
+    {
+      "label": "Vitamin K date",
+      "section": "Neonatal Visit",
+      "required": false,
+      "input_type": "date",
+      "question_code": "vitamin_k_date"
+    },
+    {
+      "label": "Thermal care practices",
+      "options": [
+        { "label": "Wiped/dried", "sort_order": 0, "value_code": "wiped_dried" },
+        { "label": "Kept warm", "sort_order": 1, "value_code": "kept_warm" },
+        { "label": "Not bathed early", "sort_order": 2, "value_code": "not_bathed_early" },
+        { "label": "Kept with mother", "sort_order": 3, "value_code": "kept_with_mother" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "thermal_care_practices",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Is Kangaroo Mother Care Practiced by mother or family?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "is_kmc_practiced",
+      "visibleWhen": { "field": "birth_weight_kg", "operator": "lt", "value": 2.5 }
+    },
+    {
+      "label": "KMC Duration",
+      "options": [
+        { "label": "0-4 hours daily", "sort_order": 0, "value_code": "0_to_4_hours" },
+        { "label": "4.1-8 Hours Daily", "sort_order": 1, "value_code": "4_1_to_8_hours" },
+        { "label": "8.1-12 Hours daily", "sort_order": 2, "value_code": "8_1_to_12_hours" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "kmc_duration",
+      "visibleWhen": { "field": "is_kmc_practiced", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "KMC-Breastfeeding Duration",
+      "options": [
+        { "label": "Every 2 hourly", "sort_order": 0, "value_code": "every_2_hourly" },
+        { "label": "Every 4 Hourly", "sort_order": 1, "value_code": "every_4_hourly" },
+        { "label": "Whenever baby cries", "sort_order": 2, "value_code": "whenever_baby_cries" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "kmc_breastfeeding_duration",
+      "visibleWhen": { "field": "is_kmc_practiced", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Umbilical cord care",
+      "options": [
+        { "label": "Clean & dry", "sort_order": 0, "value_code": "clean_and_dry" },
+        {
+          "label": "Redness/discharge/poor condition",
+          "sort_order": 1,
+          "value_code": "redness_discharge_poor_condition"
+        }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "umbilical_cord_care",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Has baby passed urine within last 24 hours",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" },
+        { "label": "Not sure", "sort_order": 2, "value_code": "not_sure" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "passed_urine_last_24h",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Has baby passed stool within last 48 hours",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" },
+        { "label": "Not sure", "sort_order": 2, "value_code": "not_sure" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "passed_stool_last_48h",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Activity level",
+      "options": [
+        { "label": "Active & moving", "sort_order": 0, "value_code": "active_and_moving" },
+        { "label": "Reduced movement", "sort_order": 1, "value_code": "reduced_movement" },
+        { "label": "Lethargic", "sort_order": 2, "value_code": "lethargic" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "activity_level",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Current Length of the baby in cm",
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "current_length_cm",
+      "numericRange": { "min": 35, "max": 60 },
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Current Weight of the baby in kg",
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "current_weight_kg",
+      "numericRange": { "min": 0.5, "max": 6 },
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Nutritional status (Wasting)",
+      "options": [
+        { "label": "Normal", "sort_order": 0, "value_code": "normal" },
+        { "label": "MAM", "sort_order": 1, "value_code": "mam" },
+        { "label": "SAM", "sort_order": 2, "value_code": "sam" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "nutritional_status_wasting",
+      "computedFrom": "NUTRITIONAL_ZSCORE",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Nutritional status (Stunting)",
+      "options": [
+        { "label": "Normal", "sort_order": 0, "value_code": "normal" },
+        { "label": "Moderately stunted", "sort_order": 1, "value_code": "moderately_stunted" },
+        { "label": "Severely stunted", "sort_order": 2, "value_code": "severely_stunted" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "nutritional_status_stunting",
+      "computedFrom": "NUTRITIONAL_ZSCORE",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Nutritional status (Underweight)",
+      "options": [
+        { "label": "Normal", "sort_order": 0, "value_code": "normal" },
+        { "label": "MUW", "sort_order": 1, "value_code": "muw" },
+        { "label": "SUW", "sort_order": 2, "value_code": "suw" }
+      ],
+      "section": "Neonatal Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "nutritional_status_underweight",
+      "computedFrom": "NUTRITIONAL_ZSCORE",
+      "visibleWhen": { "field": "is_newborn_alive_now", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Remarks",
+      "section": "Neonatal Visit",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    }
+  ],
+  "validationJson": [
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "danger_signs",
+      "exclusiveValues": ["no_abnormal_signs_symptoms"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "feeding_concerns",
+      "exclusiveValues": ["no_concerns"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "vaccination_taken_at_birth",
+      "exclusiveValues": ["none"]
+    },
+    {
+      "rule": "REQUIRED_IF_SELECTED",
+      "field": "vaccination_taken_at_birth",
+      "optionFieldMap": {
+        "bcg": "bcg_date",
+        "opv": "opv_date",
+        "hepatitis_b": "hepatitis_b_date",
+        "vitamin_k": "vitamin_k_date"
+      }
+    }
+  ]
+}

--- a/apps/visit-form-service/prisma/seed-data/postpartum-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/postpartum-visit.json
@@ -1,0 +1,614 @@
+{
+  "schemaJson": [
+    {
+      "label": "Actual visit date",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "date",
+      "question_code": "actual_visit_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Visit name",
+      "options": [
+        { "label": "PP1 - 0 to 15 days (±2 days)", "sort_order": 0, "value_code": "pp1" },
+        { "label": "PP2 - 15 to 28 days (±2 days)", "sort_order": 1, "value_code": "pp2" },
+        { "label": "PP3 - 60 days (±5 days)", "sort_order": 2, "value_code": "pp3" },
+        { "label": "PP4 - 90 days (±5 days)", "sort_order": 3, "value_code": "pp4" },
+        { "label": "PP5 - 120 days (±5 days)", "sort_order": 4, "value_code": "pp5" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "visit_name"
+    },
+    {
+      "label": "Is mother alive?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "is_mother_alive"
+    },
+    {
+      "label": "Have you experienced any of the following danger signs after delivery/ since last visit?",
+      "options": [
+        { "label": "Lower abdominal pain", "sort_order": 0, "value_code": "lower_abdominal_pain" },
+        {
+          "label": "Swelling or heaviness in legs",
+          "sort_order": 1,
+          "value_code": "swelling_or_heaviness_in_legs"
+        },
+        {
+          "label": "Abnormal Vaginal discharge (foul smelling and yellow)",
+          "sort_order": 2,
+          "value_code": "abnormal_vaginal_discharge"
+        },
+        {
+          "label": "Extreme weakness or paleness",
+          "sort_order": 3,
+          "value_code": "extreme_weakness_or_paleness"
+        },
+        { "label": "Convulsions", "sort_order": 4, "value_code": "convulsions" },
+        {
+          "label": "Severe Headaches/blurred vision",
+          "sort_order": 5,
+          "value_code": "severe_headaches_blurred_vision"
+        },
+        { "label": "Dizziness", "sort_order": 6, "value_code": "dizziness" },
+        {
+          "label": "Breathlessness/Palpitation",
+          "sort_order": 7,
+          "value_code": "breathlessness_palpitation"
+        },
+        {
+          "label": "Difficulty/burning sensation while passing urine",
+          "sort_order": 8,
+          "value_code": "difficulty_burning_sensation_passing_urine"
+        },
+        { "label": "Burning micturition", "sort_order": 9, "value_code": "burning_micturition" },
+        {
+          "label": "No abnormal signs and symptoms",
+          "sort_order": 10,
+          "value_code": "no_abnormal_signs_and_symptoms"
+        }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "danger_signs_since_delivery_or_last_visit",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Checking Palm and Nails",
+      "options": [
+        { "label": "Pale", "sort_order": 0, "value_code": "pale" },
+        { "label": "Yellow", "sort_order": 1, "value_code": "yellow" },
+        { "label": "Normal", "sort_order": 2, "value_code": "normal" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "checking_palm_and_nails",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Checking Sclera (Eyes)",
+      "options": [
+        { "label": "Pale", "sort_order": 0, "value_code": "pale" },
+        { "label": "Yellow", "sort_order": 1, "value_code": "yellow" },
+        { "label": "Normal", "sort_order": 2, "value_code": "normal" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "checking_sclera_eyes",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Checking Skin",
+      "options": [
+        { "label": "Pale", "sort_order": 0, "value_code": "pale" },
+        { "label": "Yellow", "sort_order": 1, "value_code": "yellow" },
+        { "label": "Normal", "sort_order": 2, "value_code": "normal" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "checking_skin",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Swelling",
+      "options": [
+        { "label": "No swelling", "sort_order": 0, "value_code": "no_swelling" },
+        { "label": "Swollen hands", "sort_order": 1, "value_code": "swollen_hands" },
+        { "label": "Swollen feet", "sort_order": 2, "value_code": "swollen_feet" },
+        { "label": "Swollen Face", "sort_order": 3, "value_code": "swollen_face" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "swelling",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Dehydration",
+      "options": [
+        { "label": "Dry tongue", "sort_order": 0, "value_code": "dry_tongue" },
+        { "label": "Loss of skin turgor", "sort_order": 1, "value_code": "loss_of_skin_turgor" },
+        { "label": "No", "sort_order": 2, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "dehydration",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Have you experienced any of the following at your episiotomy or C-section wound site?",
+      "options": [
+        { "label": "Severe Pain", "sort_order": 0, "value_code": "severe_pain" },
+        { "label": "Swelling", "sort_order": 1, "value_code": "swelling" },
+        { "label": "Discharge", "sort_order": 2, "value_code": "discharge" },
+        { "label": "None of the above", "sort_order": 3, "value_code": "none_of_the_above" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "episiotomy_or_csection_wound_issues",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Has the vaginal bleeding stopped post pregnancy?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "vaginal_bleeding_stopped",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If no, How many Pads are changed in a day during your periods?",
+      "options": [
+        { "label": "Less than 3", "sort_order": 0, "value_code": "less_than_3" },
+        { "label": "3 to 4 (Take Follow Up)", "sort_order": 1, "value_code": "3_to_4" },
+        {
+          "label": "5 or more than 5 (Immediately Refer to Hospital)",
+          "sort_order": 2,
+          "value_code": "5_or_more"
+        }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "pads_changed_per_day",
+      "visibleWhen": { "field": "vaginal_bleeding_stopped", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Are you able to breastfeed comfortably?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "able_to_breastfeed_comfortably",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If no, What difficulties are you facing while breastfeeding?",
+      "options": [
+        { "label": "Feel pain", "sort_order": 0, "value_code": "feel_pain" },
+        {
+          "label": "Have cracked/inverted nipples",
+          "sort_order": 1,
+          "value_code": "cracked_inverted_nipples"
+        },
+        {
+          "label": "Baby not latching properly",
+          "sort_order": 2,
+          "value_code": "baby_not_latching_properly"
+        },
+        { "label": "Low milk supply", "sort_order": 3, "value_code": "low_milk_supply" },
+        {
+          "label": "Breast engorgement or swelling",
+          "sort_order": 4,
+          "value_code": "breast_engorgement_or_swelling"
+        },
+        { "label": "Baby refusing to feed", "sort_order": 5, "value_code": "baby_refusing_to_feed" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "breastfeeding_difficulties",
+      "visibleWhen": { "field": "able_to_breastfeed_comfortably", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "How many times do you take meal in a day? (Full meal Excluding snacks)",
+      "options": [
+        { "label": "Once in a day", "sort_order": 0, "value_code": "once" },
+        { "label": "Twice in a day", "sort_order": 1, "value_code": "twice" },
+        { "label": "Three times in a day", "sort_order": 2, "value_code": "three_times" },
+        { "label": "More than 3 time in a day", "sort_order": 3, "value_code": "more_than_3" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "meals_per_day",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Which of these food stuff have you consumed in the last 24 hours?",
+      "options": [
+        {
+          "label": "Cereals (nachni, bajra, jwari, gahu, rice etc.)",
+          "sort_order": 0,
+          "value_code": "cereals"
+        },
+        {
+          "label": "Pulses/Legumes (tur dal, chana, moong, etc.)",
+          "sort_order": 1,
+          "value_code": "pulses_legumes"
+        },
+        {
+          "label": "Nuts and seeds (Ground nuts, almond etc)",
+          "sort_order": 2,
+          "value_code": "nuts_and_seeds"
+        },
+        {
+          "label": "Dairy products Milk/milk products (paneer, dahi, taak, etc.)",
+          "sort_order": 3,
+          "value_code": "dairy_products"
+        },
+        { "label": "Fruits", "sort_order": 4, "value_code": "fruits" },
+        { "label": "Vegetables", "sort_order": 5, "value_code": "vegetables" },
+        { "label": "Green vegetables", "sort_order": 6, "value_code": "green_vegetables" },
+        {
+          "label": "Other vitamin A–rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
+          "sort_order": 7,
+          "value_code": "vitamin_a_rich_fruits_vegetables"
+        },
+        { "label": "Eggs", "sort_order": 8, "value_code": "eggs" },
+        { "label": "Poultry/meat/fish", "sort_order": 9, "value_code": "poultry_meat_fish" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "food_consumed_last_24_hours",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Which of these food stuff do you avoid eating?",
+      "options": [
+        {
+          "label": "Cereals (nachni, bajra, jwari, gahu, rice etc.)",
+          "sort_order": 0,
+          "value_code": "cereals"
+        },
+        {
+          "label": "Pulses/Legumes (tur dal, chana, moong, etc.)",
+          "sort_order": 1,
+          "value_code": "pulses_legumes"
+        },
+        {
+          "label": "Nuts and seeds (Ground nuts, almond etc)",
+          "sort_order": 2,
+          "value_code": "nuts_and_seeds"
+        },
+        {
+          "label": "Dairy products Milk/milk products (paneer, dahi, taak, etc.)",
+          "sort_order": 3,
+          "value_code": "dairy_products"
+        },
+        { "label": "Fruits", "sort_order": 4, "value_code": "fruits" },
+        { "label": "Vegetables", "sort_order": 5, "value_code": "vegetables" },
+        { "label": "Green vegetables", "sort_order": 6, "value_code": "green_vegetables" },
+        {
+          "label": "Other vitamin A–rich fruits and vegetables (Mango, papaya, pumpkin, carrot)",
+          "sort_order": 7,
+          "value_code": "vitamin_a_rich_fruits_vegetables"
+        },
+        { "label": "Eggs", "sort_order": 8, "value_code": "eggs" },
+        { "label": "Poultry/meat/fish", "sort_order": 9, "value_code": "poultry_meat_fish" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "food_avoided",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Are you taking IFA tablets?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "taking_ifa_tablets",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "How many IFA tablets did you consume since last visit?",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "ifa_tablets_consumed_since_last_visit",
+      "numericRange": { "min": 0, "max": 35 },
+      "visibleWhen": { "field": "taking_ifa_tablets", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If no, what is the reasons for non consumption of IFA tablets?",
+      "options": [
+        { "label": "Forgot to take", "sort_order": 0, "value_code": "forgot_to_take" },
+        {
+          "label": "Due to side effects (Constipation, black stool, nausea)",
+          "sort_order": 1,
+          "value_code": "side_effects"
+        },
+        {
+          "label": "Misconception about IFA",
+          "sort_order": 2,
+          "value_code": "misconception_about_ifa"
+        },
+        {
+          "label": "Tablets not available",
+          "sort_order": 3,
+          "value_code": "tablets_not_available"
+        },
+        { "label": "Other", "sort_order": 4, "value_code": "other" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "reason_for_non_consumption_of_ifa",
+      "visibleWhen": { "field": "taking_ifa_tablets", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Calcium tablets received and consumed?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "calcium_tablets_received_and_consumed",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Are you currently using any family planning method?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "using_family_planning",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If yes, which method(s) are you using? (Tick all that apply)",
+      "options": [
+        { "label": "Condoms", "sort_order": 0, "value_code": "condoms" },
+        {
+          "label": "Oral contraceptive pills (Mala-N or other)",
+          "sort_order": 1,
+          "value_code": "oral_contraceptive_pills"
+        },
+        {
+          "label": "Emergency contraceptive pills",
+          "sort_order": 2,
+          "value_code": "emergency_contraceptive_pills"
+        },
+        {
+          "label": "Injectable contraceptives (Antara)",
+          "sort_order": 3,
+          "value_code": "injectable_contraceptives_antara"
+        },
+        { "label": "IUCD (Copper-T)", "sort_order": 4, "value_code": "iucd_copper_t" },
+        { "label": "Lactational Amenorrhea Method (LAM)", "sort_order": 5, "value_code": "lam" },
+        {
+          "label": "Safe period / calendar method",
+          "sort_order": 6,
+          "value_code": "safe_period_calendar_method"
+        },
+        {
+          "label": "Withdrawal method (coitus interruptus)",
+          "sort_order": 7,
+          "value_code": "withdrawal_method"
+        },
+        {
+          "label": "Female sterilization (Tubectomy)",
+          "sort_order": 8,
+          "value_code": "female_sterilization_tubectomy"
+        },
+        {
+          "label": "Male sterilization (Vasectomy/NSSK)",
+          "sort_order": 9,
+          "value_code": "male_sterilization_vasectomy_nssk"
+        },
+        { "label": "Sexual abstinence", "sort_order": 10, "value_code": "sexual_abstinence" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "family_planning_methods",
+      "visibleWhen": { "field": "using_family_planning", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Are you facing any difficulties or side effects due to contraceptive method?",
+      "options": [
+        { "label": "Irregular bleeding", "sort_order": 0, "value_code": "irregular_bleeding" },
+        { "label": "Headache", "sort_order": 1, "value_code": "headache" },
+        { "label": "Nausea", "sort_order": 2, "value_code": "nausea" },
+        { "label": "Weight changes", "sort_order": 3, "value_code": "weight_changes" },
+        { "label": "Mood changes", "sort_order": 4, "value_code": "mood_changes" },
+        {
+          "label": "Decreased sexual desire",
+          "sort_order": 5,
+          "value_code": "decreased_sexual_desire"
+        },
+        {
+          "label": "Pain or discomfort (for IUCD users)",
+          "sort_order": 6,
+          "value_code": "pain_or_discomfort_iucd"
+        },
+        { "label": "None", "sort_order": 7, "value_code": "none" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "contraceptive_side_effects",
+      "visibleWhen": { "field": "using_family_planning", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Feeling sad, anxious, or stressed most days?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "feeling_sad_anxious_stressed",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Adequate family support during post partum?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "adequate_family_support",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Current weight of the woman in kg",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "current_weight_kg",
+      "numericRange": { "min": 25, "max": 100 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Current BMI",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "current_bmi",
+      "computedFrom": "BMI",
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Current Mid-Upper Arm Circumference in cm",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "current_muac_cm",
+      "numericRange": { "min": 10, "max": 40 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Blood Pressure (BP) Systolic",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "bp_systolic",
+      "numericRange": { "min": 70, "max": 300 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Blood Pressure (BP) Diastolic",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "bp_diastolic",
+      "numericRange": { "min": 40, "max": 130 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Body Temperature in °F",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "body_temperature_f",
+      "numericRange": { "min": 94, "max": 105 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Haemoglobin (Hb) g/dl",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "haemoglobin_g_dl",
+      "numericRange": { "min": 1, "max": 18 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Random blood glucose in mg/dl",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "random_blood_glucose_mg_dl",
+      "numericRange": { "min": 40, "max": 400 },
+      "visibleWhen": { "field": "is_mother_alive", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Remarks",
+      "section": "Postpartum Visit",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    },
+    {
+      "label": "How many ANC visits to the nearest health facility did the beneficiary complete before delivery? (Take the number from the MCP card)",
+      "section": "Postpartum Visit",
+      "required": true,
+      "input_type": "number",
+      "question_code": "anc_visits_completed_before_delivery",
+      "numericRange": { "min": 0, "max": 20 }
+    }
+  ],
+  "validationJson": [
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "danger_signs_since_delivery_or_last_visit",
+      "exclusiveValues": ["no_abnormal_signs_and_symptoms"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "episiotomy_or_csection_wound_issues",
+      "exclusiveValues": ["none_of_the_above"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "dehydration",
+      "exclusiveValues": ["no"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "swelling",
+      "exclusiveValues": ["no_swelling"]
+    },
+    {
+      "rule": "EXCLUSIVE_OPTION",
+      "field": "contraceptive_side_effects",
+      "exclusiveValues": ["none"]
+    }
+  ]
+}

--- a/apps/visit-form-service/prisma/seed.ts
+++ b/apps/visit-form-service/prisma/seed.ts
@@ -4,6 +4,9 @@ import motherRegistrationPayload from './seed-data/mother-registration.json';
 import childRegistrationPayload from './seed-data/child-registration.json';
 import ancVisitPayload from './seed-data/anc-visit.json';
 import infantVisitPayload from './seed-data/infant-visit.json';
+import deliveryVisitPayload from './seed-data/delivery-visit.json';
+import postpartumVisitPayload from './seed-data/postpartum-visit.json';
+import neonatalVisitPayload from './seed-data/neonatal-visit.json';
 
 const prisma = new PrismaClient();
 
@@ -69,6 +72,27 @@ const FORMS: FormDraft[] = [
     entityType: 'CHILD',
     versionNo: 'v1',
     payload: infantVisitPayload,
+  },
+  {
+    formCode: 'DELIVERY_VISIT',
+    formName: 'Delivery Visit',
+    entityType: 'MOTHER',
+    versionNo: 'v1',
+    payload: deliveryVisitPayload,
+  },
+  {
+    formCode: 'POSTPARTUM_VISIT',
+    formName: 'Postpartum Visit',
+    entityType: 'MOTHER',
+    versionNo: 'v1',
+    payload: postpartumVisitPayload,
+  },
+  {
+    formCode: 'NEONATAL_VISIT',
+    formName: 'Neonatal Visit',
+    entityType: 'CHILD',
+    versionNo: 'v1',
+    payload: neonatalVisitPayload,
   },
 ];
 

--- a/apps/visit-form-service/src/beneficiaries/beneficiary.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiary.client.spec.ts
@@ -13,16 +13,43 @@ describe('findBeneficiaryById', () => {
     global.fetch = originalFetch;
   });
 
-  it('returns the beneficiary case (id/sakhiId) when beneficiary-service returns 200', async () => {
+  it('returns the beneficiary case (id/sakhiId/projectId/lookup ids/geography) when beneficiary-service returns 200', async () => {
+    const data = {
+      id: 'ben-1',
+      sakhiId: 'sakhi-1',
+      projectId: 'project-1',
+      beneficiaryTypeLookupId: 'type-1',
+      caseTypeLookupId: 'case-type-1',
+      pii: {
+        villageId: 'village-1',
+        padaId: 'pada-1',
+        healthSubCentreId: 'sc-1',
+        phcId: 'phc-1',
+        stateId: 'state-1',
+        districtId: 'district-1',
+      },
+    };
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
-      json: () => Promise.resolve({ success: true, data: { id: 'ben-1', sakhiId: 'sakhi-1' } }),
+      json: () => Promise.resolve({ success: true, data }),
     });
 
     const result = await findBeneficiaryById('ben-1', 'Bearer test-token');
 
-    expect(result).toEqual({ id: 'ben-1', sakhiId: 'sakhi-1' });
+    expect(result).toEqual({
+      id: 'ben-1',
+      sakhiId: 'sakhi-1',
+      projectId: 'project-1',
+      beneficiaryTypeLookupId: 'type-1',
+      caseTypeLookupId: 'case-type-1',
+      villageId: 'village-1',
+      padaId: 'pada-1',
+      healthSubCentreId: 'sc-1',
+      phcId: 'phc-1',
+      stateId: 'state-1',
+      districtId: 'district-1',
+    });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/beneficiaries/ben-1'),
       expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),

--- a/apps/visit-form-service/src/beneficiaries/beneficiary.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiary.client.ts
@@ -11,15 +11,50 @@ const GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:
 export interface BeneficiaryCase {
   id: string;
   sakhiId: string;
+  projectId: string;
+  beneficiaryTypeLookupId: string;
+  caseTypeLookupId: string;
+  /** Geography — mirrors piiSchema's required fields in beneficiary-service's
+   * createBeneficiarySchema. Used by create-child.client.ts so a newborn's
+   * case can be created without asking the Sakhi to re-enter geography
+   * already captured for the mother — the child is, by definition, at the
+   * same village/pada/PHC/sub-centre as the mother at delivery time. */
+  villageId: string;
+  padaId: string;
+  healthSubCentreId: string;
+  phcId: string;
+  stateId: string;
+  districtId: string;
+}
+
+/** Raw shape of `GET /beneficiaries/:id`'s response — geography lives under `pii`. */
+interface BeneficiaryCaseDetailResponse {
+  id: string;
+  sakhiId: string;
+  projectId: string;
+  beneficiaryTypeLookupId: string;
+  caseTypeLookupId: string;
+  pii: {
+    villageId: string;
+    padaId: string;
+    healthSubCentreId: string;
+    phcId: string;
+    stateId: string;
+    districtId: string;
+  };
 }
 
 /**
- * Fetches a beneficiary case's id/sakhiId via beneficiary-service's
- * `GET /beneficiaries/:id`, called through the gateway with the original
- * caller's own bearer token forwarded unchanged. `sakhiId` is what lets the
- * caller (visitSchedule.service.ts) enforce real ownership — a SAKHI may
- * only upload a schedule for her own beneficiaries, a SUPERVISOR only for
- * beneficiaries whose Sakhi is assigned to them.
+ * Fetches a beneficiary case via beneficiary-service's `GET /beneficiaries/:id`,
+ * called through the gateway with the original caller's own bearer token
+ * forwarded unchanged. `sakhiId` is what lets the caller
+ * (visitSchedule.service.ts) enforce real ownership — a SAKHI may only
+ * upload a schedule for her own beneficiaries, a SUPERVISOR only for
+ * beneficiaries whose Sakhi is assigned to them. `projectId`/
+ * `beneficiaryTypeLookupId`/`caseTypeLookupId`/geography are used by
+ * create-child.client.ts (DELIVERY_VISIT's auto child-profile creation) so
+ * the new child case inherits the same project/lookup/geography context as
+ * its mother's case, rather than this service guessing or re-resolving them.
  */
 export async function findBeneficiaryById(
   beneficiaryId: string,
@@ -38,6 +73,15 @@ export async function findBeneficiaryById(
     throw badGateway('Unable to verify the beneficiary — beneficiary-service returned an error.');
   }
 
-  const body = (await res.json()) as { data: BeneficiaryCase };
-  return body.data;
+  const body = (await res.json()) as { data: BeneficiaryCaseDetailResponse };
+  const { pii, ...rest } = body.data;
+  return {
+    ...rest,
+    villageId: pii.villageId,
+    padaId: pii.padaId,
+    healthSubCentreId: pii.healthSubCentreId,
+    phcId: pii.phcId,
+    stateId: pii.stateId,
+    districtId: pii.districtId,
+  };
 }

--- a/apps/visit-form-service/src/beneficiaries/create-child.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/create-child.client.spec.ts
@@ -1,0 +1,133 @@
+import { createChildBeneficiary } from './create-child.client';
+import type { BeneficiaryCase } from './beneficiary.client';
+
+describe('createChildBeneficiary', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let warnSpy: jest.SpyInstance;
+
+  const motherCase: BeneficiaryCase = {
+    id: 'mother-1',
+    sakhiId: 'sakhi-1',
+    projectId: 'project-1',
+    beneficiaryTypeLookupId: 'type-1',
+    caseTypeLookupId: 'case-type-1',
+    villageId: 'village-1',
+    padaId: 'pada-1',
+    healthSubCentreId: 'sc-1',
+    phcId: 'phc-1',
+    stateId: 'state-1',
+    districtId: 'district-1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("POSTs a CHILD case to beneficiary-service with the mother's project/lookup context", async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+
+    await createChildBeneficiary(
+      {
+        motherCase,
+        localCaseUuid: 'uuid-1-child1',
+        registrationDate: new Date('2026-08-01T00:00:00.000Z'),
+        dateOfBirth: new Date('2026-08-01T00:00:00.000Z'),
+        sex: 'MALE',
+        birthWeightKg: 2.4,
+        birthLengthCm: 45,
+      },
+      'Bearer test-token',
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/beneficiaries'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.case).toEqual(
+      expect.objectContaining({
+        localCaseUuid: 'uuid-1-child1',
+        projectId: 'project-1',
+        caseType: 'CHILD',
+        motherBeneficiaryId: 'mother-1',
+        beneficiaryTypeLookupId: 'type-1',
+        caseTypeLookupId: 'case-type-1',
+      }),
+    );
+    expect(body.childDetails).toEqual(
+      expect.objectContaining({ sex: 'MALE', birthWeightKg: 2.4, birthLengthCm: 45 }),
+    );
+    expect(body.pii).toEqual(
+      expect.objectContaining({
+        villageId: 'village-1',
+        padaId: 'pada-1',
+        healthSubCentreId: 'sc-1',
+        phcId: 'phc-1',
+        stateId: 'state-1',
+        districtId: 'district-1',
+      }),
+    );
+  });
+
+  it('acknowledges beneficiary-service duplicate detection — same mother + same DOB is expected for twins/triplets, not a real duplicate', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+
+    await createChildBeneficiary(
+      {
+        motherCase,
+        localCaseUuid: 'uuid-1-child2',
+        registrationDate: new Date('2026-08-01T00:00:00.000Z'),
+        dateOfBirth: new Date('2026-08-01T00:00:00.000Z'),
+      },
+      'Bearer test-token',
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.acknowledgeDuplicate).toBe(true);
+  });
+
+  it('swallows a non-ok response so the Delivery submission is never failed by it', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(
+      createChildBeneficiary(
+        {
+          motherCase,
+          localCaseUuid: 'uuid-1-child1',
+          registrationDate: new Date(),
+          dateOfBirth: new Date(),
+        },
+        'Bearer test-token',
+      ),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows a network failure so the Delivery submission is never failed by it', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(
+      createChildBeneficiary(
+        {
+          motherCase,
+          localCaseUuid: 'uuid-1-child1',
+          registrationDate: new Date(),
+          dateOfBirth: new Date(),
+        },
+        'Bearer test-token',
+      ),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/visit-form-service/src/beneficiaries/create-child.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/create-child.client.ts
@@ -1,0 +1,106 @@
+import type { BeneficiaryCase } from './beneficiary.client';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — matches geography.client.ts's/socio-demographics.client.ts's stance.
+const API_GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+export interface CreateChildBeneficiaryInput {
+  /** The delivering mother's own case — its projectId/beneficiaryTypeLookupId/
+   * caseTypeLookupId are reused for the new child case rather than this
+   * service guessing or re-resolving them. */
+  motherCase: BeneficiaryCase;
+  /** Client-generated, per-child idempotency key — see localCaseUuid in
+   * beneficiary-service's createBeneficiarySchema. Must be independent of
+   * the Delivery submission's own localSubmissionUuid so a retry after a
+   * partial multi-child failure can re-attempt only the children that
+   * didn't yet get a case, without re-running the whole submission. */
+  localCaseUuid: string;
+  registrationDate: Date;
+  dateOfBirth: Date;
+  sex?: 'MALE' | 'FEMALE' | 'INTERSEX_OTHER';
+  birthWeightKg?: number;
+  birthLengthCm?: number;
+}
+
+/**
+ * Creates a CHILD beneficiary case for one live-born child from a
+ * DELIVERY_VISIT submission, via beneficiary-service's existing
+ * `POST /beneficiaries` — no beneficiary-service changes needed, that
+ * endpoint already accepts everything a Delivery-form child needs
+ * (caseType: 'CHILD', motherBeneficiaryId set).
+ *
+ * Best-effort by design, matching syncSocioDemographics/triggerRiskAssessment:
+ * the Delivery submission itself is already durably saved by the time this
+ * runs. A failure here is logged and swallowed rather than failing the
+ * Sakhi's submission — a missing child profile is a follow-up/ops concern,
+ * rejecting a completed delivery record in the field is not.
+ */
+export async function createChildBeneficiary(
+  input: CreateChildBeneficiaryInput,
+  authorizationHeader: string,
+): Promise<void> {
+  const body = {
+    // No name/phone is captured on the Delivery form for the newborn — the
+    // Infant Registration (CHILD_REGISTRATION) form is where a Sakhi later
+    // fills those in; this call only needs to exist so scheduling
+    // (NN/INC visit generation) and later registration have a beneficiary
+    // case row to attach to.
+    pii: {
+      fullName: 'Unnamed',
+      phone: '0000000000',
+      dateOfBirth: input.dateOfBirth.toISOString(),
+      sex: input.sex,
+      villageId: input.motherCase.villageId,
+      padaId: input.motherCase.padaId,
+      healthSubCentreId: input.motherCase.healthSubCentreId,
+      phcId: input.motherCase.phcId,
+      stateId: input.motherCase.stateId,
+      districtId: input.motherCase.districtId,
+    },
+    case: {
+      localCaseUuid: input.localCaseUuid,
+      projectId: input.motherCase.projectId,
+      caseType: 'CHILD',
+      registrationDate: input.registrationDate.toISOString(),
+      motherBeneficiaryId: input.motherCase.id,
+      beneficiaryTypeLookupId: input.motherCase.beneficiaryTypeLookupId,
+      caseTypeLookupId: input.motherCase.caseTypeLookupId,
+    },
+    childDetails: {
+      dateOfBirth: input.dateOfBirth.toISOString(),
+      sex: input.sex,
+      birthWeightKg: input.birthWeightKg,
+      birthLengthCm: input.birthLengthCm,
+    },
+    consent: {
+      status: 'GIVEN',
+      date: input.registrationDate.toISOString(),
+    },
+    // The Delivery form has already confirmed the birth details (outcome,
+    // sex, weight) for this specific child — beneficiary-service's
+    // same-mother/same-DOB duplicate check would otherwise 409 on the
+    // second child of a twin/triplet delivery (identical dateOfBirth,
+    // same motherBeneficiaryId), which is not a real duplicate here.
+    acknowledgeDuplicate: true,
+  };
+
+  try {
+    const res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/beneficiaries`, {
+      method: 'POST',
+      headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.warn(
+        `Failed to auto-create child beneficiary for mother ${input.motherCase.id} ` +
+          `(beneficiary-service returned ${res.status}); the Delivery submission itself was still saved.`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Unable to reach beneficiary-service to auto-create child beneficiary for mother ` +
+        `${input.motherCase.id}; the Delivery submission itself was still saved. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/beneficiaries/create-child.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/create-child.client.ts
@@ -10,10 +10,12 @@ export interface CreateChildBeneficiaryInput {
    * service guessing or re-resolving them. */
   motherCase: BeneficiaryCase;
   /** Client-generated, per-child idempotency key — see localCaseUuid in
-   * beneficiary-service's createBeneficiarySchema. Must be independent of
-   * the Delivery submission's own localSubmissionUuid so a retry after a
-   * partial multi-child failure can re-attempt only the children that
-   * didn't yet get a case, without re-running the whole submission. */
+   * beneficiary-service's createBeneficiarySchema. Guards only against a
+   * dropped-connection retry of this specific HTTP call landing twice (see
+   * findByLocalCaseUuid in beneficiary.repository.ts); it does NOT give the
+   * Delivery submission itself a retry path — a resubmit of the same form
+   * never reaches this call again, so a failure here is a genuine one-shot
+   * best-effort attempt (see form.service.ts's DELIVERY_VISIT branch). */
   localCaseUuid: string;
   registrationDate: Date;
   dateOfBirth: Date;

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -3,10 +3,14 @@ import type { FormRepository } from './form.repository';
 import * as geographyClient from '../geography/geography.client';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
+import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
+import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
 jest.mock('../beneficiaries/health-history.client');
+jest.mock('../beneficiaries/beneficiary.client');
+jest.mock('../beneficiaries/create-child.client');
 
 describe('FormService', () => {
   const repository = {
@@ -703,6 +707,220 @@ describe('FormService', () => {
             ]),
           );
         });
+    });
+
+    describe('DELIVERY_VISIT child-profile auto-creation', () => {
+      const motherCase = {
+        id: 'b1',
+        sakhiId: 'sakhi-1',
+        projectId: 'project-1',
+        beneficiaryTypeLookupId: 'type-1',
+        caseTypeLookupId: 'case-type-1',
+        villageId: 'village-1',
+        padaId: 'pada-1',
+        healthSubCentreId: 'sc-1',
+        phcId: 'phc-1',
+        stateId: 'state-1',
+        districtId: 'district-1',
+      };
+
+      const deliveryVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'DELIVERY_VISIT' },
+        // Minimal — none required, so these tests can submit whichever
+        // childN_* fields each case needs without also having to satisfy an
+        // unrelated required field from a different form's schema.
+        schemaJson: [
+          { question_code: 'date_of_delivery', label: 'x', input_type: 'date', required: false },
+          {
+            question_code: 'number_of_babies_born',
+            label: 'x',
+            input_type: 'number',
+            required: false,
+          },
+          ...['child1', 'child2', 'child3'].flatMap((prefix) => [
+            {
+              question_code: `${prefix}_delivery_outcome`,
+              label: 'x',
+              input_type: 'dropdown',
+              required: false,
+            },
+            {
+              question_code: `${prefix}_sex_of_baby`,
+              label: 'x',
+              input_type: 'dropdown',
+              required: false,
+            },
+            {
+              question_code: `${prefix}_birth_weight_kg`,
+              label: 'x',
+              input_type: 'number',
+              required: false,
+            },
+            {
+              question_code: `${prefix}_birth_length_cm`,
+              label: 'x',
+              input_type: 'number',
+              required: false,
+            },
+          ]),
+        ],
+        validationJson: [],
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(deliveryVersion as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue(motherCase);
+      });
+
+      it('creates a child beneficiary for a single live birth', async () => {
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              child1_sex_of_baby: 'male',
+              child1_birth_weight_kg: 2.4,
+              child1_birth_length_cm: 45,
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledTimes(1);
+        expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            motherCase,
+            localCaseUuid: 'uuid-1-child1',
+            sex: 'MALE',
+            birthWeightKg: 2.4,
+            birthLengthCm: 45,
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('creates one child beneficiary per live-born child in a multi-birth submission', async () => {
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              number_of_babies_born: 2,
+              child1_delivery_outcome: 'live_birth',
+              child1_sex_of_baby: 'male',
+              child2_delivery_outcome: 'live_birth',
+              child2_sex_of_baby: 'female',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledTimes(2);
+        expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledWith(
+          expect.objectContaining({ localCaseUuid: 'uuid-1-child1', sex: 'MALE' }),
+          'Bearer test-token',
+        );
+        expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledWith(
+          expect.objectContaining({ localCaseUuid: 'uuid-1-child2', sex: 'FEMALE' }),
+          'Bearer test-token',
+        );
+      });
+
+      it('does not create a beneficiary for a stillborn child', async () => {
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'antepartum_still_birth_fresh',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createChildBeneficiary)).not.toHaveBeenCalled();
+      });
+
+      it('does not create a beneficiary for a non-existent child slot', async () => {
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              // child2/child3 absent — single birth.
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not attempt child creation for a non-DELIVERY_VISIT form', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...publishedVersion,
+          formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+        } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(findBeneficiaryById)).not.toHaveBeenCalled();
+        expect(jest.mocked(createChildBeneficiary)).not.toHaveBeenCalled();
+      });
+
+      it('does not throw and skips child creation when the mother case cannot be found', async () => {
+        jest.mocked(findBeneficiaryById).mockResolvedValue(null);
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual({ id: 'sub-1' });
+        expect(jest.mocked(createChildBeneficiary)).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -13,6 +13,8 @@ import {
 import { validateSubmission } from './form-validation';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
+import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
+import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
@@ -195,6 +197,62 @@ export class FormService {
     if (formCode === 'MOTHER_REGISTRATION') {
       await syncSocioDemographics(dto.beneficiaryId, dto.formData, authorizationHeader);
       await syncHealthHistory(dto.beneficiaryId, dto.formData, authorizationHeader);
+    }
+
+    // Auto-creates a CHILD beneficiary case for each live-born child on a
+    // Delivery submission (SRS: "Delivery form... auto-creates the child
+    // profile on submission") — one createChildBeneficiary() call per
+    // childN_* block whose delivery outcome is LIVE_BIRTH, independent and
+    // best-effort per child so one failing call (e.g. in a twin/triplet
+    // birth) never blocks the others or the already-saved submission.
+    if (formCode === 'DELIVERY_VISIT') {
+      const motherCase = await findBeneficiaryById(dto.beneficiaryId, authorizationHeader);
+      if (motherCase) {
+        const dateOfDelivery = dto.formData.date_of_delivery
+          ? new Date(String(dto.formData.date_of_delivery))
+          : null;
+        const childPrefixes = ['child1', 'child2', 'child3'] as const;
+        const SEX_MAP: Record<string, 'MALE' | 'FEMALE' | 'INTERSEX_OTHER'> = {
+          male: 'MALE',
+          female: 'FEMALE',
+          intersex_other: 'INTERSEX_OTHER',
+        };
+
+        await Promise.all(
+          childPrefixes.map(async (prefix) => {
+            const outcome = dto.formData[`${prefix}_delivery_outcome`];
+            if (outcome !== 'live_birth' || !dateOfDelivery) return;
+
+            const sexCode = dto.formData[`${prefix}_sex_of_baby`];
+            const birthWeightKg = dto.formData[`${prefix}_birth_weight_kg`];
+            const birthLengthCm = dto.formData[`${prefix}_birth_length_cm`];
+
+            await createChildBeneficiary(
+              {
+                motherCase,
+                // Deterministic and independent of localSubmissionUuid — a
+                // resubmit of the same Delivery form (idempotent replay,
+                // handled above) always derives the same per-child key, so a
+                // retry after a partial failure re-attempts only the
+                // children beneficiary-service hasn't already created.
+                localCaseUuid: `${dto.localSubmissionUuid}-${prefix}`,
+                registrationDate: dateOfDelivery,
+                dateOfBirth: dateOfDelivery,
+                sex: typeof sexCode === 'string' ? SEX_MAP[sexCode] : undefined,
+                birthWeightKg:
+                  typeof birthWeightKg === 'number' || typeof birthWeightKg === 'string'
+                    ? Number(birthWeightKg)
+                    : undefined,
+                birthLengthCm:
+                  typeof birthLengthCm === 'number' || typeof birthLengthCm === 'string'
+                    ? Number(birthLengthCm)
+                    : undefined,
+              },
+              authorizationHeader,
+            );
+          }),
+        );
+      }
     }
 
     // Triggers the risk-grading pipeline for every visit-linked submission

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -204,7 +204,13 @@ export class FormService {
     // profile on submission") — one createChildBeneficiary() call per
     // childN_* block whose delivery outcome is LIVE_BIRTH, independent and
     // best-effort per child so one failing call (e.g. in a twin/triplet
-    // birth) never blocks the others or the already-saved submission.
+    // birth) never blocks the others or the already-saved submission. This
+    // is a genuine one-shot attempt, same stance as syncSocioDemographics
+    // above: if createChildBeneficiary fails here, nothing retries it later
+    // — a resubmit with the same localSubmissionUuid short-circuits on the
+    // idempotent-replay check earlier in this method and never reaches this
+    // block again. A missing child case has to be caught and fixed out of
+    // band (see the console.warn in createChildBeneficiary's catch).
     if (formCode === 'DELIVERY_VISIT') {
       const motherCase = await findBeneficiaryById(dto.beneficiaryId, authorizationHeader);
       if (motherCase) {
@@ -230,11 +236,10 @@ export class FormService {
             await createChildBeneficiary(
               {
                 motherCase,
-                // Deterministic and independent of localSubmissionUuid — a
-                // resubmit of the same Delivery form (idempotent replay,
-                // handled above) always derives the same per-child key, so a
-                // retry after a partial failure re-attempts only the
-                // children beneficiary-service hasn't already created.
+                // Deterministic per child so a dropped-connection retry of
+                // this specific call (network blip, not a form resubmit —
+                // see the block comment above) lands on the same case
+                // instead of creating a duplicate.
                 localCaseUuid: `${dto.localSubmissionUuid}-${prefix}`,
                 registrationDate: dateOfDelivery,
                 dateOfBirth: dateOfDelivery,


### PR DESCRIPTION
Closes #157

## Summary
- Seeds three new form definitions per `docs/Revised_App_Form_Final_20.3.26.xlsx.md`'s "DeliveryPPNeonatal visit" section — the forms that make up the delivery-event session:
  - **DELIVERY_VISIT** (44 fields) — mother-level delivery details + flattened `child1_*`/`child2_*`/`child3_*` blocks (up to 3 births, gated by `number_of_babies_born`), plus remarks.
  - **POSTPARTUM_VISIT** (36 fields) — shared PP1–PP5 template.
  - **NEONATAL_VISIT** (32 fields) — shared NN1/NN2 template, plus two pre-filled fields (`birth_weight_kg`, `term_of_delivery`) so the KMC-eligibility gate can reference the Delivery form's own data without a cross-service lookup.
- No Prisma migration — reuses the existing generic `FormDefinition`/`FormVersion`/`FormSubmission`/`FormAnswer` tables, same as `MOTHER_REGISTRATION`/`ANC_VISIT`.
- `DELIVERY_VISIT` submission auto-creates a `CHILD` beneficiary case (via beneficiary-service's existing `POST /beneficiaries`) for each live-born child, best-effort — matches the resilience stance already used for `syncSocioDemographics`/`triggerRiskAssessment`. Stillbirths are correctly skipped.
- `beneficiary.client.ts`'s `findBeneficiaryById` now also returns the mother's geography/lookup ids, so the auto-created child case inherits them rather than requiring a separate resolution step.
- `acknowledgeDuplicate: true` is passed on the child-create call — without it, twins/triplets sharing the same mother + date of birth would false-positive beneficiary-service's duplicate-beneficiary check.

## Design note
The Child1/2/3 block is implemented as flattened, individually-gated fields (`childN_*`, `visibleWhen: number_of_babies_born >= N`) rather than a new repeating-group schema primitive — this needed no changes to `form-field.dto.ts`/`form-validation.ts`/`form.mapper.ts`, keeping the change scoped to seed data + one new cross-service client + one new branch in `FormService.createSubmission()`.

## Explicitly out of scope
- PP1/NN1 auto-sequencing within the same Sakhi session (opening PP1/NN1 immediately after a Delivery submission) — this PR only adds the three form definitions and their submission validation, not the session-orchestration logic. Tracked as a follow-up.

## Test plan
- [x] `npx nx lint visit-form-service` — clean
- [x] `npx nx test visit-form-service` — 310/310 passing (added coverage: `seed-data.spec.ts` round-trips all 3 new seed files against `schemaJsonSchema`/`validationJsonSchema` + field-count/gating assertions; `form.service.spec.ts` covers single-birth, twin, stillbirth, missing-mother-case, and non-DELIVERY_VISIT-form cases for the new child-creation branch; `create-child.client.spec.ts` covers the POST payload shape, duplicate-acknowledgement, and best-effort failure handling)
- [x] `npx tsc --noEmit` (app + spec tsconfigs) — clean
- [x] Live end-to-end verification against the real dev DB/gateway:
  - `prisma:seed` — created all 3 forms, idempotent on rerun
  - `GET /forms/{DELIVERY_VISIT,POSTPARTUM_VISIT,NEONATAL_VISIT}/active-version` — 200, correct field counts (44/36/32)
  - `POST /forms/DELIVERY_VISIT/submissions` — valid single birth (201, child auto-created), valid twins (201, both children auto-created with distinct cases), stillbirth (201, no child created), missing-mandatory-field (422 with precise violations), out-of-range value (422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)