### PR TITLE
fix: media checksum, event completion photo, and inventory detail alias

### DIFF
--- a/apps/media-service/src/media/mediaAsset.controller.spec.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.spec.ts
@@ -1,0 +1,72 @@
+import type { Request, Response } from 'express';
+import { createMediaAssetController } from './mediaAsset.controller';
+import type { MediaAssetService } from './mediaAsset.service';
+
+/**
+ * Regression coverage for the checksum response bug: the DB stores checksum
+ * as a `Bytes`/Buffer column (correct — see mediaAsset.service.spec.ts), but
+ * a raw Buffer serializes over JSON as `{type:"Buffer",data:[...]}`, not a
+ * usable string. The controller must convert it to a hex string before it
+ * ever reaches `res.json()`.
+ */
+describe('createMediaAssetController', () => {
+  const checksumBuffer = Buffer.from('bf48f6236dae5154c342cf06397b396e', 'hex');
+  const baseAsset = {
+    id: 'asset-1',
+    assetType: 'CONSENT_PHOTO',
+    storageUri: 's3://bucket/key',
+    checksum: checksumBuffer,
+    mimeType: 'image/jpeg',
+    sizeBytes: BigInt(204800),
+    uploadedByUserId: null,
+    uploadedAt: new Date('2026-08-18T06:00:00.000Z'),
+    linkedEntityType: null,
+    linkedEntityId: null,
+    encryptedFlag: true,
+    beneficiaryId: null,
+    visitId: null,
+    submissionId: null,
+    referralId: null,
+    followupId: null,
+    eventId: null,
+    createdAt: new Date('2026-08-18T06:00:00.000Z'),
+    updatedAt: new Date('2026-08-18T06:00:00.000Z'),
+    isDeleted: false,
+    deletedAt: null,
+  };
+
+  function mockRes() {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    return { json, status, res: { json, status } as unknown as Response };
+  }
+
+  it('returns checksum as a hex string on finalize (POST /media)', async () => {
+    const service = {
+      create: jest.fn().mockResolvedValue(baseAsset),
+    } as unknown as jest.Mocked<MediaAssetService>;
+    const controller = createMediaAssetController(service);
+    const { status, json, res } = mockRes();
+
+    await controller.create({ body: {} } as Request, res, jest.fn());
+
+    expect(status).toHaveBeenCalledWith(201);
+    const [{ data }] = json.mock.calls[0];
+    expect(data.checksum).toBe('bf48f6236dae5154c342cf06397b396e');
+    expect(typeof data.checksum).toBe('string');
+  });
+
+  it('returns checksum as a hex string on list (GET /media)', async () => {
+    const service = {
+      list: jest.fn().mockResolvedValue([baseAsset]),
+    } as unknown as jest.Mocked<MediaAssetService>;
+    const controller = createMediaAssetController(service);
+    const { json, res } = mockRes();
+
+    await controller.list({} as Request, res, jest.fn());
+
+    const [{ data }] = json.mock.calls[0];
+    expect(data[0].checksum).toBe('bf48f6236dae5154c342cf06397b396e');
+    expect(typeof data[0].checksum).toBe('string');
+  });
+});

--- a/apps/media-service/src/media/mediaAsset.controller.spec.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.spec.ts
@@ -1,5 +1,4 @@
 import type { Request, Response } from 'express';
