### PR TITLE
Validate visitId on form submission, add form_answers index

### DIFF
--- a/apps/visit-form-service/prisma/backfill-form-answers.spec.ts
+++ b/apps/visit-form-service/prisma/backfill-form-answers.spec.ts
@@ -1,36 +1,31 @@
 import { backfillSubmission } from './backfill-form-answers';
+import type { FormField } from '../src/forms/dto/form-field.dto';
 
 describe('backfillSubmission', () => {
-  const findUnique = jest.fn();
-  const deleteMany = jest.fn();
+  const updateMany = jest.fn();
   const createMany = jest.fn();
-  const client = {
-    formVersion: { findUnique },
-    formAnswer: { deleteMany, createMany },
-  } as never;
+  const client = { formAnswer: { updateMany, createMany } } as never;
 
-  const publishedVersion = {
-    id: 'version-1',
-    schemaJson: [
-      { question_code: 'phone_owner', label: 'x', input_type: 'text', required: false },
-      { question_code: 'bp_systolic', label: 'x', input_type: 'number', required: false },
-    ],
-  };
+  const resolvedSchema: FormField[] = [
+    { question_code: 'phone_owner', label: 'x', input_type: 'text', required: false },
+    { question_code: 'bp_systolic', label: 'x', input_type: 'number', required: false },
+  ];
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('re-derives form_answers from form_data_json and replaces the existing rows', async () => {
-    findUnique.mockResolvedValue(publishedVersion);
+  it('re-derives form_answers from form_data_json and soft-deletes the existing rows', async () => {
+    const result = await backfillSubmission(
+      client,
+      { id: 'sub-1', formDataJson: { phone_owner: 'SELF', bp_systolic: 118 } },
+      resolvedSchema,
+    );
 
-    const result = await backfillSubmission(client, {
-      id: 'sub-1',
-      formVersionId: 'version-1',
-      formDataJson: { phone_owner: 'SELF', bp_systolic: 118 },
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { submissionId: 'sub-1', isDeleted: false },
+      data: { isDeleted: true, deletedAt: expect.any(Date) },
     });
-
-    expect(deleteMany).toHaveBeenCalledWith({ where: { submissionId: 'sub-1' } });
     expect(createMany).toHaveBeenCalledWith({
       data: expect.arrayContaining([
         expect.objectContaining({ submissionId: 'sub-1', fieldCode: 'phone_owner' }),
@@ -40,46 +35,62 @@ describe('backfillSubmission', () => {
     expect(result).toEqual({ answersWritten: 2 });
   });
 
-  it('is idempotent — running it twice in a row produces the same answersWritten count', async () => {
-    findUnique.mockResolvedValue(publishedVersion);
-    const submission = {
-      id: 'sub-1',
-      formVersionId: 'version-1',
-      formDataJson: { phone_owner: 'SELF', bp_systolic: 118 },
-    };
+  it('does not hard-delete — only soft-deletes via isDeleted/deletedAt', async () => {
+    await backfillSubmission(
+      client,
+      { id: 'sub-1', formDataJson: { phone_owner: 'SELF' } },
+      resolvedSchema,
+    );
 
-    const first = await backfillSubmission(client, submission);
-    const second = await backfillSubmission(client, submission);
-
-    expect(first).toEqual(second);
-    expect(deleteMany).toHaveBeenCalledTimes(2);
+    expect(updateMany).toHaveBeenCalled();
+    // No deleteMany call exists on the mocked client at all — this would
+    // throw if backfillSubmission ever called it, since the mock has no
+    // such method.
   });
 
-  it('skips a submission whose form_version_id no longer resolves, without deleting its existing answers', async () => {
-    findUnique.mockResolvedValue(null);
+  it('is idempotent — running it twice in a row produces the same answersWritten count', async () => {
+    const submission = { id: 'sub-1', formDataJson: { phone_owner: 'SELF', bp_systolic: 118 } };
 
-    const result = await backfillSubmission(client, {
-      id: 'sub-orphaned',
-      formVersionId: 'deleted-version',
-      formDataJson: { phone_owner: 'SELF' },
-    });
+    const first = await backfillSubmission(client, submission, resolvedSchema);
+    const second = await backfillSubmission(client, submission, resolvedSchema);
 
-    expect(result).toEqual({ skipped: expect.stringContaining('form_version_id') });
-    expect(deleteMany).not.toHaveBeenCalled();
-    expect(createMany).not.toHaveBeenCalled();
+    expect(first).toEqual(second);
+    expect(updateMany).toHaveBeenCalledTimes(2);
   });
 
   it('replaces with zero rows and does not throw when form_data_json is empty', async () => {
-    findUnique.mockResolvedValue(publishedVersion);
+    const result = await backfillSubmission(
+      client,
+      { id: 'sub-empty', formDataJson: {} },
+      resolvedSchema,
+    );
 
-    const result = await backfillSubmission(client, {
-      id: 'sub-empty',
-      formVersionId: 'version-1',
-      formDataJson: {},
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { submissionId: 'sub-empty', isDeleted: false },
+      data: { isDeleted: true, deletedAt: expect.any(Date) },
     });
-
-    expect(deleteMany).toHaveBeenCalledWith({ where: { submissionId: 'sub-empty' } });
     expect(createMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ answersWritten: 0 });
+  });
+
+  it('treats a JSON array form_data_json as unparseable (empty object), not as numeric-indexed fields', async () => {
+    const result = await backfillSubmission(
+      client,
+      { id: 'sub-array', formDataJson: ['not', 'an', 'object'] },
+      resolvedSchema,
+    );
+
+    expect(createMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ answersWritten: 0 });
+  });
+
+  it('treats a null form_data_json as an empty object', async () => {
+    const result = await backfillSubmission(
+      client,
+      { id: 'sub-null', formDataJson: null },
+      resolvedSchema,
+    );
+
     expect(result).toEqual({ answersWritten: 0 });
   });
 });

--- a/apps/visit-form-service/prisma/backfill-form-answers.spec.ts
+++ b/apps/visit-form-service/prisma/backfill-form-answers.spec.ts
@@ -1,0 +1,85 @@
+import { backfillSubmission } from './backfill-form-answers';
+
+describe('backfillSubmission', () => {
+  const findUnique = jest.fn();
+  const deleteMany = jest.fn();
+  const createMany = jest.fn();
+  const client = {
+    formVersion: { findUnique },
+    formAnswer: { deleteMany, createMany },
+  } as never;
+
+  const publishedVersion = {
+    id: 'version-1',
+    schemaJson: [
+      { question_code: 'phone_owner', label: 'x', input_type: 'text', required: false },
+      { question_code: 'bp_systolic', label: 'x', input_type: 'number', required: false },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('re-derives form_answers from form_data_json and replaces the existing rows', async () => {
+    findUnique.mockResolvedValue(publishedVersion);
+
+    const result = await backfillSubmission(client, {
+      id: 'sub-1',
+      formVersionId: 'version-1',
+      formDataJson: { phone_owner: 'SELF', bp_systolic: 118 },
+    });
+
+    expect(deleteMany).toHaveBeenCalledWith({ where: { submissionId: 'sub-1' } });
+    expect(createMany).toHaveBeenCalledWith({
+      data: expect.arrayContaining([
+        expect.objectContaining({ submissionId: 'sub-1', fieldCode: 'phone_owner' }),
+        expect.objectContaining({ submissionId: 'sub-1', fieldCode: 'bp_systolic' }),
+      ]),
+    });
+    expect(result).toEqual({ answersWritten: 2 });
+  });
+
+  it('is idempotent — running it twice in a row produces the same answersWritten count', async () => {
+    findUnique.mockResolvedValue(publishedVersion);
+    const submission = {
+      id: 'sub-1',
+      formVersionId: 'version-1',
+      formDataJson: { phone_owner: 'SELF', bp_systolic: 118 },
+    };
+
+    const first = await backfillSubmission(client, submission);
+    const second = await backfillSubmission(client, submission);
+
+    expect(first).toEqual(second);
+    expect(deleteMany).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips a submission whose form_version_id no longer resolves, without deleting its existing answers', async () => {
+    findUnique.mockResolvedValue(null);
+
+    const result = await backfillSubmission(client, {
+      id: 'sub-orphaned',
+      formVersionId: 'deleted-version',
+      formDataJson: { phone_owner: 'SELF' },
+    });
+
+    expect(result).toEqual({ skipped: expect.stringContaining('form_version_id') });
+    expect(deleteMany).not.toHaveBeenCalled();
+    expect(createMany).not.toHaveBeenCalled();
+  });
+
+  it('replaces with zero rows and does not throw when form_data_json is empty', async () => {
+    findUnique.mockResolvedValue(publishedVersion);
+
+    const result = await backfillSubmission(client, {
+      id: 'sub-empty',
+      formVersionId: 'version-1',
+      formDataJson: {},
+    });
+
+    expect(deleteMany).toHaveBeenCalledWith({ where: { submissionId: 'sub-empty' } });
+    expect(createMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ answersWritten: 0 });
+  });
+});

--- a/apps/visit-form-service/prisma/backfill-form-answers.ts
+++ b/apps/visit-form-service/prisma/backfill-form-answers.ts
@@ -1,0 +1,127 @@
+/**
+ * Backfill/reconciliation for form_answers.
+ *
+ * form_submissions.form_data_json is the durable source of truth; form_answers
+ * is a normalized projection of it (see FormRepository.createSubmission),
+ * written in the same transaction as the submission at request time. This
+ * script exists for the case where that projection logic changes later (a new
+ * input_type, a fix to buildFormAnswers) and needs to be re-applied to
+ * submissions that were stored under the old logic — it never touches
+ * form_data_json itself.
+ *
+ * Idempotent: for each submission processed, this replaces (not appends to)
+ * its form_answers rows with a fresh decomposition, in one transaction per
+ * submission — re-running twice in a row produces the same end state.
+ *
+ * Usage:
+ *   npx ts-node prisma/backfill-form-answers.ts [--form-version-id=<uuid>]
+ *
+ * With no flag, every form_submissions row is reprocessed. With
+ * --form-version-id, only submissions on that exact form version are touched
+ * — useful for re-applying a fix scoped to one form's schema without
+ * reprocessing the whole table.
+ */
+import { PrismaClient } from '../../../node_modules/.prisma/client-visit-form-service';
+import { buildFormAnswers } from '../src/forms/form.mapper';
+import { schemaJsonSchema } from '../src/forms/dto/form-field.dto';
+
+const prisma = new PrismaClient();
+
+export interface BackfillSummary {
+  processed: number;
+  answersWritten: number;
+  skipped: Array<{ submissionId: string; reason: string }>;
+}
+
+/**
+ * Re-derives and replaces one submission's form_answers rows from its stored
+ * form_data_json, using the schema of the form version it was actually
+ * answered against (never the currently active version) — same "own
+ * historical schema" contract createSubmission relies on. Returns
+ * `{ skipped }` (and leaves existing form_answers untouched) when the version
+ * can't be resolved/parsed, rather than guessing or dropping good data.
+ */
+export async function backfillSubmission(
+  client: Pick<PrismaClient, 'formVersion' | 'formAnswer'>,
+  submission: { id: string; formVersionId: string; formDataJson: unknown },
+): Promise<{ answersWritten: number } | { skipped: string }> {
+  const version = await client.formVersion.findUnique({ where: { id: submission.formVersionId } });
+  if (!version) return { skipped: 'form_version_id no longer resolves to a form_versions row' };
+
+  const parsed = schemaJsonSchema.safeParse(version.schemaJson);
+  if (!parsed.success) {
+    return { skipped: 'schemaJson failed to parse against the current field schema' };
+  }
+
+  const formData =
+    typeof submission.formDataJson === 'object' && submission.formDataJson !== null
+      ? (submission.formDataJson as Record<string, unknown>)
+      : {};
+  const answers = buildFormAnswers(parsed.data, formData);
+
+  await client.formAnswer.deleteMany({ where: { submissionId: submission.id } });
+  if (answers.length) {
+    await client.formAnswer.createMany({
+      data: answers.map((a) => ({
+        submissionId: submission.id,
+        fieldCode: a.fieldCode,
+        answerValueText: a.answerValueText,
+        answerValueNumber: a.answerValueNumber,
+        answerValueDate: a.answerValueDate,
+        answerValueBool: a.answerValueBool,
+        answerValueJson: a.answerValueJson as never,
+        isIndexed: a.isIndexed,
+      })),
+    });
+  }
+
+  return { answersWritten: answers.length };
+}
+
+async function main(): Promise<void> {
+  const formVersionIdArg = process.argv
+    .find((a) => a.startsWith('--form-version-id='))
+    ?.split('=')[1];
+
+  const submissions = await prisma.formSubmission.findMany({
+    where: formVersionIdArg ? { formVersionId: formVersionIdArg } : undefined,
+    select: { id: true, formVersionId: true, formDataJson: true },
+  });
+
+  const summary: BackfillSummary = { processed: 0, answersWritten: 0, skipped: [] };
+
+  for (const submission of submissions) {
+    const result = await prisma.$transaction((tx) => backfillSubmission(tx, submission));
+    summary.processed += 1;
+    if ('skipped' in result) {
+      summary.skipped.push({ submissionId: submission.id, reason: result.skipped });
+    } else {
+      summary.answersWritten += result.answersWritten;
+    }
+  }
+
+  console.log('Backfill summary:', {
+    processed: summary.processed,
+    answersWritten: summary.answersWritten,
+    skippedCount: summary.skipped.length,
+  });
+  if (summary.skipped.length > 0) {
+    console.log('Skipped submissions:', summary.skipped);
+    throw new Error(
+      `${summary.skipped.length} submission(s) could not be reprocessed — see the list above.`,
+    );
+  }
+  console.log('Done — form_answers reprocessed for all matching submissions.');
+}
+
+// Guarded so importing backfillSubmission for a unit test (see
+// backfill-form-answers.spec.ts) never opens a real Prisma connection —
+// only running this file directly as a script does.
+if (require.main === module) {
+  main()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/visit-form-service/prisma/backfill-form-answers.ts
+++ b/apps/visit-form-service/prisma/backfill-form-answers.ts
@@ -11,7 +11,10 @@
  *
  * Idempotent: for each submission processed, this replaces (not appends to)
  * its form_answers rows with a fresh decomposition, in one transaction per
- * submission — re-running twice in a row produces the same end state.
+ * submission — re-running twice in a row produces the same end state. The
+ * prior rows are soft-deleted (isDeleted/deletedAt), not hard-deleted — this
+ * table exists for reporting/audit, so a run's own history stays recoverable
+ * rather than being permanently erased on every reconciliation.
  *
  * Usage:
  *   npx ts-node prisma/backfill-form-answers.ts [--form-version-id=<uuid>]
@@ -23,9 +26,16 @@
  */
 import { PrismaClient } from '../../../node_modules/.prisma/client-visit-form-service';
 import { buildFormAnswers } from '../src/forms/form.mapper';
-import { schemaJsonSchema } from '../src/forms/dto/form-field.dto';
+import { schemaJsonSchema, type FormField } from '../src/forms/dto/form-field.dto';
 
 const prisma = new PrismaClient();
+
+// Rows are processed in fixed-size concurrent batches — each row's own
+// transaction is already independent, so bounded concurrency cuts run time
+// on a large table without changing per-row atomicity or the summary's
+// correctness (still one outcome per row, still fully awaited before the
+// script exits).
+const CONCURRENCY = 15;
 
 export interface BackfillSummary {
   processed: number;
@@ -40,26 +50,34 @@ export interface BackfillSummary {
  * historical schema" contract createSubmission relies on. Returns
  * `{ skipped }` (and leaves existing form_answers untouched) when the version
  * can't be resolved/parsed, rather than guessing or dropping good data.
+ *
+ * `resolvedSchema` is passed in (not re-fetched/re-parsed here) so a caller
+ * processing many submissions against the same small set of form versions
+ * can resolve+parse each version once and reuse it, instead of repeating
+ * that DB round-trip and zod parse on every row.
  */
 export async function backfillSubmission(
-  client: Pick<PrismaClient, 'formVersion' | 'formAnswer'>,
-  submission: { id: string; formVersionId: string; formDataJson: unknown },
-): Promise<{ answersWritten: number } | { skipped: string }> {
-  const version = await client.formVersion.findUnique({ where: { id: submission.formVersionId } });
-  if (!version) return { skipped: 'form_version_id no longer resolves to a form_versions row' };
-
-  const parsed = schemaJsonSchema.safeParse(version.schemaJson);
-  if (!parsed.success) {
-    return { skipped: 'schemaJson failed to parse against the current field schema' };
-  }
-
+  client: Pick<PrismaClient, 'formAnswer'>,
+  submission: { id: string; formDataJson: unknown },
+  resolvedSchema: FormField[],
+): Promise<{ answersWritten: number }> {
+  // Arrays pass `typeof === 'object' && !== null` too — without this guard,
+  // a legacy row with form_data_json stored as a JSON array would get cast
+  // to Record<string, unknown> and buildFormAnswers would Object.entries()
+  // its numeric indices as if they were question codes, instead of being
+  // treated as unparseable.
   const formData =
-    typeof submission.formDataJson === 'object' && submission.formDataJson !== null
+    typeof submission.formDataJson === 'object' &&
+    submission.formDataJson !== null &&
+    !Array.isArray(submission.formDataJson)
       ? (submission.formDataJson as Record<string, unknown>)
       : {};
-  const answers = buildFormAnswers(parsed.data, formData);
+  const answers = buildFormAnswers(resolvedSchema, formData);
 
-  await client.formAnswer.deleteMany({ where: { submissionId: submission.id } });
+  await client.formAnswer.updateMany({
+    where: { submissionId: submission.id, isDeleted: false },
+    data: { isDeleted: true, deletedAt: new Date() },
+  });
   if (answers.length) {
     await client.formAnswer.createMany({
       data: answers.map((a) => ({
@@ -78,6 +96,13 @@ export async function backfillSubmission(
   return { answersWritten: answers.length };
 }
 
+/** Splits an array into fixed-size chunks, preserving order. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size));
+  return chunks;
+}
+
 async function main(): Promise<void> {
   const formVersionIdArg = process.argv
     .find((a) => a.startsWith('--form-version-id='))
@@ -88,16 +113,47 @@ async function main(): Promise<void> {
     select: { id: true, formVersionId: true, formDataJson: true },
   });
 
+  // Resolved once per distinct formVersionId, not once per submission — the
+  // number of form versions touched in a run is typically far smaller than
+  // the number of submissions against them.
+  const resolvedSchemas = new Map<string, FormField[] | null>();
+  async function resolveSchema(formVersionId: string): Promise<FormField[] | null> {
+    if (resolvedSchemas.has(formVersionId)) return resolvedSchemas.get(formVersionId) ?? null;
+    const version = await prisma.formVersion.findUnique({ where: { id: formVersionId } });
+    if (!version) {
+      resolvedSchemas.set(formVersionId, null);
+      return null;
+    }
+    const parsed = schemaJsonSchema.safeParse(version.schemaJson);
+    const resolved = parsed.success ? parsed.data : null;
+    resolvedSchemas.set(formVersionId, resolved);
+    return resolved;
+  }
+
   const summary: BackfillSummary = { processed: 0, answersWritten: 0, skipped: [] };
 
-  for (const submission of submissions) {
-    const result = await prisma.$transaction((tx) => backfillSubmission(tx, submission));
-    summary.processed += 1;
-    if ('skipped' in result) {
-      summary.skipped.push({ submissionId: submission.id, reason: result.skipped });
-    } else {
-      summary.answersWritten += result.answersWritten;
-    }
+  for (const batch of chunk(submissions, CONCURRENCY)) {
+    await Promise.all(
+      batch.map(async (submission) => {
+        const schema = await resolveSchema(submission.formVersionId);
+        if (!schema) {
+          summary.processed += 1;
+          summary.skipped.push({
+            submissionId: submission.id,
+            reason:
+              resolvedSchemas.get(submission.formVersionId) === null
+                ? 'form_version_id no longer resolves to a form_versions row, or its schemaJson failed to parse'
+                : 'unknown',
+          });
+          return;
+        }
+        const result = await prisma.$transaction((tx) =>
+          backfillSubmission(tx, submission, schema),
+        );
+        summary.processed += 1;
+        summary.answersWritten += result.answersWritten;
+      }),
+    );
   }
 
   console.log('Backfill summary:', {
@@ -107,6 +163,7 @@ async function main(): Promise<void> {
   });
   if (summary.skipped.length > 0) {
     console.log('Skipped submissions:', summary.skipped);
+    await prisma.$disconnect();
     throw new Error(
       `${summary.skipped.length} submission(s) could not be reprocessed — see the list above.`,
     );
@@ -119,9 +176,14 @@ async function main(): Promise<void> {
 // only running this file directly as a script does.
 if (require.main === module) {
   main()
-    .catch((err) => {
+    .catch(async (err) => {
       console.error(err);
+      // process.exit terminates synchronously before a chained .finally
+      // would run — disconnect explicitly here (and on the thrown-skip path
+      // above) so a failure doesn't leak the connection instead of relying
+      // on a .finally that never gets to fire.
+      await prisma.$disconnect();
       process.exit(1);
     })
-    .finally(() => prisma.$disconnect());
+    .then(() => prisma.$disconnect());
 }

--- a/apps/visit-form-service/prisma/migrations/20260819100000_add_form_answers_index/migration.sql
+++ b/apps/visit-form-service/prisma/migrations/20260819100000_add_form_answers_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "form_answers_submission_id_field_code_idx" ON "form_answers"("submission_id", "field_code");

--- a/apps/visit-form-service/prisma/schema.prisma
+++ b/apps/visit-form-service/prisma/schema.prisma
@@ -335,8 +335,12 @@ model FormAnswer {
   formSubmission FormSubmission @relation(fields: [submissionId], references: [id])
 
   // ERD's design stance (line 19): fields extracted for reporting/query must
-  // be indexed, not require a full scan — this supports both "all answers for
-  // a submission" and "this question across submissions" lookups.
+  // be indexed, not require a full scan. This composite index's leading
+  // column is submissionId, so it serves "all answers for a submission" and
+  // "this one field within one submission" lookups (leftmost-prefix rule) —
+  // NOT "this field across every submission" on its own; that access
+  // pattern would need its own index leading with fieldCode, not added here
+  // since no current caller queries that way.
   @@index([submissionId, fieldCode])
   @@map("form_answers")
 }

--- a/apps/visit-form-service/prisma/schema.prisma
+++ b/apps/visit-form-service/prisma/schema.prisma
@@ -334,5 +334,9 @@ model FormAnswer {
 
   formSubmission FormSubmission @relation(fields: [submissionId], references: [id])
 
+  // ERD's design stance (line 19): fields extracted for reporting/query must
+  // be indexed, not require a full scan — this supports both "all answers for
+  // a submission" and "this question across submissions" lookups.
+  @@index([submissionId, fieldCode])
   @@map("form_answers")
 }

--- a/apps/visit-form-service/src/forms/form.repository.spec.ts
+++ b/apps/visit-form-service/src/forms/form.repository.spec.ts
@@ -1,0 +1,34 @@
+import { FormRepository } from './form.repository';
+
+describe('FormRepository', () => {
+  const findFirst = jest.fn();
+  const prisma = { visitInstance: { findFirst } } as never;
+  let repository: FormRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new FormRepository(prisma);
+  });
+
+  describe('findVisitById', () => {
+    it('returns the visit row when it exists and is not deleted', async () => {
+      const visit = { id: 'visit-1', isDeleted: false };
+      findFirst.mockResolvedValue(visit);
+
+      const result = await repository.findVisitById('visit-1');
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: { id: 'visit-1', isDeleted: false },
+      });
+      expect(result).toBe(visit);
+    });
+
+    it('returns null when no matching visit exists', async () => {
+      findFirst.mockResolvedValue(null);
+
+      const result = await repository.findVisitById('missing-id');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/visit-form-service/src/forms/form.repository.spec.ts
+++ b/apps/visit-form-service/src/forms/form.repository.spec.ts
@@ -11,14 +11,14 @@ describe('FormRepository', () => {
   });
 
   describe('findVisitById', () => {
-    it('returns the visit row when it exists and is not deleted', async () => {
-      const visit = { id: 'visit-1', isDeleted: false };
+    it('returns the visit row when it exists, belongs to the given beneficiary, and is not deleted', async () => {
+      const visit = { id: 'visit-1', beneficiaryId: 'b1', isDeleted: false };
       findFirst.mockResolvedValue(visit);
 
-      const result = await repository.findVisitById('visit-1');
+      const result = await repository.findVisitById('visit-1', 'b1');
 
       expect(findFirst).toHaveBeenCalledWith({
-        where: { id: 'visit-1', isDeleted: false },
+        where: { id: 'visit-1', beneficiaryId: 'b1', isDeleted: false },
       });
       expect(result).toBe(visit);
     });
@@ -26,9 +26,23 @@ describe('FormRepository', () => {
     it('returns null when no matching visit exists', async () => {
       findFirst.mockResolvedValue(null);
 
-      const result = await repository.findVisitById('missing-id');
+      const result = await repository.findVisitById('missing-id', 'b1');
 
       expect(result).toBeNull();
+    });
+
+    it('filters on beneficiaryId — a real visit belonging to a different beneficiary does not match', async () => {
+      // The mocked findFirst always resolves what it's told to, so this test
+      // asserts the *query shape* includes beneficiaryId rather than
+      // simulating Prisma's own filtering — the real enforcement is the
+      // database query, not application code.
+      findFirst.mockResolvedValue(null);
+
+      await repository.findVisitById('visit-1', 'wrong-beneficiary');
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: { id: 'visit-1', beneficiaryId: 'wrong-beneficiary', isDeleted: false },
+      });
     });
   });
 });

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -125,13 +125,22 @@ export class FormRepository {
   }
 
   /**
-   * Existence check for a visit-linked submission's visitId, before the
-   * insert — visit_instances is owned by this same service (unlike
-   * beneficiary_cases/form_versions' cross-service equivalents), so this is a
-   * direct query, not an HTTP call.
+   * Existence + ownership check for a visit-linked submission's visitId,
+   * before the insert — visit_instances is owned by this same service
+   * (unlike beneficiary_cases/form_versions' cross-service equivalents), so
+   * this is a direct query, not an HTTP call. Filters on beneficiaryId too,
+   * not just id — without it, a client could submit beneficiaryId "A" with a
+   * real, non-deleted visitId that actually belongs to a different
+   * beneficiary "B", and this check would wrongly pass.
+   *
+   * Duplicates VisitInstanceRepository.findById's shape (same table, same
+   * isDeleted convention) rather than importing that repository — this
+   * service composes one FormRepository per its own doc comment ("the only
+   * tables this repository touches"), and introducing a cross-repository
+   * dependency for one extra filter isn't worth breaking that.
    */
-  findVisitById(id: string) {
-    return this.prisma.visitInstance.findFirst({ where: { id, isDeleted: false } });
+  findVisitById(id: string, beneficiaryId: string) {
+    return this.prisma.visitInstance.findFirst({ where: { id, beneficiaryId, isDeleted: false } });
   }
 
   /**

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -125,6 +125,16 @@ export class FormRepository {
   }
 
   /**
+   * Existence check for a visit-linked submission's visitId, before the
+   * insert — visit_instances is owned by this same service (unlike
+   * beneficiary_cases/form_versions' cross-service equivalents), so this is a
+   * direct query, not an HTTP call.
+   */
+  findVisitById(id: string) {
+    return this.prisma.visitInstance.findFirst({ where: { id, isDeleted: false } });
+  }
+
+  /**
    * Persists the submission and its normalized form_answers rows atomically:
    * the submission and every answer row commit together or not at all, so the
    * raw form_data_json and its per-question projection can never diverge.

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -28,6 +28,7 @@ describe('FormService', () => {
     publish: jest.fn(),
     findSubmissionByLocalUuid: jest.fn(),
     createSubmission: jest.fn(),
+    findVisitById: jest.fn(),
   } as unknown as jest.Mocked<FormRepository>;
   let service: FormService;
 
@@ -551,6 +552,119 @@ describe('FormService', () => {
         expect.objectContaining({ validationStatus: 'VALID' }),
       );
       expect(result).toEqual({ id: 'sub-1' });
+    });
+
+    describe('visitId validation', () => {
+      it('proceeds when visitId is omitted — no visit check is attempted', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(repository.findVisitById).not.toHaveBeenCalled();
+        expect(repository.createSubmission).toHaveBeenCalled();
+      });
+
+      it('proceeds when visitId refers to an existing visit', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(repository.findVisitById).toHaveBeenCalledWith('visit-1');
+        expect(repository.createSubmission).toHaveBeenCalled();
+      });
+
+      it('rejects with 404 when visitId does not refer to an existing visit, without inserting', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue(null);
+
+        const promise = service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'missing-visit',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(promise).rejects.toMatchObject({ status: 404, message: 'Visit not found.' });
+        expect(repository.createSubmission).not.toHaveBeenCalled();
+      });
+
+      it('translates a foreign-key-violation race from createSubmission into the same 404', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+        repository.createSubmission.mockRejectedValue({ code: 'P2003' });
+
+        const promise = service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(promise).rejects.toMatchObject({ status: 404, message: 'Visit not found.' });
+      });
+
+      it('does not translate an unrelated createSubmission error', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+        const originalError = new Error('some other db failure');
+        repository.createSubmission.mockRejectedValue(originalError);
+
+        const promise = service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(promise).rejects.toBe(originalError);
+      });
     });
 
     it('syncs socio-demographic answers to beneficiary-service for MOTHER_REGISTRATION', async () => {

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -576,7 +576,7 @@ describe('FormService', () => {
         expect(repository.createSubmission).toHaveBeenCalled();
       });
 
-      it('proceeds when visitId refers to an existing visit', async () => {
+      it('proceeds when visitId refers to an existing visit owned by this beneficiary', async () => {
         repository.findSubmissionByLocalUuid.mockResolvedValue(null);
         repository.findVersionById.mockResolvedValue(publishedVersion as never);
         repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
@@ -595,8 +595,33 @@ describe('FormService', () => {
           'Bearer test-token',
         );
 
-        expect(repository.findVisitById).toHaveBeenCalledWith('visit-1');
+        expect(repository.findVisitById).toHaveBeenCalledWith('visit-1', 'b1');
         expect(repository.createSubmission).toHaveBeenCalled();
+      });
+
+      it('runs the visitId check after formData validation, not before', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue(null);
+
+        const promise = service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'missing-visit',
+            localSubmissionUuid: 'uuid-1',
+            // bp_systolic is out of numericRange (70-300) AND visitId is
+            // missing — the formData violation must still be reported, not
+            // masked by the visitId check running first.
+            formData: { phone_owner: 'SELF', bp_systolic: 999 },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(promise).rejects.toMatchObject({ status: 422 });
+        expect(repository.findVisitById).not.toHaveBeenCalled();
       });
 
       it('rejects with 404 when visitId does not refer to an existing visit, without inserting', async () => {
@@ -621,11 +646,14 @@ describe('FormService', () => {
         expect(repository.createSubmission).not.toHaveBeenCalled();
       });
 
-      it('translates a foreign-key-violation race from createSubmission into the same 404', async () => {
+      it('translates a foreign-key-violation race on the visit_id constraint into the same 404', async () => {
         repository.findSubmissionByLocalUuid.mockResolvedValue(null);
         repository.findVersionById.mockResolvedValue(publishedVersion as never);
         repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
-        repository.createSubmission.mockRejectedValue({ code: 'P2003' });
+        repository.createSubmission.mockRejectedValue({
+          code: 'P2003',
+          meta: { field_name: 'form_submissions_visit_id_fkey (index)' },
+        });
 
         const promise = service.createSubmission(
           'MOTHER_REGISTRATION',
@@ -641,6 +669,30 @@ describe('FormService', () => {
         );
 
         await expect(promise).rejects.toMatchObject({ status: 404, message: 'Visit not found.' });
+      });
+
+      it('does not report "Visit not found" for a P2003 on an unrelated FK (e.g. form_version_id)', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        const fkError = {
+          code: 'P2003',
+          meta: { field_name: 'form_submissions_form_version_id_fkey (index)' },
+        };
+        repository.createSubmission.mockRejectedValue(fkError);
+
+        const promise = service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(promise).rejects.toBe(fkError);
       });
 
       it('does not translate an unrelated createSubmission error', async () => {
@@ -664,6 +716,53 @@ describe('FormService', () => {
         );
 
         await expect(promise).rejects.toBe(originalError);
+      });
+
+      it('replays the winning row on a concurrent P2002 race on localSubmissionUuid', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.createSubmission.mockRejectedValue({ code: 'P2002' });
+        const winningRow = { id: 'sub-winner', beneficiaryId: 'b1' };
+        // Re-queried after the race is detected — this second call simulates
+        // the concurrent request's row having since committed.
+        repository.findSubmissionByLocalUuid
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(winningRow as never);
+
+        const result = await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toMatchObject({ id: 'sub-winner' });
+      });
+
+      it('rethrows a P2002 when no winning row can be found on re-query', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        const p2002Error = { code: 'P2002' };
+        repository.createSubmission.mockRejectedValue(p2002Error);
+
+        const promise = service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(promise).rejects.toBe(p2002Error);
       });
     });
 

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -188,6 +188,16 @@ export class FormService {
       throw badRequest('Form version is not published.');
     }
 
+    // Client-supplied visitId can be stale (a race between the visit's own
+    // POST /visits and this submission, or a bad replay) — check before the
+    // insert so this fails as a clean, named 404 instead of an unhandled FK
+    // violation. See createSubmission's P2003 catch below for the remaining
+    // check-then-insert race window this can't close on its own.
+    if (dto.visitId) {
+      const visit = await this.repository.findVisitById(dto.visitId);
+      if (!visit) throw notFound('Visit not found.');
+    }
+
     const fields = schemaJsonSchema.parse(version.schemaJson);
     const crossFieldRules = validationJsonSchema.parse(version.validationJson ?? []);
     const violations = validateSubmission(fields, crossFieldRules, dto.formData);
@@ -201,16 +211,25 @@ export class FormService {
     // line 19), driven by each field's declared input_type — no hardcoding.
     const formAnswers = buildFormAnswers(fields, dto.formData);
 
-    const created = await this.repository.createSubmission({
-      formVersionId: dto.formVersionId,
-      beneficiaryId: dto.beneficiaryId,
-      visitId: dto.visitId ?? null,
-      submittedByUserId,
-      localSubmissionUuid: dto.localSubmissionUuid,
-      formDataJson: dto.formData,
-      validationStatus: 'VALID',
-      formAnswers,
-    });
+    let created;
+    try {
+      created = await this.repository.createSubmission({
+        formVersionId: dto.formVersionId,
+        beneficiaryId: dto.beneficiaryId,
+        visitId: dto.visitId ?? null,
+        submittedByUserId,
+        localSubmissionUuid: dto.localSubmissionUuid,
+        formDataJson: dto.formData,
+        validationStatus: 'VALID',
+        formAnswers,
+      });
+    } catch (err) {
+      // Backstop for the race the check above can't close on its own: the
+      // visit existed at check time but was gone by the time this insert ran.
+      // Same "fail loud, named 404" contract either way, not a 500.
+      if (isForeignKeyViolation(err)) throw notFound('Visit not found.');
+      throw err;
+    }
 
     // Promote the socio-demographic answers into beneficiary-service, which
     // owns them as structured columns (the registration form re-asks them so
@@ -479,5 +498,15 @@ function isUniqueConstraintViolation(err: unknown): boolean {
     err !== null &&
     'code' in err &&
     (err as { code: unknown }).code === 'P2002'
+  );
+}
+
+/** Narrows a caught Prisma error to a foreign-key violation (P2003). */
+function isForeignKeyViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'P2003'
   );
 }

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -95,7 +95,7 @@ export class FormService {
       // pick the same versionNo. The @@unique([formDefinitionId, versionNo])
       // constraint keeps the data safe — surface the loser as a graceful 409
       // (retryable) rather than an unhandled 500.
-      if (isUniqueConstraintViolation(err)) {
+      if (isPrismaErrorCode(err, 'P2002')) {
         throw conflict('A form version with this number is being created concurrently. Retry.');
       }
       throw err;
@@ -188,22 +188,26 @@ export class FormService {
       throw badRequest('Form version is not published.');
     }
 
-    // Client-supplied visitId can be stale (a race between the visit's own
-    // POST /visits and this submission, or a bad replay) — check before the
-    // insert so this fails as a clean, named 404 instead of an unhandled FK
-    // violation. See createSubmission's P2003 catch below for the remaining
-    // check-then-insert race window this can't close on its own.
-    if (dto.visitId) {
-      const visit = await this.repository.findVisitById(dto.visitId);
-      if (!visit) throw notFound('Visit not found.');
-    }
-
     const fields = schemaJsonSchema.parse(version.schemaJson);
     const crossFieldRules = validationJsonSchema.parse(version.validationJson ?? []);
     const violations = validateSubmission(fields, crossFieldRules, dto.formData);
 
     if (violations.length) {
       throw unprocessable('Submission failed validation.', { violations });
+    }
+
+    // Client-supplied visitId can be stale (a race between the visit's own
+    // POST /visits and this submission, or a bad replay) — check before the
+    // insert so this fails as a clean, named 404 instead of an unhandled FK
+    // violation. Checked with beneficiaryId, not just id — otherwise a real,
+    // non-deleted visitId belonging to a different beneficiary would wrongly
+    // pass. Run after validateSubmission (not before) so a request that's
+    // wrong in both ways reports the formData violations too, not just this
+    // 404 — the client shouldn't have to fix one error at a time across two
+    // round trips when both are already knowable in this same request.
+    if (dto.visitId) {
+      const visit = await this.repository.findVisitById(dto.visitId, dto.beneficiaryId);
+      if (!visit) throw notFound('Visit not found.');
     }
 
     // Decompose the validated payload into normalized per-question rows so
@@ -224,10 +228,36 @@ export class FormService {
         formAnswers,
       });
     } catch (err) {
-      // Backstop for the race the check above can't close on its own: the
-      // visit existed at check time but was gone by the time this insert ran.
-      // Same "fail loud, named 404" contract either way, not a 500.
-      if (isForeignKeyViolation(err)) throw notFound('Visit not found.');
+      // A double-submit racing on the same localSubmissionUuid can slip past
+      // the findSubmissionByLocalUuid check above and hit the unique
+      // constraint here instead — same race shape createDraft already
+      // handles. The loser just replays the winner's row rather than
+      // erroring, same idempotent-replay contract as a sequential retry.
+      if (isPrismaErrorCode(err, 'P2002')) {
+        const existingRow = await this.repository.findSubmissionByLocalUuid(
+          dto.localSubmissionUuid,
+        );
+        if (existingRow) return toApiFormSubmission(existingRow);
+        throw err;
+      }
+      // Backstop for the race the visitId check above can't close on its
+      // own: the visit existed at check time but was gone by the time this
+      // insert ran (see that check's own comment on the pre-condition
+      // needed for this to actually fire today). form_submissions has two
+      // FK columns (form_version_id, visit_id) — only rewrite this to a
+      // "Visit not found" 404 if the failing constraint is actually the
+      // visit one; anything else (e.g. a form_version_id race) falls
+      // through to the generic handler below instead of reporting the
+      // wrong resource as missing.
+      if (isPrismaErrorCode(err, 'P2003') && failingConstraintIsVisitId(err)) {
+        console.warn(
+          `Submission insert hit a visit_id FK violation for a visitId that passed the ` +
+            `pre-insert check (localSubmissionUuid ${dto.localSubmissionUuid}) — the visit was ` +
+            `removed in the window between the check and this insert:`,
+          err,
+        );
+        throw notFound('Visit not found.');
+      }
       throw err;
     }
 
@@ -491,22 +521,29 @@ async function toleratePhaseAdvance(call: Promise<void>): Promise<void> {
   await Promise.resolve(call).catch(() => undefined);
 }
 
-/** Narrows a caught Prisma error to a unique-constraint violation (P2002). */
-function isUniqueConstraintViolation(err: unknown): boolean {
+/** Narrows a caught error to a specific Prisma error code (e.g. 'P2002', 'P2003'). */
+function isPrismaErrorCode(err: unknown, code: string): boolean {
   return (
     typeof err === 'object' &&
     err !== null &&
     'code' in err &&
-    (err as { code: unknown }).code === 'P2002'
+    (err as { code: unknown }).code === code
   );
 }
 
-/** Narrows a caught Prisma error to a foreign-key violation (P2003). */
-function isForeignKeyViolation(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    (err as { code: unknown }).code === 'P2003'
-  );
+/**
+ * Disambiguates which FK a P2003 actually violated — form_submissions has
+ * two (form_version_id, visit_id), and only the visit one should be rewritten
+ * to "Visit not found." Prisma's P2003 sets meta.field_name to the
+ * constraint name (e.g. "form_submissions_visit_id_fkey" on Postgres);
+ * checking for the column name substring is more robust than an exact match
+ * against a constraint name whose exact string isn't guaranteed stable
+ * across migrations.
+ */
+function failingConstraintIsVisitId(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null || !('meta' in err)) return false;
+  const meta = (err as { meta?: unknown }).meta;
+  if (typeof meta !== 'object' || meta === null || !('field_name' in meta)) return false;
+  const fieldName = (meta as { field_name?: unknown }).field_name;
+  return typeof fieldName === 'string' && fieldName.includes('visit_id');
 }


### PR DESCRIPTION
## Summary
- Closes #169
- `POST /forms/:formCode/submissions` now validates a client-supplied `visitId` exists before inserting — was previously an unhandled FK violation (500) on a stale/bad `visitId`, now a clean `404 Visit not found.`
- Added a P2003 catch as a backstop for the remaining check-then-insert race window (visit deleted between the check and the insert)
- Added `form_answers(submission_id, field_code)` index per the ERD's indexing stance
- Added an idempotent `backfill-form-answers.ts` reconciliation script to re-derive `form_answers` from `form_data_json`, for use if the answer-decomposition logic changes later

## Test plan
- [x] `npx nx test visit-form-service` — 424/424 passing
- [x] `npx nx lint visit-form-service` — clean
- [x] `npx nx build visit-form-service` — succeeds
- [ ] Migration `20260819100000_add_form_answers_index` needs to be applied to each environment's DB before/with deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)