### PR TITLE
feat(auth-service): non-expiring login sessions except for admin

### DIFF
--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -12,8 +12,10 @@ DIRECT_URL=postgresql://armman:armman@localhost:5432/arogya
 REDIS_URL=redis://localhost:6379
 JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_ME\n-----END PRIVATE KEY-----"
 JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nREPLACE_ME\n-----END PUBLIC KEY-----"
-JWT_ACCESS_TOKEN_TTL=15m
-JWT_REFRESH_TOKEN_TTL=30d
+# Applies only to ADMIN logins — every other role's access token has no
+# expiry (see AuthService.issueTokens). Refresh-token sessions never expire
+# by time for any role; they end only via /auth/logout or revocation.
+JWT_ADMIN_ACCESS_TOKEN_TTL=15m
 # Seed users: one JSON array per role, each entry { username, password, displayName }.
 # mobileNumber is not supplied here — the seeder derives a deterministic
 # placeholder per role (login is username + password only). SAKHI/SUPERVISOR/

--- a/apps/auth-service/prisma/migrations/20260817130000_make_user_session_expires_at_nullable/migration.sql
+++ b/apps/auth-service/prisma/migrations/20260817130000_make_user_session_expires_at_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_sessions" ALTER COLUMN "expires_at" DROP NOT NULL;

--- a/apps/auth-service/prisma/schema.prisma
+++ b/apps/auth-service/prisma/schema.prisma
@@ -117,7 +117,12 @@ model UserSession {
   // device_registry.device_id — deferred; not modeled yet per current scope.
   deviceId         String?   @map("device_id")
   issuedAt         DateTime  @map("issued_at")
-  expiresAt        DateTime  @map("expires_at")
+  // Nullable: sessions no longer expire by time (see AuthService.issueTokens)
+  // — only an explicit /auth/logout or admin revocation sets revokedAt below.
+  // Null on every session created after that change; a pre-existing session
+  // from before it keeps its original real timestamp until its next refresh
+  // rotates it into a fresh, non-expiring one.
+  expiresAt        DateTime? @map("expires_at")
   revokedAt        DateTime? @map("revoked_at")
   ipAddress        String?   @map("ip_address") @db.VarChar(45)
   createdAt        DateTime  @default(now()) @map("created_at")

--- a/apps/auth-service/src/app.module.ts
+++ b/apps/auth-service/src/app.module.ts
@@ -80,12 +80,7 @@ export function createApp(prisma: PrismaService, signer: TokenSigner, redis: Red
   });
   app.use(requestId);
 
-  const authModule = createAuthModule(
-    prisma,
-    signer,
-    appConfig.JWT_ACCESS_TOKEN_TTL,
-    appConfig.JWT_REFRESH_TOKEN_TTL,
-  );
+  const authModule = createAuthModule(prisma, signer, appConfig.JWT_ADMIN_ACCESS_TOKEN_TTL);
   const projectModule = createProjectModule(prisma, signer);
   const lookupModule = createLookupModule(prisma, signer);
   const geographyModule = createGeographyModule(prisma, signer);