-import { createMediaAssetController } from './mediaAsset.controller';
 import type { MediaAssetService } from './mediaAsset.service';
 
 /**
@@ -8,7 +7,18 @@ import type { MediaAssetService } from './mediaAsset.service';
  * a raw Buffer serializes over JSON as `{type:"Buffer",data:[...]}`, not a
  * usable string. The controller must convert it to a hex string before it
  * ever reaches `res.json()`.
+ *
+ * `mediaAsset.controller.ts` imports from `../app.module`, which imports
+ * `./config/app-config`, which calls `process.exit(1)` at module-load time if
+ * `DATABASE_URL`/`S3_BUCKET_NAME` aren't set — true in CI, unlike local dev's
+ * `.env` — so they must be set before the module under test is required
+ * (matches reporting-etl-service/info.controller.spec.ts's same workaround).
  */
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/test';
+process.env.S3_BUCKET_NAME ??= 'test-bucket';
+
+const { createMediaAssetController } =
+  require('./mediaAsset.controller') as typeof import('./mediaAsset.controller');
 describe('createMediaAssetController', () => {
   const checksumBuffer = Buffer.from('bf48f6236dae5154c342cf06397b396e', 'hex');
   const baseAsset = {

--- a/apps/media-service/src/media/mediaAsset.controller.ts
+++ b/apps/media-service/src/media/mediaAsset.controller.ts
@@ -17,7 +17,11 @@ import type { MediaAsset } from '../../../../node_modules/.prisma/client-media-s
  * ("BigInt serialized as string").
  */
 function toResponse(asset: MediaAsset) {
-  return { ...asset, sizeBytes: asset.sizeBytes.toString() };
+  return {
+    ...asset,
+    sizeBytes: asset.sizeBytes.toString(),
+    checksum: asset.checksum.toString('hex'),
+  };
 }
 
 /**
@@ -45,7 +49,7 @@ function toFinalizeResponse(asset: MediaAsset) {
     id,
     assetType,
     storageUri,
-    checksum,
+    checksum: checksum.toString('hex'),
     mimeType,
     sizeBytes: asset.sizeBytes.toString(),
     uploadedByUserId,

--- a/apps/supervisor-operations-service/src/operations/inventory.routes.ts
+++ b/apps/supervisor-operations-service/src/operations/inventory.routes.ts
@@ -233,6 +233,30 @@ export function registerInventoryRoutes(doc: DocumentedRouter, service: Operatio
     controller.getTransactionById,
   );
 
+  // Second dedicated-path alias for GET /inventory-transactions/:id — same
+  // handler, same response — for consumers that expect the detail row
+  // nested under the /inventory-transactions collection path instead of
+  // /item-transactions.
+  doc.get(
+    '/inventory-transactions/:id/details',
+    {
+      summary:
+        'Fetch a single inventory transaction by id (alias for GET /inventory-transactions/:id)',
+      tags: ['Supervisor Operations'],
+      params: transactionIdParamsSchema,
+      responses: {
+        200: { description: 'Inventory transaction', schema: envelope(inventoryTransactionSchema) },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller does not own this transaction', schema: apiErrorSchema },
+        404: { description: 'Transaction not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(transactionIdParamsSchema, 'params'),
+    controller.getTransactionById,
+  );
+
   doc.put(
     '/inventory-transactions/:id',
     {

--- a/apps/supervisor-operations-service/src/operations/operations.repository.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.spec.ts
@@ -1,0 +1,71 @@
+import { OperationsRepository } from './operations.repository';
+
+/**
+ * `createEventPhoto` is the one method covered here for now — added
+ * specifically to regression-test the PR #165 review's race-condition fix,
+ * which a service-level mock (operations.service.meeting-training.spec.ts)
+ * can't verify: the "first photo wins" invariant now lives entirely in the
+ * conditional `WHERE photoMediaId IS NULL` sent to the database, not in any
+ * application-level boolean.
+ */
+describe('OperationsRepository — createEventPhoto', () => {
+  const create = jest.fn();
+  const updateMany = jest.fn();
+  const $transaction = jest.fn();
+  const prisma = {
+    eventPhoto: { create },
+    supervisorEvent: { updateMany },
+    $transaction,
+  } as never;
+  let repository: OperationsRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new OperationsRepository(prisma);
+  });
+
+  it('creates the gallery row and conditionally updates photoMediaId in one transaction', async () => {
+    const photoRow = {
+      id: 'photo-1',
+      eventId: 'event-1',
+      mediaId: 'media-1',
+      createdAt: new Date(),
+    };
+    const createOp = Symbol('createOp');
+    const updateManyOp = Symbol('updateManyOp');
+    create.mockReturnValue(createOp);
+    updateMany.mockReturnValue(updateManyOp);
+    $transaction.mockResolvedValue([photoRow, { count: 1 }]);
+
+    const result = await repository.createEventPhoto('event-1', 'media-1', 'caller-1');
+
+    expect(create).toHaveBeenCalledWith({
+      data: { eventId: 'event-1', mediaId: 'media-1', createdByUserId: 'caller-1' },
+    });
+    // The "does this event already have a completion photo" check is the
+    // WHERE clause itself, sent to the DB inside the same transaction as the
+    // gallery write — not a boolean decided by a read beforehand. This is
+    // what makes concurrent calls safe: row-level locking on this UPDATE
+    // serializes them, so only the first to commit ever changes a row.
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'event-1', photoMediaId: null },
+      data: { photoMediaId: 'media-1', updatedByUserId: 'caller-1' },
+    });
+    expect($transaction).toHaveBeenCalledWith([createOp, updateManyOp]);
+    expect(result).toBe(photoRow);
+  });
+
+  it('returns the created photo row even when the event already had a completion photo (updateMany affects 0 rows)', async () => {
+    const photoRow = {
+      id: 'photo-2',
+      eventId: 'event-1',
+      mediaId: 'media-2',
+      createdAt: new Date(),
+    };
+    $transaction.mockResolvedValue([photoRow, { count: 0 }]);
+
+    const result = await repository.createEventPhoto('event-1', 'media-2', 'caller-1');
+
+    expect(result).toBe(photoRow);
+  });
+});

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -327,10 +327,30 @@ export class OperationsRepository {
     });
   }
 
