### PR TITLE
Beneficiary lifecycle write-path: phase advance, closure, and reopen idempotency

### DIFF
--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -114,6 +114,32 @@ export function createBeneficiaryController(service: BeneficiaryService) {
       res.json(ok(updated));
     }),
 
+    applyClosure: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.applyClosure(
+        req.params.id,
+        req.body.reasonCode,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
+    }),
+
+    applyPhaseChange: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.applyPhaseChange(
+        req.params.id,
+        req.body.phase,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
+    }),
+
     upsertRiskConditionSummary: asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -1,5 +1,5 @@
 import type { PrismaService } from '../prisma/prisma.service';
-import type { CaseType } from './beneficiary.constants';
+import type { CasePhase, CaseType } from './beneficiary.constants';
 import type {
   BeneficiaryListFilters,
   BeneficiarySummaryFilters,
@@ -533,6 +533,63 @@ export class BeneficiaryRepository {
       data: { lmpDate, eddDate },
     });
     return result.count > 0;
+  }
+
+  /**
+   * Advances currentPhase (CR-041) — only if the case is still at
+   * `fromPhase` when this runs. Same optimistic-concurrency shape as
+   * reactivateCase: the `where` clause is the guard (not a separate
+   * read-then-write), so a case whose phase already changed between the
+   * service's findById and this call returns count 0 and the service turns
+   * that into a 409 instead of silently overwriting a since-changed case.
+   */
+  async updatePhase(beneficiaryId: string, fromPhase: CasePhase, toPhase: CasePhase) {
+    const result = await this.prisma.beneficiaryCase.updateMany({
+      where: { id: beneficiaryId, isDeleted: false, currentPhase: fromPhase },
+      data: { currentPhase: toPhase },
+    });
+    return result.count > 0;
+  }
+
+  /**
+   * Closes a beneficiary case after a closure submission (mobile
+   * closure-request backend-needs ticket) — flips currentStatus to CLOSED
+   * and records the transition in beneficiary_status_history for audit, in
+   * one transaction. Only updates a row that isn't already CLOSED —
+   * updateMany's affected count is the concurrency guard, same pattern as
+   * reactivateCase. Unlike reactivateCase, a race here (or a retry landing
+   * after the case is already CLOSED) is NOT reported as a conflict by this
+   * method — it returns false and the service layer re-reads the case to
+   * treat "already CLOSED" as an idempotent success, since the mobile app's
+   * offline sync may retry this call and a second attempt must not error.
+   */
+  async closeCase(beneficiaryId: string, closedByUserId: string, reasonCode: string) {
+    return this.prisma.$transaction(async (tx) => {
+      const existing = await tx.beneficiaryCase.findFirst({
+        where: { id: beneficiaryId, isDeleted: false },
+        select: { currentStatus: true },
+      });
+      if (!existing) return false;
+      if (existing.currentStatus === 'CLOSED') return true;
+
+      const result = await tx.beneficiaryCase.updateMany({
+        where: { id: beneficiaryId, isDeleted: false, currentStatus: { not: 'CLOSED' } },
+        data: { currentStatus: 'CLOSED' },
+      });
+      if (result.count === 0) return false;
+
+      await tx.beneficiaryStatusHistory.create({
+        data: {
+          beneficiaryId,
+          fromStatus: existing.currentStatus,
+          toStatus: 'CLOSED',
+          reasonCode,
+          changedByUserId: closedByUserId,
+          changedAt: new Date(),
+        },
+      });
+      return true;
+    });
   }
 
   /**

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
@@ -18,6 +18,8 @@ import { byIdsWithRiskQuerySchema } from './dto/by-ids-with-risk-query.dto';
 import { upsertSocioDemographicsSchema } from './dto/upsert-socio-demographics.dto';
 import { upsertRiskConditionSummarySchema } from './dto/upsert-risk-condition-summary.dto';
 import { applyLmpChangeSchema } from './dto/apply-lmp-change.dto';
+import { updatePhaseSchema } from './dto/update-phase.dto';
+import { applyClosureSchema } from './dto/apply-closure.dto';
 import {
   errorResponse,
   requireRoles,
@@ -554,6 +556,69 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
     validate(idParamsSchema, 'params'),
     validateBody(applyLmpChangeSchema),
     controller.applyLmpChange,
+  );
+
+  doc.patch(
+    '/beneficiaries/:id/phase',
+    {
+      summary:
+        'Advance currentPhase after a DELIVERY_VISIT submission (CR-041) — ' +
+        "gated by requireRoles('SAKHI') since this codebase has no machine/service-account " +
+        "identity: the call chain originates from a SAKHI's DELIVERY_VISIT form submission " +
+        "(visit-form-service -> here), forwarding the SAKHI's own token. Only ANC->PP (mother) " +
+        'and *->NN (child) are accepted; any other transition 409s.',
+      tags: ['Beneficiaries'],
+      params: idParamsSchema,
+      responses: {
+        200: {
+          description: 'currentPhase updated; the updated case is returned',
+          schema: envelope(beneficiaryCaseDetailSchema),
+        },
+        400: errorResponse(400, { message: 'phase: Invalid enum value' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        409: errorResponse(409, { message: 'Cannot move a MOTHER case from PP to ANC.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validate(idParamsSchema, 'params'),
+    validateBody(updatePhaseSchema),
+    controller.applyPhaseChange,
+  );
+
+  doc.patch(
+    '/beneficiaries/:id/close',
+    {
+      summary:
+        'Close a beneficiary case after a closure submission (ANC_CLOSURE_VISIT / ' +
+        'CHILD_CLOSURE_VISIT) — server-to-server only, called by closure-reopen-service. ' +
+        "Forwards the submitting SAKHI's own token for a non-reviewed closure, or the " +
+        "deciding Supervisor's token once a MIGRATION closure is approved — this codebase " +
+        'has no machine/service-account identity. Idempotent: closing an already-CLOSED case ' +
+        'is a no-op success, not a 409, since the mobile app may retry this call offline.',
+      tags: ['Beneficiaries'],
+      params: idParamsSchema,
+      responses: {
+        200: {
+          description: 'Case closed (or already CLOSED); the current case is returned',
+          schema: envelope(beneficiaryCaseDetailSchema),
+        },
+        400: errorResponse(400, { message: 'reasonCode: Required' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        409: errorResponse(409, { message: 'Unable to close this beneficiary case.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(idParamsSchema, 'params'),
+    validateBody(applyClosureSchema),
+    controller.applyClosure,
   );
 
   doc.patch(

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
@@ -594,11 +594,16 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
     {
       summary:
         'Close a beneficiary case after a closure submission (ANC_CLOSURE_VISIT / ' +
-        'CHILD_CLOSURE_VISIT) — server-to-server only, called by closure-reopen-service. ' +
-        "Forwards the submitting SAKHI's own token for a non-reviewed closure, or the " +
-        "deciding Supervisor's token once a MIGRATION closure is approved — this codebase " +
-        'has no machine/service-account identity. Idempotent: closing an already-CLOSED case ' +
-        'is a no-op success, not a 409, since the mobile app may retry this call offline.',
+        'CHILD_CLOSURE_VISIT) — intended to be called server-to-server by ' +
+        "closure-reopen-service, forwarding the submitting SAKHI's own token for a " +
+        "non-reviewed closure, or the deciding Supervisor's token once a MIGRATION closure " +
+        'is approved. KNOWN GAP: this codebase has no machine/service-account identity, so ' +
+        'this is also reachable directly by a SAKHI who owns the case, bypassing the ' +
+        'closures audit row and any required supervisor review (see BeneficiaryService.' +
+        'applyClosure doc comment) — tracked as a follow-up, not enforced here. Idempotent: ' +
+        'closing an already-CLOSED case with the same reasonCode is a no-op success, not a ' +
+        '409, since the mobile app may retry this call offline; a genuinely different ' +
+        'reasonCode 409s instead of silently overwriting the audit trail.',
       tags: ['Beneficiaries'],
       params: idParamsSchema,
       responses: {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -30,6 +30,8 @@ describe('BeneficiaryService', () => {
     findDuplicateCandidate: jest.fn(),
     createEnrollment: jest.fn(),
     updateMotherLmp: jest.fn(),
+    updatePhase: jest.fn(),
+    closeCase: jest.fn(),
     reactivateCase: jest.fn(),
     countByCaseType: jest.fn(),
     countByRiskGrade: jest.fn(),
@@ -232,6 +234,354 @@ describe('BeneficiaryService', () => {
       );
 
       expect(repository.updateMotherLmp).toHaveBeenCalled();
+    });
+  });
+
+  describe('applyPhaseChange', () => {
+    const beneficiaryId = '22222222-2222-2222-2222-222222222222';
+    const sakhiId = '55555555-5555-5555-5555-555555555555';
+    const otherSakhiId = '66666666-6666-6666-6666-666666666666';
+
+    function caseRow(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        id: beneficiaryId,
+        sakhiId,
+        caseType: 'MOTHER',
+        currentPhase: 'ANC',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        ...overrides,
+      };
+    }
+
+    it('advances a MOTHER case from ANC to PP', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.updatePhase.mockResolvedValue(true);
+
+      await service.applyPhaseChange(
+        beneficiaryId,
+        'PP',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'ANC', 'PP');
+    });
+
+    it('advances a CHILD case to NN', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ caseType: 'CHILD', currentPhase: 'ANC' }) as never,
+      );
+      repository.updatePhase.mockResolvedValue(true);
+
+      await service.applyPhaseChange(
+        beneficiaryId,
+        'NN',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'ANC', 'NN');
+    });
+
+    it('returns the updated case via getById', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.updatePhase.mockResolvedValue(true);
+
+      const result = await service.applyPhaseChange(
+        beneficiaryId,
+        'PP',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('404s on an unknown beneficiary id', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'PP',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+    });
+
+    it('409s on a regressive transition (PP back to ANC)', async () => {
+      repository.findById.mockResolvedValue(caseRow({ currentPhase: 'PP' }) as never);
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'ANC',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+    });
+
+    it('409s on an unsupported forward jump (MOTHER case ANC -> NN)', async () => {
+      repository.findById.mockResolvedValue(caseRow({ currentPhase: 'ANC' }) as never);
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'NN',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when the case is already at the target phase', async () => {
+      repository.findById.mockResolvedValue(caseRow({ currentPhase: 'PP' }) as never);
+
+      const result = await service.applyPhaseChange(
+        beneficiaryId,
+        'PP',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('403s when a SAKHI targets a case outside their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'PP',
+          caller({ id: otherSakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+    });
+
+    it('allows a SAKHI to advance their own case', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.updatePhase.mockResolvedValue(true);
+
+      await service.applyPhaseChange(
+        beneficiaryId,
+        'PP',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updatePhase).toHaveBeenCalled();
+    });
+
+    it('409s when the conditional update races with a concurrent phase change', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.updatePhase.mockResolvedValue(false);
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'PP',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+  });
+
+  describe('applyClosure', () => {
+    const beneficiaryId = '22222222-2222-2222-2222-222222222222';
+    const sakhiId = '55555555-5555-5555-5555-555555555555';
+    const otherSakhiId = '66666666-6666-6666-6666-666666666666';
+
+    function caseRow(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        id: beneficiaryId,
+        sakhiId,
+        caseType: 'MOTHER',
+        currentStatus: 'ACTIVE',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        ...overrides,
+      };
+    }
+
+    it('closes an ACTIVE case', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.closeCase.mockResolvedValue(true);
+
+      await service.applyClosure(
+        beneficiaryId,
+        'MEDICAL',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.closeCase).toHaveBeenCalledWith(beneficiaryId, sakhiId, 'MEDICAL');
+    });
+
+    it('returns the closed case via getById', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.closeCase.mockResolvedValue(true);
+
+      const result = await service.applyClosure(
+        beneficiaryId,
+        'MEDICAL',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('404s on an unknown beneficiary id', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MEDICAL',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.closeCase).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when the case is already CLOSED — no repository write, no error', async () => {
+      repository.findById.mockResolvedValue(caseRow({ currentStatus: 'CLOSED' }) as never);
+
+      const result = await service.applyClosure(
+        beneficiaryId,
+        'MEDICAL',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.closeCase).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('403s when a SAKHI targets a case outside their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MEDICAL',
+          caller({ id: otherSakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.closeCase).not.toHaveBeenCalled();
+    });
+
+    it('allows a SAKHI to close their own case', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.closeCase.mockResolvedValue(true);
+
+      await service.applyClosure(
+        beneficiaryId,
+        'MEDICAL',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.closeCase).toHaveBeenCalled();
+    });
+
+    it('403s when a SUPERVISOR targets a case outside their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['some-other-sakhi']);
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MIGRATION',
+          caller({ roles: ['SUPERVISOR'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.closeCase).not.toHaveBeenCalled();
+    });
+
+    it('allows a SUPERVISOR to close a case in their own roster', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.closeCase.mockResolvedValue(true);
+      listSakhiIdsForSupervisorMock.mockResolvedValue([sakhiId]);
+
+      await service.applyClosure(
+        beneficiaryId,
+        'MIGRATION',
+        caller({ roles: ['SUPERVISOR'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.closeCase).toHaveBeenCalled();
+    });
+
+    it('allows a MANAGER/ADMIN unrestricted', async () => {
+      repository.findById.mockResolvedValue(caseRow() as never);
+      repository.closeCase.mockResolvedValue(true);
+
+      await service.applyClosure(
+        beneficiaryId,
+        'MIGRATION',
+        caller({ roles: ['ADMIN'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.closeCase).toHaveBeenCalled();
+    });
+
+    it('re-reads and returns success when closeCase races and the case is already CLOSED', async () => {
+      repository.findById
+        .mockResolvedValueOnce(caseRow() as never)
+        .mockResolvedValueOnce(caseRow({ currentStatus: 'CLOSED' }) as never);
+      repository.closeCase.mockResolvedValue(false);
+
+      const result = await service.applyClosure(
+        beneficiaryId,
+        'MEDICAL',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('409s when closeCase fails and the case is still not CLOSED on re-read', async () => {
+      repository.findById
+        .mockResolvedValueOnce(caseRow() as never)
+        .mockResolvedValueOnce(caseRow({ currentStatus: 'ACTIVE' }) as never);
+      repository.closeCase.mockResolvedValue(false);
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MEDICAL',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it('404s when closeCase fails because the case was deleted mid-request', async () => {
+      repository.findById.mockResolvedValueOnce(caseRow() as never).mockResolvedValueOnce(null);
+      repository.closeCase.mockResolvedValue(false);
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MEDICAL',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 404 });
     });
   });
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -267,20 +267,36 @@ describe('BeneficiaryService', () => {
       expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'ANC', 'PP');
     });
 
-    it('advances a CHILD case to NN', async () => {
+    it('is a no-op when a CHILD case is already at NN (its creation default)', async () => {
       repository.findById.mockResolvedValue(
-        caseRow({ caseType: 'CHILD', currentPhase: 'ANC' }) as never,
+        caseRow({ caseType: 'CHILD', currentPhase: 'NN' }) as never,
       );
-      repository.updatePhase.mockResolvedValue(true);
 
-      await service.applyPhaseChange(
+      const result = await service.applyPhaseChange(
         beneficiaryId,
         'NN',
         caller({ id: sakhiId, roles: ['SAKHI'] }),
         AUTH_HEADER,
       );
 
-      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'ANC', 'NN');
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('409s a CHILD case transition from any phase other than NN — regression: the CHILD branch must validate fromPhase, not just toPhase', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ caseType: 'CHILD', currentPhase: 'INC' }) as never,
+      );
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'NN',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
     });
 
     it('returns the updated case via getById', async () => {
@@ -406,6 +422,7 @@ describe('BeneficiaryService', () => {
         sakhiId,
         caseType: 'MOTHER',
         currentStatus: 'ACTIVE',
+        statusHistory: [],
         pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
         ...overrides,
       };
@@ -452,8 +469,13 @@ describe('BeneficiaryService', () => {
       expect(repository.closeCase).not.toHaveBeenCalled();
     });
 
-    it('is idempotent when the case is already CLOSED — no repository write, no error', async () => {
-      repository.findById.mockResolvedValue(caseRow({ currentStatus: 'CLOSED' }) as never);
+    it('is idempotent when the case is already CLOSED with the same reasonCode — no repository write, no error', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({
+          currentStatus: 'CLOSED',
+          statusHistory: [{ toStatus: 'CLOSED', reasonCode: 'MEDICAL' }],
+        }) as never,
+      );
 
       const result = await service.applyClosure(
         beneficiaryId,
@@ -464,6 +486,41 @@ describe('BeneficiaryService', () => {
 
       expect(repository.closeCase).not.toHaveBeenCalled();
       expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('is idempotent when already CLOSED with no statusHistory row recorded (pre-existing data)', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ currentStatus: 'CLOSED', statusHistory: [] }) as never,
+      );
+
+      const result = await service.applyClosure(
+        beneficiaryId,
+        'MEDICAL',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.closeCase).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('409s when already CLOSED with a genuinely different reasonCode — regression: must not silently drop the discrepancy', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({
+          currentStatus: 'CLOSED',
+          statusHistory: [{ toStatus: 'CLOSED', reasonCode: 'MEDICAL' }],
+        }) as never,
+      );
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MIGRATION',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.closeCase).not.toHaveBeenCalled();
     });
 
     it('403s when a SAKHI targets a case outside their own roster', async () => {
@@ -552,6 +609,25 @@ describe('BeneficiaryService', () => {
       );
 
       expect(result).toMatchObject({ id: beneficiaryId });
+    });
+
+    it('409s when closeCase races to a genuinely different reasonCode than the race winner', async () => {
+      repository.findById.mockResolvedValueOnce(caseRow() as never).mockResolvedValueOnce(
+        caseRow({
+          currentStatus: 'CLOSED',
+          statusHistory: [{ toStatus: 'CLOSED', reasonCode: 'MIGRATION' }],
+        }) as never,
+      );
+      repository.closeCase.mockResolvedValue(false);
+
+      await expect(
+        service.applyClosure(
+          beneficiaryId,
+          'MEDICAL',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
     });
 
     it('409s when closeCase fails and the case is still not CLOSED on re-read', async () => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -16,7 +16,7 @@ import type {
   BeneficiaryStatusHistory,
   Prisma,
 } from '../../../../node_modules/.prisma/client-beneficiary-service';
-import type { BeneficiaryStatus, CaseType } from './beneficiary.constants';
+import type { BeneficiaryStatus, CasePhase, CaseType } from './beneficiary.constants';
 import { buildSearchTokens, evaluateDuplicateMatch } from './beneficiary.duplicate-detection';
 import { computeBmi, withDecryptedName } from './beneficiary.mapper';
 import type { BeneficiaryListFilters, BeneficiaryRepository } from './beneficiary.repository';
@@ -698,6 +698,125 @@ export class BeneficiaryService {
     const eddDate = addDays(lmpDate, GESTATION_DAYS);
     const updated = await this.repository.updateMotherLmp(beneficiaryId, lmpDate, eddDate);
     if (!updated) throw notFound('Beneficiary case not found.');
+    return this.projectCase(beneficiaryId, authorizationHeader);
+  }
+
+  /**
+   * Advances currentPhase after a DELIVERY_VISIT submission (CR-041):
+   * ANC->PP for the mother, or ->NN for an auto-created child. Called
+   * server-to-server by visit-form-service, forwarding the submitting
+   * SAKHI's own token — this codebase has no machine/service-account
+   * identity (same pattern as upsertRiskConditionSummary). Only these two
+   * transitions are accepted; anything else 409s rather than silently
+   * moving a case backward or into an unrelated phase.
+   *
+   * Idempotent for a same-value "transition" (e.g. a child case already at
+   * NN from creation, or a retried delivery submission) — repository
+   * updatePhase's guard is `currentPhase = fromPhase`, and fromPhase here is
+   * derived from the target itself for the child leg / from the case's own
+   * current value when it already matches, so a repeat call is a no-op
+   * success rather than a spurious 409.
+   *
+   * A SAKHI caller may only apply this to their own case (same ownership
+   * check as upsertRiskConditionSummary) — assertCallerCanTouchCase alone
+   * doesn't cover this route, since it only scopes SUPERVISOR callers.
+   */
+  async applyPhaseChange(
+    beneficiaryId: string,
+    toPhase: CasePhase,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(beneficiaryId);
+    if (!existing) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (existing.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else {
+      await assertCallerCanTouchCase(existing.sakhiId, caller, authorizationHeader);
+    }
+
+    const fromPhase = existing.currentPhase as CasePhase;
+    if (fromPhase === toPhase) {
+      return this.projectCase(beneficiaryId, authorizationHeader, existing);
+    }
+
+    const isValidTransition =
+      (existing.caseType === 'MOTHER' && fromPhase === 'ANC' && toPhase === 'PP') ||
+      (existing.caseType === 'CHILD' && toPhase === 'NN');
+    if (!isValidTransition) {
+      throw conflict(`Cannot move a ${existing.caseType} case from ${fromPhase} to ${toPhase}.`);
+    }
+
+    const updated = await this.repository.updatePhase(beneficiaryId, fromPhase, toPhase);
+    if (!updated) {
+      // Raced with another phase change between the read above and the
+      // conditional update — same outcome as the check above, just caught a
+      // beat later instead of trusting a stale read.
+      throw conflict(`Cannot move a ${existing.caseType} case from ${fromPhase} to ${toPhase}.`);
+    }
+
+    return this.projectCase(beneficiaryId, authorizationHeader);
+  }
+
+  /**
+   * Closes a beneficiary case after a closure submission (ANC_CLOSURE_VISIT
+   * / CHILD_CLOSURE_VISIT) — the "beneficiary moves to the Closed list"
+   * consequence closure-reopen-service's own ClosureService is documented
+   * as NOT owning (forklift rule). Called server-to-server by
+   * closure-reopen-service, forwarding the submitting SAKHI's own token for
+   * an immediate (non-reviewed) closure, or the deciding Supervisor's token
+   * for an approved MIGRATION closure — this codebase has no
+   * machine/service-account identity (same pattern as
+   * upsertRiskConditionSummary/applyPhaseChange).
+   *
+   * Idempotent by design (mobile is offline-first and may retry this call
+   * after a dropped connection): closing an already-CLOSED case is a
+   * no-op success, not a 409 — repository.closeCase returning true for
+   * "already CLOSED" and this method short-circuiting on that read both
+   * exist for the same reason, so a retry never fails just because the
+   * first attempt actually succeeded.
+   *
+   * A SAKHI caller may only apply this to their own case (same ownership
+   * check as applyPhaseChange) — assertCallerCanTouchCase alone doesn't
+   * cover this route, since it only scopes SUPERVISOR callers.
+   */
+  async applyClosure(
+    beneficiaryId: string,
+    reasonCode: string,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(beneficiaryId);
+    if (!existing) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (existing.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else {
+      await assertCallerCanTouchCase(existing.sakhiId, caller, authorizationHeader);
+    }
+
+    if (existing.currentStatus === 'CLOSED') {
+      return this.projectCase(beneficiaryId, authorizationHeader, existing);
+    }
+
+    const closed = await this.repository.closeCase(beneficiaryId, caller.id, reasonCode);
+    if (!closed) {
+      // Either the case was deleted between the read above and this call,
+      // or (per closeCase's own doc comment) it raced to CLOSED via another
+      // path in that same window — re-read rather than assuming either.
+      const recheck = await this.repository.findById(beneficiaryId);
+      if (!recheck) throw notFound('Beneficiary case not found.');
+      if (recheck.currentStatus === 'CLOSED') {
+        return this.projectCase(beneficiaryId, authorizationHeader, recheck);
+      }
+      throw conflict('Unable to close this beneficiary case.');
+    }
+
     return this.projectCase(beneficiaryId, authorizationHeader);
   }
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -745,7 +745,7 @@ export class BeneficiaryService {
 
     const isValidTransition =
       (existing.caseType === 'MOTHER' && fromPhase === 'ANC' && toPhase === 'PP') ||
-      (existing.caseType === 'CHILD' && toPhase === 'NN');
+      (existing.caseType === 'CHILD' && fromPhase === 'NN' && toPhase === 'NN');
     if (!isValidTransition) {
       throw conflict(`Cannot move a ${existing.caseType} case from ${fromPhase} to ${toPhase}.`);
     }
@@ -782,6 +782,19 @@ export class BeneficiaryService {
    * A SAKHI caller may only apply this to their own case (same ownership
    * check as applyPhaseChange) — assertCallerCanTouchCase alone doesn't
    * cover this route, since it only scopes SUPERVISOR callers.
+   *
+   * KNOWN GAP: this is reachable directly by a SAKHI (not just via
+   * closure-reopen-service's own call chain) — this codebase has no
+   * machine/service-account identity, so "server-to-server only" can't be
+   * cryptographically enforced today. A SAKHI who owns the case can call
+   * this endpoint directly with any reasonCode and close it without ever
+   * creating a `closures` row via POST /closures — bypassing that record's
+   * audit trail and (for a MIGRATION-equivalent reason) the supervisor
+   * review closure-reopen-service's ClosureService.create() would have
+   * required. The ownership check above bounds this to a SAKHI's own case
+   * (not a cross-tenant IDOR), but it is a real gap in the review workflow.
+   * Tracked as a follow-up, not fixed here — would need a real machine
+   * identity concept to close properly.
    */
   async applyClosure(
     beneficiaryId: string,
@@ -801,7 +814,21 @@ export class BeneficiaryService {
     }
 
     if (existing.currentStatus === 'CLOSED') {
-      return this.projectCase(beneficiaryId, authorizationHeader, existing);
+      // Idempotent no-op only for a genuine retry of the SAME closure
+      // (matching reasonCode) — the doc comment above claims reasonCode is
+      // "recorded on beneficiary_status_history for audit," which would be
+      // false for a differing reasonCode silently swallowed here (e.g.
+      // closed once as MEDICAL, then a real MIGRATION closure attempt
+      // returning 200 with no trace of ever happening). A genuinely
+      // different closure reason for an already-closed case is a caller
+      // error, not a retry — surfaced as a 409 rather than silently dropped.
+      const lastClose = existing.statusHistory.find((h) => h.toStatus === 'CLOSED');
+      if (!lastClose || lastClose.reasonCode === reasonCode) {
+        return this.projectCase(beneficiaryId, authorizationHeader, existing);
+      }
+      throw conflict(
+        `This case was already closed with reason ${lastClose.reasonCode}, not ${reasonCode}.`,
+      );
     }
 
     const closed = await this.repository.closeCase(beneficiaryId, caller.id, reasonCode);
@@ -812,7 +839,13 @@ export class BeneficiaryService {
       const recheck = await this.repository.findById(beneficiaryId);
       if (!recheck) throw notFound('Beneficiary case not found.');
       if (recheck.currentStatus === 'CLOSED') {
-        return this.projectCase(beneficiaryId, authorizationHeader, recheck);
+        const raceWinner = recheck.statusHistory.find((h) => h.toStatus === 'CLOSED');
+        if (!raceWinner || raceWinner.reasonCode === reasonCode) {
+          return this.projectCase(beneficiaryId, authorizationHeader, recheck);
+        }
+        throw conflict(
+          `This case was already closed with reason ${raceWinner.reasonCode}, not ${reasonCode}.`,
+        );
       }
       throw conflict('Unable to close this beneficiary case.');
     }

--- a/apps/beneficiary-service/src/beneficiary/dto/apply-closure.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/apply-closure.dto.spec.ts
@@ -1,0 +1,20 @@
+import { applyClosureSchema } from './apply-closure.dto';
+
+describe('applyClosureSchema', () => {
+  it('accepts a valid reasonCode', () => {
+    expect(applyClosureSchema.safeParse({ reasonCode: 'MEDICAL' }).success).toBe(true);
+  });
+
+  it('rejects a missing reasonCode', () => {
+    expect(applyClosureSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects an empty reasonCode', () => {
+    expect(applyClosureSchema.safeParse({ reasonCode: '' }).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = applyClosureSchema.safeParse({ reasonCode: 'MEDICAL', extra: 'x' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/beneficiary-service/src/beneficiary/dto/apply-closure.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/apply-closure.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Body for `PATCH /beneficiaries/:id/close` — closes a beneficiary case
+ * after a closure submission (ANC_CLOSURE_VISIT / CHILD_CLOSURE_VISIT).
+ * Called server-to-server by closure-reopen-service: immediately for a
+ * non-reviewed closure (MEDICAL/NON_MEDICAL/PROGRAM_COMPLETION), or once a
+ * Supervisor approves a MIGRATION closure. `reasonCode` is the closure's own
+ * `closureType`, recorded on beneficiary_status_history for audit — not
+ * re-validated against the CLOSURE_REASON lookup here, since
+ * closure-reopen-service (which owns that lookup relationship) already did.
+ */
+export const applyClosureSchema = z
+  .object({
+    reasonCode: z.string().trim().min(1).max(60),
+  })
+  .strict();
+
+export type ApplyClosureInput = z.infer<typeof applyClosureSchema>;

--- a/apps/beneficiary-service/src/beneficiary/dto/update-phase.dto.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/update-phase.dto.spec.ts
@@ -1,0 +1,24 @@
+import { updatePhaseSchema } from './update-phase.dto';
+
+describe('updatePhaseSchema', () => {
+  it('accepts phase: PP', () => {
+    expect(updatePhaseSchema.safeParse({ phase: 'PP' }).success).toBe(true);
+  });
+
+  it('accepts phase: NN', () => {
+    expect(updatePhaseSchema.safeParse({ phase: 'NN' }).success).toBe(true);
+  });
+
+  it('rejects a missing phase', () => {
+    expect(updatePhaseSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects a phase value outside CasePhase', () => {
+    expect(updatePhaseSchema.safeParse({ phase: 'FOO' }).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    const result = updatePhaseSchema.safeParse({ phase: 'PP', extra: 'x' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/beneficiary-service/src/beneficiary/dto/update-phase.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/update-phase.dto.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { CASE_PHASES } from '../beneficiary.constants';
+
+/**
+ * Body for `PATCH /beneficiaries/:id/phase` — advances a case's currentPhase
+ * (CR-041). Called server-to-server by visit-form-service on a DELIVERY_VISIT
+ * submission: once for the mother (phase: 'PP') and once per auto-created
+ * child (phase: 'NN'), forwarding the submitting Sakhi's own token (this
+ * codebase has no machine/service-account identity — same pattern as
+ * PATCH /beneficiaries/:id/risk-condition-summary).
+ *
+ * Only the transitions BeneficiaryService.applyPhaseChange actually allows
+ * (ANC->PP for a MOTHER case, *->NN for a CHILD case) succeed — any other
+ * value is rejected there with a 409, not here; this schema only checks the
+ * value is a real CasePhase.
+ */
+export const updatePhaseSchema = z
+  .object({
+    phase: z.enum(CASE_PHASES),
+  })
+  .strict();
+
+export type UpdatePhaseInput = z.infer<typeof updatePhaseSchema>;

--- a/apps/closure-reopen-service/prisma/migrations/20260818140000_add_closure_local_closure_uuid/migration.sql
+++ b/apps/closure-reopen-service/prisma/migrations/20260818140000_add_closure_local_closure_uuid/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: add local_closure_uuid as nullable first so any existing rows
+-- don't violate NOT NULL, backfill them with a generated value, then add the
+-- NOT NULL + UNIQUE constraints.
+ALTER TABLE "closures" ADD COLUMN "local_closure_uuid" VARCHAR(80);
+
+UPDATE "closures" SET "local_closure_uuid" = gen_random_uuid()::text WHERE "local_closure_uuid" IS NULL;
+
+ALTER TABLE "closures" ALTER COLUMN "local_closure_uuid" SET NOT NULL;
+
+CREATE UNIQUE INDEX "closures_local_closure_uuid_key" ON "closures"("local_closure_uuid");

--- a/apps/closure-reopen-service/prisma/migrations/20260818150000_add_reopen_request_local_uuid/migration.sql
+++ b/apps/closure-reopen-service/prisma/migrations/20260818150000_add_reopen_request_local_uuid/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable: add local_reopen_request_uuid as nullable first so any
+-- existing rows don't violate NOT NULL, backfill them with a generated
+-- value, then add the NOT NULL + UNIQUE constraints.
+ALTER TABLE "reopen_requests" ADD COLUMN "local_reopen_request_uuid" VARCHAR(80);
+
+UPDATE "reopen_requests" SET "local_reopen_request_uuid" = gen_random_uuid()::text WHERE "local_reopen_request_uuid" IS NULL;
+
+ALTER TABLE "reopen_requests" ALTER COLUMN "local_reopen_request_uuid" SET NOT NULL;
+
+CREATE UNIQUE INDEX "reopen_requests_local_reopen_request_uuid_key" ON "reopen_requests"("local_reopen_request_uuid");

--- a/apps/closure-reopen-service/prisma/schema.prisma
+++ b/apps/closure-reopen-service/prisma/schema.prisma
@@ -46,6 +46,8 @@ enum ReopenSupervisorStatus {
 
 model Closure {
   id                         String                   @id @default(uuid()) @map("closure_id")
+  // Client-generated idempotency key — see createClosureSchema's doc comment.
+  localClosureUuid           String                   @unique @map("local_closure_uuid") @db.VarChar(80)
   // beneficiary_cases.beneficiary_id — owned by another service, no cross-service relation.
   beneficiaryId              String                   @map("beneficiary_id")
   closureType                ClosureType              @map("closure_type")
@@ -73,6 +75,8 @@ model Closure {
 
 model ReopenRequest {
   id                         String                 @id @default(uuid()) @map("reopen_request_id")
+  // Client-generated idempotency key — see createReopenRequestSchema's doc comment.
+  localReopenRequestUuid     String                 @unique @map("local_reopen_request_uuid") @db.VarChar(80)
   // beneficiary_cases.beneficiary_id — owned by another service, no cross-service relation.
   beneficiaryId              String                 @map("beneficiary_id")
   requestReason              ReopenRequestReason    @map("request_reason")

--- a/apps/closure-reopen-service/src/closures/closure.module.ts
+++ b/apps/closure-reopen-service/src/closures/closure.module.ts
@@ -6,6 +6,7 @@ import { registerClosureRoutes } from './closure.routes';
 import { ApprovalClient } from '../reopen-requests/approval.client';
 import { LookupClient } from '../reopen-requests/lookup.client';
 import { NotificationClient } from '../reopen-requests/notification.client';
+import { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
 
 /**
  * Composition root for the closures feature: wires repository → service → routes.
@@ -16,7 +17,14 @@ export function createClosureModule(prisma: PrismaService): DocumentedRouter {
   const approvalClient = new ApprovalClient();
   const lookupClient = new LookupClient();
   const notificationClient = new NotificationClient();
-  const service = new ClosureService(repository, approvalClient, lookupClient, notificationClient);
+  const beneficiaryClient = new BeneficiaryClient();
+  const service = new ClosureService(
+    repository,
+    approvalClient,
+    lookupClient,
+    notificationClient,
+    beneficiaryClient,
+  );
   const doc = createDocumentedRouter();
   registerClosureRoutes(doc, service);
   return doc;

--- a/apps/closure-reopen-service/src/closures/closure.repository.ts
+++ b/apps/closure-reopen-service/src/closures/closure.repository.ts
@@ -23,8 +23,13 @@ export class ClosureRepository {
     return this.prisma.closure.findFirst({ where: { localClosureUuid, isDeleted: false } });
   }
 
-  create(data: CreateClosureInput) {
-    return this.prisma.closure.create({ data });
+  /**
+   * supervisorStatus is a server-derived value (see ClosureService.create),
+   * never client-suppliable — passed explicitly here rather than as part of
+   * CreateClosureInput, which no longer carries it.
+   */
+  create(data: CreateClosureInput, supervisorStatus: 'PENDING' | null) {
+    return this.prisma.closure.create({ data: { ...data, supervisorStatus } });
   }
 
   /**

--- a/apps/closure-reopen-service/src/closures/closure.repository.ts
+++ b/apps/closure-reopen-service/src/closures/closure.repository.ts
@@ -14,6 +14,15 @@ export class ClosureRepository {
     return this.prisma.closure.findFirst({ where: { id, isDeleted: false } });
   }
 
+  /**
+   * Finds a closure previously created from this exact client-generated
+   * localClosureUuid — lets create() treat a dropped-connection retry as an
+   * idempotent replay instead of a new closure.
+   */
+  findByLocalClosureUuid(localClosureUuid: string) {
+    return this.prisma.closure.findFirst({ where: { localClosureUuid, isDeleted: false } });
+  }
+
   create(data: CreateClosureInput) {
     return this.prisma.closure.create({ data });
   }

--- a/apps/closure-reopen-service/src/closures/closure.routes.ts
+++ b/apps/closure-reopen-service/src/closures/closure.routes.ts
@@ -17,6 +17,9 @@ extendZodWithOpenApi(z);
 // Request DTO annotated with examples for Swagger UI; validation behavior is
 // unchanged (`.openapi()` only attaches documentation metadata).
 const createClosureRequestSchema = createClosureSchema.extend({
+  localClosureUuid: createClosureSchema.shape.localClosureUuid.openapi({
+    example: 'device-abc-closure-001',
+  }),
   beneficiaryId: createClosureSchema.shape.beneficiaryId.openapi({
     example: '123e4567-e89b-12d3-a456-426614174000',
   }),
@@ -36,6 +39,7 @@ const createClosureRequestSchema = createClosureSchema.extend({
 // fields — for accurate Swagger documentation only.
 const closureSchema = z.object({
   id: z.string().uuid(),
+  localClosureUuid: z.string(),
   beneficiaryId: z.string().uuid(),
   closureType: z.enum(['MEDICAL', 'NON_MEDICAL', 'PROGRAM_COMPLETION']),
   closureReasonLookupValueId: z.string().uuid(),

--- a/apps/closure-reopen-service/src/closures/closure.service.spec.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.spec.ts
@@ -3,14 +3,39 @@ import type { ClosureRepository } from './closure.repository';
 import type { ApprovalClient } from '../reopen-requests/approval.client';
 import type { LookupClient } from '../reopen-requests/lookup.client';
 import type { NotificationClient } from '../reopen-requests/notification.client';
+import type { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
 import type { DecideClosureInput } from './dto/decide-closure.dto';
 import type { ClosureType } from '../../../../node_modules/.prisma/client-closure-reopen-service';
+
+function closureRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    localClosureUuid: 'device-abc-closure-001',
+    beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    closureType: 'MEDICAL' as ClosureType,
+    closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    eventDate: null,
+    closureDate: new Date('2026-06-05'),
+    submittedByUserId: '33333333-3333-3333-3333-333333333333',
+    supervisorStatus: null,
+    supervisorId: null,
+    supervisorNotes: null,
+    createdAt: new Date(),
+    createdByUserId: null,
+    updatedAt: new Date(),
+    updatedByUserId: null,
+    isDeleted: false,
+    deletedAt: null,
+    ...overrides,
+  };
+}
 
 describe('ClosureService', () => {
   const repository = {
     findMany: jest.fn(),
     findById: jest.fn(),
+    findByLocalClosureUuid: jest.fn(),
     create: jest.fn(),
     decide: jest.fn(),
   } as unknown as jest.Mocked<ClosureRepository>;
@@ -19,6 +44,9 @@ describe('ClosureService', () => {
     resolveApprovalStatusId: jest.fn(),
   } as unknown as jest.Mocked<LookupClient>;
   const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
+  const beneficiaryClient = {
+    closeCase: jest.fn(),
+  } as unknown as jest.Mocked<BeneficiaryClient>;
   let service: ClosureService;
   const authHeader = 'Bearer token';
   const supervisorId = '44444444-4444-4444-4444-444444444444';
@@ -27,7 +55,18 @@ describe('ClosureService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    service = new ClosureService(repository, approvalClient, lookupClient, notificationClient);
+    repository.findByLocalClosureUuid.mockResolvedValue(null);
+    beneficiaryClient.closeCase.mockResolvedValue({
+      id: '22222222-2222-2222-2222-222222222222',
+      currentStatus: 'CLOSED',
+    });
+    service = new ClosureService(
+      repository,
+      approvalClient,
+      lookupClient,
+      notificationClient,
+      beneficiaryClient,
+    );
   });
 
   afterEach(() => {
@@ -41,77 +80,14 @@ describe('ClosureService', () => {
   });
 
   it('returns the repository list unchanged', async () => {
-    const rows = [
-      {
-        id: '11111111-1111-1111-1111-111111111111',
-        beneficiaryId: '22222222-2222-2222-2222-222222222222',
-        closureType: 'MEDICAL' as ClosureType,
-        closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        eventDate: new Date('2026-06-01'),
-        closureDate: new Date('2026-06-05'),
-        submittedByUserId: '33333333-3333-3333-3333-333333333333',
-        supervisorStatus: null,
-        supervisorId: null,
-        supervisorNotes: null,
-        createdAt: new Date(),
-        createdByUserId: null,
-        updatedAt: new Date(),
-        updatedByUserId: null,
-        isDeleted: false,
-        deletedAt: null,
-      },
-    ];
+    const rows = [closureRow()];
     repository.findMany.mockResolvedValue(rows);
     await expect(service.list()).resolves.toBe(rows);
   });
 
-  it('creates via repository with the given data', async () => {
+  describe('create', () => {
     const dto: CreateClosureInput = {
-      beneficiaryId: '22222222-2222-2222-2222-222222222222',
-      closureType: 'MEDICAL',
-      closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-      eventDate: new Date('2026-06-01'),
-      closureDate: new Date('2026-06-05'),
-      submittedByUserId: '33333333-3333-3333-3333-333333333333',
-    };
-    const created = {
-      id: '11111111-1111-1111-1111-111111111111',
-      beneficiaryId: dto.beneficiaryId,
-      closureType: dto.closureType as ClosureType,
-      closureReasonLookupValueId: dto.closureReasonLookupValueId,
-      eventDate: dto.eventDate ?? null,
-      closureDate: dto.closureDate,
-      submittedByUserId: dto.submittedByUserId,
-      supervisorStatus: null,
-      supervisorId: null,
-      supervisorNotes: null,
-      createdAt: new Date(),
-      createdByUserId: null,
-      updatedAt: new Date(),
-      updatedByUserId: null,
-      isDeleted: false,
-      deletedAt: null,
-    };
-    repository.create.mockResolvedValue(created);
-    await expect(service.create(dto, authHeader)).resolves.toBe(created);
-    expect(repository.create).toHaveBeenCalledWith(dto);
-    expect(approvalClient.create).not.toHaveBeenCalled();
-  });
-
-  it('propagates repository errors on create', async () => {
-    const dto: CreateClosureInput = {
-      beneficiaryId: '22222222-2222-2222-2222-222222222222',
-      closureType: 'MEDICAL',
-      closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-      closureDate: new Date('2026-06-05'),
-      submittedByUserId: '33333333-3333-3333-3333-333333333333',
-    };
-    repository.create.mockRejectedValue(new Error('db down'));
-    await expect(service.create(dto, authHeader)).rejects.toThrow('db down');
-  });
-
-  describe('create — CLOSURE_REVIEW linkage', () => {
-    const dto: CreateClosureInput = {
+      localClosureUuid: 'device-abc-closure-001',
       beneficiaryId: '22222222-2222-2222-2222-222222222222',
       closureType: 'MEDICAL',
       closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
@@ -119,108 +95,151 @@ describe('ClosureService', () => {
       submittedByUserId: '33333333-3333-3333-3333-333333333333',
     };
 
-    function pendingClosure() {
-      return {
-        id: '11111111-1111-1111-1111-111111111111',
-        beneficiaryId: dto.beneficiaryId,
-        closureType: dto.closureType as ClosureType,
-        closureReasonLookupValueId: dto.closureReasonLookupValueId,
-        eventDate: null,
-        closureDate: dto.closureDate,
-        submittedByUserId: dto.submittedByUserId,
-        supervisorStatus: 'PENDING' as const,
-        supervisorId: null,
-        supervisorNotes: null,
-        createdAt: new Date(),
-        createdByUserId: null,
-        updatedAt: new Date(),
-        updatedByUserId: null,
-        isDeleted: false,
-        deletedAt: null,
-      };
-    }
-
-    it('raises a CLOSURE_REVIEW card when the closure needs supervisor review', async () => {
-      const created = pendingClosure();
-      repository.create.mockResolvedValue(created);
-      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
-
-      await service.create(dto, authHeader);
-
-      expect(lookupClient.resolveApprovalStatusId).toHaveBeenCalledWith('PENDING', authHeader);
-      expect(approvalClient.create).toHaveBeenCalledWith(
-        {
-          requestType: 'CLOSURE_REVIEW',
-          beneficiaryId: created.beneficiaryId,
-          sourceEntityType: 'Closure',
-          sourceEntityId: created.id,
-          closureId: created.id,
-          requestedByUserId: created.submittedByUserId,
-          decisionStatusLookupId: 'pending-lookup-id',
-        },
-        authHeader,
-      );
-    });
-
-    it('does not raise a card for a closure that does not need supervisor review', async () => {
-      const created = {
-        id: '11111111-1111-1111-1111-111111111111',
-        beneficiaryId: dto.beneficiaryId,
-        closureType: dto.closureType as ClosureType,
-        closureReasonLookupValueId: dto.closureReasonLookupValueId,
-        eventDate: null,
-        closureDate: dto.closureDate,
-        submittedByUserId: dto.submittedByUserId,
-        supervisorStatus: null,
-        supervisorId: null,
-        supervisorNotes: null,
-        createdAt: new Date(),
-        createdByUserId: null,
-        updatedAt: new Date(),
-        updatedByUserId: null,
-        isDeleted: false,
-        deletedAt: null,
-      };
+    it('creates via repository with the given data', async () => {
+      const created = closureRow();
       repository.create.mockResolvedValue(created);
 
-      await service.create(dto, authHeader);
-
+      await expect(service.create(dto, authHeader)).resolves.toBe(created);
+      expect(repository.create).toHaveBeenCalledWith(dto);
       expect(approvalClient.create).not.toHaveBeenCalled();
     });
 
-    it('still returns the created closure when raising the card fails', async () => {
-      const created = pendingClosure();
-      repository.create.mockResolvedValue(created);
-      lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
-      approvalClient.create.mockRejectedValue(
-        Object.assign(new Error('Bad gateway'), { status: 502 }),
-      );
+    it('propagates repository errors on create', async () => {
+      repository.create.mockRejectedValue(new Error('db down'));
+      await expect(service.create(dto, authHeader)).rejects.toThrow('db down');
+    });
 
-      await expect(service.create(dto, authHeader)).resolves.toBe(created);
-      expect(consoleErrorSpy).toHaveBeenCalled();
+    describe('idempotent replay via localClosureUuid', () => {
+      it('returns the existing closure without creating a new row on a retried submission', async () => {
+        const existing = closureRow();
+        repository.findByLocalClosureUuid.mockResolvedValue(existing);
+
+        await expect(service.create(dto, authHeader)).resolves.toBe(existing);
+        expect(repository.create).not.toHaveBeenCalled();
+      });
+
+      it('does not re-raise a Quick Response card or re-close the beneficiary on a retried submission', async () => {
+        const existing = closureRow({ supervisorStatus: 'PENDING' });
+        repository.findByLocalClosureUuid.mockResolvedValue(existing);
+
+        await service.create(dto, authHeader);
+
+        expect(approvalClient.create).not.toHaveBeenCalled();
+        expect(beneficiaryClient.closeCase).not.toHaveBeenCalled();
+      });
+
+      it("looks up by this submission's own localClosureUuid", async () => {
+        repository.create.mockResolvedValue(closureRow());
+        await service.create(dto, authHeader);
+        expect(repository.findByLocalClosureUuid).toHaveBeenCalledWith(dto.localClosureUuid);
+      });
+    });
+
+    describe('CLOSURE_REVIEW linkage', () => {
+      function pendingClosure() {
+        return closureRow({ supervisorStatus: 'PENDING' as const });
+      }
+
+      it('raises a CLOSURE_REVIEW card when the closure needs supervisor review', async () => {
+        const created = pendingClosure();
+        repository.create.mockResolvedValue(created);
+        lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+
+        await service.create(dto, authHeader);
+
+        expect(lookupClient.resolveApprovalStatusId).toHaveBeenCalledWith('PENDING', authHeader);
+        expect(approvalClient.create).toHaveBeenCalledWith(
+          {
+            requestType: 'CLOSURE_REVIEW',
+            beneficiaryId: created.beneficiaryId,
+            sourceEntityType: 'Closure',
+            sourceEntityId: created.id,
+            closureId: created.id,
+            requestedByUserId: created.submittedByUserId,
+            decisionStatusLookupId: 'pending-lookup-id',
+          },
+          authHeader,
+        );
+      });
+
+      it('does not close the beneficiary when the closure needs supervisor review', async () => {
+        repository.create.mockResolvedValue(pendingClosure());
+        lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+
+        await service.create(dto, authHeader);
+
+        expect(beneficiaryClient.closeCase).not.toHaveBeenCalled();
+      });
+
+      it('still returns the created closure when raising the card fails', async () => {
+        const created = pendingClosure();
+        repository.create.mockResolvedValue(created);
+        lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+        approvalClient.create.mockRejectedValue(
+          Object.assign(new Error('Bad gateway'), { status: 502 }),
+        );
+
+        await expect(service.create(dto, authHeader)).resolves.toBe(created);
+        expect(consoleErrorSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('immediate beneficiary closure (no supervisor review needed)', () => {
+      it('closes the beneficiary for a MEDICAL closure', async () => {
+        const created = closureRow({ closureType: 'MEDICAL', supervisorStatus: null });
+        repository.create.mockResolvedValue(created);
+
+        await service.create(dto, authHeader);
+
+        expect(beneficiaryClient.closeCase).toHaveBeenCalledWith(
+          created.beneficiaryId,
+          'MEDICAL',
+          authHeader,
+        );
+      });
+
+      it('closes the beneficiary for a NON_MEDICAL closure', async () => {
+        const created = closureRow({ closureType: 'NON_MEDICAL', supervisorStatus: null });
+        repository.create.mockResolvedValue(created);
+
+        await service.create({ ...dto, closureType: 'NON_MEDICAL' }, authHeader);
+
+        expect(beneficiaryClient.closeCase).toHaveBeenCalledWith(
+          created.beneficiaryId,
+          'NON_MEDICAL',
+          authHeader,
+        );
+      });
+
+      it('closes the beneficiary for a PROGRAM_COMPLETION closure', async () => {
+        const created = closureRow({ closureType: 'PROGRAM_COMPLETION', supervisorStatus: null });
+        repository.create.mockResolvedValue(created);
+
+        await service.create({ ...dto, closureType: 'PROGRAM_COMPLETION' }, authHeader);
+
+        expect(beneficiaryClient.closeCase).toHaveBeenCalledWith(
+          created.beneficiaryId,
+          'PROGRAM_COMPLETION',
+          authHeader,
+        );
+      });
+
+      it('still returns the created closure when closing the beneficiary fails', async () => {
+        const created = closureRow({ supervisorStatus: null });
+        repository.create.mockResolvedValue(created);
+        beneficiaryClient.closeCase.mockRejectedValue(
+          Object.assign(new Error('Bad gateway'), { status: 502 }),
+        );
+
+        await expect(service.create(dto, authHeader)).resolves.toBe(created);
+        expect(consoleErrorSpy).toHaveBeenCalled();
+      });
     });
   });
 
   describe('decide', () => {
     function pendingClosure() {
-      return {
-        id: '11111111-1111-1111-1111-111111111111',
-        beneficiaryId: '22222222-2222-2222-2222-222222222222',
-        closureType: 'MEDICAL' as ClosureType,
-        closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        eventDate: null,
-        closureDate: new Date('2026-06-05'),
-        submittedByUserId: '33333333-3333-3333-3333-333333333333',
-        supervisorStatus: 'PENDING' as const,
-        supervisorId: null,
-        supervisorNotes: null,
-        createdAt: new Date(),
-        createdByUserId: null,
-        updatedAt: new Date(),
-        updatedByUserId: null,
-        isDeleted: false,
-        deletedAt: null,
-      };
+      return closureRow({ supervisorStatus: 'PENDING' as const });
     }
 
     it('approves a PENDING closure and notifies the Sakhi', async () => {
@@ -241,6 +260,47 @@ describe('ClosureService', () => {
         expect.any(String),
         authHeader,
       );
+    });
+
+    it('closes the beneficiary on APPROVED', async () => {
+      const pending = pendingClosure();
+      const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+
+      await service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader);
+
+      expect(beneficiaryClient.closeCase).toHaveBeenCalledWith(
+        pending.beneficiaryId,
+        pending.closureType,
+        authHeader,
+      );
+    });
+
+    it('does not close the beneficiary on REJECTED', async () => {
+      const pending = pendingClosure();
+      const decided = { ...pending, supervisorStatus: 'REJECTED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+
+      await service.decide(pending.id, supervisorId, { decision: 'REJECTED' }, authHeader);
+
+      expect(beneficiaryClient.closeCase).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the decision when closing the beneficiary fails after APPROVED', async () => {
+      const pending = pendingClosure();
+      const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+      beneficiaryClient.closeCase.mockRejectedValue(
+        Object.assign(new Error('Bad gateway'), { status: 502 }),
+      );
+
+      await expect(
+        service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+      ).resolves.toBe(decided);
+      expect(consoleErrorSpy).toHaveBeenCalled();
     });
 
     it('rejects a PENDING closure', async () => {
@@ -267,7 +327,7 @@ describe('ClosureService', () => {
     });
 
     it('422s when the closure does not require supervisor review', async () => {
-      repository.findById.mockResolvedValue({ ...pendingClosure(), supervisorStatus: null });
+      repository.findById.mockResolvedValue(closureRow({ supervisorStatus: null }));
       await expect(
         service.decide(
           '11111111-1111-1111-1111-111111111111',
@@ -280,10 +340,7 @@ describe('ClosureService', () => {
     });
 
     it('409s on an already-APPROVED closure', async () => {
-      repository.findById.mockResolvedValue({
-        ...pendingClosure(),
-        supervisorStatus: 'APPROVED' as const,
-      });
+      repository.findById.mockResolvedValue(closureRow({ supervisorStatus: 'APPROVED' as const }));
       await expect(
         service.decide(
           '11111111-1111-1111-1111-111111111111',

--- a/apps/closure-reopen-service/src/closures/closure.service.spec.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.spec.ts
@@ -42,10 +42,12 @@ describe('ClosureService', () => {
   const approvalClient = { create: jest.fn() } as unknown as jest.Mocked<ApprovalClient>;
   const lookupClient = {
     resolveApprovalStatusId: jest.fn(),
+    resolveClosureReasonCode: jest.fn(),
   } as unknown as jest.Mocked<LookupClient>;
   const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
   const beneficiaryClient = {
     closeCase: jest.fn(),
+    getById: jest.fn(),
   } as unknown as jest.Mocked<BeneficiaryClient>;
   let service: ClosureService;
   const authHeader = 'Bearer token';
@@ -60,6 +62,11 @@ describe('ClosureService', () => {
       id: '22222222-2222-2222-2222-222222222222',
       currentStatus: 'CLOSED',
     });
+    beneficiaryClient.getById.mockResolvedValue({
+      id: '22222222-2222-2222-2222-222222222222',
+      currentStatus: 'ACTIVE',
+    });
+    lookupClient.resolveClosureReasonCode.mockResolvedValue('WITHDRAWAL');
     service = new ClosureService(
       repository,
       approvalClient,
@@ -95,13 +102,47 @@ describe('ClosureService', () => {
       submittedByUserId: '33333333-3333-3333-3333-333333333333',
     };
 
-    it('creates via repository with the given data', async () => {
+    it('creates via repository with the given data and server-derived supervisorStatus', async () => {
       const created = closureRow();
       repository.create.mockResolvedValue(created);
 
       await expect(service.create(dto, authHeader)).resolves.toBe(created);
-      expect(repository.create).toHaveBeenCalledWith(dto);
+      expect(repository.create).toHaveBeenCalledWith(dto, null);
       expect(approvalClient.create).not.toHaveBeenCalled();
+    });
+
+    it('checks ownership via beneficiaryClient.getById before creating', async () => {
+      repository.create.mockResolvedValue(closureRow());
+      await service.create(dto, authHeader);
+      expect(beneficiaryClient.getById).toHaveBeenCalledWith(dto.beneficiaryId, authHeader);
+    });
+
+    it('propagates a 403 from the ownership check without creating a closure', async () => {
+      beneficiaryClient.getById.mockRejectedValue(
+        Object.assign(new Error('This beneficiary case is outside your own roster.'), {
+          status: 403,
+        }),
+      );
+      await expect(service.create(dto, authHeader)).rejects.toMatchObject({ status: 403 });
+      expect(repository.create).not.toHaveBeenCalled();
+    });
+
+    it('derives supervisorStatus: PENDING only when the resolved reason is MIGRATION — never from client input', async () => {
+      lookupClient.resolveClosureReasonCode.mockResolvedValue('MIGRATION');
+      repository.create.mockResolvedValue(closureRow({ supervisorStatus: 'PENDING' }));
+
+      await service.create(dto, authHeader);
+
+      expect(repository.create).toHaveBeenCalledWith(dto, 'PENDING');
+    });
+
+    it('derives supervisorStatus: null for a non-review reason', async () => {
+      lookupClient.resolveClosureReasonCode.mockResolvedValue('WITHDRAWAL');
+      repository.create.mockResolvedValue(closureRow({ supervisorStatus: null }));
+
+      await service.create(dto, authHeader);
+
+      expect(repository.create).toHaveBeenCalledWith(dto, null);
     });
 
     it('propagates repository errors on create', async () => {
@@ -139,6 +180,10 @@ describe('ClosureService', () => {
       function pendingClosure() {
         return closureRow({ supervisorStatus: 'PENDING' as const });
       }
+
+      beforeEach(() => {
+        lookupClient.resolveClosureReasonCode.mockResolvedValue('MIGRATION');
+      });
 
       it('raises a CLOSURE_REVIEW card when the closure needs supervisor review', async () => {
         const created = pendingClosure();

--- a/apps/closure-reopen-service/src/closures/closure.service.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.ts
@@ -3,6 +3,7 @@ import type { ClosureRepository } from './closure.repository';
 import type { ApprovalClient } from '../reopen-requests/approval.client';
 import type { LookupClient } from '../reopen-requests/lookup.client';
 import type { NotificationClient } from '../reopen-requests/notification.client';
+import type { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
 import type { DecideClosureInput } from './dto/decide-closure.dto';
 
@@ -13,6 +14,7 @@ export class ClosureService {
     private readonly approvalClient: ApprovalClient,
     private readonly lookupClient: LookupClient,
     private readonly notificationClient: NotificationClient,
+    private readonly beneficiaryClient: BeneficiaryClient,
   ) {}
 
   list() {
@@ -20,14 +22,16 @@ export class ClosureService {
   }
 
   /**
-   * Creates the closure and, only when it needs supervisor review
-   * (supervisorStatus is set — per the schema, only MIGRATION-reason
-   * closures), also raises the matching CLOSURE_REVIEW Quick Response card
-   * in approval-service (FR-SV-4.4). A failure raising the card is logged
-   * and tolerated rather than failing an already-successful closure
-   * submission — same tolerance reopen-request.service.ts's create() uses.
+   * Idempotent replay: a dropped-connection retry of a Sakhi's closure
+   * submission resubmits the same client-generated localClosureUuid. Return
+   * the original closure unchanged instead of creating a duplicate row or
+   * re-firing the Quick Response card / beneficiary-close side effects below
+   * a second time — this mobile flow is offline-first and expected to retry.
    */
   async create(dto: CreateClosureInput, authorizationHeader: string) {
+    const existing = await this.repository.findByLocalClosureUuid(dto.localClosureUuid);
+    if (existing) return existing;
+
     const created = await this.repository.create(dto);
 
     if (created.supervisorStatus === 'PENDING') {
@@ -60,6 +64,24 @@ export class ClosureService {
           err,
         );
       }
+    } else {
+      // No supervisor review needed (MEDICAL/NON_MEDICAL/PROGRAM_COMPLETION)
+      // — close the beneficiary right away instead of waiting on a decision
+      // that will never come. Best-effort/tolerated, same stance as the
+      // Quick Response card raise above: the closures row is already the
+      // source of truth for this submission having happened.
+      try {
+        await this.beneficiaryClient.closeCase(
+          created.beneficiaryId,
+          created.closureType,
+          authorizationHeader,
+        );
+      } catch (err) {
+        console.error(
+          `Closure ${created.id} was created but closing beneficiary ${created.beneficiaryId} failed:`,
+          err,
+        );
+      }
     }
 
     return created;
@@ -67,10 +89,18 @@ export class ClosureService {
 
   /**
    * Decides a pending closure review (FR-SV-4.4). Approve/Reject both flip
-   * supervisorStatus here — the "beneficiary moves to Closed/Open list"
-   * consequence lives in beneficiary-service, out of this service's
-   * ownership (forklift rule). The Sakhi notification is best-effort — its
-   * failure doesn't fail an already-committed decision.
+   * supervisorStatus here. On APPROVED, also closes the beneficiary case via
+   * beneficiary-service (the "beneficiary moves to the Closed list"
+   * consequence — out of this service's own ownership per the forklift
+   * rule). REJECTED leaves the beneficiary exactly as it was — same
+   * "rejection changes nothing beyond the closures row" contract
+   * reopen-request.service.ts's decide() uses for a rejected reopen.
+   *
+   * The beneficiary-close call is best-effort (logged, not thrown) — the
+   * decision above is already committed, and this method's own guard
+   * (supervisorStatus !== 'PENDING') means a closure can never be decided a
+   * second time to retry just this step; same tolerance/manual-follow-up
+   * stance as reopen-request.service.ts's decide() uses for reactivateCase.
    */
   async decide(
     id: string,
@@ -96,6 +126,22 @@ export class ClosureService {
     }
 
     const decided = await this.repository.findById(id);
+
+    if (dto.decision === 'APPROVED') {
+      try {
+        await this.beneficiaryClient.closeCase(
+          existing.beneficiaryId,
+          existing.closureType,
+          authorizationHeader,
+        );
+      } catch (err) {
+        console.error(
+          `Closure ${id} was approved but closing beneficiary ${existing.beneficiaryId} ` +
+            `failed (this closure cannot be re-decided to retry — needs manual follow-up):`,
+          err,
+        );
+      }
+    }
 
     try {
       await this.notificationClient.notify(

--- a/apps/closure-reopen-service/src/closures/closure.service.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.ts
@@ -7,6 +7,24 @@ import type { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
 import type { DecideClosureInput } from './dto/decide-closure.dto';
 
+/** Narrows a caught Prisma error to a unique-constraint violation (P2002). */
+function isUniqueConstraintViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'P2002'
+  );
+}
+
+/**
+ * CLOSURE_REASON valueCodes that require Supervisor review before the
+ * beneficiary closes — resolved from the server's own read of
+ * closureReasonLookupValueId, never from client input (see
+ * createClosureSchema's doc comment for the trust gap this closes).
+ */
+const REASONS_REQUIRING_REVIEW = new Set(['MIGRATION']);
+
 /** Closure domain logic. Data access is delegated to the repository. */
 export class ClosureService {
   constructor(
@@ -27,12 +45,49 @@ export class ClosureService {
    * the original closure unchanged instead of creating a duplicate row or
    * re-firing the Quick Response card / beneficiary-close side effects below
    * a second time — this mobile flow is offline-first and expected to retry.
+   *
+   * supervisorStatus is derived here from the server's own read of
+   * closureReasonLookupValueId (REASONS_REQUIRING_REVIEW), never from client
+   * input — a client can no longer set supervisorStatus/supervisorId
+   * directly to self-approve a closure and skip review (see
+   * createClosureSchema's doc comment).
+   *
+   * A concurrent retry racing on the same localClosureUuid (two near-
+   * simultaneous requests both passing the findByLocalClosureUuid check as
+   * null) hits the column's own unique constraint on create() — caught here
+   * and turned into the same idempotent-replay result as a sequential retry,
+   * rather than a raw 500.
    */
   async create(dto: CreateClosureInput, authorizationHeader: string) {
     const existing = await this.repository.findByLocalClosureUuid(dto.localClosureUuid);
     if (existing) return existing;
 
-    const created = await this.repository.create(dto);
+    // Delegates ownership scoping to beneficiary-service's own
+    // GET /beneficiaries/:id (SAKHI-own-case / SUPERVISOR-roster /
+    // MANAGER-unrestricted) rather than duplicating that IDOR check here —
+    // this service owns no sakhiId data of its own. Without this, any
+    // authenticated SAKHI could raise a closure (and, for a MIGRATION
+    // reason, a real supervisor-approval card) for a beneficiary they have
+    // no relationship to. Throws 403/404 as-is on failure.
+    await this.beneficiaryClient.getById(dto.beneficiaryId, authorizationHeader);
+
+    const reasonCode = await this.lookupClient.resolveClosureReasonCode(
+      dto.closureReasonLookupValueId,
+      authorizationHeader,
+    );
+    const supervisorStatus =
+      reasonCode && REASONS_REQUIRING_REVIEW.has(reasonCode) ? ('PENDING' as const) : null;
+
+    let created;
+    try {
+      created = await this.repository.create(dto, supervisorStatus);
+    } catch (err) {
+      if (isUniqueConstraintViolation(err)) {
+        const winner = await this.repository.findByLocalClosureUuid(dto.localClosureUuid);
+        if (winner) return winner;
+      }
+      throw err;
+    }
 
     if (created.supervisorStatus === 'PENDING') {
       try {

--- a/apps/closure-reopen-service/src/closures/dto/create-closure.dto.spec.ts
+++ b/apps/closure-reopen-service/src/closures/dto/create-closure.dto.spec.ts
@@ -1,0 +1,54 @@
+import { createClosureSchema } from './create-closure.dto';
+
+const validBase = {
+  localClosureUuid: 'device-abc-closure-001',
+  beneficiaryId: '22222222-2222-2222-2222-222222222222',
+  closureType: 'MEDICAL' as const,
+  closureReasonLookupValueId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  closureDate: '2026-06-05',
+  submittedByUserId: '33333333-3333-3333-3333-333333333333',
+};
+
+describe('createClosureSchema', () => {
+  it('accepts a valid minimal closure', () => {
+    expect(createClosureSchema.safeParse(validBase).success).toBe(true);
+  });
+
+  it('accepts an optional eventDate/supervisorStatus/supervisorId/supervisorNotes', () => {
+    const result = createClosureSchema.safeParse({
+      ...validBase,
+      eventDate: '2026-06-01',
+      supervisorStatus: 'PENDING',
+      supervisorId: '44444444-4444-4444-4444-444444444444',
+      supervisorNotes: 'Migrating out of the project area.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing localClosureUuid', () => {
+    const { localClosureUuid: _omit, ...rest } = validBase;
+    expect(createClosureSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects an empty localClosureUuid', () => {
+    expect(createClosureSchema.safeParse({ ...validBase, localClosureUuid: '' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects a localClosureUuid over 80 characters', () => {
+    expect(
+      createClosureSchema.safeParse({ ...validBase, localClosureUuid: 'x'.repeat(81) }).success,
+    ).toBe(false);
+  });
+
+  it('rejects an invalid closureType', () => {
+    expect(createClosureSchema.safeParse({ ...validBase, closureType: 'MIGRATION' }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects an unknown extra field', () => {
+    expect(createClosureSchema.safeParse({ ...validBase, extra: 'x' }).success).toBe(false);
+  });
+});

--- a/apps/closure-reopen-service/src/closures/dto/create-closure.dto.spec.ts
+++ b/apps/closure-reopen-service/src/closures/dto/create-closure.dto.spec.ts
@@ -14,15 +14,25 @@ describe('createClosureSchema', () => {
     expect(createClosureSchema.safeParse(validBase).success).toBe(true);
   });
 
-  it('accepts an optional eventDate/supervisorStatus/supervisorId/supervisorNotes', () => {
+  it('accepts an optional eventDate', () => {
     const result = createClosureSchema.safeParse({
       ...validBase,
       eventDate: '2026-06-01',
-      supervisorStatus: 'PENDING',
-      supervisorId: '44444444-4444-4444-4444-444444444444',
-      supervisorNotes: 'Migrating out of the project area.',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects a client-supplied supervisorStatus — server-derived only, never client input', () => {
+    const result = createClosureSchema.safeParse({ ...validBase, supervisorStatus: 'APPROVED' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a client-supplied supervisorId', () => {
+    const result = createClosureSchema.safeParse({
+      ...validBase,
+      supervisorId: '44444444-4444-4444-4444-444444444444',
+    });
+    expect(result.success).toBe(false);
   });
 
   it('rejects a missing localClosureUuid', () => {

--- a/apps/closure-reopen-service/src/closures/dto/create-closure.dto.ts
+++ b/apps/closure-reopen-service/src/closures/dto/create-closure.dto.ts
@@ -10,6 +10,13 @@ import { z } from 'zod';
  */
 export const createClosureSchema = z
   .object({
+    // Client-generated idempotency key — the mobile app is offline-first and
+    // may retry this submission after a dropped connection; a retry with the
+    // same value returns the original closure instead of creating a
+    // duplicate row or re-firing the Quick Response card / beneficiary-close
+    // side effects a second time. Same convention as beneficiary
+    // enrollment's localCaseUuid.
+    localClosureUuid: z.string().trim().min(1).max(80),
     beneficiaryId: z.string().uuid(),
     closureType: z.enum(['MEDICAL', 'NON_MEDICAL', 'PROGRAM_COMPLETION']),
     // lookup_values.lookup_value_id (category CLOSURE_REASON) — fetched via

--- a/apps/closure-reopen-service/src/closures/dto/create-closure.dto.ts
+++ b/apps/closure-reopen-service/src/closures/dto/create-closure.dto.ts
@@ -5,6 +5,15 @@ import { z } from 'zod';
  * (prisma/schema.prisma model Closure) — no invented fields. Audit/soft-delete
  * columns (createdByUserId, updatedByUserId, isDeleted, deletedAt) are
  * server-set and excluded from client input.
+ *
+ * supervisorStatus/supervisorId/supervisorNotes are deliberately NOT fields
+ * here — they used to be client-suppliable, which let a SAKHI POST
+ * `supervisorStatus: "APPROVED"` directly and bypass supervisor review
+ * entirely (the beneficiary gets closed immediately with a row falsely
+ * showing a decision that was never made). ClosureService.create() now
+ * derives supervisorStatus itself from the server's own read of
+ * closureReasonLookupValueId — a client can never set it.
+ *
  * `.strict()` rejects unknown fields, matching the previous global
  * ValidationPipe `forbidNonWhitelisted: true`.
  */
@@ -27,9 +36,6 @@ export const createClosureSchema = z
     eventDate: z.coerce.date().optional(),
     closureDate: z.coerce.date(),
     submittedByUserId: z.string().uuid(),
-    supervisorStatus: z.enum(['PENDING', 'APPROVED', 'REJECTED']).optional(),
-    supervisorId: z.string().uuid().optional(),
-    supervisorNotes: z.string().trim().min(1).optional(),
   })
   .strict();
 

--- a/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.spec.ts
@@ -1,0 +1,113 @@
+import { BeneficiaryClient } from './beneficiary.client';
+
+describe('BeneficiaryClient', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let client: BeneficiaryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    client = new BeneficiaryClient();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('closeCase', () => {
+    it('PATCHes beneficiary-service via the gateway with the reasonCode', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { id: 'b1', currentStatus: 'CLOSED' } }),
+      });
+
+      const result = await client.closeCase('b1', 'MEDICAL', 'Bearer test-token');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/beneficiaries/b1/close'),
+        expect.objectContaining({
+          method: 'PATCH',
+          headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+          body: JSON.stringify({ reasonCode: 'MEDICAL' }),
+        }),
+      );
+      expect(result).toEqual({ id: 'b1', currentStatus: 'CLOSED' });
+    });
+
+    it('throws HttpError with the upstream status/message on a 4xx response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ message: 'This beneficiary case is outside your own roster.' }),
+      });
+
+      await expect(client.closeCase('b1', 'MEDICAL', 'Bearer test-token')).rejects.toMatchObject({
+        status: 403,
+        message: 'This beneficiary case is outside your own roster.',
+      });
+    });
+
+    it('throws a badGateway error on a 5xx response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+
+      await expect(client.closeCase('b1', 'MEDICAL', 'Bearer test-token')).rejects.toMatchObject({
+        status: 502,
+      });
+    });
+
+    it('throws a badGateway error on a network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+
+      await expect(client.closeCase('b1', 'MEDICAL', 'Bearer test-token')).rejects.toMatchObject({
+        status: 502,
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it("GETs beneficiary-service via the gateway with the caller's own token", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { id: 'b1', currentStatus: 'CLOSED' } }),
+      });
+
+      const result = await client.getById('b1', 'Bearer test-token');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/beneficiaries/b1'),
+        expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+      );
+      expect(result).toEqual({ id: 'b1', currentStatus: 'CLOSED' });
+    });
+
+    it('throws HttpError with the upstream status/message on a 4xx response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ message: 'Beneficiary case not found.' }),
+      });
+
+      await expect(client.getById('b1', 'Bearer test-token')).rejects.toMatchObject({
+        status: 404,
+        message: 'Beneficiary case not found.',
+      });
+    });
+
+    it('throws a badGateway error on a 5xx response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+
+      await expect(client.getById('b1', 'Bearer test-token')).rejects.toMatchObject({
+        status: 502,
+      });
+    });
+
+    it('throws a badGateway error on a network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+
+      await expect(client.getById('b1', 'Bearer test-token')).rejects.toMatchObject({
+        status: 502,
+      });
+    });
+  });
+});

--- a/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
@@ -1,5 +1,11 @@
 import { badGateway, HttpError } from '@armman/service-commons';
-import { appConfig } from '../config/app-config';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema (requires DATABASE_URL etc. with no defaults),
+// which process.exit(1)s at module-load time in any test that never
+// otherwise loads config — matches every other service's HTTP-only client
+// convention (e.g. visit-form-service's create-child.client.ts).
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
 
 export interface BeneficiaryCaseRecord {
   id: string;
@@ -22,7 +28,7 @@ export class BeneficiaryClient {
     let res: Response;
     try {
       res = await fetch(
-        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/reactivate`,
+        `${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/reactivate`,
         {
           method: 'PATCH',
           headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
@@ -63,14 +69,11 @@ export class BeneficiaryClient {
   ): Promise<BeneficiaryCaseRecord> {
     let res: Response;
     try {
-      res = await fetch(
-        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/close`,
-        {
-          method: 'PATCH',
-          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
-          body: JSON.stringify({ reasonCode }),
-        },
-      );
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/close`, {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reasonCode }),
+      });
     } catch {
       throw badGateway('Unable to close the beneficiary — beneficiary-service is unreachable.');
     }
@@ -102,7 +105,7 @@ export class BeneficiaryClient {
   ): Promise<BeneficiaryCaseRecord> {
     let res: Response;
     try {
-      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
         headers: { Authorization: authorizationHeader },
       });
     } catch {

--- a/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
@@ -47,4 +47,79 @@ export class BeneficiaryClient {
     const body = (await res.json()) as { data: BeneficiaryCaseRecord };
     return body.data;
   }
+
+  /**
+   * Closes a beneficiary case by calling beneficiary-service's
+   * PATCH /beneficiaries/:id/close through the gateway, forwarding the
+   * caller's own Authorization header — same pattern as reactivateCase.
+   * Used after a non-reviewed closure submission (immediate close) or an
+   * approved MIGRATION closure, so the "beneficiary moves to the Closed
+   * list" consequence actually happens, not just the closures row updating.
+   */
+  async closeCase(
+    beneficiaryId: string,
+    reasonCode: string,
+    authorizationHeader: string,
+  ): Promise<BeneficiaryCaseRecord> {
+    let res: Response;
+    try {
+      res = await fetch(
+        `${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/close`,
+        {
+          method: 'PATCH',
+          headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reasonCode }),
+        },
+      );
+    } catch {
+      throw badGateway('Unable to close the beneficiary — beneficiary-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to close the beneficiary.');
+      }
+      throw badGateway('Unable to close the beneficiary — beneficiary-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: BeneficiaryCaseRecord };
+    return body.data;
+  }
+
+  /**
+   * Resolves a beneficiary case by calling beneficiary-service's
+   * GET /beneficiaries/:id through the gateway, forwarding the caller's own
+   * Authorization header. Used by GET /reopen-requests?beneficiaryId=... to
+   * delegate ownership scoping to beneficiary-service's own SAKHI-own-case /
+   * SUPERVISOR-roster / MANAGER-unrestricted check — this service has no
+   * sakhiId data of its own to check against, and duplicating that IDOR
+   * logic here would drift from beneficiary-service's as it evolves.
+   */
+  async getById(
+    beneficiaryId: string,
+    authorizationHeader: string,
+  ): Promise<BeneficiaryCaseRecord> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the beneficiary — beneficiary-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the beneficiary.');
+      }
+      throw badGateway(
+        'Unable to resolve the beneficiary — beneficiary-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: BeneficiaryCaseRecord };
+    return body.data;
+  }
 }

--- a/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.spec.ts
@@ -2,6 +2,7 @@ import { createReopenRequestSchema } from './create-reopen-request.dto';
 
 describe('createReopenRequestSchema', () => {
   const baseInput = {
+    localReopenRequestUuid: 'device-abc-reopen-001',
     beneficiaryId: '22222222-2222-2222-2222-222222222222',
     requestReason: 'MIGRATION_RETURNED' as const,
   };
@@ -26,6 +27,26 @@ describe('createReopenRequestSchema', () => {
   it('rejects a missing beneficiaryId', () => {
     const { beneficiaryId: _omit, ...rest } = baseInput;
     expect(createReopenRequestSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects a missing localReopenRequestUuid', () => {
+    const { localReopenRequestUuid: _omit, ...rest } = baseInput;
+    expect(createReopenRequestSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects an empty localReopenRequestUuid', () => {
+    expect(
+      createReopenRequestSchema.safeParse({ ...baseInput, localReopenRequestUuid: '' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a localReopenRequestUuid over 80 characters', () => {
+    expect(
+      createReopenRequestSchema.safeParse({
+        ...baseInput,
+        localReopenRequestUuid: 'x'.repeat(81),
+      }).success,
+    ).toBe(false);
   });
 
   it('rejects a non-UUID beneficiaryId', () => {

--- a/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/dto/create-reopen-request.dto.ts
@@ -11,6 +11,13 @@ import { z } from 'zod';
  */
 export const createReopenRequestSchema = z
   .object({
+    // Client-generated idempotency key — the mobile app is offline-first and
+    // may retry this submission after a dropped connection; a retry with the
+    // same value returns the original reopen request instead of creating a
+    // duplicate row or re-firing the Quick Response card a second time. Same
+    // convention as beneficiary enrollment's localCaseUuid / closures'
+    // localClosureUuid.
+    localReopenRequestUuid: z.string().trim().min(1).max(80),
     beneficiaryId: z.string().uuid(),
     requestReason: z.enum(['MIGRATION_RETURNED', 'CLOSED_BY_MISTAKE', 'OTHER']),
   })

--- a/apps/closure-reopen-service/src/reopen-requests/lookup.client.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/lookup.client.spec.ts
@@ -1,0 +1,112 @@
+import { LookupClient } from './lookup.client';
+
+describe('LookupClient', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let client: LookupClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    client = new LookupClient();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('resolveApprovalStatusId', () => {
+    it('resolves a known valueCode to its id', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: { categoryCode: 'APPROVAL_STATUS', values: [{ id: 'id-1', valueCode: 'PENDING' }] },
+        }),
+      });
+
+      await expect(client.resolveApprovalStatusId('PENDING', 'Bearer test-token')).resolves.toBe(
+        'id-1',
+      );
+    });
+
+    it('returns null for an unknown valueCode', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { categoryCode: 'APPROVAL_STATUS', values: [] } }),
+      });
+
+      await expect(
+        client.resolveApprovalStatusId('NOT_A_CODE', 'Bearer test-token'),
+      ).resolves.toBeNull();
+    });
+
+    it('returns null on a 404 response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 404 });
+      await expect(
+        client.resolveApprovalStatusId('PENDING', 'Bearer test-token'),
+      ).resolves.toBeNull();
+    });
+
+    it('throws a badGateway error on a network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+      await expect(
+        client.resolveApprovalStatusId('PENDING', 'Bearer test-token'),
+      ).rejects.toMatchObject({ status: 502 });
+    });
+  });
+
+  describe('resolveClosureReasonCode', () => {
+    it('resolves a known lookup_value_id to its valueCode', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {
+            categoryCode: 'CLOSURE_REASON',
+            values: [{ id: 'reason-1', valueCode: 'MIGRATION' }],
+          },
+        }),
+      });
+
+      await expect(client.resolveClosureReasonCode('reason-1', 'Bearer test-token')).resolves.toBe(
+        'MIGRATION',
+      );
+    });
+
+    it('returns null for an unknown lookup_value_id', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { categoryCode: 'CLOSURE_REASON', values: [] } }),
+      });
+
+      await expect(
+        client.resolveClosureReasonCode('unknown-id', 'Bearer test-token'),
+      ).resolves.toBeNull();
+    });
+
+    it('throws HttpError with the upstream status/message on a 4xx response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({ message: 'Authentication required.' }),
+      });
+
+      await expect(
+        client.resolveClosureReasonCode('reason-1', 'Bearer test-token'),
+      ).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('throws a badGateway error on a 5xx response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+      await expect(
+        client.resolveClosureReasonCode('reason-1', 'Bearer test-token'),
+      ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it('throws a badGateway error on a network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+      await expect(
+        client.resolveClosureReasonCode('reason-1', 'Bearer test-token'),
+      ).rejects.toMatchObject({ status: 502 });
+    });
+  });
+});

--- a/apps/closure-reopen-service/src/reopen-requests/lookup.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/lookup.client.ts
@@ -1,5 +1,11 @@
 import { badGateway, HttpError } from '@armman/service-commons';
-import { appConfig } from '../config/app-config';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema (requires DATABASE_URL etc. with no defaults),
+// which process.exit(1)s at module-load time in any test that never
+// otherwise loads config — matches every other HTTP-only client's
+// convention in this repo (e.g. beneficiary.client.ts).
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
 
 interface LookupValue {
   id: string;
@@ -26,7 +32,7 @@ export class LookupClient {
   ): Promise<string | null> {
     let res: Response;
     try {
-      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/lookups/APPROVAL_STATUS`, {
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/lookups/APPROVAL_STATUS`, {
         headers: { Authorization: authorizationHeader },
       });
     } catch {
@@ -44,5 +50,38 @@ export class LookupClient {
 
     const body = (await res.json()) as { data: LookupCategory };
     return body.data.values.find((v) => v.valueCode === valueCode)?.id ?? null;
+  }
+
+  /**
+   * Resolves a CLOSURE_REASON lookup_value_id (client-supplied on
+   * POST /closures) to its own valueCode — used so ClosureService.create()
+   * can derive whether a closure needs supervisor review from the server's
+   * own read of the reason, never from a client-supplied supervisorStatus
+   * (see createClosureSchema — that field no longer exists on the DTO
+   * specifically to close this trust gap).
+   */
+  async resolveClosureReasonCode(
+    lookupValueId: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/lookups/CLOSURE_REASON`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve CLOSURE_REASON — auth-service is unreachable.');
+    }
+
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve CLOSURE_REASON.');
+      }
+      throw badGateway('Unable to resolve CLOSURE_REASON — auth-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: LookupCategory };
+    return body.data.values.find((v) => v.id === lookupValueId)?.valueCode ?? null;
   }
 }

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.controller.ts
@@ -7,6 +7,15 @@ import type { ReopenRequestService } from './reopen-request.service';
  */
 export function createReopenRequestController(service: ReopenRequestService) {
   return {
+    listByBeneficiaryId: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const results = await service.listByBeneficiaryId(
+        req.query.beneficiaryId as string,
+        req.headers.authorization ?? '',
+      );
+      res.json(ok(results));
+    }),
+
     create: asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
       const created = await service.create(req.body, req.user.id, req.headers.authorization ?? '');

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.repository.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.repository.ts
@@ -10,6 +10,32 @@ export class ReopenRequestRepository {
     return this.prisma.reopenRequest.findFirst({ where: { id, isDeleted: false } });
   }
 
+  /**
+   * Finds a reopen request previously created from this exact
+   * client-generated localReopenRequestUuid — lets create() treat a
+   * dropped-connection retry as an idempotent replay instead of a new
+   * reopen request.
+   */
+  findByLocalReopenRequestUuid(localReopenRequestUuid: string) {
+    return this.prisma.reopenRequest.findFirst({
+      where: { localReopenRequestUuid, isDeleted: false },
+    });
+  }
+
+  /**
+   * All reopen requests raised for one beneficiary, most-recent first — lets
+   * the app show "Reopen pending review" (any entry with
+   * supervisorStatus: 'PENDING') instead of just "Closed" while a request is
+   * mid-flow. A beneficiary with no reopen requests returns an empty array,
+   * not an error — most beneficiaries never had one.
+   */
+  findByBeneficiaryId(beneficiaryId: string) {
+    return this.prisma.reopenRequest.findMany({
+      where: { beneficiaryId, isDeleted: false },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
   create(data: CreateReopenRequestInput & { requestedByUserId: string }) {
     return this.prisma.reopenRequest.create({
       data: { ...data, requestedAt: new Date() },

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.routes.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.routes.ts
@@ -18,6 +18,12 @@ const reopenRequestIdParamsSchema = z
   .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
   .strict();
 
+const listByBeneficiaryQuerySchema = z
+  .object({
+    beneficiaryId: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }),
+  })
+  .strict();
+
 const decideReopenRequestRequestSchema = decideReopenRequestSchema.extend({
   decision: decideReopenRequestSchema.shape.decision.openapi({ example: 'APPROVED' }),
 });
@@ -26,6 +32,7 @@ const decideReopenRequestRequestSchema = decideReopenRequestSchema.extend({
 // invented fields — for accurate Swagger documentation only.
 const reopenRequestSchema = z.object({
   id: z.string().uuid(),
+  localReopenRequestUuid: z.string(),
   beneficiaryId: z.string().uuid(),
   requestReason: z.enum(['MIGRATION_RETURNED', 'CLOSED_BY_MISTAKE', 'OTHER']),
   requestedByUserId: z.string().uuid(),
@@ -66,6 +73,39 @@ function envelope<T extends z.ZodTypeAny>(data: T) {
  */
 export function registerReopenRequestRoutes(doc: DocumentedRouter, service: ReopenRequestService) {
   const controller = createReopenRequestController(service);
+
+  doc.get(
+    '/reopen-requests',
+    {
+      summary:
+        "A beneficiary's reopen-request history, most-recent first — lets the app show " +
+        '"Reopen pending review" (any entry with supervisorStatus: \'PENDING\') instead of ' +
+        'just "Closed" while a request is mid-flow, since currentStatus alone stays CLOSED ' +
+        'for the entire pending window. Ownership scoping is delegated to ' +
+        "beneficiary-service's own GET /beneficiaries/:id (SAKHI-own-case / SUPERVISOR-roster " +
+        '/ MANAGER-unrestricted) — a beneficiaryId the caller cannot access 403s/404s the same ' +
+        'way that lookup would.',
+      tags: ['Reopen Requests'],
+      query: listByBeneficiaryQuerySchema,
+      responses: {
+        200: {
+          description: "Beneficiary's reopen requests (empty array if none)",
+          schema: envelope(z.array(reopenRequestSchema)),
+        },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: {
+          description: 'Caller role not permitted, or outside their own roster/case',
+          schema: apiErrorSchema,
+        },
+        404: { description: 'Beneficiary not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    validate(listByBeneficiaryQuerySchema, 'query'),
+    controller.listByBeneficiaryId,
+  );
 
   doc.post(
     '/reopen-requests',

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -11,6 +11,7 @@ import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 function reopenRequest(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     id: '11111111-1111-1111-1111-111111111111',
+    localReopenRequestUuid: 'device-abc-reopen-001',
     beneficiaryId: '22222222-2222-2222-2222-222222222222',
     requestReason: 'CLOSED_BY_MISTAKE' as const,
     requestedByUserId: '33333333-3333-3333-3333-333333333333',
@@ -33,6 +34,8 @@ function reopenRequest(overrides: Partial<Record<string, unknown>> = {}) {
 describe('ReopenRequestService', () => {
   const repository = {
     findById: jest.fn(),
+    findByBeneficiaryId: jest.fn(),
+    findByLocalReopenRequestUuid: jest.fn(),
     decide: jest.fn(),
     create: jest.fn(),
   } as unknown as jest.Mocked<ReopenRequestRepository>;
@@ -44,6 +47,7 @@ describe('ReopenRequestService', () => {
   } as unknown as jest.Mocked<LookupClient>;
   const beneficiaryClient = {
     reactivateCase: jest.fn(),
+    getById: jest.fn(),
   } as unknown as jest.Mocked<BeneficiaryClient>;
   let service: ReopenRequestService;
   const supervisorId = '44444444-4444-4444-4444-444444444444';
@@ -53,6 +57,7 @@ describe('ReopenRequestService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    repository.findByLocalReopenRequestUuid.mockResolvedValue(null);
     beneficiaryClient.reactivateCase.mockResolvedValue({
       id: '22222222-2222-2222-2222-222222222222',
       currentStatus: 'ACTIVE',
@@ -71,12 +76,100 @@ describe('ReopenRequestService', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  describe('listByBeneficiaryId', () => {
+    const beneficiaryId = '22222222-2222-2222-2222-222222222222';
+
+    it('returns the reopen requests when the beneficiary lookup succeeds', async () => {
+      beneficiaryClient.getById.mockResolvedValue({ id: beneficiaryId, currentStatus: 'CLOSED' });
+      const rows = [reopenRequest()];
+      repository.findByBeneficiaryId.mockResolvedValue(rows);
+
+      await expect(service.listByBeneficiaryId(beneficiaryId, authHeader)).resolves.toBe(rows);
+      expect(repository.findByBeneficiaryId).toHaveBeenCalledWith(beneficiaryId);
+    });
+
+    it('returns an empty array when the beneficiary has no reopen requests', async () => {
+      beneficiaryClient.getById.mockResolvedValue({ id: beneficiaryId, currentStatus: 'CLOSED' });
+      repository.findByBeneficiaryId.mockResolvedValue([]);
+
+      await expect(service.listByBeneficiaryId(beneficiaryId, authHeader)).resolves.toEqual([]);
+    });
+
+    it('propagates a 403 from the beneficiary lookup without querying reopen requests', async () => {
+      beneficiaryClient.getById.mockRejectedValue(
+        Object.assign(new Error('This beneficiary case is outside your own roster.'), {
+          status: 403,
+        }),
+      );
+
+      await expect(service.listByBeneficiaryId(beneficiaryId, authHeader)).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(repository.findByBeneficiaryId).not.toHaveBeenCalled();
+    });
+
+    it('propagates a 404 from the beneficiary lookup without querying reopen requests', async () => {
+      beneficiaryClient.getById.mockRejectedValue(
+        Object.assign(new Error('Beneficiary case not found.'), { status: 404 }),
+      );
+
+      await expect(service.listByBeneficiaryId(beneficiaryId, authHeader)).rejects.toMatchObject({
+        status: 404,
+      });
+      expect(repository.findByBeneficiaryId).not.toHaveBeenCalled();
+    });
+
+    it('propagates a badGateway error when the beneficiary lookup is unreachable', async () => {
+      beneficiaryClient.getById.mockRejectedValue(
+        Object.assign(new Error('Unable to resolve the beneficiary — unreachable.'), {
+          status: 502,
+        }),
+      );
+
+      await expect(service.listByBeneficiaryId(beneficiaryId, authHeader)).rejects.toMatchObject({
+        status: 502,
+      });
+      expect(repository.findByBeneficiaryId).not.toHaveBeenCalled();
+    });
+  });
+
   describe('create', () => {
     const sakhiId = '55555555-5555-5555-5555-555555555555';
     const dto: CreateReopenRequestInput = {
+      localReopenRequestUuid: 'device-abc-reopen-001',
       beneficiaryId: '22222222-2222-2222-2222-222222222222',
       requestReason: 'CLOSED_BY_MISTAKE',
     };
+
+    describe('idempotent replay via localReopenRequestUuid', () => {
+      it('returns the existing reopen request without creating a new row on a retried submission', async () => {
+        const existing = reopenRequest();
+        repository.findByLocalReopenRequestUuid.mockResolvedValue(existing);
+
+        await expect(service.create(dto, sakhiId, authHeader)).resolves.toBe(existing);
+        expect(repository.create).not.toHaveBeenCalled();
+      });
+
+      it('does not re-raise a Quick Response card on a retried submission', async () => {
+        const existing = reopenRequest();
+        repository.findByLocalReopenRequestUuid.mockResolvedValue(existing);
+
+        await service.create(dto, sakhiId, authHeader);
+
+        expect(approvalClient.create).not.toHaveBeenCalled();
+      });
+
+      it("looks up by this submission's own localReopenRequestUuid", async () => {
+        repository.create.mockResolvedValue(reopenRequest());
+        lookupClient.resolveApprovalStatusId.mockResolvedValue('pending-lookup-id');
+
+        await service.create(dto, sakhiId, authHeader);
+
+        expect(repository.findByLocalReopenRequestUuid).toHaveBeenCalledWith(
+          dto.localReopenRequestUuid,
+        );
+      });
+    });
 
     it('creates via repository with requestedByUserId stamped from the caller', async () => {
       const created = reopenRequest({ requestedByUserId: sakhiId });

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -20,17 +20,44 @@ export class ReopenRequestService {
   ) {}
 
   /**
+   * All reopen requests for one beneficiary, most-recent first — for the
+   * app's "Reopen pending review" state (any entry with
+   * supervisorStatus: 'PENDING'), which currentStatus alone can't show since
+   * a beneficiary stays CLOSED for the entire time a reopen request is
+   * pending, only flipping to ACTIVE on approval.
+   *
+   * Delegates ownership scoping to beneficiary-service's own
+   * GET /beneficiaries/:id (SAKHI-own-case / SUPERVISOR-roster /
+   * MANAGER-unrestricted) rather than duplicating that IDOR check here —
+   * this service owns no sakhiId data of its own. A 403/404 from that call
+   * propagates as-is; only on success does this query reopen_requests.
+   */
+  async listByBeneficiaryId(beneficiaryId: string, authorizationHeader: string) {
+    await this.beneficiaryClient.getById(beneficiaryId, authorizationHeader);
+    return this.repository.findByBeneficiaryId(beneficiaryId);
+  }
+
+  /**
    * Raises a Sakhi's reopen request (FR-S-10.3) and, on success, raises the
    * matching REOPEN Quick Response card in approval-service. The reopen
    * request is the source of truth — a failure raising the card is logged
    * and tolerated rather than failing an already-successful submission
    * (same tolerance the decide() audit/notification calls use).
+   *
+   * Idempotent replay: a dropped-connection retry resubmits the same
+   * client-generated localReopenRequestUuid. Return the original request
+   * unchanged instead of creating a duplicate row or re-firing the Quick
+   * Response card a second time — this mobile flow is offline-first and
+   * expected to retry, same as closures' localClosureUuid.
    */
   async create(
     dto: CreateReopenRequestInput,
     requestedByUserId: string,
     authorizationHeader: string,
   ) {
+    const existing = await this.repository.findByLocalReopenRequestUuid(dto.localReopenRequestUuid);
+    if (existing) return existing;
+
     const created = await this.repository.create({ ...dto, requestedByUserId });
 
     try {

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -8,6 +8,16 @@ import type { BeneficiaryClient } from './beneficiary.client';
 import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
+/** Narrows a caught Prisma error to a unique-constraint violation (P2002). */
+function isUniqueConstraintViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'P2002'
+  );
+}
+
 /** Reopen request domain logic. Data access is delegated to the repository. */
 export class ReopenRequestService {
   constructor(
@@ -49,6 +59,12 @@ export class ReopenRequestService {
    * unchanged instead of creating a duplicate row or re-firing the Quick
    * Response card a second time — this mobile flow is offline-first and
    * expected to retry, same as closures' localClosureUuid.
+   *
+   * A concurrent retry racing on the same localReopenRequestUuid (two near-
+   * simultaneous requests both passing the findByLocalReopenRequestUuid
+   * check as null) hits the column's own unique constraint on create() —
+   * caught here and turned into the same idempotent-replay result as a
+   * sequential retry, rather than a raw 500.
    */
   async create(
     dto: CreateReopenRequestInput,
@@ -58,7 +74,18 @@ export class ReopenRequestService {
     const existing = await this.repository.findByLocalReopenRequestUuid(dto.localReopenRequestUuid);
     if (existing) return existing;
 
-    const created = await this.repository.create({ ...dto, requestedByUserId });
+    let created;
+    try {
+      created = await this.repository.create({ ...dto, requestedByUserId });
+    } catch (err) {
+      if (isUniqueConstraintViolation(err)) {
+        const winner = await this.repository.findByLocalReopenRequestUuid(
+          dto.localReopenRequestUuid,
+        );
+        if (winner) return winner;
+      }
+      throw err;
+    }
 
     try {
       const decisionStatusLookupId = await this.lookupClient.resolveApprovalStatusId(

--- a/apps/visit-form-service/prisma/seed-data/anc-closure-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/anc-closure-visit.json
@@ -1,0 +1,159 @@
+{
+  "schemaJson": [
+    {
+      "label": "Closure visit date",
+      "section": "Closure",
+      "required": true,
+      "input_type": "date",
+      "question_code": "closure_visit_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Do you want to continue with the beneficiary closure?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "continue_with_closure"
+    },
+    {
+      "label": "If yes, Why do you want to close/deactivate this beneficiary?",
+      "options": [
+        {
+          "label": "Withdrawal of consent",
+          "sort_order": 0,
+          "value_code": "withdrawal_of_consent"
+        },
+        { "label": "Miscarriage", "sort_order": 1, "value_code": "miscarriage" },
+        {
+          "label": "Abortion/Spontaneous Abortion/Induced Abortion/MTP",
+          "sort_order": 2,
+          "value_code": "abortion_spontaneous_induced_mtp"
+        },
+        { "label": "Migration", "sort_order": 3, "value_code": "migration" },
+        {
+          "label": "Program cycle completed",
+          "sort_order": 4,
+          "value_code": "program_cycle_completed"
+        },
+        { "label": "Maternal Death", "sort_order": 5, "value_code": "maternal_death" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "closure_reason",
+      "visibleWhen": { "field": "continue_with_closure", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Date of event",
+      "section": "Closure",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_event",
+      "dateRule": { "notFuture": true },
+      "visibleWhen": { "field": "continue_with_closure", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If Maternal death, time of death",
+      "section": "Closure",
+      "required": true,
+      "input_type": "time",
+      "question_code": "maternal_death_time",
+      "visibleWhen": { "field": "closure_reason", "operator": "eq", "value": "maternal_death" }
+    },
+    {
+      "label": "If Maternal death, cause of death",
+      "options": [
+        { "label": "Haemorrhage", "sort_order": 0, "value_code": "haemorrhage" },
+        {
+          "label": "Hypertensive disorders of pregnancy (including eclampsia)",
+          "sort_order": 1,
+          "value_code": "hypertensive_disorders_including_eclampsia"
+        },
+        {
+          "label": "Sepsis / pregnancy-related infections",
+          "sort_order": 2,
+          "value_code": "sepsis_pregnancy_related_infections"
+        },
+        {
+          "label": "Obstructed or prolonged labour",
+          "sort_order": 3,
+          "value_code": "obstructed_or_prolonged_labour"
+        },
+        {
+          "label": "Complications of unsafe abortion",
+          "sort_order": 4,
+          "value_code": "complications_of_unsafe_abortion"
+        },
+        {
+          "label": "Medical disorders complicating pregnancy (cardiac, renal, respiratory)",
+          "sort_order": 5,
+          "value_code": "medical_disorders_complicating_pregnancy"
+        },
+        {
+          "label": "Anaemia (as contributing factor)",
+          "sort_order": 6,
+          "value_code": "anaemia_contributing_factor"
+        },
+        { "label": "Tuberculosis", "sort_order": 7, "value_code": "tuberculosis" },
+        {
+          "label": "Delay in reaching the health centre",
+          "sort_order": 8,
+          "value_code": "delay_reaching_health_centre"
+        },
+        {
+          "label": "Delay in provision of services at the health centre",
+          "sort_order": 9,
+          "value_code": "delay_in_services_at_health_centre"
+        },
+        { "label": "Accidental/Suicide", "sort_order": 10, "value_code": "accidental_suicide" },
+        { "label": "Other (specify)", "sort_order": 11, "value_code": "other" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "maternal_death_cause",
+      "visibleWhen": { "field": "closure_reason", "operator": "eq", "value": "maternal_death" }
+    },
+    {
+      "label": "If other, specify",
+      "section": "Closure",
+      "required": true,
+      "input_type": "text",
+      "question_code": "maternal_death_cause_other_specify",
+      "visibleWhen": { "field": "maternal_death_cause", "operator": "contains", "value": "other" }
+    },
+    {
+      "label": "If Maternal death, place of death",
+      "options": [
+        { "label": "Home", "sort_order": 0, "value_code": "home" },
+        { "label": "Health facility", "sort_order": 1, "value_code": "health_facility" },
+        { "label": "Other", "sort_order": 2, "value_code": "other" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "maternal_death_place",
+      "visibleWhen": { "field": "closure_reason", "operator": "eq", "value": "maternal_death" }
+    },
+    {
+      "label": "Remarks",
+      "section": "Closure",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    }
+  ],
+  "validationJson": [
+    {
+      "rule": "REQUIRED_IF_SELECTED",
+      "field": "maternal_death_cause",
+      "optionFieldMap": {
+        "other": "maternal_death_cause_other_specify"
+      }
+    }
+  ]
+}

--- a/apps/visit-form-service/prisma/seed-data/beneficiary-reopen-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/beneficiary-reopen-visit.json
@@ -1,0 +1,36 @@
+{
+  "schemaJson": [
+    {
+      "label": "Date of request",
+      "section": "Reopen",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_request",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Do you want to reopen this case?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Reopen",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "want_to_reopen"
+    },
+    {
+      "label": "Reason for reopening",
+      "options": [
+        { "label": "Migrated back", "sort_order": 0, "value_code": "migrated_back" },
+        { "label": "Closed by mistake", "sort_order": 1, "value_code": "closed_by_mistake" }
+      ],
+      "section": "Reopen",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "reopen_reason",
+      "visibleWhen": { "field": "want_to_reopen", "operator": "eq", "value": "yes" }
+    }
+  ],
+  "validationJson": []
+}

--- a/apps/visit-form-service/prisma/seed-data/child-closure-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/child-closure-visit.json
@@ -1,0 +1,130 @@
+{
+  "schemaJson": [
+    {
+      "label": "Closure visit date",
+      "section": "Closure",
+      "required": true,
+      "input_type": "date",
+      "question_code": "closure_visit_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Do you want to continue with the beneficiary closure?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "continue_with_closure"
+    },
+    {
+      "label": "If yes, Why do you want to close/deactivate this beneficiary?",
+      "options": [
+        {
+          "label": "Withdrawal of consent",
+          "sort_order": 0,
+          "value_code": "withdrawal_of_consent"
+        },
+        { "label": "Migration", "sort_order": 1, "value_code": "migration" },
+        {
+          "label": "Program cycle completed",
+          "sort_order": 2,
+          "value_code": "program_cycle_completed"
+        },
+        { "label": "Infant/Child death", "sort_order": 3, "value_code": "infant_child_death" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "closure_reason",
+      "visibleWhen": { "field": "continue_with_closure", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Date of event",
+      "section": "Closure",
+      "required": true,
+      "input_type": "date",
+      "question_code": "date_of_event",
+      "dateRule": { "notFuture": true },
+      "visibleWhen": { "field": "continue_with_closure", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If infant death, time of death",
+      "section": "Closure",
+      "required": true,
+      "input_type": "time",
+      "question_code": "infant_death_time",
+      "visibleWhen": { "field": "closure_reason", "operator": "eq", "value": "infant_child_death" }
+    },
+    {
+      "label": "If infant death, cause of death",
+      "options": [
+        { "label": "Infections", "sort_order": 0, "value_code": "infections" },
+        { "label": "Diarrhea", "sort_order": 1, "value_code": "diarrhea" },
+        { "label": "Dehydration", "sort_order": 2, "value_code": "dehydration" },
+        {
+          "label": "Malnourished Children (Grade 3 and 4)",
+          "sort_order": 3,
+          "value_code": "malnourished_grade_3_4"
+        },
+        { "label": "Congenital defects", "sort_order": 4, "value_code": "congenital_defects" },
+        { "label": "Accidental", "sort_order": 5, "value_code": "accidental" },
+        {
+          "label": "Delay in reaching the health centre",
+          "sort_order": 6,
+          "value_code": "delay_reaching_health_centre"
+        },
+        {
+          "label": "Delay in provision of services at the health centre",
+          "sort_order": 7,
+          "value_code": "delay_in_services_at_health_centre"
+        },
+        { "label": "Other (specify)", "sort_order": 8, "value_code": "other" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "infant_death_cause",
+      "visibleWhen": { "field": "closure_reason", "operator": "eq", "value": "infant_child_death" }
+    },
+    {
+      "label": "If other, specify",
+      "section": "Closure",
+      "required": true,
+      "input_type": "text",
+      "question_code": "infant_death_cause_other_specify",
+      "visibleWhen": { "field": "infant_death_cause", "operator": "contains", "value": "other" }
+    },
+    {
+      "label": "If infant death, place of death",
+      "options": [
+        { "label": "Home", "sort_order": 0, "value_code": "home" },
+        { "label": "Health facility", "sort_order": 1, "value_code": "health_facility" },
+        { "label": "Other", "sort_order": 2, "value_code": "other" }
+      ],
+      "section": "Closure",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "infant_death_place",
+      "visibleWhen": { "field": "closure_reason", "operator": "eq", "value": "infant_child_death" }
+    },
+    {
+      "label": "Remark",
+      "section": "Closure",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    }
+  ],
+  "validationJson": [
+    {
+      "rule": "REQUIRED_IF_SELECTED",
+      "field": "infant_death_cause",
+      "optionFieldMap": {
+        "other": "infant_death_cause_other_specify"
+      }
+    }
+  ]
+}

--- a/apps/visit-form-service/prisma/seed-data/referral-followup-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/referral-followup-visit.json
@@ -1,0 +1,391 @@
+{
+  "schemaJson": [
+    {
+      "label": "Date of the form filled",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "date",
+      "question_code": "form_filled_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Referral visit name",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "text",
+      "question_code": "referral_visit_name"
+    },
+    {
+      "label": "Referral followup visit name",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "text",
+      "question_code": "referral_followup_visit_name"
+    },
+    {
+      "label": "How is the information collected?",
+      "options": [
+        { "label": "On call", "sort_order": 0, "value_code": "on_call" },
+        { "label": "In person", "sort_order": 1, "value_code": "in_person" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "information_collection_mode"
+    },
+    {
+      "label": "Did beneficiary visit any health facility?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "visited_health_facility"
+    },
+    {
+      "label": "If No, mention reason",
+      "options": [
+        {
+          "label": "Belief that the condition is not serious enough to require referral",
+          "sort_order": 0,
+          "value_code": "condition_not_serious_enough"
+        },
+        {
+          "label": "Family opposition to visit health facility",
+          "sort_order": 1,
+          "value_code": "family_opposition"
+        },
+        {
+          "label": "Cost of transportation to the facility",
+          "sort_order": 2,
+          "value_code": "cost_of_transportation"
+        },
+        {
+          "label": "Fear of unnecessary procedures and cost of treatment",
+          "sort_order": 3,
+          "value_code": "fear_of_procedures_and_cost"
+        },
+        {
+          "label": "Preference for home remedies or traditional healers",
+          "sort_order": 4,
+          "value_code": "preference_for_home_remedies"
+        },
+        {
+          "label": "Cultural norms restricting women's mobility",
+          "sort_order": 5,
+          "value_code": "cultural_norms_restricting_mobility"
+        },
+        { "label": "Woman migrating", "sort_order": 6, "value_code": "woman_migrating" },
+        { "label": "Other", "sort_order": 7, "value_code": "other" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "not_visited_reason",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "If No, do you want to accompany the beneficiary for the visit?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "accompany_for_new_referral",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "no" }
+    },
+    {
+      "label": "Type of the first health facility beneficiary visited for the referral",
+      "options": [
+        { "label": "SC", "sort_order": 0, "value_code": "sc" },
+        { "label": "PHC", "sort_order": 1, "value_code": "phc" },
+        { "label": "RH", "sort_order": 2, "value_code": "rh" },
+        { "label": "SDH", "sort_order": 3, "value_code": "sdh" },
+        { "label": "DH", "sort_order": 4, "value_code": "dh" },
+        { "label": "Private clinic", "sort_order": 5, "value_code": "private_clinic" },
+        { "label": "NGO", "sort_order": 6, "value_code": "ngo" },
+        { "label": "Anganwadi Center", "sort_order": 7, "value_code": "anganwadi_center" },
+        { "label": "Private laboratory", "sort_order": 8, "value_code": "private_laboratory" },
+        { "label": "Private hospital", "sort_order": 9, "value_code": "private_hospital" },
+        { "label": "Other", "sort_order": 10, "value_code": "other" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "first_facility_type",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Name of the first health facility beneficiary visited for the referral",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "text",
+      "question_code": "first_facility_name",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Date when the beneficiary visited the first health facility?",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "date",
+      "question_code": "first_facility_visit_date",
+      "dateRule": { "notFuture": true },
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Did beneficiary visit multiple health facilities?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "visited_multiple_facilities",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If yes, number of health centers visited",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "number",
+      "question_code": "number_of_facilities_visited",
+      "numericRange": { "min": 1, "max": 9 },
+      "visibleWhen": { "field": "visited_multiple_facilities", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If yes, Type of the LAST health facility beneficiary visited for the referral",
+      "options": [
+        { "label": "SC", "sort_order": 0, "value_code": "sc" },
+        { "label": "PHC", "sort_order": 1, "value_code": "phc" },
+        { "label": "RH", "sort_order": 2, "value_code": "rh" },
+        { "label": "SDH", "sort_order": 3, "value_code": "sdh" },
+        { "label": "DH", "sort_order": 4, "value_code": "dh" },
+        { "label": "Private clinic", "sort_order": 5, "value_code": "private_clinic" },
+        { "label": "NGO", "sort_order": 6, "value_code": "ngo" },
+        { "label": "Anganwadi Center", "sort_order": 7, "value_code": "anganwadi_center" },
+        { "label": "Private laboratory", "sort_order": 8, "value_code": "private_laboratory" },
+        { "label": "Private hospital", "sort_order": 9, "value_code": "private_hospital" },
+        { "label": "Other", "sort_order": 10, "value_code": "other" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "last_facility_type",
+      "visibleWhen": { "field": "visited_multiple_facilities", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Name of the LAST health facility beneficiary visited for the referral",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "text",
+      "question_code": "last_facility_name",
+      "visibleWhen": { "field": "visited_multiple_facilities", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Date when the beneficiary visited the LAST referred center?",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "date",
+      "question_code": "last_facility_visit_date",
+      "dateRule": { "notFuture": true, "notBefore": { "field": "first_facility_visit_date" } },
+      "visibleWhen": { "field": "visited_multiple_facilities", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "What was the final outcome of this referral?",
+      "options": [
+        {
+          "label": "IPD: Still Hospitalized for management",
+          "sort_order": 0,
+          "value_code": "ipd_still_hospitalized"
+        },
+        { "label": "IPD: Delivered", "sort_order": 1, "value_code": "ipd_delivered" },
+        {
+          "label": "IPD: Discharged with management",
+          "sort_order": 2,
+          "value_code": "ipd_discharged_with_management"
+        },
+        {
+          "label": "OPD and given medications",
+          "sort_order": 3,
+          "value_code": "opd_given_medications"
+        },
+        {
+          "label": "Further referral advised",
+          "sort_order": 4,
+          "value_code": "further_referral_advised"
+        },
+        {
+          "label": "Addressed as no high risk and sent back",
+          "sort_order": 5,
+          "value_code": "addressed_no_high_risk_sent_back"
+        },
+        { "label": "Health center closed", "sort_order": 6, "value_code": "health_center_closed" },
+        {
+          "label": "No staff available at the health centre",
+          "sort_order": 7,
+          "value_code": "no_staff_available"
+        }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "referral_final_outcome",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Was diagnosis confirmed?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "diagnosis_confirmed",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Was treatment given?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "treatment_given",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If yes, what type of treatment was provided for the HR condition",
+      "options": [
+        { "label": "Injection", "sort_order": 0, "value_code": "injection" },
+        { "label": "Tablet", "sort_order": 1, "value_code": "tablet" },
+        {
+          "label": "Iron sucrose injection",
+          "sort_order": 2,
+          "value_code": "iron_sucrose_injection"
+        },
+        { "label": "Saline injection", "sort_order": 3, "value_code": "saline_injection" },
+        { "label": "Syrup", "sort_order": 4, "value_code": "syrup" },
+        { "label": "Blood transfusion", "sort_order": 5, "value_code": "blood_transfusion" },
+        {
+          "label": "Supplementary feeding to the Mother (shatavari/protein/multivitamin etc.)",
+          "sort_order": 6,
+          "value_code": "supplementary_feeding_mother"
+        },
+        {
+          "label": "Supplementary feeding to the Child (formula milk, etc.)",
+          "sort_order": 7,
+          "value_code": "supplementary_feeding_child"
+        },
+        {
+          "label": "Further investigations advised",
+          "sort_order": 8,
+          "value_code": "further_investigations_advised"
+        },
+        { "label": "Other", "sort_order": 9, "value_code": "other" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "multiselect",
+      "question_code": "treatment_type",
+      "visibleWhen": { "field": "treatment_given", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Clinical status of beneficiary now?",
+      "options": [
+        { "label": "Resolved", "sort_order": 0, "value_code": "resolved" },
+        { "label": "Improving", "sort_order": 1, "value_code": "improving" },
+        { "label": "Same", "sort_order": 2, "value_code": "same" },
+        { "label": "Worsened", "sort_order": 3, "value_code": "worsened" }
+      ],
+      "section": "Referral Follow-up",
+      "required": false,
+      "input_type": "dropdown",
+      "question_code": "clinical_status_now"
+    },
+    {
+      "label": "Photo of case paper/discharge summary, health facility, and Sakhi photo with the beneficiary",
+      "section": "Referral Follow-up",
+      "required": false,
+      "input_type": "image",
+      "question_code": "case_paper_photo"
+    },
+    {
+      "label": "Is there any further referral/investigation advised and pending?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "further_referral_pending",
+      "visibleWhen": { "field": "visited_health_facility", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If yes, Photo of further investigation advised",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "image",
+      "question_code": "further_investigation_photo",
+      "visibleWhen": { "field": "further_referral_pending", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Date when beneficiary planning to visit further referral center",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "date",
+      "question_code": "further_referral_planned_date",
+      "visibleWhen": { "field": "further_referral_pending", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Place of further referral",
+      "options": [
+        { "label": "SC", "sort_order": 0, "value_code": "sc" },
+        { "label": "PHC", "sort_order": 1, "value_code": "phc" },
+        { "label": "RH", "sort_order": 2, "value_code": "rh" },
+        { "label": "SDH", "sort_order": 3, "value_code": "sdh" },
+        { "label": "DH", "sort_order": 4, "value_code": "dh" },
+        { "label": "Private clinic", "sort_order": 5, "value_code": "private_clinic" },
+        { "label": "NGO", "sort_order": 6, "value_code": "ngo" },
+        { "label": "Anganwadi Center", "sort_order": 7, "value_code": "anganwadi_center" },
+        { "label": "Private laboratory", "sort_order": 8, "value_code": "private_laboratory" },
+        { "label": "Private hospital", "sort_order": 9, "value_code": "private_hospital" },
+        { "label": "Other", "sort_order": 10, "value_code": "other" }
+      ],
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "further_referral_place",
+      "visibleWhen": { "field": "further_referral_pending", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Name of further referral",
+      "section": "Referral Follow-up",
+      "required": true,
+      "input_type": "text",
+      "question_code": "further_referral_name",
+      "visibleWhen": { "field": "further_referral_pending", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "Remarks",
+      "section": "Referral Follow-up",
+      "required": false,
+      "input_type": "text",
+      "question_code": "remarks"
+    }
+  ],
+  "validationJson": [
+    {
+      "rule": "ANY_OF_REQUIRED",
+      "fields": ["first_facility_type", "not_visited_reason"]
+    }
+  ]
+}

--- a/apps/visit-form-service/prisma/seed-data/referral-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/referral-visit.json
@@ -1,0 +1,162 @@
+{
+  "schemaJson": [
+    {
+      "label": "Referral visit form filled date",
+      "section": "Referral",
+      "required": true,
+      "input_type": "date",
+      "question_code": "referral_form_filled_date",
+      "dateRule": { "notFuture": true }
+    },
+    {
+      "label": "Visit name",
+      "section": "Referral",
+      "required": true,
+      "input_type": "text",
+      "question_code": "visit_name"
+    },
+    {
+      "label": "Referral visit name",
+      "section": "Referral",
+      "required": true,
+      "input_type": "text",
+      "question_code": "referral_visit_name"
+    },
+    {
+      "label": "Referral needed as this is a new condition",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "referral_needed_new_condition"
+    },
+    {
+      "label": "Is beneficiary willing to go for the referral?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "beneficiary_willing_for_referral",
+      "visibleWhen": { "field": "referral_needed_new_condition", "operator": "eq", "value": "yes" }
+    },
+    {
+      "label": "If No, state reasons",
+      "options": [
+        {
+          "label": "Belief that the condition is not serious enough to require referral",
+          "sort_order": 0,
+          "value_code": "condition_not_serious_enough"
+        },
+        {
+          "label": "Family opposition to visit health facility",
+          "sort_order": 1,
+          "value_code": "family_opposition"
+        },
+        { "label": "Woman migrating", "sort_order": 2, "value_code": "woman_migrating" },
+        {
+          "label": "Cost of transportation to the facility",
+          "sort_order": 3,
+          "value_code": "cost_of_transportation"
+        },
+        {
+          "label": "Fear of unnecessary procedures and cost of treatment",
+          "sort_order": 4,
+          "value_code": "fear_of_procedures_and_cost"
+        },
+        {
+          "label": "Preference for home remedies or traditional healers",
+          "sort_order": 5,
+          "value_code": "preference_for_home_remedies"
+        },
+        {
+          "label": "Cultural norms restricting women's mobility",
+          "sort_order": 6,
+          "value_code": "cultural_norms_restricting_mobility"
+        },
+        { "label": "Other", "sort_order": 7, "value_code": "other" }
+      ],
+      "section": "Referral",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "referral_declined_reason",
+      "visibleWhen": {
+        "field": "beneficiary_willing_for_referral",
+        "operator": "eq",
+        "value": "no"
+      }
+    },
+    {
+      "label": "Is this an accompanied referral?",
+      "options": [
+        { "label": "Yes", "sort_order": 0, "value_code": "yes" },
+        { "label": "No", "sort_order": 1, "value_code": "no" }
+      ],
+      "section": "Referral",
+      "required": true,
+      "input_type": "radio",
+      "question_code": "is_accompanied_referral",
+      "visibleWhen": {
+        "field": "beneficiary_willing_for_referral",
+        "operator": "eq",
+        "value": "yes"
+      }
+    },
+    {
+      "label": "Decided date for visit to health facility",
+      "section": "Referral",
+      "required": true,
+      "input_type": "date",
+      "question_code": "decided_visit_date",
+      "dateRule": { "notBefore": { "field": "referral_form_filled_date" } },
+      "visibleWhen": {
+        "field": "beneficiary_willing_for_referral",
+        "operator": "eq",
+        "value": "yes"
+      }
+    },
+    {
+      "label": "Place of referral",
+      "options": [
+        { "label": "SC", "sort_order": 0, "value_code": "sc" },
+        { "label": "PHC", "sort_order": 1, "value_code": "phc" },
+        { "label": "RH", "sort_order": 2, "value_code": "rh" },
+        { "label": "SDH", "sort_order": 3, "value_code": "sdh" },
+        { "label": "DH", "sort_order": 4, "value_code": "dh" },
+        { "label": "Private clinic", "sort_order": 5, "value_code": "private_clinic" },
+        { "label": "NGO", "sort_order": 6, "value_code": "ngo" },
+        { "label": "Anganwadi Center", "sort_order": 7, "value_code": "anganwadi_center" },
+        { "label": "Private laboratory", "sort_order": 8, "value_code": "private_laboratory" },
+        { "label": "Private hospital", "sort_order": 9, "value_code": "private_hospital" },
+        { "label": "Other", "sort_order": 10, "value_code": "other" }
+      ],
+      "section": "Referral",
+      "required": true,
+      "input_type": "dropdown",
+      "question_code": "place_of_referral",
+      "visibleWhen": {
+        "field": "beneficiary_willing_for_referral",
+        "operator": "eq",
+        "value": "yes"
+      }
+    },
+    {
+      "label": "Name of the health facility",
+      "section": "Referral",
+      "required": true,
+      "input_type": "text",
+      "question_code": "health_facility_name",
+      "visibleWhen": {
+        "field": "beneficiary_willing_for_referral",
+        "operator": "eq",
+        "value": "yes"
+      }
+    }
+  ],
+  "validationJson": []
+}

--- a/apps/visit-form-service/prisma/seed.ts
+++ b/apps/visit-form-service/prisma/seed.ts
@@ -7,6 +7,11 @@ import infantVisitPayload from './seed-data/infant-visit.json';
 import deliveryVisitPayload from './seed-data/delivery-visit.json';
 import postpartumVisitPayload from './seed-data/postpartum-visit.json';
 import neonatalVisitPayload from './seed-data/neonatal-visit.json';
+import referralVisitPayload from './seed-data/referral-visit.json';
+import referralFollowupVisitPayload from './seed-data/referral-followup-visit.json';
+import ancClosureVisitPayload from './seed-data/anc-closure-visit.json';
+import childClosureVisitPayload from './seed-data/child-closure-visit.json';
+import beneficiaryReopenVisitPayload from './seed-data/beneficiary-reopen-visit.json';
 
 const prisma = new PrismaClient();
 
@@ -19,7 +24,7 @@ interface SeedResult {
 interface FormDraft {
   formCode: string;
   formName: string;
-  entityType: 'MOTHER' | 'CHILD';
+  entityType: 'MOTHER' | 'CHILD' | 'REFERRAL' | 'SYSTEM';
   versionNo: string;
   payload: { schemaJson: unknown[]; validationJson: unknown[] };
 }
@@ -118,6 +123,54 @@ const FORMS: FormDraft[] = [
     entityType: 'CHILD',
     versionNo: 'v1',
     payload: neonatalVisitPayload,
+  },
+  // Referral, closure, and reopen workflow forms — transcribed field-for-field
+  // from docs/Revised_App_Form_Final_20.3.26.xlsx.md ("Referral form",
+  // "ANC Closure form _D", "Child Closure form", "Beneficiary reopen form").
+  // Not triggered by a VisitSchedule/VisitCodeType today (same as
+  // MOTHER_REGISTRATION/CHILD_REGISTRATION) — the app calls
+  // GET /forms/:formCode/active-version directly by these codes.
+  {
+    formCode: 'REFERRAL_VISIT',
+    formName: 'Referral',
+    entityType: 'REFERRAL',
+    versionNo: 'v1',
+    payload: referralVisitPayload,
+  },
+  // Distinct form code from REFERRAL_VISIT — SRS treats the initial referral
+  // and its 7-day follow-up as separate entities with separate linelists
+  // (Referral Linelist vs. Referral Follow-up Linelist), not one form with a
+  // mode flag.
+  {
+    formCode: 'REFERRAL_FOLLOWUP_VISIT',
+    formName: 'Referral Follow-up',
+    entityType: 'REFERRAL',
+    versionNo: 'v1',
+    payload: referralFollowupVisitPayload,
+  },
+  {
+    formCode: 'ANC_CLOSURE_VISIT',
+    formName: 'ANC Closure',
+    entityType: 'MOTHER',
+    versionNo: 'v1',
+    payload: ancClosureVisitPayload,
+  },
+  {
+    formCode: 'CHILD_CLOSURE_VISIT',
+    formName: 'Child Closure',
+    entityType: 'CHILD',
+    versionNo: 'v1',
+    payload: childClosureVisitPayload,
+  },
+  // Not MOTHER- or CHILD-specific — a reopen request can target either a
+  // closed ANC or a closed child case, so this uses SYSTEM rather than
+  // defaulting to one entity.
+  {
+    formCode: 'BENEFICIARY_REOPEN_VISIT',
+    formName: 'Beneficiary Reopen',
+    entityType: 'SYSTEM',
+    versionNo: 'v1',
+    payload: beneficiaryReopenVisitPayload,
   },
 ];
 

--- a/apps/visit-form-service/src/beneficiaries/create-child.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/create-child.client.spec.ts
@@ -35,7 +35,11 @@ describe('createChildBeneficiary', () => {
   });
 
   it("POSTs a CHILD case to beneficiary-service with the mother's project/lookup context", async () => {
-    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { id: 'child-1' } }),
+    });
 
     await createChildBeneficiary(
       {
@@ -80,8 +84,32 @@ describe('createChildBeneficiary', () => {
     );
   });
 
+  it('returns the created case id', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { id: 'child-42' } }),
+    });
+
+    const id = await createChildBeneficiary(
+      {
+        motherCase,
+        localCaseUuid: 'uuid-1-child1',
+        registrationDate: new Date('2026-08-01T00:00:00.000Z'),
+        dateOfBirth: new Date('2026-08-01T00:00:00.000Z'),
+      },
+      'Bearer test-token',
+    );
+
+    expect(id).toBe('child-42');
+  });
+
   it('acknowledges beneficiary-service duplicate detection — same mother + same DOB is expected for twins/triplets, not a real duplicate', async () => {
-    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { id: 'child-1' } }),
+    });
 
     await createChildBeneficiary(
       {
@@ -97,7 +125,7 @@ describe('createChildBeneficiary', () => {
     expect(body.acknowledgeDuplicate).toBe(true);
   });
 
-  it('swallows a non-ok response so the Delivery submission is never failed by it', async () => {
+  it('swallows a non-ok response so the Delivery submission is never failed by it, returning null', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 500 });
 
     await expect(
@@ -110,11 +138,11 @@ describe('createChildBeneficiary', () => {
         },
         'Bearer test-token',
       ),
-    ).resolves.toBeUndefined();
+    ).resolves.toBeNull();
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it('swallows a network failure so the Delivery submission is never failed by it', async () => {
+  it('swallows a network failure so the Delivery submission is never failed by it, returning null', async () => {
     fetchMock.mockRejectedValue(new Error('network down'));
 
     await expect(
@@ -127,7 +155,7 @@ describe('createChildBeneficiary', () => {
         },
         'Bearer test-token',
       ),
-    ).resolves.toBeUndefined();
+    ).resolves.toBeNull();
     expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/apps/visit-form-service/src/beneficiaries/create-child.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/create-child.client.ts
@@ -36,11 +36,15 @@ export interface CreateChildBeneficiaryInput {
  * runs. A failure here is logged and swallowed rather than failing the
  * Sakhi's submission — a missing child profile is a follow-up/ops concern,
  * rejecting a completed delivery record in the field is not.
+ *
+ * Returns the created case's id (CR-041: needed to advance its currentPhase
+ * to NN right after), or null on any failure — the caller must only attempt
+ * the phase-advance for a child that actually got created.
  */
 export async function createChildBeneficiary(
   input: CreateChildBeneficiaryInput,
   authorizationHeader: string,
-): Promise<void> {
+): Promise<string | null> {
   const body = {
     // No name/phone is captured on the Delivery form for the newborn — the
     // Infant Registration (CHILD_REGISTRATION) form is where a Sakhi later
@@ -97,12 +101,16 @@ export async function createChildBeneficiary(
         `Failed to auto-create child beneficiary for mother ${input.motherCase.id} ` +
           `(beneficiary-service returned ${res.status}); the Delivery submission itself was still saved.`,
       );
+      return null;
     }
+    const responseBody = (await res.json()) as { data: { id: string } };
+    return responseBody.data.id;
   } catch (err) {
     console.warn(
       `Unable to reach beneficiary-service to auto-create child beneficiary for mother ` +
         `${input.motherCase.id}; the Delivery submission itself was still saved. ` +
         `${err instanceof Error ? err.message : String(err)}`,
     );
+    return null;
   }
 }

--- a/apps/visit-form-service/src/beneficiaries/update-phase.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/update-phase.client.spec.ts
@@ -1,0 +1,54 @@
+import { updateBeneficiaryPhase } from './update-phase.client';
+
+describe('updateBeneficiaryPhase', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('PATCHes the phase to beneficiary-service via the gateway', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+    await updateBeneficiaryPhase('mother-1', 'PP', 'Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/beneficiaries/mother-1/phase'),
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+        body: JSON.stringify({ phase: 'PP' }),
+      }),
+    );
+  });
+
+  it('swallows a non-ok response so the Delivery submission is never failed by it', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 409 });
+
+    await expect(
+      updateBeneficiaryPhase('mother-1', 'PP', 'Bearer test-token'),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows a network failure so the Delivery submission is never failed by it', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(
+      updateBeneficiaryPhase('mother-1', 'PP', 'Bearer test-token'),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/visit-form-service/src/beneficiaries/update-phase.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/update-phase.client.ts
@@ -1,0 +1,41 @@
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — matches create-child.client.ts's/geography.client.ts's stance.
+const API_GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+/**
+ * Advances a beneficiary case's currentPhase via beneficiary-service's
+ * `PATCH /beneficiaries/:id/phase` (CR-041) — called after a DELIVERY_VISIT
+ * submission, once for the mother (phase: 'PP') and once per auto-created
+ * child (phase: 'NN').
+ *
+ * Best-effort by design, same stance as createChildBeneficiary: the Delivery
+ * submission (and any child case it created) is already durably saved by the
+ * time this runs. A failure here is logged and swallowed rather than failing
+ * the Sakhi's submission — a stale currentPhase is a follow-up/ops concern,
+ * rejecting a completed delivery record in the field is not.
+ */
+export async function updateBeneficiaryPhase(
+  beneficiaryId: string,
+  phase: string,
+  authorizationHeader: string,
+): Promise<void> {
+  try {
+    const res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/phase`, {
+      method: 'PATCH',
+      headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ phase }),
+    });
+    if (!res.ok) {
+      console.warn(
+        `Failed to advance currentPhase to ${phase} for beneficiary ${beneficiaryId} ` +
+          `(beneficiary-service returned ${res.status}); the Delivery submission itself was still saved.`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Unable to reach beneficiary-service to advance currentPhase to ${phase} for beneficiary ` +
+        `${beneficiaryId}; the Delivery submission itself was still saved. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/closures/closure.client.spec.ts
+++ b/apps/visit-form-service/src/closures/closure.client.spec.ts
@@ -1,0 +1,123 @@
+import { createClosure, resolveClosureReasonLookupId } from './closure.client';
+
+describe('resolveClosureReasonLookupId', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  const CLOSURE_REASON_VALUES = [
+    { id: 'id-miscarriage', valueCode: 'MISCARRIAGE' },
+    { id: 'id-abortion', valueCode: 'ABORTION' },
+    { id: 'id-maternal-death', valueCode: 'MATERNAL_DEATH' },
+    { id: 'id-infant-death', valueCode: 'INFANT_OR_CHILD_DEATH' },
+    { id: 'id-migration', valueCode: 'MIGRATION' },
+    { id: 'id-withdrawal', valueCode: 'WITHDRAWAL' },
+    { id: 'id-program-complete', valueCode: 'PROGRAM_CYCLE_COMPLETED' },
+    { id: 'id-other', valueCode: 'OTHER' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: { categoryCode: 'CLOSURE_REASON', values: CLOSURE_REASON_VALUES },
+      }),
+    });
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it.each([
+    ['withdrawal_of_consent', 'id-withdrawal'],
+    ['miscarriage', 'id-miscarriage'],
+    ['abortion_spontaneous_induced_mtp', 'id-abortion'],
+    ['migration', 'id-migration'],
+    ['program_cycle_completed', 'id-program-complete'],
+    ['maternal_death', 'id-maternal-death'],
+    ['infant_child_death', 'id-infant-death'],
+  ])('maps form value_code %s to lookup id %s', async (formCode, expectedId) => {
+    await expect(resolveClosureReasonLookupId(formCode, 'Bearer test-token')).resolves.toBe(
+      expectedId,
+    );
+  });
+
+  it('returns null for an unrecognized form value_code', async () => {
+    await expect(
+      resolveClosureReasonLookupId('not_a_real_reason', 'Bearer test-token'),
+    ).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a badGateway error when the lookup call fails (network)', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await expect(
+      resolveClosureReasonLookupId('migration', 'Bearer test-token'),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+
+  it('throws a badGateway error when the lookup call returns non-ok', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    await expect(
+      resolveClosureReasonLookupId('migration', 'Bearer test-token'),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+});
+
+describe('createClosure', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let warnSpy: jest.SpyInstance;
+
+  const baseInput = {
+    localClosureUuid: 'uuid-1-closure',
+    beneficiaryId: 'b1',
+    closureType: 'NON_MEDICAL' as const,
+    closureReasonLookupValueId: 'reason-1',
+    closureDate: '2026-08-18',
+    submittedByUserId: 'sakhi-1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('POSTs to closure-reopen-service via the gateway', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 201 });
+
+    await createClosure(baseInput, 'Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/closures'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+        body: JSON.stringify(baseInput),
+      }),
+    );
+  });
+
+  it('swallows a non-ok response so the closure-form submission is never failed by it', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400 });
+    await expect(createClosure(baseInput, 'Bearer test-token')).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows a network failure so the closure-form submission is never failed by it', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await expect(createClosure(baseInput, 'Bearer test-token')).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/visit-form-service/src/closures/closure.client.ts
+++ b/apps/visit-form-service/src/closures/closure.client.ts
@@ -1,0 +1,111 @@
+import { badGateway } from '@armman/service-commons';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — matches create-child.client.ts's/lookup.client.ts's stance.
+const API_GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+interface LookupValue {
+  id: string;
+  valueCode: string;
+}
+
+interface LookupCategory {
+  categoryCode: string;
+  values: LookupValue[];
+}
+
+/**
+ * Maps ANC_CLOSURE_VISIT's/CHILD_CLOSURE_VISIT's `closure_reason` field
+ * value_codes (snake_case, per the seeded form schema) to the
+ * CLOSURE_REASON lookup category's own valueCodes (SCREAMING_SNAKE) — the
+ * two vocabularies were authored independently and don't match by simple
+ * case transform (e.g. `abortion_spontaneous_induced_mtp` -> `ABORTION`,
+ * `infant_child_death` -> `INFANT_OR_CHILD_DEATH`).
+ */
+const FORM_REASON_TO_LOOKUP_CODE: Record<string, string> = {
+  withdrawal_of_consent: 'WITHDRAWAL',
+  miscarriage: 'MISCARRIAGE',
+  abortion_spontaneous_induced_mtp: 'ABORTION',
+  migration: 'MIGRATION',
+  program_cycle_completed: 'PROGRAM_CYCLE_COMPLETED',
+  maternal_death: 'MATERNAL_DEATH',
+  infant_child_death: 'INFANT_OR_CHILD_DEATH',
+};
+
+/**
+ * Resolves a closure form's `closure_reason` answer to a
+ * closure_reason_lookup_value_id, for POST /closures' required field —
+ * returns null (not a throw) for an unrecognized reason, so the caller can
+ * skip auto-closure rather than fail an already-valid form submission over
+ * a mapping gap.
+ */
+export async function resolveClosureReasonLookupId(
+  formReasonCode: string,
+  authorizationHeader: string,
+): Promise<string | null> {
+  const lookupCode = FORM_REASON_TO_LOOKUP_CODE[formReasonCode];
+  if (!lookupCode) return null;
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/lookups/CLOSURE_REASON`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve the closure reason — auth-service is unreachable.');
+  }
+  if (!res.ok) {
+    throw badGateway('Unable to resolve the closure reason — auth-service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: LookupCategory };
+  return body.data.values.find((v) => v.valueCode === lookupCode)?.id ?? null;
+}
+
+export interface CreateClosureInput {
+  localClosureUuid: string;
+  beneficiaryId: string;
+  closureType: 'MEDICAL' | 'NON_MEDICAL' | 'PROGRAM_COMPLETION';
+  closureReasonLookupValueId: string;
+  eventDate?: string;
+  closureDate: string;
+  submittedByUserId: string;
+  supervisorStatus?: 'PENDING';
+}
+
+/**
+ * Creates a closure via closure-reopen-service's POST /closures, called
+ * automatically after an ANC_CLOSURE_VISIT/CHILD_CLOSURE_VISIT submission
+ * (with continue_with_closure: 'yes') — closes the loop the SRS's closure
+ * flow otherwise leaves open: submitting the form alone has no effect on
+ * the beneficiary's own record without this call.
+ *
+ * Best-effort by design, matching createChildBeneficiary/updateBeneficiaryPhase:
+ * the closure submission's own form data is already durably saved by the
+ * time this runs. A failure here is logged and swallowed rather than
+ * failing the Sakhi's submission.
+ */
+export async function createClosure(
+  input: CreateClosureInput,
+  authorizationHeader: string,
+): Promise<void> {
+  try {
+    const res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/closures`, {
+      method: 'POST',
+      headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!res.ok) {
+      console.warn(
+        `Failed to auto-create closure for beneficiary ${input.beneficiaryId} ` +
+          `(closure-reopen-service returned ${res.status}); the closure-form submission itself was still saved.`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Unable to reach closure-reopen-service to auto-create closure for beneficiary ` +
+        `${input.beneficiaryId}; the closure-form submission itself was still saved. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/forms/form.mapper.spec.ts
+++ b/apps/visit-form-service/src/forms/form.mapper.spec.ts
@@ -1,5 +1,22 @@
-import { buildFormAnswers } from './form.mapper';
+import { buildFormAnswers, toApiFormSubmission } from './form.mapper';
 import type { FormField } from './dto/form-field.dto';
+
+/** Minimal FormSubmissionRow factory — only the fields toApiFormSubmission reads. */
+function submissionRow() {
+  return {
+    id: 'sub-1',
+    formVersionId: 'version-1',
+    beneficiaryId: 'b1',
+    visitId: null,
+    submittedByUserId: 'u1',
+    submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+    localSubmissionUuid: 'uuid-1',
+    formDataJson: { date_of_delivery: '2026-08-01' },
+    validationStatus: 'VALID' as const,
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+  };
+}
 
 /** Minimal FormField factory — only the fields buildFormAnswers reads. */
 function field(question_code: string, input_type: string): FormField {
@@ -152,6 +169,25 @@ describe('buildFormAnswers', () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]).toEqual(
         expect.objectContaining({ fieldCode: 'gravida', answerValueNumber: 2 }),
+      );
+    });
+  });
+
+  describe('toApiFormSubmission', () => {
+    it('omits childBeneficiaryIds when called without a second argument', () => {
+      const result = toApiFormSubmission(submissionRow());
+      expect('childBeneficiaryIds' in result).toBe(false);
+    });
+
+    it('omits childBeneficiaryIds when passed an empty array', () => {
+      const result = toApiFormSubmission(submissionRow(), []);
+      expect('childBeneficiaryIds' in result).toBe(false);
+    });
+
+    it('includes childBeneficiaryIds, in order, when passed a non-empty array', () => {
+      const result = toApiFormSubmission(submissionRow(), ['child-1', 'child-2']);
+      expect(result).toEqual(
+        expect.objectContaining({ childBeneficiaryIds: ['child-1', 'child-2'] }),
       );
     });
   });

--- a/apps/visit-form-service/src/forms/form.mapper.ts
+++ b/apps/visit-form-service/src/forms/form.mapper.ts
@@ -210,7 +210,10 @@ export function buildFormAnswers(
  * columns ruleVersionId/syncBatchId/createdByUserId/updatedByUserId/
  * isDeleted/deletedAt so they never leak into a response.
  */
-export function toApiFormSubmission<T extends FormSubmissionRow>(s: T) {
+export function toApiFormSubmission<T extends FormSubmissionRow>(
+  s: T,
+  childBeneficiaryIds?: string[],
+) {
   return {
     id: s.id,
     formVersionId: s.formVersionId,
@@ -223,5 +226,6 @@ export function toApiFormSubmission<T extends FormSubmissionRow>(s: T) {
     validationStatus: s.validationStatus,
     createdAt: s.createdAt,
     updatedAt: s.updatedAt,
+    ...(childBeneficiaryIds?.length ? { childBeneficiaryIds } : {}),
   };
 }

--- a/apps/visit-form-service/src/forms/form.schemas.spec.ts
+++ b/apps/visit-form-service/src/forms/form.schemas.spec.ts
@@ -1,0 +1,45 @@
+import { formSubmissionSchema } from './form.schemas';
+
+function submission(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '9a1b2c3d-4e5f-6789-0abc-def012345678',
+    formVersionId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    beneficiaryId: '34197cd7-7a54-4e7f-885c-f297313b9e81',
+    visitId: null,
+    submittedByUserId: 'ba9c28fa-35fc-44e5-947c-eeca811bc052',
+    submittedAt: '2026-07-20T10:15:00.000Z',
+    localSubmissionUuid: 'device-abc-submission-001',
+    formData: { weightKg: 58 },
+    validationStatus: 'VALID',
+    createdAt: '2026-07-20T10:15:00.000Z',
+    updatedAt: '2026-07-20T10:15:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('formSubmissionSchema', () => {
+  it('accepts a submission without childBeneficiaryIds', () => {
+    expect(() => formSubmissionSchema.parse(submission())).not.toThrow();
+  });
+
+  it('accepts a submission with childBeneficiaryIds', () => {
+    const result = formSubmissionSchema.parse(
+      submission({
+        childBeneficiaryIds: [
+          '34197cd7-7a54-4e7f-885c-f297313b9e81',
+          '9a1b2c3d-4e5f-6789-0abc-def012345678',
+        ],
+      }),
+    );
+    expect(result.childBeneficiaryIds).toEqual([
+      '34197cd7-7a54-4e7f-885c-f297313b9e81',
+      '9a1b2c3d-4e5f-6789-0abc-def012345678',
+    ]);
+  });
+
+  it('rejects a childBeneficiaryIds entry that is not a uuid', () => {
+    expect(() =>
+      formSubmissionSchema.parse(submission({ childBeneficiaryIds: ['not-a-uuid'] })),
+    ).toThrow();
+  });
+});

--- a/apps/visit-form-service/src/forms/form.schemas.ts
+++ b/apps/visit-form-service/src/forms/form.schemas.ts
@@ -63,4 +63,14 @@ export const formSubmissionSchema = z.object({
   validationStatus: z.enum(['VALID', 'INVALID', 'WARNING']).openapi({ example: 'VALID' }),
   createdAt: z.string().datetime().openapi({ example: '2026-07-20T10:15:00.000Z' }),
   updatedAt: z.string().datetime().openapi({ example: '2026-07-20T10:15:00.000Z' }),
+  childBeneficiaryIds: z
+    .array(z.string().uuid())
+    .optional()
+    .openapi({
+      description:
+        'Ids of the CHILD beneficiary cases auto-created from this submission, in ' +
+        'child1/child2/child3 order — present only for a DELIVERY_VISIT submission ' +
+        'with at least one live birth. Omitted (not an empty array) otherwise.',
+      example: ['34197cd7-7a54-4e7f-885c-f297313b9e81'],
+    }),
 });

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -5,12 +5,14 @@ import { syncSocioDemographics } from '../beneficiaries/socio-demographics.clien
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
 import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
+import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
 jest.mock('../beneficiaries/health-history.client');
 jest.mock('../beneficiaries/beneficiary.client');
 jest.mock('../beneficiaries/create-child.client');
+jest.mock('../beneficiaries/update-phase.client');
 
 describe('FormService', () => {
   const repository = {
@@ -774,6 +776,7 @@ describe('FormService', () => {
         repository.findVersionById.mockResolvedValue(deliveryVersion as never);
         repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
         jest.mocked(findBeneficiaryById).mockResolvedValue(motherCase);
+        jest.mocked(createChildBeneficiary).mockResolvedValue('child-1');
       });
 
       it('creates a child beneficiary for a single live birth', async () => {
@@ -920,6 +923,185 @@ describe('FormService', () => {
 
         expect(result).toEqual({ id: 'sub-1' });
         expect(jest.mocked(createChildBeneficiary)).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('DELIVERY_VISIT currentPhase advance (CR-041)', () => {
+      const motherCase = {
+        id: 'b1',
+        sakhiId: 'sakhi-1',
+        projectId: 'project-1',
+        beneficiaryTypeLookupId: 'type-1',
+        caseTypeLookupId: 'case-type-1',
+        villageId: 'village-1',
+        padaId: 'pada-1',
+        healthSubCentreId: 'sc-1',
+        phcId: 'phc-1',
+        stateId: 'state-1',
+        districtId: 'district-1',
+      };
+
+      const deliveryVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'DELIVERY_VISIT' },
+        schemaJson: [
+          { question_code: 'date_of_delivery', label: 'x', input_type: 'date', required: false },
+          ...['child1', 'child2'].flatMap((prefix) => [
+            {
+              question_code: `${prefix}_delivery_outcome`,
+              label: 'x',
+              input_type: 'dropdown',
+              required: false,
+            },
+          ]),
+        ],
+        validationJson: [],
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(deliveryVersion as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue(motherCase);
+      });
+
+      it("advances the mother's phase to PP after a successful submission", async () => {
+        jest.mocked(createChildBeneficiary).mockResolvedValue(null);
+
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { date_of_delivery: '2026-08-01' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'b1',
+          'PP',
+          'Bearer test-token',
+        );
+      });
+
+      it('advances each successfully created child to NN', async () => {
+        jest
+          .mocked(createChildBeneficiary)
+          .mockResolvedValueOnce('child-1')
+          .mockResolvedValueOnce('child-2');
+
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              child2_delivery_outcome: 'live_birth',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'child-1',
+          'NN',
+          'Bearer test-token',
+        );
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'child-2',
+          'NN',
+          'Bearer test-token',
+        );
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'b1',
+          'PP',
+          'Bearer test-token',
+        );
+      });
+
+      it('only advances a child that was actually created — a failed creation is skipped', async () => {
+        jest
+          .mocked(createChildBeneficiary)
+          .mockResolvedValueOnce('child-1')
+          .mockResolvedValueOnce(null);
+
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              child2_delivery_outcome: 'live_birth',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'child-1',
+          'NN',
+          'Bearer test-token',
+        );
+        expect(jest.mocked(updateBeneficiaryPhase)).not.toHaveBeenCalledWith(
+          null,
+          'NN',
+          'Bearer test-token',
+        );
+      });
+
+      it('still advances the mother even if child auto-creation fails entirely', async () => {
+        jest.mocked(createChildBeneficiary).mockResolvedValue(null);
+
+        await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { date_of_delivery: '2026-08-01', child1_delivery_outcome: 'live_birth' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'b1',
+          'PP',
+          'Bearer test-token',
+        );
+      });
+
+      it('does not call updateBeneficiaryPhase for a non-DELIVERY_VISIT form', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...publishedVersion,
+          formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+        } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -6,6 +6,7 @@ import { syncHealthHistory } from '../beneficiaries/health-history.client';
 import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
+import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
@@ -13,6 +14,7 @@ jest.mock('../beneficiaries/health-history.client');
 jest.mock('../beneficiaries/beneficiary.client');
 jest.mock('../beneficiaries/create-child.client');
 jest.mock('../beneficiaries/update-phase.client');
+jest.mock('../closures/closure.client');
 
 describe('FormService', () => {
   const repository = {
@@ -1102,6 +1104,667 @@ describe('FormService', () => {
         );
 
         expect(jest.mocked(updateBeneficiaryPhase)).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('DELIVERY_VISIT childBeneficiaryIds in response', () => {
+      const motherCase = {
+        id: 'b1',
+        sakhiId: 'sakhi-1',
+        projectId: 'project-1',
+        beneficiaryTypeLookupId: 'type-1',
+        caseTypeLookupId: 'case-type-1',
+        villageId: 'village-1',
+        padaId: 'pada-1',
+        healthSubCentreId: 'sc-1',
+        phcId: 'phc-1',
+        stateId: 'state-1',
+        districtId: 'district-1',
+      };
+
+      const deliveryVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'DELIVERY_VISIT' },
+        schemaJson: [
+          { question_code: 'date_of_delivery', label: 'x', input_type: 'date', required: false },
+          ...['child1', 'child2', 'child3'].flatMap((prefix) => [
+            {
+              question_code: `${prefix}_delivery_outcome`,
+              label: 'x',
+              input_type: 'dropdown',
+              required: false,
+            },
+          ]),
+        ],
+        validationJson: [],
+      };
+
+      const deliveryFormData = {
+        date_of_delivery: '2026-08-01',
+        child1_delivery_outcome: 'live_birth',
+        child2_delivery_outcome: 'live_birth',
+        child3_delivery_outcome: 'live_birth',
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(deliveryVersion as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue(motherCase);
+      });
+
+      it('includes a single child id for a single live birth', async () => {
+        jest.mocked(createChildBeneficiary).mockResolvedValue('child-1');
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { date_of_delivery: '2026-08-01', child1_delivery_outcome: 'live_birth' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(expect.objectContaining({ childBeneficiaryIds: ['child-1'] }));
+      });
+
+      it('includes both child ids, in order, for twins', async () => {
+        jest
+          .mocked(createChildBeneficiary)
+          .mockImplementation(async (input) =>
+            input.localCaseUuid === 'uuid-1-child1' ? 'child-1' : 'child-2',
+          );
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              child2_delivery_outcome: 'live_birth',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ childBeneficiaryIds: ['child-1', 'child-2'] }),
+        );
+      });
+
+      it('includes all three child ids, in order, for triplets', async () => {
+        jest.mocked(createChildBeneficiary).mockImplementation(async (input) => {
+          if (input.localCaseUuid === 'uuid-1-child1') return 'child-1';
+          if (input.localCaseUuid === 'uuid-1-child2') return 'child-2';
+          return 'child-3';
+        });
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: deliveryFormData,
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ childBeneficiaryIds: ['child-1', 'child-2', 'child-3'] }),
+        );
+      });
+
+      it('omits childBeneficiaryIds entirely when there is no live birth', async () => {
+        jest.mocked(createChildBeneficiary).mockResolvedValue(null);
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'antepartum_still_birth_fresh',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect('childBeneficiaryIds' in result).toBe(false);
+      });
+
+      it('includes only the live-born child when one of two is stillborn', async () => {
+        jest.mocked(createChildBeneficiary).mockResolvedValue('child-1');
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              child2_delivery_outcome: 'antepartum_still_birth_fresh',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(expect.objectContaining({ childBeneficiaryIds: ['child-1'] }));
+      });
+
+      it('omits a child whose beneficiary-service creation call failed, keeps the others', async () => {
+        jest
+          .mocked(createChildBeneficiary)
+          .mockImplementation(async (input) =>
+            input.localCaseUuid === 'uuid-1-child1' ? 'child-1' : null,
+          );
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              date_of_delivery: '2026-08-01',
+              child1_delivery_outcome: 'live_birth',
+              child2_delivery_outcome: 'live_birth',
+            },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(expect.objectContaining({ childBeneficiaryIds: ['child-1'] }));
+      });
+
+      it('still returns the child id even when its phase-advance call fails', async () => {
+        jest.mocked(createChildBeneficiary).mockResolvedValue('child-1');
+        jest.mocked(updateBeneficiaryPhase).mockRejectedValue(new Error('network error'));
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { date_of_delivery: '2026-08-01', child1_delivery_outcome: 'live_birth' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(expect.objectContaining({ childBeneficiaryIds: ['child-1'] }));
+      });
+
+      it('omits childBeneficiaryIds for a non-DELIVERY_VISIT form', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...publishedVersion,
+          formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+        } as never);
+
+        const result = await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect('childBeneficiaryIds' in result).toBe(false);
+      });
+
+      it('omits childBeneficiaryIds when the mother case cannot be found', async () => {
+        jest.mocked(findBeneficiaryById).mockResolvedValue(null);
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { date_of_delivery: '2026-08-01', child1_delivery_outcome: 'live_birth' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect('childBeneficiaryIds' in result).toBe(false);
+      });
+
+      describe('idempotent replay', () => {
+        it('re-resolves the same child ids on a retried DELIVERY_VISIT submission', async () => {
+          const existing = { id: 'sub-1' };
+          repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
+          jest
+            .mocked(createChildBeneficiary)
+            .mockImplementation(async (input) =>
+              input.localCaseUuid === 'uuid-1-child1' ? 'child-1' : 'child-2',
+            );
+
+          const result = await service.createSubmission(
+            'DELIVERY_VISIT',
+            {
+              formVersionId: 'version-1',
+              beneficiaryId: 'b1',
+              localSubmissionUuid: 'uuid-1',
+              formData: {
+                date_of_delivery: '2026-08-01',
+                child1_delivery_outcome: 'live_birth',
+                child2_delivery_outcome: 'live_birth',
+              },
+            },
+            'u1',
+            'Bearer test-token',
+          );
+
+          expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledWith(
+            expect.objectContaining({ localCaseUuid: 'uuid-1-child1' }),
+            'Bearer test-token',
+          );
+          expect(jest.mocked(createChildBeneficiary)).toHaveBeenCalledWith(
+            expect.objectContaining({ localCaseUuid: 'uuid-1-child2' }),
+            'Bearer test-token',
+          );
+          expect(result).toEqual(
+            expect.objectContaining({ childBeneficiaryIds: ['child-1', 'child-2'] }),
+          );
+          expect(repository.findVersionById).not.toHaveBeenCalled();
+        });
+
+        it('does not attempt child resolution on replay of a non-DELIVERY_VISIT submission', async () => {
+          const existing = { id: 'sub-1' };
+          repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
+
+          const result = await service.createSubmission(
+            'MOTHER_REGISTRATION',
+            {
+              formVersionId: 'version-1',
+              beneficiaryId: 'b1',
+              localSubmissionUuid: 'retry-uuid',
+              formData: {},
+            },
+            'u1',
+            'Bearer test-token',
+          );
+
+          expect(jest.mocked(findBeneficiaryById)).not.toHaveBeenCalled();
+          expect(jest.mocked(createChildBeneficiary)).not.toHaveBeenCalled();
+          expect('childBeneficiaryIds' in result).toBe(false);
+        });
+
+        it('omits childBeneficiaryIds on replay when child resolution now fails', async () => {
+          const existing = { id: 'sub-1' };
+          repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
+          jest.mocked(createChildBeneficiary).mockResolvedValue(null);
+
+          const result = await service.createSubmission(
+            'DELIVERY_VISIT',
+            {
+              formVersionId: 'version-1',
+              beneficiaryId: 'b1',
+              localSubmissionUuid: 'uuid-1',
+              formData: { date_of_delivery: '2026-08-01', child1_delivery_outcome: 'live_birth' },
+            },
+            'u1',
+            'Bearer test-token',
+          );
+
+          expect('childBeneficiaryIds' in result).toBe(false);
+        });
+      });
+    });
+
+    describe('ANC_CLOSURE_VISIT / CHILD_CLOSURE_VISIT auto-closure', () => {
+      const ancClosureVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'ANC_CLOSURE_VISIT' },
+        schemaJson: [
+          {
+            question_code: 'continue_with_closure',
+            label: 'x',
+            input_type: 'radio',
+            required: false,
+          },
+          { question_code: 'closure_reason', label: 'x', input_type: 'dropdown', required: false },
+          {
+            question_code: 'closure_visit_date',
+            label: 'x',
+            input_type: 'date',
+            required: false,
+          },
+          { question_code: 'date_of_event', label: 'x', input_type: 'date', required: false },
+        ],
+        validationJson: [],
+      };
+
+      const childClosureVersion = {
+        ...ancClosureVersion,
+        formDefinition: { formCode: 'CHILD_CLOSURE_VISIT' },
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        jest.mocked(resolveClosureReasonLookupId).mockResolvedValue('reason-lookup-id');
+      });
+
+      it.each([
+        ['withdrawal_of_consent', 'NON_MEDICAL'],
+        ['miscarriage', 'MEDICAL'],
+        ['abortion_spontaneous_induced_mtp', 'MEDICAL'],
+        ['maternal_death', 'MEDICAL'],
+        ['program_cycle_completed', 'PROGRAM_COMPLETION'],
+      ])('maps closure_reason %s to closureType %s', async (reason, expectedType) => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: reason,
+              closure_visit_date: '2026-08-18',
+              date_of_event: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.objectContaining({ closureType: expectedType }),
+          'Bearer test-token',
+        );
+      });
+
+      it('maps CHILD_CLOSURE_VISIT infant_child_death to MEDICAL', async () => {
+        repository.findVersionById.mockResolvedValue(childClosureVersion as never);
+
+        await service.createSubmission(
+          'CHILD_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'infant_child_death',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.objectContaining({ closureType: 'MEDICAL' }),
+          'Bearer test-token',
+        );
+      });
+
+      it('sets supervisorStatus: PENDING only for migration', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'migration',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.objectContaining({ supervisorStatus: 'PENDING' }),
+          'Bearer test-token',
+        );
+      });
+
+      it('does not set supervisorStatus for a non-migration reason', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'withdrawal_of_consent',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.not.objectContaining({ supervisorStatus: expect.anything() }),
+          'Bearer test-token',
+        );
+      });
+
+      it('does not create a closure when continue_with_closure is no', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { continue_with_closure: 'no' },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).not.toHaveBeenCalled();
+      });
+
+      it('does not create a closure when continue_with_closure is missing', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { closure_reason: 'migration', closure_visit_date: '2026-08-18' },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).not.toHaveBeenCalled();
+      });
+
+      it('does not create a closure when the reason does not resolve to a lookup value', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+        jest.mocked(resolveClosureReasonLookupId).mockResolvedValue(null);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'not_a_real_reason',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).not.toHaveBeenCalled();
+      });
+
+      it('still returns a successful submission when createClosure throws', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+        jest.mocked(createClosure).mockRejectedValue(new Error('down'));
+
+        const result = await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'migration',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual({ id: 'sub-1' });
+      });
+
+      it('derives localClosureUuid deterministically from localSubmissionUuid', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-42',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'migration',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.objectContaining({ localClosureUuid: 'uuid-42-closure' }),
+          'Bearer test-token',
+        );
+      });
+
+      it('passes eventDate/closureDate/submittedByUserId/beneficiaryId through', async () => {
+        repository.findVersionById.mockResolvedValue(ancClosureVersion as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b42',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'migration',
+              closure_visit_date: '2026-08-20',
+              date_of_event: '2026-08-15',
+            },
+          },
+          'sakhi-99',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            beneficiaryId: 'b42',
+            closureDate: '2026-08-20',
+            eventDate: '2026-08-15',
+            submittedByUserId: 'sakhi-99',
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('does not call createClosure for a non-closure form', async () => {
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(createClosure)).not.toHaveBeenCalled();
+      });
+
+      it('re-runs createClosure on an idempotent replay (same localSubmissionUuid)', async () => {
+        const existing = {
+          id: 'sub-1',
+          beneficiaryId: 'b1',
+          ruleVersionId: null,
+          syncBatchId: null,
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
+
+        await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {
+              continue_with_closure: 'yes',
+              closure_reason: 'migration',
+              closure_visit_date: '2026-08-18',
+            },
+          },
+          'sakhi-1',
+          'Bearer test-token',
+        );
+
+        // createClosure itself is idempotent downstream (same localClosureUuid
+        // resolves to the same closure via closure-reopen-service), so a
+        // replay re-running this call is safe and matches resolveDeliveryChildren's
+        // own re-run-on-replay behavior.
+        expect(jest.mocked(createClosure)).toHaveBeenCalledWith(
+          expect.objectContaining({ localClosureUuid: 'uuid-1-closure' }),
+          'Bearer test-token',
+        );
       });
     });
   });

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -15,6 +15,7 @@ import { syncSocioDemographics } from '../beneficiaries/socio-demographics.clien
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
 import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
+import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
@@ -233,7 +234,7 @@ export class FormService {
             const birthWeightKg = dto.formData[`${prefix}_birth_weight_kg`];
             const birthLengthCm = dto.formData[`${prefix}_birth_length_cm`];
 
-            await createChildBeneficiary(
+            const childId = await createChildBeneficiary(
               {
                 motherCase,
                 // Deterministic per child so a dropped-connection retry of
@@ -255,8 +256,21 @@ export class FormService {
               },
               authorizationHeader,
             );
+
+            // Only for a child that actually got created — a failed
+            // createChildBeneficiary call above already logged its own
+            // warning; there is no case here to advance.
+            if (childId) {
+              await updateBeneficiaryPhase(childId, 'NN', authorizationHeader);
+            }
           }),
         );
+
+        // Mother's phase always advances once a DELIVERY_VISIT is recorded,
+        // independent of whether any child case above succeeded — the
+        // mother's own journey (ANC -> PP) doesn't depend on a child profile
+        // existing (CR-041).
+        await updateBeneficiaryPhase(dto.beneficiaryId, 'PP', authorizationHeader);
       }
     }
 

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -160,7 +160,7 @@ export class FormService {
     if (existing) {
       const childBeneficiaryIds =
         formCode === 'DELIVERY_VISIT'
-          ? await this.resolveDeliveryChildren(dto, authorizationHeader)
+          ? await this.resolveDeliveryChildren(dto, existing.beneficiaryId, authorizationHeader)
           : undefined;
       if (formCode === 'ANC_CLOSURE_VISIT' || formCode === 'CHILD_CLOSURE_VISIT') {
         // Re-run on replay same as resolveDeliveryChildren above — createClosure
@@ -228,7 +228,7 @@ export class FormService {
     // resolveDeliveryChildren for the per-child best-effort details.
     const childBeneficiaryIds =
       formCode === 'DELIVERY_VISIT'
-        ? await this.resolveDeliveryChildren(dto, authorizationHeader)
+        ? await this.resolveDeliveryChildren(dto, dto.beneficiaryId, authorizationHeader)
         : undefined;
 
     // Closes the loop the SRS's closure flow otherwise leaves open:
@@ -280,12 +280,38 @@ export class FormService {
    * that were created the first time, without creating duplicates — this is
    * what lets a retried submission still return childBeneficiaryIds instead
    * of the caller having no way to find the child it already created.
+   *
+   * `beneficiaryId` is a separate parameter (not read off `dto`) so a replay
+   * call site can pass the originally-stored `existing.beneficiaryId`
+   * instead of trusting the retry request's own body — same reasoning
+   * resolveClosureRequest already applies to its own replay call site; a
+   * retried request with a swapped beneficiaryId in its body must not run
+   * child-creation against a different beneficiary than the one actually
+   * recorded.
    */
   private async resolveDeliveryChildren(
     dto: CreateSubmissionInput,
+    beneficiaryId: string,
     authorizationHeader: string,
   ): Promise<string[] | undefined> {
-    const motherCase = await findBeneficiaryById(dto.beneficiaryId, authorizationHeader);
+    // Unlike every other downstream call in createSubmission
+    // (createChildBeneficiary, updateBeneficiaryPhase, createClosure, risk/
+    // socio-demographic/health-history syncs), findBeneficiaryById throws
+    // (badGateway) on anything but a 404 — caught here so a transient
+    // beneficiary-service failure can't turn an already-durably-saved
+    // submission into a failed HTTP response; only a genuine 404 (no
+    // motherCase) is expected to short-circuit this method.
+    let motherCase;
+    try {
+      motherCase = await findBeneficiaryById(beneficiaryId, authorizationHeader);
+    } catch (err) {
+      console.warn(
+        `Unable to resolve mother beneficiary ${dto.beneficiaryId} for DELIVERY_VISIT ` +
+          `child auto-creation; the submission itself was still saved. ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
     if (!motherCase) return undefined;
 
     const dateOfDelivery = dto.formData.date_of_delivery

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -16,6 +16,7 @@ import { syncHealthHistory } from '../beneficiaries/health-history.client';
 import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
+import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
 import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
@@ -156,7 +157,27 @@ export class FormService {
   ) {
     const existing = await this.repository.findSubmissionByLocalUuid(dto.localSubmissionUuid);
     // idempotent replay — matches sync's local_submission_uuid dedup key
-    if (existing) return toApiFormSubmission(existing);
+    if (existing) {
+      const childBeneficiaryIds =
+        formCode === 'DELIVERY_VISIT'
+          ? await this.resolveDeliveryChildren(dto, authorizationHeader)
+          : undefined;
+      if (formCode === 'ANC_CLOSURE_VISIT' || formCode === 'CHILD_CLOSURE_VISIT') {
+        // Re-run on replay same as resolveDeliveryChildren above — createClosure
+        // derives a deterministic localClosureUuid from localSubmissionUuid, so
+        // a repeat call resolves to the same closure via closure-reopen-service's
+        // own idempotency check rather than creating a duplicate.
+        await toleratePhaseAdvance(
+          this.resolveClosureRequest(
+            dto,
+            existing.beneficiaryId,
+            submittedByUserId,
+            authorizationHeader,
+          ),
+        );
+      }
+      return toApiFormSubmission(existing, childBeneficiaryIds);
+    }
 
     const version = await this.repository.findVersionById(dto.formVersionId);
     if (!version) throw notFound('Form version not found.');
@@ -202,76 +223,23 @@ export class FormService {
 
     // Auto-creates a CHILD beneficiary case for each live-born child on a
     // Delivery submission (SRS: "Delivery form... auto-creates the child
-    // profile on submission") — one createChildBeneficiary() call per
-    // childN_* block whose delivery outcome is LIVE_BIRTH, independent and
-    // best-effort per child so one failing call (e.g. in a twin/triplet
-    // birth) never blocks the others or the already-saved submission. This
-    // is a genuine one-shot attempt, same stance as syncSocioDemographics
-    // above: if createChildBeneficiary fails here, nothing retries it later
-    // — a resubmit with the same localSubmissionUuid short-circuits on the
-    // idempotent-replay check earlier in this method and never reaches this
-    // block again. A missing child case has to be caught and fixed out of
-    // band (see the console.warn in createChildBeneficiary's catch).
-    if (formCode === 'DELIVERY_VISIT') {
-      const motherCase = await findBeneficiaryById(dto.beneficiaryId, authorizationHeader);
-      if (motherCase) {
-        const dateOfDelivery = dto.formData.date_of_delivery
-          ? new Date(String(dto.formData.date_of_delivery))
-          : null;
-        const childPrefixes = ['child1', 'child2', 'child3'] as const;
-        const SEX_MAP: Record<string, 'MALE' | 'FEMALE' | 'INTERSEX_OTHER'> = {
-          male: 'MALE',
-          female: 'FEMALE',
-          intersex_other: 'INTERSEX_OTHER',
-        };
+    // profile on submission") and returns their ids so the caller can
+    // prefill the new child's records in the same mobile session — see
+    // resolveDeliveryChildren for the per-child best-effort details.
+    const childBeneficiaryIds =
+      formCode === 'DELIVERY_VISIT'
+        ? await this.resolveDeliveryChildren(dto, authorizationHeader)
+        : undefined;
 
-        await Promise.all(
-          childPrefixes.map(async (prefix) => {
-            const outcome = dto.formData[`${prefix}_delivery_outcome`];
-            if (outcome !== 'live_birth' || !dateOfDelivery) return;
-
-            const sexCode = dto.formData[`${prefix}_sex_of_baby`];
-            const birthWeightKg = dto.formData[`${prefix}_birth_weight_kg`];
-            const birthLengthCm = dto.formData[`${prefix}_birth_length_cm`];
-
-            const childId = await createChildBeneficiary(
-              {
-                motherCase,
-                // Deterministic per child so a dropped-connection retry of
-                // this specific call (network blip, not a form resubmit —
-                // see the block comment above) lands on the same case
-                // instead of creating a duplicate.
-                localCaseUuid: `${dto.localSubmissionUuid}-${prefix}`,
-                registrationDate: dateOfDelivery,
-                dateOfBirth: dateOfDelivery,
-                sex: typeof sexCode === 'string' ? SEX_MAP[sexCode] : undefined,
-                birthWeightKg:
-                  typeof birthWeightKg === 'number' || typeof birthWeightKg === 'string'
-                    ? Number(birthWeightKg)
-                    : undefined,
-                birthLengthCm:
-                  typeof birthLengthCm === 'number' || typeof birthLengthCm === 'string'
-                    ? Number(birthLengthCm)
-                    : undefined,
-              },
-              authorizationHeader,
-            );
-
-            // Only for a child that actually got created — a failed
-            // createChildBeneficiary call above already logged its own
-            // warning; there is no case here to advance.
-            if (childId) {
-              await updateBeneficiaryPhase(childId, 'NN', authorizationHeader);
-            }
-          }),
-        );
-
-        // Mother's phase always advances once a DELIVERY_VISIT is recorded,
-        // independent of whether any child case above succeeded — the
-        // mother's own journey (ANC -> PP) doesn't depend on a child profile
-        // existing (CR-041).
-        await updateBeneficiaryPhase(dto.beneficiaryId, 'PP', authorizationHeader);
-      }
+    // Closes the loop the SRS's closure flow otherwise leaves open:
+    // submitting ANC_CLOSURE_VISIT/CHILD_CLOSURE_VISIT alone has no effect on
+    // the beneficiary's own record — see resolveClosureRequest for the
+    // continue_with_closure gate and reason-mapping details. Best-effort,
+    // same tolerance as the phase-advance calls above.
+    if (formCode === 'ANC_CLOSURE_VISIT' || formCode === 'CHILD_CLOSURE_VISIT') {
+      await toleratePhaseAdvance(
+        this.resolveClosureRequest(dto, dto.beneficiaryId, submittedByUserId, authorizationHeader),
+      );
     }
 
     // Triggers the risk-grading pipeline for every visit-linked submission
@@ -292,8 +260,190 @@ export class FormService {
       );
     }
 
-    return toApiFormSubmission(created);
+    return toApiFormSubmission(created, childBeneficiaryIds);
   }
+
+  /**
+   * Resolves the CHILD beneficiary case(s) for a DELIVERY_VISIT submission —
+   * one createChildBeneficiary() call per childN_* block whose delivery
+   * outcome is LIVE_BIRTH, independent and best-effort per child so one
+   * failing call (e.g. in a twin/triplet birth) never blocks the others or
+   * the already-saved submission. Also advances the mother's phase to PP and
+   * each created child's phase to NN (CR-041) — a phase-advance failure never
+   * drops that child's id from the result, since the id already exists by
+   * the time phase-advance is attempted.
+   *
+   * Deliberately re-run on an idempotent replay (same localSubmissionUuid) as
+   * well as on first submission: createChildBeneficiary is itself idempotent
+   * on its deterministic per-child localCaseUuid (beneficiary-service's own
+   * POST /beneficiaries dedup), so a replay resolves to the same child ids
+   * that were created the first time, without creating duplicates — this is
+   * what lets a retried submission still return childBeneficiaryIds instead
+   * of the caller having no way to find the child it already created.
+   */
+  private async resolveDeliveryChildren(
+    dto: CreateSubmissionInput,
+    authorizationHeader: string,
+  ): Promise<string[] | undefined> {
+    const motherCase = await findBeneficiaryById(dto.beneficiaryId, authorizationHeader);
+    if (!motherCase) return undefined;
+
+    const dateOfDelivery = dto.formData.date_of_delivery
+      ? new Date(String(dto.formData.date_of_delivery))
+      : null;
+    const childPrefixes = ['child1', 'child2', 'child3'] as const;
+    const SEX_MAP: Record<string, 'MALE' | 'FEMALE' | 'INTERSEX_OTHER'> = {
+      male: 'MALE',
+      female: 'FEMALE',
+      intersex_other: 'INTERSEX_OTHER',
+    };
+
+    const childIds = await Promise.all(
+      childPrefixes.map(async (prefix) => {
+        const outcome = dto.formData[`${prefix}_delivery_outcome`];
+        if (outcome !== 'live_birth' || !dateOfDelivery) return undefined;
+
+        const sexCode = dto.formData[`${prefix}_sex_of_baby`];
+        const birthWeightKg = dto.formData[`${prefix}_birth_weight_kg`];
+        const birthLengthCm = dto.formData[`${prefix}_birth_length_cm`];
+
+        const childId = await createChildBeneficiary(
+          {
+            motherCase,
+            // Deterministic per child so a dropped-connection retry of this
+            // specific call, or a full submission replay, lands on the same
+            // case instead of creating a duplicate.
+            localCaseUuid: `${dto.localSubmissionUuid}-${prefix}`,
+            registrationDate: dateOfDelivery,
+            dateOfBirth: dateOfDelivery,
+            sex: typeof sexCode === 'string' ? SEX_MAP[sexCode] : undefined,
+            birthWeightKg:
+              typeof birthWeightKg === 'number' || typeof birthWeightKg === 'string'
+                ? Number(birthWeightKg)
+                : undefined,
+            birthLengthCm:
+              typeof birthLengthCm === 'number' || typeof birthLengthCm === 'string'
+                ? Number(birthLengthCm)
+                : undefined,
+          },
+          authorizationHeader,
+        );
+
+        // Only for a child that actually got created — a failed
+        // createChildBeneficiary call above already logged its own warning;
+        // there is no case here to advance. The phase-advance call is
+        // tolerated separately so its failure never drops childId from the
+        // result — the id is already resolved by this point.
+        if (childId) {
+          // updateBeneficiaryPhase already logs its own warning on a non-2xx
+          // response; toleratePhaseAdvance only guards against the call
+          // rejecting outright (e.g. a thrown network error) so it can never
+          // take down submission handling — same best-effort stance as
+          // createChildBeneficiary above.
+          await toleratePhaseAdvance(updateBeneficiaryPhase(childId, 'NN', authorizationHeader));
+        }
+
+        return childId ?? undefined;
+      }),
+    );
+
+    // Mother's phase always advances once a DELIVERY_VISIT is recorded,
+    // independent of whether any child case above succeeded — the mother's
+    // own journey (ANC -> PP) doesn't depend on a child profile existing
+    // (CR-041). Tolerated the same way as the per-child calls above.
+    await toleratePhaseAdvance(
+      updateBeneficiaryPhase(dto.beneficiaryId, 'PP', authorizationHeader),
+    );
+
+    return childIds.filter((id): id is string => id !== undefined);
+  }
+
+  /**
+   * Auto-creates a closure via closure-reopen-service's POST /closures on an
+   * ANC_CLOSURE_VISIT/CHILD_CLOSURE_VISIT submission — without this, the
+   * closure form's own answers are saved (this service's job), but the
+   * beneficiary's currentStatus never advances, since nothing else calls
+   * POST /closures on the Sakhi's behalf.
+   *
+   * Skips entirely when continue_with_closure isn't 'yes' — the form's own
+   * visibleWhen gating means every closure-relevant field is absent/moot in
+   * that case (a Sakhi who backed out of the closure decision on this
+   * screen), so there is nothing to close.
+   *
+   * closureType (MEDICAL/NON_MEDICAL/PROGRAM_COMPLETION) is derived from the
+   * resolved CLOSURE_REASON lookup valueCode, not asked separately on the
+   * form — MEDICAL for death/miscarriage/abortion reasons, PROGRAM_COMPLETION
+   * for program-cycle-completed, NON_MEDICAL for everything else (withdrawal,
+   * migration). supervisorStatus: 'PENDING' is set only for MIGRATION,
+   * matching POST /closures' own existing review-gating rule — every other
+   * reason closes the beneficiary immediately.
+   *
+   * An unrecognized/missing closure_reason value skips the call rather than
+   * throwing — the form submission itself is already valid and saved; a
+   * reason-mapping gap is a follow-up/ops concern, not a reason to fail an
+   * otherwise-successful submission.
+   */
+  private async resolveClosureRequest(
+    dto: CreateSubmissionInput,
+    beneficiaryId: string,
+    submittedByUserId: string,
+    authorizationHeader: string,
+  ): Promise<void> {
+    if (dto.formData.continue_with_closure !== 'yes') return;
+
+    const closureReasonCode = dto.formData.closure_reason;
+    if (typeof closureReasonCode !== 'string') return;
+
+    const closureReasonLookupValueId = await resolveClosureReasonLookupId(
+      closureReasonCode,
+      authorizationHeader,
+    );
+    if (!closureReasonLookupValueId) return;
+
+    const MEDICAL_REASONS = new Set([
+      'miscarriage',
+      'abortion_spontaneous_induced_mtp',
+      'maternal_death',
+      'infant_child_death',
+    ]);
+    const closureType =
+      closureReasonCode === 'program_cycle_completed'
+        ? 'PROGRAM_COMPLETION'
+        : MEDICAL_REASONS.has(closureReasonCode)
+          ? 'MEDICAL'
+          : 'NON_MEDICAL';
+
+    const closureDate = dto.formData.closure_visit_date;
+    if (typeof closureDate !== 'string') return;
+    const eventDate = dto.formData.date_of_event;
+
+    await createClosure(
+      {
+        // Deterministic so a dropped-connection retry of this specific call,
+        // or a full submission replay, resolves to the same closure via
+        // closure-reopen-service's own localClosureUuid dedup instead of
+        // creating a duplicate.
+        localClosureUuid: `${dto.localSubmissionUuid}-closure`,
+        beneficiaryId,
+        closureType,
+        closureReasonLookupValueId,
+        eventDate: typeof eventDate === 'string' ? eventDate : undefined,
+        closureDate,
+        submittedByUserId,
+        ...(closureReasonCode === 'migration' ? { supervisorStatus: 'PENDING' as const } : {}),
+      },
+      authorizationHeader,
+    );
+  }
+}
+
+/**
+ * Swallows a rejected updateBeneficiaryPhase call so it can never fail
+ * submission handling — the client itself already logs a warning on a
+ * non-2xx response; this only guards against the call rejecting outright.
+ */
+async function toleratePhaseAdvance(call: Promise<void>): Promise<void> {
+  await Promise.resolve(call).catch(() => undefined);
 }
 
 /** Narrows a caught Prisma error to a unique-constraint violation (P2002). */

--- a/docs/Arogya_Sakhi_SRS_v3.0.md
+++ b/docs/Arogya_Sakhi_SRS_v3.0.md
@@ -198,7 +198,7 @@ The program covers the full 1000-day care journey — from early pregnancy throu
 | Enrolment — Mother        | Register pregnant women. ANC schedule auto-generated offline.                                                      | Confirmed                      |
 | Enrolment — Child         | Register children 0–12 months. NN and INC schedule generated offline.                                              | Confirmed                      |
 | ANC Visit Scheduling      | Formula-driven, uncapped. Max 10 visits. ANC for late delivery post EDD.                                           | Confirmed                      |
-| PP Visit Scheduling       | PP1–PP5. Day 0, 15, 45, 75, 105 from delivery.                                                                     | Confirmed                      |
+| PP Visit Scheduling       | PP1–PP5. Day 0, 15, 58, 88, 118 from delivery.                                                                     | Confirmed                      |
 | NN Visit Scheduling       | NN1 and NN2 within first 28 days. Three scenarios based on delivery form date.                                     | Confirmed                      |
 | INC Visit Scheduling      | 0–12m. Two-formula approach. Max 11 visits. DOB+370(365+5) cutoff.                                                 | Confirmed                      |
 | CCV Visit Scheduling      | 13–24m. State-dependent cadence. Four risk states.                                                                 | Confirmed                      |
@@ -289,9 +289,9 @@ All PP visits are anchored to the delivery date. Schedule is generated on delive
 | PP2   | Day +15                                          | Day +15      | Day +28       | 1 missed → Supervisor immediately |
 | PP3   | Delivery Day+58 (PP2 Window close days(28) + 30) | Day +53      | Day +63       | 1 missed → Supervisor immediately |
 | PP4   | Delivery Day+88 (PP3 scheduled(58 + 30))         | Day +83      | Day +93       | 1 missed → Supervisor immediately |
-| PP5   | Day +105 (PP4 scheduled(88 + 30))                | Day +113     | Day +123      | 1 missed → Supervisor immediately |
+| PP5   | Day +118 (PP4 scheduled(88 + 30))                | Day +113     | Day +123      | 1 missed → Supervisor immediately |
 
-_Note: PP1 and PP2 use fixed date ranges (not ±N windows). PP3–PP5 use ±5 day windows. PP5 completion triggers the mother closure prompt._
+_Note: PP1 and PP2 use fixed date ranges (not ±N windows). PP3–PP5 use ±5–10 day windows. PP5 completion triggers the mother closure prompt. Resolved 2026-08-18: PP5 = Day+118 (window 113–123) is authoritative, matching the implemented GoRules scheduling pack (`apps/rules-service/src/rules/scheduling/pp.rulesJson.ts`) and the Appendix A.2 table below — not the earlier Day+105 figure that appeared here._
 
 **NN Visit Schedule**
 
@@ -608,7 +608,7 @@ Last CCV visit form submission (or CCV-HR if journey extended) immediately opens
 | BR-02   | INC schedule is fixed at enrolment (early registration) or at registration date (late registration). Does not shift on missed visits.                                                                                            | Confirmed — Shweta/Prajakta, 5 May 2026      |
 | BR-03   | HR visit anchor is the actual date the Sakhi completed the triggering visit — not the scheduled date. Applies to ANC-HR, INC-HR, and CCV-HR.                                                                                     | Confirmed — ARMMAN answers file, 23 Apr 2026 |
 | BR-04   | When delivery form is submitted, ALL open ANC visits are automatically marked as Lapsed.                                                                                                                                         | Confirmed — ARMMAN answers file, 23 Apr 2026 |
-| BR-05   | PP3, PP4, PP5 are anchored to scheduled dates, not actual completion dates. If PP2 completed late, PP3 stays at Day 45.                                                                                                          | Confirmed — ARMMAN visit logic table         |
+| BR-05   | PP3, PP4, PP5 are anchored to scheduled dates, not actual completion dates. If PP2 completed late, PP3 stays at Day +58.                                                                                                         | Confirmed — ARMMAN visit logic table         |
 | BR-06   | No HR visits are generated during the neonatal phase (NN1, NN2). Critical conditions in neonatal phase trigger the referral flow only. [SR-NN-01]                                                                                | Confirmed — May 2026                         |
 | BR-07   | A 7-day referral follow-up window blocks only the form filling of the next scheduled visit. Follow-up must be completed before the next visit opens.                                                                             | Confirmed — PRD 2.0                          |
 | BR-08   | ANC Post-EDD visit name is system-generated dynamically as ANC(n+1) where n = total regular ANC visits. [SR-ANC-01]                                                                                                              | Confirmed — ANC schedule walkthrough session |


### PR DESCRIPTION
## Summary
- Closes #167
- Adds `PATCH /beneficiaries/:id/phase` — advances a mother's `currentPhase` ANC→PP and an auto-created child's to NN on a `DELIVERY_VISIT` submission (CR-041)
- Adds `PATCH /beneficiaries/:id/close` (idempotent) and wires `closure-reopen-service`'s `POST /closures` / decision-approval flow to call it — a closure decision now actually flips the beneficiary's `currentStatus`
- Wires `ANC_CLOSURE_VISIT`/`CHILD_CLOSURE_VISIT` form submissions to auto-call `POST /closures`, closing the gap where submitting the closure form had no effect on the beneficiary record at all
- Adds `localClosureUuid` / `localReopenRequestUuid` client-generated idempotency keys to `POST /closures` / `POST /reopen-requests`, matching beneficiary enrollment's `localCaseUuid` convention, so an offline-first mobile retry can't create duplicate rows
- Adds `GET /reopen-requests?beneficiaryId=...` so the app can show "reopen pending review" instead of just "closed" while a request is mid-flow
- Reconciles the SRS's PP3/PP5 schedule table (Day+105 vs Day+113 discrepancy) — Day+118/window 113–123 confirmed authoritative, matching the already-implemented GoRules scheduling pack

## Test plan
- [x] `npx nx test beneficiary-service` — 258 passing
- [x] `npx nx test closure-reopen-service` — 78 passing
- [x] `npx nx test visit-form-service` — 413 passing
- [x] `npx nx lint` on all three — clean (only pre-existing unrelated warnings)
- [x] Verified live end-to-end on the shared dev environment: delivery→phase advance, closure form submission→beneficiary `CLOSED`, and reopen-request idempotent retry all confirmed working
- [x] Prisma migrations applied to dev DB (`add_closure_local_closure_uuid`, `add_reopen_request_local_uuid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)