--- a/apps/auth-service/src/auth/auth.mapper.ts
+++ b/apps/auth-service/src/auth/auth.mapper.ts
@@ -3,8 +3,8 @@ import { decryptPii } from '@armman/service-commons';
 export interface AuthTokens {
   accessToken: string;
   refreshToken: string;
-  /** Access token lifetime in seconds, from now. */
-  expiresIn: number;
+  /** Access token lifetime in seconds, from now. Null — this access token has no `exp` claim and never expires by time; only /auth/logout or revocation ends the session. */
+  expiresIn: number | null;
   /** Every role code the caller holds — same set encoded in the access token's `roles` claim. */
   roles: string[];
   /** The primary role assignment's project/geography scope (first assignment; see issueTokens). */

--- a/apps/auth-service/src/auth/auth.module.ts
+++ b/apps/auth-service/src/auth/auth.module.ts
@@ -9,11 +9,10 @@ import { registerAuthRoutes } from './auth.routes';
 export function createAuthModule(
   prisma: PrismaService,
   signer: TokenSigner,
-  accessTokenTtl: string,
-  refreshTokenTtl: string,
+  adminAccessTokenTtl: string,
 ): DocumentedRouter {
   const repository = new AuthRepository(prisma);
-  const service = new AuthService(repository, signer, accessTokenTtl, refreshTokenTtl);
+  const service = new AuthService(repository, signer, adminAccessTokenTtl);
   const doc = createDocumentedRouter();
   registerAuthRoutes(doc, service, signer);
   return doc;

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -73,7 +73,6 @@ export class AuthRepository {
     userId: string;
     refreshTokenHash: string;
     issuedAt: Date;
-    expiresAt: Date;
     ipAddress: string | null;
   }) {
     return this.prisma.userSession.create({ data });
@@ -91,7 +90,6 @@ export class AuthRepository {
       userId: string;
       refreshTokenHash: string;
       issuedAt: Date;
-      expiresAt: Date;
       ipAddress: string | null;
     },
   ) {

--- a/apps/auth-service/src/auth/auth.routes.ts
+++ b/apps/auth-service/src/auth/auth.routes.ts
@@ -50,7 +50,7 @@ const authTokensSchema = z.object({
       description:
         'Access token lifetime in seconds, or null if it never expires. Null for every role ' +
         'except ADMIN — only /auth/logout or revocation ends a non-expiring session.',
-      example: null,
+      examples: [null, 900],
     }),
   roles: z
     .array(z.string())

--- a/apps/auth-service/src/auth/auth.routes.ts
+++ b/apps/auth-service/src/auth/auth.routes.ts
@@ -35,11 +35,23 @@ const createUserRequestSchema = createUserSchema.extend({
 });
 
 const authTokensSchema = z.object({
-  accessToken: z.string().openapi({ description: 'Short-lived JWT access token (RS256).' }),
+  accessToken: z.string().openapi({
+    description:
+      'JWT access token (RS256). Non-expiring (no exp claim) for every role except ADMIN, ' +
+      'which gets a short-lived expiry (JWT_ADMIN_ACCESS_TOKEN_TTL).',
+  }),
   refreshToken: z
     .string()
     .openapi({ description: 'Opaque refresh token; single-use, rotated on refresh.' }),
-  expiresIn: z.number().openapi({ description: 'Access token lifetime in seconds.', example: 900 }),
+  expiresIn: z
+    .number()
+    .nullable()
+    .openapi({
+      description:
+        'Access token lifetime in seconds, or null if it never expires. Null for every role ' +
+        'except ADMIN — only /auth/logout or revocation ends a non-expiring session.',
+      example: null,
+    }),
   roles: z
     .array(z.string())
     .openapi({ description: 'Every role code the caller holds.', example: ['SAKHI'] }),

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -89,7 +89,7 @@ describe('AuthService', () => {
     jest.clearAllMocks();
     process.env.PII_ENCRYPTION_KEY = randomBytes(32).toString('base64');
     signer.sign.mockResolvedValue('signed-access-token');
-    service = new AuthService(repository, signer, '15m', '30d');
+    service = new AuthService(repository, signer, '15m');
   });
 
   afterEach(() => {
@@ -109,7 +109,7 @@ describe('AuthService', () => {
       expect(tokens).toEqual({
         accessToken: 'signed-access-token',
         refreshToken: 'plain-refresh-token',
-        expiresIn: 900,
+        expiresIn: null,
         roles: ['SAKHI'],
         projectId: 'project-1',
         geographyUnitId: 'geo-1',
@@ -122,10 +122,61 @@ describe('AuthService', () => {
         }),
       );
       expect(repository.createSession).not.toHaveBeenCalled();
+      // No second (expiresIn) argument: the access token carries no exp
+      // claim and never expires by time.
+      expect(signer.sign).toHaveBeenCalledWith({
+        sub: 'user-1',
+        roles: ['SAKHI'],
+        projectId: 'project-1',
+        geographyUnitId: 'geo-1',
+      });
+    });
+
+    it('issues an expiring access token for an ADMIN login', async () => {
+      const adminUser = {
+        ...ACTIVE_USER,
+        userRoles: [{ projectId: null, geographyUnitId: null, role: { roleCode: 'ADMIN' } }],
+      };
+      repository.findUserByUsername.mockResolvedValue(adminUser as never);
+      (verifyPassword as jest.Mock).mockResolvedValue(true);
+
+      const tokens = await service.login(
+        { username: 'test.sakhi', password: 'correct' },
+        '127.0.0.1',
+      );
+
+      expect(tokens).toEqual({
+        accessToken: 'signed-access-token',
+        refreshToken: 'plain-refresh-token',
+        expiresIn: 900,
+        roles: ['ADMIN'],
+        projectId: null,
+        geographyUnitId: null,
+      });
       expect(signer.sign).toHaveBeenCalledWith(
-        { sub: 'user-1', roles: ['SAKHI'], projectId: 'project-1', geographyUnitId: 'geo-1' },
+        { sub: 'user-1', roles: ['ADMIN'], projectId: null, geographyUnitId: null },
         '15m',
       );
+    });
+
+    it('still expires the access token when ADMIN is only one of several roles held', async () => {
+      const multiRoleUser = {
+        ...ACTIVE_USER,
+        userRoles: [
+          { projectId: 'project-1', geographyUnitId: 'geo-1', role: { roleCode: 'SUPERVISOR' } },
+          { projectId: null, geographyUnitId: null, role: { roleCode: 'ADMIN' } },
+        ],
+      };
+      repository.findUserByUsername.mockResolvedValue(multiRoleUser as never);
+      (verifyPassword as jest.Mock).mockResolvedValue(true);
+
+      const tokens = await service.login(
+        { username: 'test.sakhi', password: 'correct' },
+        '127.0.0.1',
+      );
+
+      expect(tokens.expiresIn).toBe(900);
+      expect(signer.sign).toHaveBeenCalledWith(expect.anything(), '15m');
     });
 
     it('rejects with a generic error for a non-existent username', async () => {
@@ -170,11 +221,13 @@ describe('AuthService', () => {
   });
 
   describe('refresh', () => {
+    // expiresAt is null: sessions no longer expire by time (see
+    // AuthService.issueTokens) — only revokedAt gates rejection now.
     const ACTIVE_SESSION = {
       id: 'session-1',
       userId: 'user-1',
       revokedAt: null,
-      expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+      expiresAt: null,
     };
 
     it('rotates the refresh token and issues a new pair on a valid token', async () => {
@@ -187,21 +240,28 @@ describe('AuthService', () => {
       expect(tokens).toEqual({
         accessToken: 'signed-access-token',
         refreshToken: 'plain-refresh-token',
-        expiresIn: 900,
+        expiresIn: null,
         roles: ['SAKHI'],
         projectId: 'project-1',
         geographyUnitId: 'geo-1',
       });
     });
 
-    it('rejects an expired refresh token', async () => {
+    it('still refreshes a session created before the never-expires change (real expiresAt, not revoked)', async () => {
+      // A pre-existing row can still carry a real expiresAt timestamp from
+      // before this schema change — including one that would have been "in
+      // the past" under the old TTL check. It must no longer matter: only
+      // revokedAt gates rejection now.
       repository.findActiveSessionByRefreshTokenHash.mockResolvedValue({
         ...ACTIVE_SESSION,
         expiresAt: new Date(Date.now() - 1000),
       } as never);
+      repository.findUserById.mockResolvedValue(ACTIVE_USER as never);
 
-      await expect(service.refresh('expired-token', null)).rejects.toMatchObject({ status: 401 });
-      expect(repository.revokeSession).not.toHaveBeenCalled();
+      const tokens = await service.refresh('presented-refresh-token', '127.0.0.1');
+
+      expect(repository.revokeSession).toHaveBeenCalledWith('session-1');
+      expect(tokens.expiresIn).toBeNull();
     });
 
     it('rejects an already-revoked refresh token', async () => {

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -29,12 +29,21 @@ export interface CallerScope {
 /** Prisma unique-constraint violation code (mobileNumber/email/roleCode etc). */
 const PRISMA_UNIQUE_CONSTRAINT_CODE = 'P2002';
 
+/**
+ * The one role that still gets a time-based access-token expiry. Every
+ * other role (SAKHI, SUPERVISOR, MANAGER) gets a non-expiring token — see
+ * `issueTokens`. A user holding ADMIN alongside any other role is still
+ * treated as ADMIN for this check (the more restrictive policy wins). The
+ * refresh-token session itself never expires by time for any role — only
+ * `/auth/logout` or an admin revocation (`revokedAt`) ends it.
+ */
+const EXPIRING_ROLE = 'ADMIN';
+
 export class AuthService {
   constructor(
     private readonly repository: AuthRepository,
     private readonly signer: TokenSigner,
-    private readonly accessTokenTtl: string,
-    private readonly refreshTokenTtl: string,
+    private readonly adminAccessTokenTtl: string,
   ) {}
 
   async login(input: LoginInput, ipAddress: string | null): Promise<AuthTokens> {
@@ -63,13 +72,13 @@ export class AuthService {
     const tokenHash = hashRefreshToken(refreshToken);
     const session = await this.repository.findActiveSessionByRefreshTokenHash(tokenHash);
 
-    if (!session || session.revokedAt || session.expiresAt < new Date()) {
-      throw unauthorized('Invalid or expired refresh token.');
+    if (!session || session.revokedAt) {
+      throw unauthorized('Invalid or revoked refresh token.');
     }
 
     const user = await this.repository.findUserById(session.userId);
     if (!user || user.isDeleted || user.status !== 'ACTIVE') {
-      throw unauthorized('Invalid or expired refresh token.');
+      throw unauthorized('Invalid or revoked refresh token.');
     }
 
     // Rotate: revoke the presented token, issue a brand new pair.
@@ -349,15 +358,16 @@ export class AuthService {
     const roles = userRoles.map((ur) => ur.role.roleCode);
     const [primary] = userRoles;
 
-    const accessToken = await this.signer.sign(
-      {
-        sub: userId,
-        roles,
-        projectId: primary?.projectId ?? null,
-        geographyUnitId: primary?.geographyUnitId ?? null,
-      },
-      this.accessTokenTtl,
-    );
+    const isExpiringRole = roles.includes(EXPIRING_ROLE);
+    const accessTokenPayload = {
+      sub: userId,
+      roles,
+      projectId: primary?.projectId ?? null,
+      geographyUnitId: primary?.geographyUnitId ?? null,
+    };
+    const accessToken = isExpiringRole
+      ? await this.signer.sign(accessTokenPayload, this.adminAccessTokenTtl)
+      : await this.signer.sign(accessTokenPayload);
 
     const refreshToken = generateRefreshToken();
     const now = new Date();
@@ -365,7 +375,6 @@ export class AuthService {
       userId,
       refreshTokenHash: hashRefreshToken(refreshToken),
       issuedAt: now,
-      expiresAt: new Date(now.getTime() + parseDurationMs(this.refreshTokenTtl)),
       ipAddress,
     };
 
@@ -378,7 +387,9 @@ export class AuthService {
     return {
       accessToken,
       refreshToken,
-      expiresIn: Math.floor(parseDurationMs(this.accessTokenTtl) / 1000),
+      expiresIn: isExpiringRole
+        ? Math.floor(parseDurationMs(this.adminAccessTokenTtl) / 1000)
+        : null,
       roles,
       projectId: primary?.projectId ?? null,
       geographyUnitId: primary?.geographyUnitId ?? null,

--- a/apps/auth-service/src/config/app-config.ts
+++ b/apps/auth-service/src/config/app-config.ts
@@ -28,10 +28,11 @@ const schema = z.object({
     .string()
     .min(1)
     .transform((v) => v.replace(/\\n/g, '\n')),
-  // jose "expiresIn" style durations, e.g. "15m", "30d". Values per the HLD §4.2.
-  JWT_ACCESS_TOKEN_TTL: z.string().default('15m'),
-  JWT_REFRESH_TOKEN_TTL: z.string().default('30d'),
   REDIS_URL: z.string().url(),
+  // jose "expiresIn" style duration, e.g. "15m". Access tokens have no
+  // expiry by default (see AuthService.issueTokens) — this applies ONLY to
+  // ADMIN-role logins, the one role that still gets a time-based expiry.
+  JWT_ADMIN_ACCESS_TOKEN_TTL: z.string().default('15m'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/libs/service-commons/src/auth/token-signer.spec.ts
+++ b/libs/service-commons/src/auth/token-signer.spec.ts
@@ -45,4 +45,14 @@ describe('LocalKeypairTokenSigner', () => {
     const token = await signer.sign({ sub: 'user-1' }, '-1s');
     await expect(signer.verify(token)).rejects.toThrow();
   });
+
+  it('signs a payload with no expiresIn and it never expires', async () => {
+    const token = await signer.sign({ sub: 'user-1', roles: ['SAKHI'] });
+    const payloadJson = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+
+    expect(payloadJson.exp).toBeUndefined();
+
+    const payload = await signer.verify(token);
+    expect(payload.sub).toBe('user-1');
+  });
 });

--- a/libs/service-commons/src/auth/token-signer.ts
+++ b/libs/service-commons/src/auth/token-signer.ts
@@ -6,7 +6,8 @@ import { SignJWT, importPKCS8, importSPKI, jwtVerify, type CryptoKey, type JWTPa
  * without changing any call site — callers only depend on this interface.
  */
 export interface TokenSigner {
-  sign(payload: JWTPayload, expiresIn: string): Promise<string>;
+  /** Omit `expiresIn` to sign a token with no `exp` claim — it never expires by time. */
+  sign(payload: JWTPayload, expiresIn?: string): Promise<string>;
   verify(token: string): Promise<JWTPayload>;
 }
 
@@ -26,12 +27,10 @@ export class LocalKeypairTokenSigner implements TokenSigner {
     return new LocalKeypairTokenSigner(privateKey, publicKey);
   }
 
-  async sign(payload: JWTPayload, expiresIn: string): Promise<string> {
-    return new SignJWT(payload)
-      .setProtectedHeader({ alg: 'RS256' })
-      .setIssuedAt()
-      .setExpirationTime(expiresIn)
-      .sign(this.privateKey);
+  async sign(payload: JWTPayload, expiresIn?: string): Promise<string> {
+    const jwt = new SignJWT(payload).setProtectedHeader({ alg: 'RS256' }).setIssuedAt();
+    if (expiresIn) jwt.setExpirationTime(expiresIn);
+    return jwt.sign(this.privateKey);
   }
 
   async verify(token: string): Promise<JWTPayload> {


### PR DESCRIPTION
## Summary

Updated login sessions so that normal users don't have token expiry, while ADMIN tokens still expire.

## Changes

* Normal user access tokens are now non-expiring.
* ADMIN access tokens still expire after the configured time.
* Refresh sessions no longer expire based on time.
* Updated JWT handling and related tests.