-  createEventPhoto(eventId: string, mediaId: string, createdByUserId: string) {
-    return this.prisma.eventPhoto.create({
-      data: { eventId, mediaId, createdByUserId },
-    });
+  /**
+   * Creates the gallery row and, when the event has no completion photo yet,
+   * also sets `photoMediaId` on the event in the same transaction — so the
+   * gallery and the event's completion-eligibility flag can never disagree
+   * from a partial write (see addEventPhoto's doc comment).
+   */
+  async createEventPhoto(
+    eventId: string,
+    mediaId: string,
+    createdByUserId: string,
+    setAsCompletionPhoto: boolean,
+  ) {
+    const [photo] = await this.prisma.$transaction([
+      this.prisma.eventPhoto.create({ data: { eventId, mediaId, createdByUserId } }),
+      ...(setAsCompletionPhoto
+        ? [
+            this.prisma.supervisorEvent.update({
+              where: { id: eventId },
+              data: { photoMediaId: mediaId, updatedByUserId: createdByUserId },
+            }),
+          ]
+        : []),
+    ]);
+    return photo;
   }
 
   /**

--- a/apps/supervisor-operations-service/src/operations/operations.repository.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.repository.ts
@@ -332,23 +332,22 @@ export class OperationsRepository {
    * also sets `photoMediaId` on the event in the same transaction — so the
    * gallery and the event's completion-eligibility flag can never disagree
    * from a partial write (see addEventPhoto's doc comment).
+   *
+   * The "no completion photo yet" check is the `updateMany`'s own `WHERE
+   * photoMediaId IS NULL`, not a boolean decided from a read before this
+   * transaction started — two concurrent calls on the same photo-less event
+   * would otherwise both see `null` and both attempt the write, with the
+   * second silently overwriting the first (PR #165 review). Row-level
+   * locking on the `UPDATE` serializes concurrent attempts, so only the
+   * first to actually commit ever changes 1 row; every later call affects 0.
    */
-  async createEventPhoto(
-    eventId: string,
-    mediaId: string,
-    createdByUserId: string,
-    setAsCompletionPhoto: boolean,
-  ) {
+  async createEventPhoto(eventId: string, mediaId: string, createdByUserId: string) {
     const [photo] = await this.prisma.$transaction([
       this.prisma.eventPhoto.create({ data: { eventId, mediaId, createdByUserId } }),
-      ...(setAsCompletionPhoto
-        ? [
-            this.prisma.supervisorEvent.update({
-              where: { id: eventId },
-              data: { photoMediaId: mediaId, updatedByUserId: createdByUserId },
-            }),
-          ]
-        : []),
+      this.prisma.supervisorEvent.updateMany({
+        where: { id: eventId, photoMediaId: null },
+        data: { photoMediaId: mediaId, updatedByUserId: createdByUserId },
+      }),
     ]);
     return photo;
   }

--- a/apps/supervisor-operations-service/src/operations/operations.service.meeting-training.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.meeting-training.spec.ts
@@ -184,19 +184,14 @@ describe('OperationsService — Meeting & Training flow', () => {
       ).resolves.toEqual(photoRow);
     });
 
-    it('sets the new photo as the completion photo when the event has none yet', async () => {
-      repository.findEventById.mockResolvedValue({ ...trainingEventRow, photoMediaId: null });
-      repository.createEventPhoto.mockResolvedValue(photoRow as never);
-      await service.addEventPhoto('event-1', { mediaId: 'media-1' }, supervisorCaller);
-      expect(repository.createEventPhoto).toHaveBeenCalledWith(
-        'event-1',
-        'media-1',
-        supervisorCaller.id,
-        true,
-      );
-    });
-
-    it('does not overwrite an already-set completion photo', async () => {
+    // Whether this photo becomes the event's completion photo is decided
+    // atomically by the repository's own conditional UPDATE (see
+    // operations.repository.spec.ts), not by a boolean the service computes
+    // from a pre-read here — a pre-read boolean would race two concurrent
+    // calls into both "winning" (PR #165 review). The service always
+    // delegates with the same 3 args regardless of the event's current
+    // photoMediaId.
+    it('delegates to the repository with the same args regardless of the current photo state', async () => {
       repository.findEventById.mockResolvedValue({
         ...trainingEventRow,
         photoMediaId: 'existing-media',
@@ -207,7 +202,6 @@ describe('OperationsService — Meeting & Training flow', () => {
         'event-1',
         'media-2',
         supervisorCaller.id,
-        false,
       );
     });
 

--- a/apps/supervisor-operations-service/src/operations/operations.service.meeting-training.spec.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.meeting-training.spec.ts
@@ -184,6 +184,33 @@ describe('OperationsService — Meeting & Training flow', () => {
       ).resolves.toEqual(photoRow);
     });
 
+    it('sets the new photo as the completion photo when the event has none yet', async () => {
+      repository.findEventById.mockResolvedValue({ ...trainingEventRow, photoMediaId: null });
+      repository.createEventPhoto.mockResolvedValue(photoRow as never);
+      await service.addEventPhoto('event-1', { mediaId: 'media-1' }, supervisorCaller);
+      expect(repository.createEventPhoto).toHaveBeenCalledWith(
+        'event-1',
+        'media-1',
+        supervisorCaller.id,
+        true,
+      );
+    });
+
+    it('does not overwrite an already-set completion photo', async () => {
+      repository.findEventById.mockResolvedValue({
+        ...trainingEventRow,
+        photoMediaId: 'existing-media',
+      });
+      repository.createEventPhoto.mockResolvedValue(photoRow as never);
+      await service.addEventPhoto('event-1', { mediaId: 'media-2' }, supervisorCaller);
+      expect(repository.createEventPhoto).toHaveBeenCalledWith(
+        'event-1',
+        'media-2',
+        supervisorCaller.id,
+        false,
+      );
+    });
+
     it('throws 404 when the event does not exist', async () => {
       repository.findEventById.mockResolvedValue(null);
       await expect(
@@ -264,15 +291,19 @@ describe('OperationsService — Meeting & Training flow', () => {
   describe('listGatherings', () => {
     it('lists recent gatherings via repository when no filter is given', async () => {
       repository.findGatherings.mockResolvedValue([gatheringRow]);
-      await expect(
-        service.listGatherings(supervisorCaller, 'Bearer token'),
-      ).resolves.toEqual([gatheringRow]);
+      await expect(service.listGatherings(supervisorCaller, 'Bearer token')).resolves.toEqual([
+        gatheringRow,
+      ]);
       expect(repository.findGatherings).toHaveBeenCalledWith(undefined);
       expect(sakhiClient.findById).not.toHaveBeenCalled();
     });
 
     it("passes a sakhiId filter through to the repository when it's the caller's own Sakhi", async () => {
-      const sakhi = { sakhiId: 'sakhi-1', supervisorId: supervisorCaller.id, primaryProjectId: 'p1' };
+      const sakhi = {
+        sakhiId: 'sakhi-1',
+        supervisorId: supervisorCaller.id,
+        primaryProjectId: 'p1',
+      };
       sakhiClient.findById.mockResolvedValue(sakhi);
       repository.findGatherings.mockResolvedValue([gatheringRow]);
 
@@ -282,7 +313,11 @@ describe('OperationsService — Meeting & Training flow', () => {
     });
 
     it('returns an empty list when no gathering matches', async () => {
-      const sakhi = { sakhiId: 'sakhi-none', supervisorId: supervisorCaller.id, primaryProjectId: 'p1' };
+      const sakhi = {
+        sakhiId: 'sakhi-none',
+        supervisorId: supervisorCaller.id,
+        primaryProjectId: 'p1',
+      };
       sakhiClient.findById.mockResolvedValue(sakhi);
       repository.findGatherings.mockResolvedValue([]);
 
@@ -292,7 +327,11 @@ describe('OperationsService — Meeting & Training flow', () => {
     });
 
     it("403s when a SUPERVISOR's sakhiId filter is not on their own roster", async () => {
-      const sakhi = { sakhiId: 'sakhi-1', supervisorId: otherSupervisorCaller.id, primaryProjectId: 'p1' };
+      const sakhi = {
+        sakhiId: 'sakhi-1',
+        supervisorId: otherSupervisorCaller.id,
+        primaryProjectId: 'p1',
+      };
       sakhiClient.findById.mockResolvedValue(sakhi);
 
       await expect(

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -508,6 +508,12 @@ export class OperationsService {
    * added any time before completion — COMPLETED/CANCELLED events are
    * closed to further edits, matching every other post-terminal-status rule
    * in this service.
+   *
+   * The first photo added to an event also becomes its `photoMediaId` —
+   * completeEvent's photo-required check reads that column, so without this
+   * an event created without a photo could never satisfy completion no
+   * matter how many photos were added to its gallery. A later photo never
+   * overwrites an already-set `photoMediaId` (from this or from creation).
    */
   async addEventPhoto(id: string, dto: CreateEventPhotoInput, caller: CallerIdentity) {
     const event = await this.repository.findEventById(id);
@@ -518,7 +524,7 @@ export class OperationsService {
     if (event.status !== 'SCHEDULED') {
       throw conflict(`Cannot add a photo to an event with status ${event.status}.`);
     }
-    return this.repository.createEventPhoto(id, dto.mediaId, caller.id);
+    return this.repository.createEventPhoto(id, dto.mediaId, caller.id, !event.photoMediaId);
   }
 
   /**

--- a/apps/supervisor-operations-service/src/operations/operations.service.ts
+++ b/apps/supervisor-operations-service/src/operations/operations.service.ts
@@ -513,7 +513,9 @@ export class OperationsService {
    * completeEvent's photo-required check reads that column, so without this
    * an event created without a photo could never satisfy completion no
    * matter how many photos were added to its gallery. A later photo never
-   * overwrites an already-set `photoMediaId` (from this or from creation).
+   * overwrites an already-set `photoMediaId` (from this or from creation) —
+   * enforced by the repository's own conditional `UPDATE`, not a check here,
+   * so two concurrent calls can't both win (PR #165 review).
    */
   async addEventPhoto(id: string, dto: CreateEventPhotoInput, caller: CallerIdentity) {
     const event = await this.repository.findEventById(id);
@@ -524,7 +526,7 @@ export class OperationsService {
     if (event.status !== 'SCHEDULED') {
       throw conflict(`Cannot add a photo to an event with status ${event.status}.`);
     }
-    return this.repository.createEventPhoto(id, dto.mediaId, caller.id, !event.photoMediaId);
+    return this.repository.createEventPhoto(id, dto.mediaId, caller.id);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixed `checksum` in media-service responses — was returning a raw Buffer object, now returns a plain hex string.
- Fixed event completion: the first photo added to a Meeting/Training event now properly attaches as its completion photo, so `PATCH /supervisor-events/:id/complete` can actually succeed once a photo + attendance exist.
- Added `GET /inventory-transactions/:id/details` as an alias endpoint.
- Fixed a CI-only test failure: `mediaAsset.controller.spec.ts` transitively pulled in env-config validation that only has defaults in local `.env`, not in CI.

## Test plan
- Lint + full Jest suite green on media-service and supervisor-operations-service.
- Verified live end-to-end: upload → finalize → checksum returned correctly; event → add photo → attendance → complete → status COMPLETED.
- Verified the CI fix locally by explicitly unsetting the relevant env vars before re-running tests.

Closes #166