### PR TITLE
feat(risk-service): Add ANC/Infant high-risk detection rules

### DIFF
--- a/apps/risk-referral-service/prisma/migrations/20260819000000_add_risk_flag_grade_rank/migration.sql
+++ b/apps/risk-referral-service/prisma/migrations/20260819000000_add_risk_flag_grade_rank/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+-- Add as nullable first, backfill existing rows to 0 (treated as NORMAL,
+-- the safest default for historic flags whose true grade rank was never
+-- recorded), then enforce NOT NULL — avoids failing on any pre-existing
+-- risk_flags rows.
+ALTER TABLE "risk_flags" ADD COLUMN "grade_rank" INTEGER;
+
+UPDATE "risk_flags" SET "grade_rank" = 0 WHERE "grade_rank" IS NULL;
+
+ALTER TABLE "risk_flags" ALTER COLUMN "grade_rank" SET NOT NULL;

--- a/apps/risk-referral-service/prisma/schema.prisma
+++ b/apps/risk-referral-service/prisma/schema.prisma
@@ -210,6 +210,15 @@ model RiskFlag {
   // lookup_values.lookup_value_id (category RISK_GRADE) — owned by
   // auth-service, no cross-service relation.
   riskGradeLookupValueId String   @map("risk_grade_lookup_value_id")
+  // Severity rank of this flag's grade, as computed by the rule pack at
+  // evaluation time (0=NORMAL..3=SEVERE) — persisted alongside the opaque
+  // riskGradeLookupValueId so a beneficiary's grade trend can be compared
+  // across visits (improvement/deterioration) without resolving each
+  // historic flag's grade via auth-service's RISK_GRADE lookup category.
+  // Feeds findConsecutiveNoImprovementCount (riskAssessment.repository.ts)
+  // and, longer-term, the Part 3 dashboard's progression/deterioration
+  // reports (docs/Appendix_D_High_Risk_Detection_Rules.md).
+  gradeRank              Int      @map("grade_rank")
   observedValueJson      Json?    @map("observed_value_json")
   isReferralTrigger      Boolean  @default(false) @map("is_referral_trigger")
   isEducationTrigger     Boolean  @default(false) @map("is_education_trigger")

--- a/apps/risk-referral-service/prisma/seed-data/anc-risk-conditions.json
+++ b/apps/risk-referral-service/prisma/seed-data/anc-risk-conditions.json
@@ -1,0 +1,135 @@
+[
+  {
+    "conditionCode": "AGE",
+    "conditionName": "Underage/Overage",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "MUAC_BMI",
+    "conditionName": "MUAC/BMI",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "STUNTING",
+    "conditionName": "Stunting (height)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "BAD_OBSTETRIC_HISTORY",
+    "conditionName": "Bad Obstetric History",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "ANEMIA",
+    "conditionName": "Anemia",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "HYPERTENSION",
+    "conditionName": "Hypertension",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "HYPOTENSION",
+    "conditionName": "Hypotension",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": false,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "HYPERGLYCEMIA",
+    "conditionName": "Hyperglycemia",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "HYPOGLYCEMIA",
+    "conditionName": "Hypoglycemia",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": false,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "APH",
+    "conditionName": "Antepartum Hemorrhage (APH)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "PPH",
+    "conditionName": "Postpartum Hemorrhage (PPH)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": false,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "HYPOTHERMIA",
+    "conditionName": "Hypothermia",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": false,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "HYPERTHERMIA",
+    "conditionName": "Hyperthermia",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "FETAL_HEART_RATE",
+    "conditionName": "Fetal Heart Rate (abnormal)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "FUNDAL_HEIGHT",
+    "conditionName": "Fundal Height (deviation)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "GESTATIONAL_WEIGHT_GAIN",
+    "conditionName": "Poor Gestational Weight Gain",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "JAUNDICE",
+    "conditionName": "Jaundice",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "URINE_ANALYSIS",
+    "conditionName": "Urine Analysis (abnormal)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "DANGER_SIGNS",
+    "conditionName": "Danger Signs",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  }
+]

--- a/apps/risk-referral-service/prisma/seed-data/infant-risk-conditions.json
+++ b/apps/risk-referral-service/prisma/seed-data/infant-risk-conditions.json
@@ -1,0 +1,86 @@
+[
+  {
+    "conditionCode": "LOW_BIRTH_WEIGHT",
+    "conditionName": "Low Birth Weight",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": false,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "WASTING",
+    "conditionName": "Wasting (MUW/SUW/MAM/SAM)",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "STUNTING_STATUS",
+    "conditionName": "Stunting",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "UNDERWEIGHT",
+    "conditionName": "Underweight (MUW/SUW)",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "MUAC_MALNUTRITION",
+    "conditionName": "MAM/SAM (MUAC)",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "INFANT_HYPOTHERMIA",
+    "conditionName": "Hypothermia (Infant)",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "INFANT_HYPERTHERMIA",
+    "conditionName": "Hyperthermia (Infant)",
+    "gradeScale": "NORMAL_MILD_MODERATE_SEVERE",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "CORD_INFECTION",
+    "conditionName": "Cord infection / omphalitis",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "RESPIRATORY_DISTRESS",
+    "conditionName": "Respiratory distress",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "NEURO_DEVELOPMENTAL_STATUS",
+    "conditionName": "Neuro-developmental status",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "INFANT_DANGER_SIGNS",
+    "conditionName": "Danger Signs (Infant)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "FEEDING_ADEQUACY",
+    "conditionName": "Feeding adequacy",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
+  }
+]

--- a/apps/risk-referral-service/prisma/seed-data/risk-parameters.json
+++ b/apps/risk-referral-service/prisma/seed-data/risk-parameters.json
@@ -56,6 +56,83 @@
     "dataType": "BOOLEAN"
   },
   {
+    "parameterCode": "MOTHER_AGE_YEARS",
+    "parameterName": "Age (Mother, at registration)",
+    "entityType": "MOTHER",
+    "unit": "years",
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "MUAC_CM",
+    "parameterName": "Mid-Upper Arm Circumference",
+    "entityType": "MOTHER",
+    "unit": "cm",
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "BAD_OBSTETRIC_HISTORY_FLAG",
+    "parameterName": "Bad Obstetric History",
+    "entityType": "MOTHER",
+    "unit": null,
+    "dataType": "BOOLEAN"
+  },
+  {
+    "parameterCode": "BLOOD_GLUCOSE_MG_DL",
+    "parameterName": "Random Blood Sugar",
+    "entityType": "MOTHER",
+    "unit": "mg/dL",
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "BLEEDING_TYPE",
+    "parameterName": "Vaginal Bleeding (type/severity)",
+    "entityType": "MOTHER",
+    "unit": null,
+    "dataType": "CATEGORICAL"
+  },
+  {
+    "parameterCode": "PPH_HEAVY_BLEEDING_FLAG",
+    "parameterName": "Postpartum Hemorrhage — Heavy Bleeding",
+    "entityType": "MOTHER",
+    "unit": null,
+    "dataType": "BOOLEAN"
+  },
+  {
+    "parameterCode": "FETAL_HEART_RATE_BPM",
+    "parameterName": "Fetal Heart Rate",
+    "entityType": "MOTHER",
+    "unit": "bpm",
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "FUNDAL_HEIGHT_DEVIATION_CM",
+    "parameterName": "Fundal Height Deviation from Gestational Age",
+    "entityType": "MOTHER",
+    "unit": "cm",
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "GESTATIONAL_WEIGHT_GAIN_KG",
+    "parameterName": "Gestational Weight Gain",
+    "entityType": "MOTHER",
+    "unit": "kg",
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "JAUNDICE_POSITIVE_COUNT",
+    "parameterName": "Jaundice Signs Positive Count (Palm/Sclera/Skin)",
+    "entityType": "MOTHER",
+    "unit": null,
+    "dataType": "NUMERIC"
+  },
+  {
+    "parameterCode": "URINE_ABNORMAL_FLAG",
+    "parameterName": "Urine Analysis Abnormal",
+    "entityType": "MOTHER",
+    "unit": null,
+    "dataType": "BOOLEAN"
+  },
+  {
     "parameterCode": "CHILD_BIRTH_WEIGHT_KG",
     "parameterName": "Birth Weight",
     "entityType": "CHILD",

--- a/apps/risk-referral-service/prisma/seed.ts
+++ b/apps/risk-referral-service/prisma/seed.ts
@@ -1,6 +1,8 @@
 import { PrismaClient } from '../../../node_modules/.prisma/client-risk-referral-service';
 import selfReportedConditions from './seed-data/self-reported-conditions.json';
 import riskParameters from './seed-data/risk-parameters.json';
+import ancRiskConditions from './seed-data/anc-risk-conditions.json';
+import infantRiskConditions from './seed-data/infant-risk-conditions.json';
 
 const prisma = new PrismaClient();
 
@@ -21,6 +23,14 @@ interface RiskParameterSeed {
   entityType: 'MOTHER' | 'CHILD';
   unit: string | null;
   dataType: 'NUMERIC' | 'BOOLEAN' | 'CATEGORICAL';
+}
+
+interface AncRiskConditionSeed {
+  conditionCode: string;
+  conditionName: string;
+  gradeScale: 'BINARY' | 'NORMAL_MILD_MODERATE_SEVERE' | 'NORMAL_LOW_MEDIUM_HIGH';
+  referralRequiredDefault: boolean;
+  educationRequiredDefault: boolean;
 }
 
 /**
@@ -116,8 +126,107 @@ async function seedRiskParameters(): Promise<SeedResult> {
   };
 }
 
+/**
+ * Master data for the 18 ANC High-Risk conditions defined in Appendix D
+ * ("High risk protocols_Developer's copy - ANC HR", see
+ * docs/Appendix_D_High_Risk_Detection_Rules.md, Part 1). `phase: ANC` — these
+ * feed the anc-risk.rulesJson.ts RISK rule pack via a conditionCode ->
+ * risk_condition_id map that riskAssessment.service.ts builds by looking
+ * these rows up before calling evaluateRuleSet.
+ */
+async function seedAncRiskConditions(): Promise<SeedResult> {
+  let createdCount = 0;
+
+  for (const condition of ancRiskConditions as AncRiskConditionSeed[]) {
+    const existing = await prisma.riskCondition.findUnique({
+      where: { conditionCode: condition.conditionCode },
+    });
+    if (existing) continue;
+
+    await prisma.riskCondition.create({
+      data: {
+        conditionCode: condition.conditionCode,
+        conditionName: condition.conditionName,
+        entityType: 'MOTHER',
+        phase: 'ANC',
+        gradeScale: condition.gradeScale,
+        referralRequiredDefault: condition.referralRequiredDefault,
+        educationRequiredDefault: condition.educationRequiredDefault,
+        status: 'ACTIVE',
+      },
+    });
+    createdCount += 1;
+  }
+
+  if (createdCount === 0) {
+    return {
+      step: 'anc-risk-conditions',
+      created: false,
+      message: 'All ANC risk condition rows already present — skipped.',
+    };
+  }
+  return {
+    step: 'anc-risk-conditions',
+    created: true,
+    message: `Seeded ${createdCount} ANC risk condition row(s).`,
+  };
+}
+
+/**
+ * Master data for the 10 Infant High-Risk conditions defined in Appendix D
+ * ("High risk protocols_Developer's copy - Infant HR", see
+ * docs/Appendix_D_High_Risk_Detection_Rules.md, Part 2). Seeded once under
+ * `phase: INC` — condition_code has a global UNIQUE constraint (not
+ * unique-per-phase), and per SRS §3A.2.4 CCV reuses INC's thresholds
+ * verbatim, so both CCV_VISIT and NN (NEONATAL_VISIT) evaluations pass
+ * riskPhase: 'INC' to reuse this same seeded set rather than duplicating
+ * rows per phase (see infant-risk.rulesJson.ts's own doc comment).
+ */
+async function seedInfantRiskConditions(): Promise<SeedResult> {
+  let createdCount = 0;
+
+  for (const condition of infantRiskConditions as AncRiskConditionSeed[]) {
+    const existing = await prisma.riskCondition.findUnique({
+      where: { conditionCode: condition.conditionCode },
+    });
+    if (existing) continue;
+
+    await prisma.riskCondition.create({
+      data: {
+        conditionCode: condition.conditionCode,
+        conditionName: condition.conditionName,
+        entityType: 'CHILD',
+        phase: 'INC',
+        gradeScale: condition.gradeScale,
+        referralRequiredDefault: condition.referralRequiredDefault,
+        educationRequiredDefault: condition.educationRequiredDefault,
+        status: 'ACTIVE',
+      },
+    });
+    createdCount += 1;
+  }
+
+  if (createdCount === 0) {
+    return {
+      step: 'infant-risk-conditions',
+      created: false,
+      message: 'All infant risk condition rows already present — skipped.',
+    };
+  }
+  return {
+    step: 'infant-risk-conditions',
+    created: true,
+    message: `Seeded ${createdCount} infant risk condition row(s).`,
+  };
+}
+
 async function main(): Promise<void> {
-  const results = [await seedSelfReportedConditions(), await seedRiskParameters()];
+  const results = [
+    await seedSelfReportedConditions(),
+    await seedRiskParameters(),
+    await seedAncRiskConditions(),
+    await seedInfantRiskConditions(),
+  ];
 
   console.log('\nSeed summary:');
   for (const r of results) {

--- a/apps/risk-referral-service/src/risk-assessments/dto/create-riskAssessment.dto.ts
+++ b/apps/risk-referral-service/src/risk-assessments/dto/create-riskAssessment.dto.ts
@@ -23,12 +23,22 @@ const nestedJsonValueSchema: z.ZodType<NestedJsonValue> = z.lazy(() =>
  * its own to derive it. `visitId` is nullable since a submission need not
  * always be visit-linked (mirrors form_submissions.visitId).
  */
+// Mirrors risk-referral-service's own Prisma RiskPhase enum — kept as a
+// literal list (not imported from the generated Prisma client) since DTOs
+// in this service validate the wire shape independently of the ORM layer,
+// same convention as this file's other enum-like fields.
+const riskPhaseSchema = z.enum(['REGISTRATION', 'ANC', 'DELIVERY', 'PP', 'NN', 'INC', 'CCV']);
+
 export const createRiskAssessmentSchema = z
   .object({
     beneficiaryId: z.string().uuid(),
     visitId: z.string().uuid().nullable(),
     submissionId: z.string().uuid(),
     ruleSetId: z.string().uuid(),
+    // The caller's own formCode -> phase knowledge, needed to resolve this
+    // rule pack's conditionCode -> risk_condition_id map (see
+    // riskAssessment.service.ts's create()).
+    riskPhase: riskPhaseSchema,
     answers: z.record(nestedJsonValueSchema),
   })
   .strict();

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
@@ -1,9 +1,13 @@
-import type { Prisma } from '../../../../node_modules/.prisma/client-risk-referral-service';
+import type {
+  Prisma,
+  RiskPhase,
+} from '../../../../node_modules/.prisma/client-risk-referral-service';
 import type { PrismaService } from '../prisma/prisma.service';
 
 export interface RiskFlagCreateData {
   riskConditionId: string;
   riskGradeLookupValueId: string;
+  gradeRank: number;
   observedValueJson: Prisma.InputJsonValue | null;
   isReferralTrigger: boolean;
   isEducationTrigger: boolean;
@@ -48,6 +52,86 @@ export class RiskAssessmentRepository {
   }
 
   /**
+   * Maps risk_conditions.condition_code -> risk_condition_id for every
+   * ACTIVE condition in `phase` — a rule pack's own conditionCodes are
+   * portable across environments, but the decision graph's output must
+   * carry a real DB id (see ruleSet.evaluator.ts's RiskEvaluationResult
+   * contract), so the caller resolves this map once per evaluation and
+   * passes it into the rule pack as an input (see anc-risk.rulesJson.ts's
+   * `conditionIds`). Scoped by phase alone (not a fixed code list) so this
+   * stays correct as more phases (PP/NN/INC/CCV) get their own seeded
+   * RiskCondition rows and rule packs, with no code change here.
+   */
+  async findConditionIdsByPhase(phase: RiskPhase): Promise<Map<string, string>> {
+    const conditions = await this.prisma.riskCondition.findMany({
+      where: { phase, status: 'ACTIVE', isDeleted: false },
+      select: { id: true, conditionCode: true },
+    });
+    return new Map(conditions.map((c) => [c.conditionCode, c.id]));
+  }
+
+  /**
+   * Condition codes that have EVER been graded above NORMAL for this
+   * beneficiary, across every past assessment/phase — used to resolve the
+   * "only first instance" trigger gate (Appendix D §D.4/§D.5: Age, MUAC/BMI,
+   * Stunting, Bad Obstetric History, Gestational Weight Gain, Jaundice).
+   * Deliberately unbounded by phase/pregnancy window — a condition flagged
+   * once is never "first instance" again for that beneficiary.
+   *
+   * RiskFlag has no scalar grade column (grade lives behind
+   * riskGradeLookupValueId, owned by auth-service — no cross-service join),
+   * so "was this condition ever non-NORMAL" is inferred via
+   * isEducationTrigger, which anc-risk.rulesJson.ts sets to `grade !==
+   * 'NORMAL'` unconditionally (never gated by first-instance), unlike
+   * isReferralTrigger/isHrVisitTrigger which this very lookup feeds into.
+   */
+  async findEverFlaggedConditionCodes(beneficiaryId: string): Promise<Set<string>> {
+    const flags = await this.prisma.riskFlag.findMany({
+      where: {
+        riskAssessment: { beneficiaryId, isDeleted: false },
+        isEducationTrigger: true,
+      },
+      select: { riskCondition: { select: { conditionCode: true } } },
+    });
+    return new Set(flags.map((f) => f.riskCondition.conditionCode));
+  }
+
+  /**
+   * For each of `conditionCodes`, how many of that condition's most recent
+   * consecutive visit-flags show no improvement (gradeRank did not
+   * decrease) — used for the infant nutrition conditions' "on first
+   * instance, and if no improvement in 3 consecutive visits" referral rule
+   * (Appendix D §2.4). Streak breaks (resets the count read here) the
+   * moment gradeRank decreases from one flag to the next-most-recent one;
+   * a flat or worsening trend keeps counting. Capped at 3 visits back since
+   * the rule pack only needs to know ">=3", not the exact streak length.
+   */
+  async findConsecutiveNoImprovementCount(
+    beneficiaryId: string,
+    conditionCodes: string[],
+  ): Promise<Map<string, number>> {
+    const result = new Map<string, number>();
+    for (const conditionCode of conditionCodes) {
+      const flags = await this.prisma.riskFlag.findMany({
+        where: {
+          riskAssessment: { beneficiaryId, isDeleted: false },
+          riskCondition: { conditionCode },
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 4,
+        select: { gradeRank: true },
+      });
+      let streak = 0;
+      for (let i = 0; i < flags.length - 1; i++) {
+        if (flags[i].gradeRank < flags[i + 1].gradeRank) break;
+        streak += 1;
+      }
+      result.set(conditionCode, streak);
+    }
+    return result;
+  }
+
+  /**
    * Creates one RiskAssessment and its RiskFlag rows in a single
    * transaction — the two must never exist independently (a RiskAssessment
    * with zero flags, or flags with no parent assessment, are both
@@ -74,6 +158,7 @@ export class RiskAssessmentRepository {
           riskAssessmentId: assessment.id,
           riskConditionId: flag.riskConditionId,
           riskGradeLookupValueId: flag.riskGradeLookupValueId,
+          gradeRank: flag.gradeRank,
           observedValueJson: flag.observedValueJson ?? undefined,
           isReferralTrigger: flag.isReferralTrigger,
           isEducationTrigger: flag.isEducationTrigger,

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.spec.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.spec.ts
@@ -18,6 +18,9 @@ describe('RiskAssessmentService', () => {
     findBySubmissionId: jest.fn(),
     create: jest.fn(),
     findPhasesByConditionIds: jest.fn(),
+    findConditionIdsByPhase: jest.fn(),
+    findEverFlaggedConditionCodes: jest.fn(),
+    findConsecutiveNoImprovementCount: jest.fn(),
   } as unknown as jest.Mocked<RiskAssessmentRepository>;
   const beneficiaryClient = {
     getById: jest.fn(),
@@ -38,6 +41,7 @@ describe('RiskAssessmentService', () => {
     visitId: '22222222-2222-2222-2222-222222222222',
     submissionId: '33333333-3333-3333-3333-333333333333',
     ruleSetId: '44444444-4444-4444-4444-444444444444',
+    riskPhase: 'ANC',
     answers: { systolicBp: 145 },
   };
 
@@ -59,6 +63,9 @@ describe('RiskAssessmentService', () => {
     service = new RiskAssessmentService(repository, beneficiaryClient);
     beneficiaryClient.getById.mockResolvedValue({ id: BENEFICIARY_ID, sakhiId: CALLER_ID });
     repository.findPhasesByConditionIds.mockResolvedValue(new Map([['cond-1', 'ANC']]));
+    repository.findConditionIdsByPhase.mockResolvedValue(new Map([['ANEMIA', 'cond-1']]));
+    repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
+    repository.findConsecutiveNoImprovementCount.mockResolvedValue(new Map([['ANEMIA', 0]]));
     resolveRiskGradeLookupIdMock.mockResolvedValue('grade-lookup-id-1');
     pushRiskConditionSummaryMock.mockResolvedValue({ ok: true });
   });
@@ -154,7 +161,16 @@ describe('RiskAssessmentService', () => {
 
     await service.create(dto, caller(), AUTH_HEADER);
 
-    expect(evaluateRuleSetMock).toHaveBeenCalledWith(dto.ruleSetId, dto.answers, AUTH_HEADER);
+    expect(evaluateRuleSetMock).toHaveBeenCalledWith(
+      dto.ruleSetId,
+      {
+        ...dto.answers,
+        conditionIds: { ANEMIA: 'cond-1' },
+        isFirstInstance: { ANEMIA: true },
+        consecutiveNoImprovementCount: { ANEMIA: 0 },
+      },
+      AUTH_HEADER,
+    );
     expect(resolveRiskGradeLookupIdMock).toHaveBeenCalledWith('HIGH', AUTH_HEADER);
     expect(repository.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -169,6 +185,7 @@ describe('RiskAssessmentService', () => {
           expect.objectContaining({
             riskConditionId: 'cond-1',
             riskGradeLookupValueId: 'grade-lookup-id-1',
+            gradeRank: 3,
             isReferralTrigger: true,
             isHrVisitTrigger: true,
           }),
@@ -311,6 +328,81 @@ describe('RiskAssessmentService', () => {
 
     expect(pushRiskConditionSummaryMock).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  describe('conditionIds / isFirstInstance / consecutiveNoImprovementCount resolution', () => {
+    beforeEach(() => {
+      repository.findBySubmissionId.mockResolvedValue(null);
+      evaluateRuleSetMock.mockResolvedValue({
+        ruleVersionId: 'rule-version-1',
+        overallRiskCategory: 'NORMAL',
+        conditions: [],
+      });
+      repository.create.mockResolvedValue({ id: 'assessment-1' } as never);
+      repository.findConsecutiveNoImprovementCount.mockResolvedValue(new Map());
+    });
+
+    it('resolves conditionIds from every ACTIVE risk_conditions row in dto.riskPhase', async () => {
+      repository.findConditionIdsByPhase.mockResolvedValue(
+        new Map([
+          ['ANEMIA', 'cond-anemia'],
+          ['HYPERTENSION', 'cond-htn'],
+        ]),
+      );
+      repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
+
+      await service.create(dto, caller(), AUTH_HEADER);
+
+      expect(repository.findConditionIdsByPhase).toHaveBeenCalledWith('ANC');
+      expect(evaluateRuleSetMock).toHaveBeenCalledWith(
+        dto.ruleSetId,
+        expect.objectContaining({
+          conditionIds: { ANEMIA: 'cond-anemia', HYPERTENSION: 'cond-htn' },
+        }),
+        AUTH_HEADER,
+      );
+    });
+
+    it('marks a condition as isFirstInstance: false when it was ever flagged before for this beneficiary', async () => {
+      repository.findConditionIdsByPhase.mockResolvedValue(new Map([['AGE', 'cond-age']]));
+      repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set(['AGE']));
+
+      await service.create(dto, caller(), AUTH_HEADER);
+
+      expect(repository.findEverFlaggedConditionCodes).toHaveBeenCalledWith(dto.beneficiaryId);
+      expect(evaluateRuleSetMock).toHaveBeenCalledWith(
+        dto.ruleSetId,
+        expect.objectContaining({ isFirstInstance: { AGE: false } }),
+        AUTH_HEADER,
+      );
+    });
+
+    it('resolves consecutiveNoImprovementCount for every condition in dto.riskPhase and merges it into the evaluation input', async () => {
+      repository.findConditionIdsByPhase.mockResolvedValue(new Map([['WASTING', 'cond-wasting']]));
+      repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
+      repository.findConsecutiveNoImprovementCount.mockResolvedValue(new Map([['WASTING', 3]]));
+
+      await service.create(dto, caller(), AUTH_HEADER);
+
+      expect(repository.findConsecutiveNoImprovementCount).toHaveBeenCalledWith(dto.beneficiaryId, [
+        'WASTING',
+      ]);
+      expect(evaluateRuleSetMock).toHaveBeenCalledWith(
+        dto.ruleSetId,
+        expect.objectContaining({ consecutiveNoImprovementCount: { WASTING: 3 } }),
+        AUTH_HEADER,
+      );
+    });
+
+    it('400s when no ACTIVE risk_conditions rows are seeded for dto.riskPhase', async () => {
+      repository.findConditionIdsByPhase.mockResolvedValue(new Map());
+      repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
+
+      await expect(service.create(dto, caller(), AUTH_HEADER)).rejects.toMatchObject({
+        status: 400,
+      });
+      expect(evaluateRuleSetMock).not.toHaveBeenCalled();
+    });
   });
 
   it('propagates rules-service evaluation failures (e.g. 422 no published version)', async () => {

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
@@ -94,7 +94,38 @@ export class RiskAssessmentService {
     const existing = await this.repository.findBySubmissionId(dto.submissionId);
     if (existing) return existing;
 
-    const evaluation = await evaluateRuleSet(dto.ruleSetId, dto.answers, authorizationHeader);
+    // Resolve conditionCode -> risk_condition_id (a rule pack's decision
+    // graph output must carry a real DB id, see ruleSet.evaluator.ts's
+    // RiskEvaluationResult contract, but the pack itself only knows portable
+    // condition codes), the "only first instance" flagging history, and the
+    // "3 consecutive visits with no improvement" streak (infant nutrition
+    // conditions, Appendix D §2.4) — all merged into `answers` so the rule
+    // pack sees them as ordinary evaluation inputs (see
+    // anc-risk.rulesJson.ts / infant-risk.rulesJson.ts's `conditionIds`/
+    // `isFirstInstance`/`consecutiveNoImprovementCount`).
+    const conditionIdsByCode = await this.repository.findConditionIdsByPhase(dto.riskPhase);
+    if (conditionIdsByCode.size === 0) {
+      throw badRequest(
+        `No ACTIVE risk_conditions rows are seeded for phase "${dto.riskPhase}" — the rule ` +
+          'pack has no conditionIds to grade against.',
+      );
+    }
+    const conditionCodes = [...conditionIdsByCode.keys()];
+    const [everFlaggedCodes, consecutiveNoImprovementByCode] = await Promise.all([
+      this.repository.findEverFlaggedConditionCodes(dto.beneficiaryId),
+      this.repository.findConsecutiveNoImprovementCount(dto.beneficiaryId, conditionCodes),
+    ]);
+    const conditionIds = Object.fromEntries(conditionIdsByCode);
+    const isFirstInstance = Object.fromEntries(
+      conditionCodes.map((code) => [code, !everFlaggedCodes.has(code)]),
+    );
+    const consecutiveNoImprovementCount = Object.fromEntries(consecutiveNoImprovementByCode);
+
+    const evaluation = await evaluateRuleSet(
+      dto.ruleSetId,
+      { ...dto.answers, conditionIds, isFirstInstance, consecutiveNoImprovementCount },
+      authorizationHeader,
+    );
 
     const flags: RiskFlagCreateData[] = [];
     for (const condition of evaluation.conditions) {
@@ -111,6 +142,7 @@ export class RiskAssessmentService {
       flags.push({
         riskConditionId: condition.riskConditionId,
         riskGradeLookupValueId,
+        gradeRank: condition.gradeRank,
         // Untyped external JSON (from rules-service's evaluate response)
         // crossing into Prisma's InputJsonValue at this one boundary.
         observedValueJson: condition.observedValueJson as Prisma.InputJsonValue | null,

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
@@ -1,0 +1,436 @@
+import {
+  evaluateRulePack,
+  type RiskEvaluationResult,
+  type RulePackEvaluation,
+} from '../ruleSet.evaluator';
+import { ancRiskRulesJson } from './anc-risk.rulesJson';
+
+const CONDITION_IDS = {
+  AGE: '11111111-1111-1111-1111-111111111101',
+  MUAC_BMI: '11111111-1111-1111-1111-111111111102',
+  STUNTING: '11111111-1111-1111-1111-111111111103',
+  BAD_OBSTETRIC_HISTORY: '11111111-1111-1111-1111-111111111104',
+  ANEMIA: '11111111-1111-1111-1111-111111111105',
+  HYPERTENSION: '11111111-1111-1111-1111-111111111106',
+  HYPOTENSION: '11111111-1111-1111-1111-111111111107',
+  HYPERGLYCEMIA: '11111111-1111-1111-1111-111111111108',
+  HYPOGLYCEMIA: '11111111-1111-1111-1111-111111111109',
+  APH: '11111111-1111-1111-1111-111111111110',
+  PPH: '11111111-1111-1111-1111-111111111111',
+  HYPOTHERMIA: '11111111-1111-1111-1111-111111111112',
+  HYPERTHERMIA: '11111111-1111-1111-1111-111111111113',
+  FETAL_HEART_RATE: '11111111-1111-1111-1111-111111111114',
+  FUNDAL_HEIGHT: '11111111-1111-1111-1111-111111111115',
+  GESTATIONAL_WEIGHT_GAIN: '11111111-1111-1111-1111-111111111116',
+  JAUNDICE: '11111111-1111-1111-1111-111111111117',
+  URINE_ANALYSIS: '11111111-1111-1111-1111-111111111118',
+  DANGER_SIGNS: '11111111-1111-1111-1111-111111111119',
+};
+
+// Real ANC_VISIT question codes (see
+// apps/visit-form-service/prisma/seed-data/anc-visit.json), plus `age` and
+// `badObstetricHistoryFlag`, which form.service.ts merges in from the
+// beneficiary's MOTHER_REGISTRATION submission.
+const NORMAL_VITALS = {
+  conditionIds: CONDITION_IDS,
+  age: 25,
+  mid_upper_arm_circumference_in_cm: 24,
+  bmi: 22,
+  height_of_the_woman_in_cm: 155,
+  badObstetricHistoryFlag: false,
+  haemoglobin_hb_g_dl: 12,
+  blood_pressure_bp_systolic: 110,
+  blood_pressure_bp_diastolic: 70,
+  blood_glucose_in_mg_dl: 100,
+  have_you_been_experiencing_any_of_these_since_the_last_visit: ['no_abnormal_signs_and_symptoms'],
+  body_temperature_in_f: 98,
+  fetal_heart_rate: 140,
+  gestational_weight_gain: 'normal',
+  check_palm_and_nails: 'normal',
+  check_sclera_eyes: 'normal',
+  check_skin: 'normal',
+  urine_test: ['normal'],
+};
+
+function findCondition(result: RulePackEvaluation, conditionId: string): RiskEvaluationResult {
+  const found = result.conditions.find((c) => c.riskConditionId === conditionId);
+  if (!found) throw new Error(`No condition result found for ${conditionId}`);
+  return found;
+}
+
+describe('ancRiskRulesJson', () => {
+  it('grades every vital as NORMAL and returns overallRiskCategory NORMAL when nothing is abnormal', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, NORMAL_VITALS);
+
+    expect(result.overallRiskCategory).toBe('NORMAL');
+    for (const condition of result.conditions) {
+      expect(condition.grade).toBe('NORMAL');
+      expect(condition.isReferralTrigger).toBe(false);
+      expect(condition.isHrVisitTrigger).toBe(false);
+      expect(condition.isEducationTrigger).toBe(false);
+    }
+  });
+
+  it('grades Moderate anemia and triggers referral + HR visit (every instance of Moderate/Severe)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      haemoglobin_hb_g_dl: 9.5,
+    });
+
+    const anemia = findCondition(result, CONDITION_IDS.ANEMIA);
+    expect(anemia.grade).toBe('MODERATE');
+    expect(anemia.isReferralTrigger).toBe(true);
+    expect(anemia.isHrVisitTrigger).toBe(true);
+    expect(anemia.isEducationTrigger).toBe(true);
+  });
+
+  it('grades Mild anemia as counselling-only — no referral, no HR visit', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      haemoglobin_hb_g_dl: 10.5,
+    });
+
+    const anemia = findCondition(result, CONDITION_IDS.ANEMIA);
+    expect(anemia.grade).toBe('MILD');
+    expect(anemia.isReferralTrigger).toBe(false);
+    expect(anemia.isHrVisitTrigger).toBe(false);
+  });
+
+  it('grades Severe anemia and triggers referral + HR visit', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      haemoglobin_hb_g_dl: 6.5,
+    });
+
+    const anemia = findCondition(result, CONDITION_IDS.ANEMIA);
+    expect(anemia.grade).toBe('SEVERE');
+    expect(anemia.isReferralTrigger).toBe(true);
+    expect(anemia.isHrVisitTrigger).toBe(true);
+  });
+
+  it('classifies BP 145/95 as Hypertension MODERATE, not Hypotension', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_pressure_bp_systolic: 145,
+      blood_pressure_bp_diastolic: 95,
+    });
+
+    const htn = findCondition(result, CONDITION_IDS.HYPERTENSION);
+    const hypo = findCondition(result, CONDITION_IDS.HYPOTENSION);
+    expect(htn.grade).toBe('MODERATE');
+    expect(htn.isReferralTrigger).toBe(true);
+    expect(hypo.grade).toBe('NORMAL');
+  });
+
+  it('grades BP 137/86 as Hypertension MILD on the range alone (no history-of-hypertension field exists)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_pressure_bp_systolic: 137,
+      blood_pressure_bp_diastolic: 86,
+    });
+
+    expect(findCondition(result, CONDITION_IDS.HYPERTENSION).grade).toBe('MILD');
+  });
+
+  it('grades Hypotension MILD but does not trigger referral/HR visit when it is the only flagged condition', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_pressure_bp_systolic: 85,
+    });
+
+    const hypo = findCondition(result, CONDITION_IDS.HYPOTENSION);
+    expect(hypo.grade).toBe('MILD');
+    expect(hypo.isReferralTrigger).toBe(false);
+    expect(hypo.isHrVisitTrigger).toBe(false);
+  });
+
+  it('triggers Hypotension referral/HR visit when accompanied by another flagged condition (Anemia Moderate)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_pressure_bp_systolic: 85,
+      haemoglobin_hb_g_dl: 9.5,
+    });
+
+    const hypo = findCondition(result, CONDITION_IDS.HYPOTENSION);
+    expect(hypo.grade).toBe('MILD');
+    expect(hypo.isReferralTrigger).toBe(true);
+    expect(hypo.isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades Hyperglycemia MILD and triggers every instance', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_glucose_in_mg_dl: 145,
+    });
+
+    const hyper = findCondition(result, CONDITION_IDS.HYPERGLYCEMIA);
+    expect(hyper.grade).toBe('MILD');
+    expect(hyper.isReferralTrigger).toBe(true);
+    expect(hyper.isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades Hypoglycemia MILD without triggering when alone', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_glucose_in_mg_dl: 65,
+    });
+
+    const hypo = findCondition(result, CONDITION_IDS.HYPOGLYCEMIA);
+    expect(hypo.grade).toBe('MILD');
+    expect(hypo.isReferralTrigger).toBe(false);
+    expect(hypo.isHrVisitTrigger).toBe(false);
+  });
+
+  it('grades Hyperthermia MILD and triggers every instance; Hypothermia MILD alone does not trigger', async () => {
+    const hyper = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      body_temperature_in_f: 100,
+    });
+    const hyperthermia = findCondition(hyper, CONDITION_IDS.HYPERTHERMIA);
+    expect(hyperthermia.grade).toBe('MILD');
+    expect(hyperthermia.isReferralTrigger).toBe(true);
+
+    const hypo = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      body_temperature_in_f: 95,
+    });
+    const hypothermia = findCondition(hypo, CONDITION_IDS.HYPOTHERMIA);
+    expect(hypothermia.grade).toBe('MILD');
+    expect(hypothermia.isReferralTrigger).toBe(false);
+  });
+
+  it('grades abnormal Fetal Heart Rate MILD and triggers every instance, both below and above range', async () => {
+    const low = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      fetal_heart_rate: 110,
+    });
+    expect(findCondition(low, CONDITION_IDS.FETAL_HEART_RATE).grade).toBe('MILD');
+    expect(findCondition(low, CONDITION_IDS.FETAL_HEART_RATE).isReferralTrigger).toBe(true);
+
+    const high = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      fetal_heart_rate: 165,
+    });
+    expect(findCondition(high, CONDITION_IDS.FETAL_HEART_RATE).grade).toBe('MILD');
+
+    const normal = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      fetal_heart_rate: 140,
+    });
+    expect(findCondition(normal, CONDITION_IDS.FETAL_HEART_RATE).grade).toBe('NORMAL');
+  });
+
+  it('grades Fundal Height deviation >2cm as MILD and triggers every instance (pre-computed deviation input)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      fundalHeightDeviationCm: 3,
+    });
+
+    const fh = findCondition(result, CONDITION_IDS.FUNDAL_HEIGHT);
+    expect(fh.grade).toBe('MILD');
+    expect(fh.isReferralTrigger).toBe(true);
+  });
+
+  it('gates MUAC/BMI referral trigger by first-instance but always records the grade', async () => {
+    const first = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      mid_upper_arm_circumference_in_cm: 21,
+      bmi: 17,
+      isFirstInstance: { MUAC_BMI: true },
+    });
+    const firstResult = findCondition(first, CONDITION_IDS.MUAC_BMI);
+    expect(firstResult.grade).toBe('MILD');
+    expect(firstResult.isReferralTrigger).toBe(true);
+
+    const repeat = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      mid_upper_arm_circumference_in_cm: 21,
+      bmi: 17,
+      isFirstInstance: { MUAC_BMI: false },
+    });
+    const repeatResult = findCondition(repeat, CONDITION_IDS.MUAC_BMI);
+    expect(repeatResult.grade).toBe('MILD');
+    expect(repeatResult.isReferralTrigger).toBe(false);
+  });
+
+  it('grades obese BMI (>=35) as MILD under the combined MUAC/BMI condition', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      mid_upper_arm_circumference_in_cm: 24,
+      bmi: 36,
+      isFirstInstance: { MUAC_BMI: true },
+    });
+
+    expect(findCondition(result, CONDITION_IDS.MUAC_BMI).grade).toBe('MILD');
+  });
+
+  it('gates Stunting, Age, and Bad Obstetric History referral triggers by first-instance', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      height_of_the_woman_in_cm: 140,
+      age: 40,
+      badObstetricHistoryFlag: true,
+      isFirstInstance: { STUNTING: false, AGE: false, BAD_OBSTETRIC_HISTORY: false },
+    });
+
+    expect(findCondition(result, CONDITION_IDS.STUNTING).grade).toBe('MILD');
+    expect(findCondition(result, CONDITION_IDS.STUNTING).isReferralTrigger).toBe(false);
+    expect(findCondition(result, CONDITION_IDS.AGE).isReferralTrigger).toBe(false);
+    expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).isReferralTrigger).toBe(
+      false,
+    );
+  });
+
+  it('Gestational Weight Gain: referral gated by first-instance, HR visit trigger fires every instance (pre-graded radio value)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      gestational_weight_gain: 'severe',
+      isFirstInstance: { GESTATIONAL_WEIGHT_GAIN: false },
+    });
+
+    const gwg = findCondition(result, CONDITION_IDS.GESTATIONAL_WEIGHT_GAIN);
+    expect(gwg.grade).toBe('MILD');
+    expect(gwg.isReferralTrigger).toBe(false);
+    expect(gwg.isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades Jaundice MILD only when >=2 of 3 signs are positive (check_palm_and_nails/sclera/skin), gated by first-instance', async () => {
+    const oneSign = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      check_palm_and_nails: 'yellow',
+    });
+    expect(findCondition(oneSign, CONDITION_IDS.JAUNDICE).grade).toBe('NORMAL');
+
+    const twoSignsFirst = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      check_palm_and_nails: 'yellow',
+      check_sclera_eyes: 'yellow',
+      isFirstInstance: { JAUNDICE: true },
+    });
+    expect(findCondition(twoSignsFirst, CONDITION_IDS.JAUNDICE).grade).toBe('MILD');
+    expect(findCondition(twoSignsFirst, CONDITION_IDS.JAUNDICE).isReferralTrigger).toBe(true);
+
+    const twoSignsRepeat = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      check_palm_and_nails: 'yellow',
+      check_sclera_eyes: 'yellow',
+      isFirstInstance: { JAUNDICE: false },
+    });
+    expect(findCondition(twoSignsRepeat, CONDITION_IDS.JAUNDICE).isReferralTrigger).toBe(false);
+  });
+
+  it('grades abnormal Urine Analysis MILD and triggers every instance (no first-instance gate)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      urine_test: ['protein'],
+    });
+
+    const urine = findCondition(result, CONDITION_IDS.URINE_ANALYSIS);
+    expect(urine.grade).toBe('MILD');
+    expect(urine.isReferralTrigger).toBe(true);
+  });
+
+  it('grades any Danger Sign present (excluding bleeding, which is its own APH condition) as a single MILD condition row triggering every instance', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      have_you_been_experiencing_any_of_these_since_the_last_visit: [
+        'severe_abdominal_pain',
+        'convulsions',
+      ],
+    });
+
+    const dangerSignRows = result.conditions.filter(
+      (c) => c.riskConditionId === CONDITION_IDS.DANGER_SIGNS,
+    );
+    expect(dangerSignRows).toHaveLength(1);
+    expect(dangerSignRows[0].grade).toBe('MILD');
+    expect(dangerSignRows[0].isReferralTrigger).toBe(true);
+  });
+
+  it('does not count bleeding_from_vagina toward the Danger Signs condition — it grades APH instead', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      have_you_been_experiencing_any_of_these_since_the_last_visit: ['bleeding_from_vagina'],
+    });
+
+    expect(findCondition(result, CONDITION_IDS.DANGER_SIGNS).grade).toBe('NORMAL');
+    expect(findCondition(result, CONDITION_IDS.APH).grade).toBe('MILD');
+  });
+
+  it('grades Antepartum Hemorrhage MILD when bleeding_from_vagina is present in the shared danger-signs multiselect', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      have_you_been_experiencing_any_of_these_since_the_last_visit: ['bleeding_from_vagina'],
+    });
+
+    const aph = findCondition(result, CONDITION_IDS.APH);
+    expect(aph.grade).toBe('MILD');
+    expect(aph.isReferralTrigger).toBe(true);
+  });
+
+  it('grades Postpartum Hemorrhage MILD but never triggers referral/HR visit (undefined in Appendix D, no real form field)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      pphHeavyBleedingFlag: true,
+    });
+
+    const pph = findCondition(result, CONDITION_IDS.PPH);
+    expect(pph.grade).toBe('MILD');
+    expect(pph.isReferralTrigger).toBe(false);
+    expect(pph.isHrVisitTrigger).toBe(false);
+  });
+
+  it('rolls up overallRiskCategory to the worst grade present: CRITICAL when any condition is SEVERE', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      haemoglobin_hb_g_dl: 6.5,
+    });
+    expect(result.overallRiskCategory).toBe('CRITICAL');
+  });
+
+  it('rolls up overallRiskCategory to HIGH when the worst grade is MODERATE', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      haemoglobin_hb_g_dl: 9.5,
+    });
+    expect(result.overallRiskCategory).toBe('HIGH');
+  });
+
+  it('rolls up overallRiskCategory to LOW when the worst grade is MILD', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_glucose_in_mg_dl: 145,
+    });
+    expect(result.overallRiskCategory).toBe('LOW');
+  });
+
+  it('reports multiple simultaneous HR conditions independently and rolls up to the worst', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      haemoglobin_hb_g_dl: 6.5,
+      blood_pressure_bp_systolic: 145,
+      blood_pressure_bp_diastolic: 95,
+      have_you_been_experiencing_any_of_these_since_the_last_visit: ['convulsions'],
+    });
+
+    expect(findCondition(result, CONDITION_IDS.ANEMIA).grade).toBe('SEVERE');
+    expect(findCondition(result, CONDITION_IDS.HYPERTENSION).grade).toBe('MODERATE');
+    expect(findCondition(result, CONDITION_IDS.DANGER_SIGNS).grade).toBe('MILD');
+    expect(result.overallRiskCategory).toBe('CRITICAL');
+  });
+
+  it('throws when conditionIds is missing', async () => {
+    const rest: Record<string, unknown> = { ...NORMAL_VITALS };
+    delete rest.conditionIds;
+    await expect(evaluateRulePack(ancRiskRulesJson, rest)).rejects.toThrow();
+  });
+
+  it('throws when conditionIds is missing an entry the graded vitals require', async () => {
+    const incompleteIds: Record<string, string | undefined> = { ...CONDITION_IDS };
+    incompleteIds.ANEMIA = undefined;
+
+    await expect(
+      evaluateRulePack(ancRiskRulesJson, { ...NORMAL_VITALS, conditionIds: incompleteIds }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
@@ -1,0 +1,392 @@
+/**
+ * ANC High-Risk clinical grading decision graph (SRS Appendix D — "High risk
+ * protocols_Developer's copy - ANC HR", see docs/Appendix_D_High_Risk_Detection_Rules.md, Part 1).
+ *
+ * Evaluated via the generic `POST /rules/:setId/evaluate` (ruleSet.evaluator.ts,
+ * ruleCategory RISK) by risk-referral-service's riskAssessment.service.ts. This
+ * pack has no DB access, so anything requiring persisted history is resolved
+ * by the caller and passed in as an input:
+ *  - `conditionIds`: map of conditionCode -> risk_conditions.risk_condition_id
+ *    (UUID), since the output contract (ruleSet.evaluator.ts's
+ *    RiskEvaluationResult) requires a real DB id per condition, and this pack
+ *    is otherwise portable/environment-agnostic.
+ *  - `isFirstInstance`: map of conditionCode -> boolean, for the "only first
+ *    instance" conditions (Age, MUAC/BMI, Stunting, Bad Obstetric History,
+ *    Gestational Weight Gain, Jaundice) per Appendix D §D.4/§D.5 — computed
+ *    by scanning that beneficiary's prior risk_flags history.
+ *
+ * All other input fields are read directly under their real ANC_VISIT/
+ * MOTHER_REGISTRATION question_codes (see
+ * apps/visit-form-service/prisma/seed-data/anc-visit.json and
+ * mother-registration.json) — the caller passes dto.formData through
+ * largely unchanged (plus the registration-derived age/
+ * badObstetricHistoryFlag merge, see form.service.ts's
+ * resolveAncRiskRegistrationAnswers), rather than this pack expecting a
+ * separately-named/normalized field set. This intentionally couples the
+ * pack to the form's current field names; a form schema change to any of
+ * the fields read below requires updating this pack in lockstep.
+ *
+ * Per Appendix D §D.7, every condition is graded and returned every visit,
+ * including NORMAL results — this pack never omits a condition from its
+ * output based on its own grade.
+ *
+ * Known coarser-than-spec gradings, because the form doesn't capture the
+ * finer distinction Appendix D describes:
+ *  - Bleeding (APH) has no spotting/moderate/heavy severity field — the
+ *    form only captures presence via
+ *    "bleeding_from_vagina" inside the shared danger-signs multiselect
+ *    (have_you_been_experiencing_any_of_these_since_the_last_visit). Graded
+ *    MILD (present) vs NORMAL (absent) only, not by bleeding severity.
+ *  - Hypertension's Mild band ("Systolic 135-139/Diastolic 85-89 AND
+ *    history of Hypertension or Gestational Hypertension") has no
+ *    corresponding "history of hypertension" field on either form — the
+ *    history condition is dropped; this band grades MILD on the BP range
+ *    alone.
+ *  - Hypotension's "or associated with shock features" clause has no
+ *    corresponding field — graded on the systolic-BP threshold alone.
+ *  - Gestational Weight Gain is captured as the Sakhi's own pre-graded
+ *    radio answer ('normal'/'severe' on gestational_weight_gain), not a raw
+ *    kg delta — this pack consumes that pre-graded value directly rather
+ *    than computing a kg threshold.
+ *
+ * Postpartum Hemorrhage (PPH) has no referral/HR-visit trigger rule defined
+ * in the source sheet (blank cells in §D.4/§D.5) — this pack defaults both
+ * trigger flags to `false` for PPH rather than guessing, and that gap
+ * should be confirmed with ARMMAN before this pack governs a live PPH case
+ * in production. The ANC_VISIT form also has no dedicated PPH field at all
+ * (only the shared bleeding_from_vagina danger sign) — PPH is therefore
+ * never actually graded from a real ANC_VISIT submission today; the input
+ * exists here for forward-compatibility if a dedicated PPH field is added.
+ *
+ * Age and Bad Obstetric History are captured once at MOTHER_REGISTRATION,
+ * not on the recurring ANC_VISIT form — the caller (riskAssessment.service.ts
+ * via form.service.ts) is responsible for fetching and merging those
+ * registration-time answers into this pack's input alongside the current
+ * visit's own answers.
+ */
+export const ancRiskRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeAncRiskGrading',
+      position: { x: 200, y: 0 },
+      content: `
+const GRADE_RANK = { NORMAL: 0, MILD: 1, MODERATE: 2, SEVERE: 3 };
+
+const handler = (input) => {
+  const { conditionIds, isFirstInstance } = input;
+  if (!conditionIds || typeof conditionIds !== 'object') {
+    throw new Error('conditionIds (conditionCode -> risk_condition_id map) is required.');
+  }
+  const firstInstance = isFirstInstance || {};
+
+  const results = [];
+
+  function requireConditionId(code) {
+    const id = conditionIds[code];
+    if (!id) throw new Error('conditionIds is missing an entry for ' + code);
+    return id;
+  }
+
+  // Pushes one graded condition result. onlyFirstInstance conditions get
+  // referralTrigger/hrVisitTrigger gated by firstInstance[code]; other
+  // conditions use their own trigger rule directly.
+  function record(code, grade, observedValueJson, opts) {
+    opts = opts || {};
+    const gateByFirstInstance = opts.onlyFirstInstance === true;
+    const isFirst = firstInstance[code] !== false; // default true if unknown
+    const referralEligible = opts.referralTrigger === true;
+    const hrEligible = opts.hrVisitTrigger === true;
+    results.push({
+      riskConditionId: requireConditionId(code),
+      grade,
+      gradeRank: GRADE_RANK[grade],
+      isReferralTrigger: gateByFirstInstance ? referralEligible && isFirst : referralEligible,
+      isEducationTrigger: grade !== 'NORMAL',
+      isHrVisitTrigger: opts.hrGateByFirstInstance
+        ? hrEligible && isFirst
+        : hrEligible,
+      observedValueJson,
+    });
+  }
+
+  // Danger-signs multiselect shared by several conditions
+  // (have_you_been_experiencing_any_of_these_since_the_last_visit) — read
+  // once, reused for bleeding presence and the All Danger Signs condition.
+  const experiencedSigns = Array.isArray(input.have_you_been_experiencing_any_of_these_since_the_last_visit)
+    ? input.have_you_been_experiencing_any_of_these_since_the_last_visit
+    : [];
+
+  // --- Age (only first instance; regular HR-visit trigger) ---
+  // Merged in by form.service.ts from MOTHER_REGISTRATION's
+  // age_of_the_beneficiary — not an ANC_VISIT field.
+  const age = input.age;
+  if (typeof age === 'number') {
+    const ageGrade = age < 19 || age >= 35 ? 'MILD' : 'NORMAL';
+    record('AGE', ageGrade, { age }, {
+      onlyFirstInstance: true,
+      referralTrigger: ageGrade !== 'NORMAL',
+      hrVisitTrigger: ageGrade !== 'NORMAL',
+    });
+  }
+
+  // --- Undernutrition: MUAC/BMI (only first instance) ---
+  const muacCm = input.mid_upper_arm_circumference_in_cm;
+  const bmi = input.bmi;
+  if (typeof muacCm === 'number' || typeof bmi === 'number') {
+    const abnormal = (typeof muacCm === 'number' && muacCm < 23) || (typeof bmi === 'number' && (bmi < 18.5 || bmi >= 35));
+    const grade = abnormal ? 'MILD' : 'NORMAL';
+    record('MUAC_BMI', grade, { muacCm: muacCm ?? null, bmi: bmi ?? null }, {
+      onlyFirstInstance: true,
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Undernutrition: Stunting (height, only first instance) ---
+  const heightCm = input.height_of_the_woman_in_cm;
+  if (typeof heightCm === 'number') {
+    const grade = heightCm < 145 ? 'MILD' : 'NORMAL';
+    record('STUNTING', grade, { heightCm }, {
+      onlyFirstInstance: true,
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Bad Obstetric History (only first instance) ---
+  // Merged in by form.service.ts, derived from MOTHER_REGISTRATION answers
+  // (gravida/livingChildren/abortions/prior complications).
+  if (typeof input.badObstetricHistoryFlag === 'boolean') {
+    const grade = input.badObstetricHistoryFlag ? 'MILD' : 'NORMAL';
+    record('BAD_OBSTETRIC_HISTORY', grade, { badObstetricHistoryFlag: input.badObstetricHistoryFlag }, {
+      onlyFirstInstance: true,
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Anemia (every instance of Moderate/Severe) ---
+  const hemoglobin = input.haemoglobin_hb_g_dl;
+  let anemiaFlagged = false;
+  if (typeof hemoglobin === 'number') {
+    let grade;
+    if (hemoglobin < 7) grade = 'SEVERE';
+    else if (hemoglobin < 10) grade = 'MODERATE';
+    else if (hemoglobin < 11) grade = 'MILD';
+    else grade = 'NORMAL';
+    anemiaFlagged = grade === 'MODERATE' || grade === 'SEVERE';
+    record('ANEMIA', grade, { hemoglobin }, {
+      referralTrigger: anemiaFlagged,
+      hrVisitTrigger: anemiaFlagged,
+    });
+  }
+
+  // --- Blood pressure: classify into Hypertension XOR Hypotension.
+  // No "history of hypertension" or "shock features" field exists on
+  // either form (see this pack's doc comment) - both grade on the BP
+  // threshold alone. ---
+  const systolicBp = input.blood_pressure_bp_systolic;
+  const diastolicBp = input.blood_pressure_bp_diastolic;
+  let hypotensionFlagged = false;
+  if (typeof systolicBp === 'number' && typeof diastolicBp === 'number') {
+    let htnGrade = 'NORMAL';
+    if (systolicBp >= 160 || diastolicBp >= 110) htnGrade = 'SEVERE';
+    else if (systolicBp >= 140 || diastolicBp >= 90) htnGrade = 'MODERATE';
+    else if ((systolicBp >= 135 && systolicBp <= 139) || (diastolicBp >= 85 && diastolicBp <= 89)) {
+      htnGrade = 'MILD';
+    }
+
+    const hypoGrade = systolicBp < 90 ? 'MILD' : 'NORMAL';
+    hypotensionFlagged = hypoGrade !== 'NORMAL';
+
+    const htnFlagged = htnGrade === 'MODERATE' || htnGrade === 'SEVERE';
+    record('HYPERTENSION', htnGrade, { systolicBp, diastolicBp }, {
+      referralTrigger: htnFlagged,
+      hrVisitTrigger: htnFlagged,
+    });
+    // Hypotension trigger is resolved after all conditions are known (needs
+    // "accompanied by any other flagged condition") — recorded provisionally
+    // here, patched below once every other condition has been evaluated.
+    record('HYPOTENSION', hypoGrade, { systolicBp }, {
+      referralTrigger: false,
+      hrVisitTrigger: false,
+    });
+  }
+
+  // --- Blood sugar: classify into Hyperglycemia / Hypoglycemia ---
+  const bloodGlucoseMgDl = input.blood_glucose_in_mg_dl;
+  let hypoglycemiaFlagged = false;
+  if (typeof bloodGlucoseMgDl === 'number') {
+    const hyperGrade = bloodGlucoseMgDl > 140 ? 'MILD' : 'NORMAL';
+    record('HYPERGLYCEMIA', hyperGrade, { bloodGlucoseMgDl }, {
+      referralTrigger: hyperGrade !== 'NORMAL',
+      hrVisitTrigger: hyperGrade !== 'NORMAL',
+    });
+
+    const hypoGrade = bloodGlucoseMgDl < 70 ? 'MILD' : 'NORMAL';
+    hypoglycemiaFlagged = hypoGrade !== 'NORMAL';
+    record('HYPOGLYCEMIA', hypoGrade, { bloodGlucoseMgDl }, {
+      referralTrigger: false,
+      hrVisitTrigger: false,
+    });
+  }
+
+  // --- Bleeding: Antepartum Hemorrhage (APH). No severity field exists -
+  // graded on presence of "bleeding_from_vagina" within the shared
+  // danger-signs multiselect only (see this pack's doc comment). ---
+  const aphGrade = experiencedSigns.indexOf('bleeding_from_vagina') !== -1 ? 'MILD' : 'NORMAL';
+  record('APH', aphGrade, { bleedingPresent: aphGrade !== 'NORMAL' }, {
+    referralTrigger: aphGrade !== 'NORMAL',
+    hrVisitTrigger: aphGrade !== 'NORMAL',
+  });
+
+  // --- Postpartum Hemorrhage (PPH). No field exists on ANC_VISIT today -
+  // this input is accepted for forward-compatibility only (see doc
+  // comment); never populated by a real ANC_VISIT submission. ---
+  const pphBleedingFlag = input.pphHeavyBleedingFlag;
+  if (typeof pphBleedingFlag === 'boolean') {
+    const pphGrade = pphBleedingFlag ? 'MILD' : 'NORMAL';
+    // Appendix D leaves the PPH referral/HR-visit trigger cells blank — no
+    // rule is defined. Default to false (no trigger) rather than guessing;
+    // flagged in this pack's own doc comment as a gap pending ARMMAN.
+    record('PPH', pphGrade, { pphHeavyBleedingFlag: pphBleedingFlag }, {
+      referralTrigger: false,
+      hrVisitTrigger: false,
+    });
+  }
+
+  // --- Body temperature: Hypothermia / Hyperthermia ---
+  const bodyTempF = input.body_temperature_in_f;
+  let hypothermiaFlagged = false;
+  if (typeof bodyTempF === 'number') {
+    const hypoGrade = bodyTempF < 96 ? 'MILD' : 'NORMAL';
+    hypothermiaFlagged = hypoGrade !== 'NORMAL';
+    record('HYPOTHERMIA', hypoGrade, { bodyTempF }, {
+      referralTrigger: false,
+      hrVisitTrigger: false,
+    });
+
+    const hyperGrade = bodyTempF > 99 ? 'MILD' : 'NORMAL';
+    record('HYPERTHERMIA', hyperGrade, { bodyTempF }, {
+      referralTrigger: hyperGrade !== 'NORMAL',
+      hrVisitTrigger: hyperGrade !== 'NORMAL',
+    });
+  }
+
+  // --- Fetal Heart Rate (every instance). No separate "irregular rhythm"
+  // field exists - graded on the bpm range alone. ---
+  const fetalHeartRateBpm = input.fetal_heart_rate;
+  if (typeof fetalHeartRateBpm === 'number') {
+    const grade = fetalHeartRateBpm < 120 || fetalHeartRateBpm > 160 ? 'MILD' : 'NORMAL';
+    record('FETAL_HEART_RATE', grade, { fetalHeartRateBpm }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Fundal Height (deviation from gestational-age expectation, every
+  // instance). fundal_height_in_cm is a raw measurement, not a
+  // pre-computed deviation - the deviation from expected-for-GA is not
+  // computable without a GA-to-expected-fundal-height reference table,
+  // which neither form nor this pack has; this input is accepted as a
+  // pre-computed deviation for forward-compatibility only. ---
+  const fundalHeightDeviationCm = input.fundalHeightDeviationCm;
+  if (typeof fundalHeightDeviationCm === 'number') {
+    const grade = Math.abs(fundalHeightDeviationCm) > 2 ? 'MILD' : 'NORMAL';
+    record('FUNDAL_HEIGHT', grade, { fundalHeightDeviationCm }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Gestational Weight Gain (referral: only first instance; HR visit:
+  // every instance). Pre-graded by the Sakhi on the form itself
+  // ('normal'/'severe' radio), not a raw kg delta. ---
+  const weightGainStatus = input.gestational_weight_gain;
+  if (typeof weightGainStatus === 'string') {
+    const grade = weightGainStatus === 'severe' ? 'MILD' : 'NORMAL';
+    record('GESTATIONAL_WEIGHT_GAIN', grade, { weightGainStatus }, {
+      onlyFirstInstance: true,
+      referralTrigger: grade !== 'NORMAL',
+      hrGateByFirstInstance: false,
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Jaundice (2 of 3 signs positive; only first instance) ---
+  const jaundiceFields = [input.check_palm_and_nails, input.check_sclera_eyes, input.check_skin];
+  const jaundicePositiveCount = jaundiceFields.filter((v) => v === 'yellow').length;
+  if (jaundiceFields.some((v) => typeof v === 'string')) {
+    const grade = jaundicePositiveCount >= 2 ? 'MILD' : 'NORMAL';
+    record('JAUNDICE', grade, { jaundicePositiveCount }, {
+      onlyFirstInstance: true,
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Urine Analysis (any abnormal finding, every instance) ---
+  const urineTest = input.urine_test;
+  if (Array.isArray(urineTest)) {
+    const grade = urineTest.some((v) => v !== 'normal') ? 'MILD' : 'NORMAL';
+    record('URINE_ANALYSIS', grade, { urineTest }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- All Danger Signs (any present, every instance, single condition
+  // row). "no_abnormal_signs_and_symptoms" and "bleeding_from_vagina" (its
+  // own APH condition above) are excluded from this count. ---
+  const dangerSignsExcluding = new Set(['no_abnormal_signs_and_symptoms', 'bleeding_from_vagina']);
+  const dangerSignsPresent = experiencedSigns.filter((s) => !dangerSignsExcluding.has(s));
+  if (Array.isArray(input.have_you_been_experiencing_any_of_these_since_the_last_visit)) {
+    const grade = dangerSignsPresent.length > 0 ? 'MILD' : 'NORMAL';
+    record('DANGER_SIGNS', grade, { dangerSigns: dangerSignsPresent }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Resolve "accompanied by any other flagged high-risk condition" gating
+  // for Hypotension/Hypoglycemia/Hypothermia (Appendix D §D.4/§D.5), now that
+  // every other condition on this visit has been graded. "Any other flagged
+  // condition" = any non-NORMAL grade among the *other* results recorded so
+  // far, evaluated per gate (excluding the gate's own condition and the
+  // sibling gates, since two accompanied-only conditions co-occurring with
+  // nothing else are not "accompanied by" each other's un-triggered state).
+  const nonNormalCodes = new Set(
+    results.filter((r) => r.grade !== 'NORMAL').map((r) => r.riskConditionId),
+  );
+  function patchAccompaniedTrigger(code, ownFlagged) {
+    if (!ownFlagged) return;
+    const entry = results.find((r) => r.riskConditionId === conditionIds[code]);
+    if (!entry) return;
+    const otherNonNormalExists = [...nonNormalCodes].some((id) => id !== entry.riskConditionId);
+    entry.isReferralTrigger = otherNonNormalExists;
+    entry.isHrVisitTrigger = otherNonNormalExists;
+  }
+  patchAccompaniedTrigger('HYPOTENSION', hypotensionFlagged);
+  patchAccompaniedTrigger('HYPOGLYCEMIA', hypoglycemiaFlagged);
+  patchAccompaniedTrigger('HYPOTHERMIA', hypothermiaFlagged);
+
+  // --- Overall visit-level rollup (worst grade across all conditions) ---
+  const worstRank = results.reduce((max, r) => Math.max(max, r.gradeRank), 0);
+  const overallRiskCategory =
+    worstRank === 3 ? 'CRITICAL' : worstRank === 2 ? 'HIGH' : worstRank === 1 ? 'LOW' : 'NORMAL';
+
+  return { overallRiskCategory, conditions: results };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.spec.ts
@@ -1,0 +1,378 @@
+import {
+  evaluateRulePack,
+  type RiskEvaluationResult,
+  type RulePackEvaluation,
+} from '../ruleSet.evaluator';
+import { infantRiskRulesJson } from './infant-risk.rulesJson';
+
+const CONDITION_IDS = {
+  LOW_BIRTH_WEIGHT: '22222222-2222-2222-2222-222222222201',
+  WASTING: '22222222-2222-2222-2222-222222222202',
+  STUNTING_STATUS: '22222222-2222-2222-2222-222222222203',
+  UNDERWEIGHT: '22222222-2222-2222-2222-222222222204',
+  MUAC_MALNUTRITION: '22222222-2222-2222-2222-222222222205',
+  INFANT_HYPOTHERMIA: '22222222-2222-2222-2222-222222222206',
+  INFANT_HYPERTHERMIA: '22222222-2222-2222-2222-222222222207',
+  CORD_INFECTION: '22222222-2222-2222-2222-222222222208',
+  RESPIRATORY_DISTRESS: '22222222-2222-2222-2222-222222222209',
+  NEURO_DEVELOPMENTAL_STATUS: '22222222-2222-2222-2222-222222222210',
+  INFANT_DANGER_SIGNS: '22222222-2222-2222-2222-222222222211',
+  FEEDING_ADEQUACY: '22222222-2222-2222-2222-222222222212',
+};
+
+// Real INFANT_VISIT/INC_VISIT/CCV_VISIT question codes (see
+// apps/visit-form-service/prisma/seed-data/infant-visit.json).
+const NORMAL_VITALS_INFANT = {
+  conditionIds: CONDITION_IDS,
+  birth_weight_in_kg: 3.0,
+  nutritional_status_wasting: 'normal',
+  nutritional_status_stunting: 'normal',
+  nutritional_status_underweight: 'normal',
+  muac_in_cms: 13,
+  age_in_months: 12,
+  child_temprature_in_f: 98,
+  child_respiratory_rate_2_12_months: 50,
+  is_the_child_showing_all_developmental_milestones_as_per_his_her_age: 'yes',
+  is_the_baby_showing_any_danger_signs_since_last_visit: ['no_abnormal_signs_symptoms'],
+  current_feeding_practice: ['exclusive_breastfeeding'],
+};
+
+// Real NEONATAL_VISIT question codes (see
+// apps/visit-form-service/prisma/seed-data/neonatal-visit.json) — no
+// temperature/respiratory-rate/MUAC/developmental-milestone fields exist.
+const NORMAL_VITALS_NEONATAL = {
+  conditionIds: CONDITION_IDS,
+  birth_weight_kg: 3.0,
+  nutritional_status_wasting: 'normal',
+  nutritional_status_stunting: 'normal',
+  nutritional_status_underweight: 'normal',
+  umbilical_cord_care: 'clean_and_dry',
+  danger_signs: ['no_abnormal_signs_symptoms'],
+  current_feeding_practice: 'exclusive_breastfeeding',
+};
+
+function findCondition(result: RulePackEvaluation, conditionId: string): RiskEvaluationResult {
+  const found = result.conditions.find((c) => c.riskConditionId === conditionId);
+  if (!found) throw new Error(`No condition result found for ${conditionId}`);
+  return found;
+}
+
+describe('infantRiskRulesJson', () => {
+  it('grades every vital as NORMAL and returns overallRiskCategory NORMAL when nothing is abnormal (INC_VISIT/CCV_VISIT fields)', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, NORMAL_VITALS_INFANT);
+
+    expect(result.overallRiskCategory).toBe('NORMAL');
+    for (const condition of result.conditions) {
+      expect(condition.grade).toBe('NORMAL');
+      expect(condition.isReferralTrigger).toBe(false);
+      expect(condition.isHrVisitTrigger).toBe(false);
+    }
+  });
+
+  it('grades every vital as NORMAL for a NEONATAL_VISIT payload, evaluating only the fields that form actually has', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, NORMAL_VITALS_NEONATAL);
+
+    expect(result.overallRiskCategory).toBe('NORMAL');
+    // Conditions with no corresponding NEONATAL_VISIT field must simply be
+    // absent from the output, not errored or defaulted.
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.INFANT_HYPOTHERMIA),
+    ).toBe(false);
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.RESPIRATORY_DISTRESS),
+    ).toBe(false);
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.MUAC_MALNUTRITION),
+    ).toBe(false);
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.NEURO_DEVELOPMENTAL_STATUS),
+    ).toBe(false);
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.CORD_INFECTION)).toBe(
+      true,
+    );
+  });
+
+  it('grades Low Birth Weight MILD from birth_weight_in_kg, never triggers referral, but triggers HR visit', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      birth_weight_in_kg: 2.2,
+    });
+
+    const lbw = findCondition(result, CONDITION_IDS.LOW_BIRTH_WEIGHT);
+    expect(lbw.grade).toBe('MILD');
+    expect(lbw.isReferralTrigger).toBe(false);
+    expect(lbw.isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades Low Birth Weight from birth_weight_kg on a NEONATAL_VISIT payload', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_NEONATAL,
+      birth_weight_kg: 2.0,
+    });
+
+    expect(findCondition(result, CONDITION_IDS.LOW_BIRTH_WEIGHT).grade).toBe('MILD');
+  });
+
+  it('grades wasting mam as MILD and sam as SEVERE from the form-pregraded value', async () => {
+    const mam = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'mam',
+    });
+    expect(findCondition(mam, CONDITION_IDS.WASTING).grade).toBe('MILD');
+
+    const sam = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'sam',
+    });
+    expect(findCondition(sam, CONDITION_IDS.WASTING).grade).toBe('SEVERE');
+  });
+
+  it('grades stunting moderately_stunted as MILD and severely_stunted as SEVERE', async () => {
+    const moderate = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_stunting: 'moderately_stunted',
+    });
+    expect(findCondition(moderate, CONDITION_IDS.STUNTING_STATUS).grade).toBe('MILD');
+
+    const severe = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_stunting: 'severely_stunted',
+    });
+    expect(findCondition(severe, CONDITION_IDS.STUNTING_STATUS).grade).toBe('SEVERE');
+  });
+
+  it('grades underweight muw as MILD and suw as SEVERE', async () => {
+    const muw = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_underweight: 'muw',
+    });
+    expect(findCondition(muw, CONDITION_IDS.UNDERWEIGHT).grade).toBe('MILD');
+
+    const suw = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_underweight: 'suw',
+    });
+    expect(findCondition(suw, CONDITION_IDS.UNDERWEIGHT).grade).toBe('SEVERE');
+  });
+
+  it('triggers nutrition referral on first instance', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'mam',
+      isFirstInstance: { WASTING: true },
+    });
+
+    expect(findCondition(result, CONDITION_IDS.WASTING).isReferralTrigger).toBe(true);
+  });
+
+  it('does not trigger nutrition referral on a repeat instance with fewer than 3 consecutive no-improvement visits', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'mam',
+      isFirstInstance: { WASTING: false },
+      consecutiveNoImprovementCount: { WASTING: 2 },
+    });
+
+    expect(findCondition(result, CONDITION_IDS.WASTING).isReferralTrigger).toBe(false);
+  });
+
+  it('triggers nutrition referral on a repeat instance with 3+ consecutive no-improvement visits', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'mam',
+      isFirstInstance: { WASTING: false },
+      consecutiveNoImprovementCount: { WASTING: 3 },
+    });
+
+    expect(findCondition(result, CONDITION_IDS.WASTING).isReferralTrigger).toBe(true);
+  });
+
+  it('HR-visit trigger for nutrition conditions fires every instance regardless of first-instance/improvement', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'mam',
+      isFirstInstance: { WASTING: false },
+      consecutiveNoImprovementCount: { WASTING: 0 },
+    });
+
+    expect(findCondition(result, CONDITION_IDS.WASTING).isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades MUAC 12cm (6-24 months) as MILD and 11cm as SEVERE', async () => {
+    const mild = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      muac_in_cms: 12,
+      age_in_months: 12,
+    });
+    expect(findCondition(mild, CONDITION_IDS.MUAC_MALNUTRITION).grade).toBe('MILD');
+
+    const severe = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      muac_in_cms: 11,
+      age_in_months: 12,
+    });
+    expect(findCondition(severe, CONDITION_IDS.MUAC_MALNUTRITION).grade).toBe('SEVERE');
+  });
+
+  it('does not evaluate MUAC malnutrition for an infant under 6 months', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      muac_in_cms: 10,
+      age_in_months: 3,
+    });
+
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.MUAC_MALNUTRITION),
+    ).toBe(false);
+  });
+
+  it('grades Hypothermia SEVERE below 96F and Hyperthermia SEVERE above 100F (documented default)', async () => {
+    const cold = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      child_temprature_in_f: 95,
+    });
+    const hypo = findCondition(cold, CONDITION_IDS.INFANT_HYPOTHERMIA);
+    expect(hypo.grade).toBe('SEVERE');
+    expect(hypo.isReferralTrigger).toBe(true);
+    expect(hypo.isHrVisitTrigger).toBe(true);
+
+    const hot = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      child_temprature_in_f: 101,
+    });
+    const hyper = findCondition(hot, CONDITION_IDS.INFANT_HYPERTHERMIA);
+    expect(hyper.grade).toBe('SEVERE');
+    expect(hyper.isReferralTrigger).toBe(true);
+    expect(hyper.isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades body temperature within 97-99F as NORMAL for both Hypothermia and Hyperthermia', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      child_temprature_in_f: 98,
+    });
+
+    expect(findCondition(result, CONDITION_IDS.INFANT_HYPOTHERMIA).grade).toBe('NORMAL');
+    expect(findCondition(result, CONDITION_IDS.INFANT_HYPERTHERMIA).grade).toBe('NORMAL');
+  });
+
+  it('grades Cord infection MILD from umbilical_cord_care, triggers referral but not HR visit (undocumented in source sheet)', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_NEONATAL,
+      umbilical_cord_care: 'redness_discharge_poor_condition',
+    });
+
+    const cord = findCondition(result, CONDITION_IDS.CORD_INFECTION);
+    expect(cord.grade).toBe('MILD');
+    expect(cord.isReferralTrigger).toBe(true);
+    expect(cord.isHrVisitTrigger).toBe(false);
+  });
+
+  it('grades Respiratory distress MILD for an abnormal rate, triggers referral but not HR visit', async () => {
+    const lowRate = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      child_respiratory_rate_2_12_months: 35,
+    });
+    const lowResult = findCondition(lowRate, CONDITION_IDS.RESPIRATORY_DISTRESS);
+    expect(lowResult.grade).toBe('MILD');
+    expect(lowResult.isReferralTrigger).toBe(true);
+    expect(lowResult.isHrVisitTrigger).toBe(false);
+  });
+
+  it('grades Respiratory rate 40-60 as NORMAL', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      child_respiratory_rate_2_12_months: 50,
+    });
+
+    expect(findCondition(result, CONDITION_IDS.RESPIRATORY_DISTRESS).grade).toBe('NORMAL');
+  });
+
+  it('grades Neuro-developmental status MILD when milestones answer is "no", triggers referral but not HR visit', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      is_the_child_showing_all_developmental_milestones_as_per_his_her_age: 'no',
+    });
+
+    const dev = findCondition(result, CONDITION_IDS.NEURO_DEVELOPMENTAL_STATUS);
+    expect(dev.grade).toBe('MILD');
+    expect(dev.isReferralTrigger).toBe(true);
+    expect(dev.isHrVisitTrigger).toBe(false);
+  });
+
+  it('grades any Danger Sign present (INFANT_VISIT field) as a single MILD condition row, triggering both referral and HR visit', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      is_the_baby_showing_any_danger_signs_since_last_visit: [
+        'convulsions_twitching_fits_or_abnormal_movements',
+        'lethargy_floppiness_or_inability_to_wake_up',
+      ],
+    });
+
+    const dangerRows = result.conditions.filter(
+      (c) => c.riskConditionId === CONDITION_IDS.INFANT_DANGER_SIGNS,
+    );
+    expect(dangerRows).toHaveLength(1);
+    expect(dangerRows[0].grade).toBe('MILD');
+    expect(dangerRows[0].isReferralTrigger).toBe(true);
+    expect(dangerRows[0].isHrVisitTrigger).toBe(true);
+  });
+
+  it('grades any Danger Sign present (NEONATAL_VISIT field) as MILD', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_NEONATAL,
+      danger_signs: ['convulsions'],
+    });
+
+    expect(findCondition(result, CONDITION_IDS.INFANT_DANGER_SIGNS).grade).toBe('MILD');
+  });
+
+  it('grades Feeding adequacy MILD and triggers referral for not_able_to_drink_feed', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      current_feeding_practice: ['not_able_to_drink_feed'],
+    });
+
+    const feeding = findCondition(result, CONDITION_IDS.FEEDING_ADEQUACY);
+    expect(feeding.grade).toBe('MILD');
+    expect(feeding.isReferralTrigger).toBe(true);
+    expect(feeding.isHrVisitTrigger).toBe(false);
+  });
+
+  it('grades Feeding adequacy NORMAL for exclusive_breastfeeding', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      current_feeding_practice: ['exclusive_breastfeeding'],
+    });
+
+    expect(findCondition(result, CONDITION_IDS.FEEDING_ADEQUACY).grade).toBe('NORMAL');
+  });
+
+  it('rolls up overallRiskCategory to CRITICAL when any condition is SEVERE', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      nutritional_status_wasting: 'sam',
+    });
+    expect(result.overallRiskCategory).toBe('CRITICAL');
+  });
+
+  it('rolls up overallRiskCategory to LOW when the worst grade is MILD (no Moderate band exists for infant conditions)', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      birth_weight_in_kg: 2.0,
+    });
+    expect(result.overallRiskCategory).toBe('LOW');
+  });
+
+  it('throws when conditionIds is missing an entry a graded input requires', async () => {
+    const incompleteIds: Record<string, string | undefined> = { ...CONDITION_IDS };
+    incompleteIds.WASTING = undefined;
+
+    await expect(
+      evaluateRulePack(infantRiskRulesJson, {
+        ...NORMAL_VITALS_INFANT,
+        conditionIds: incompleteIds,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.ts
@@ -1,0 +1,248 @@
+/**
+ * Infant (NN/INC/CCV) High-Risk clinical grading decision graph (SRS
+ * Appendix D Part 2 — "High risk protocols_Developer's copy - Infant HR",
+ * see docs/Appendix_D_High_Risk_Detection_Rules.md, Part 2).
+ *
+ * Covers neonatal (NN, 0-28 days) and infant/child (INC 0-12m, CCV 13-24m)
+ * visits. Per SRS §3A.2.4, CCV reuses INC's thresholds verbatim — this pack
+ * is evaluated for CCV submissions too, with the caller passing
+ * riskPhase: 'INC' (not a separate CCV phase) so both share one seeded set
+ * of risk_conditions rows (see riskAssessment.service.ts / seed.ts).
+ *
+ * Same input contract as anc-risk.rulesJson.ts: `conditionIds`
+ * (conditionCode -> risk_condition_id) and `isFirstInstance`
+ * (conditionCode -> boolean) are resolved by the caller and merged into the
+ * evaluation input. `consecutiveNoImprovementCount` (conditionCode ->
+ * count) is also caller-resolved, for the nutrition conditions' "3
+ * consecutive visits with no improvement" referral rule (Appendix D §2.4)
+ * — this pack has no DB access of its own for any of the three.
+ *
+ * All other input fields are read directly under their real
+ * NEONATAL_VISIT/INFANT_VISIT (INC_VISIT/CCV_VISIT) question_codes — see
+ * apps/visit-form-service/prisma/seed-data/neonatal-visit.json and
+ * infant-visit.json. The two forms have different field sets (NEONATAL_VISIT
+ * has no temperature/respiratory-rate/MUAC/developmental-milestone fields;
+ * INFANT_VISIT has no umbilical-cord field) — every branch below is
+ * independently gated on its own field(s) being present, so a phase whose
+ * form doesn't collect a given parameter simply skips that condition rather
+ * than erroring or defaulting.
+ *
+ * Nutrition grades (wasting/stunting/underweight) are NOT re-derived here
+ * from raw anthropometry — both forms already capture the Sakhi's own
+ * pre-graded value ('normal'/'mam'/'sam',
+ * 'normal'/'moderately_stunted'/'severely_stunted',
+ * 'normal'/'muw'/'suw') per the WHO growth-chart lookup the app performs
+ * offline; this pack only maps those pre-graded values onto referral/
+ * HR-visit/education trigger rules.
+ *
+ * Four items in this sheet are ambiguous or incomplete versus the source
+ * (see docs/Appendix_D_High_Risk_Detection_Rules.md §2.8) and are resolved
+ * here with a documented default rather than left unhandled:
+ *  1. Hypothermia/Hyperthermia: the sheet's single non-Normal threshold is
+ *     labelled "Severe hypothermia"/"Severe hyperthermia" but sits in the
+ *     Mild/At-Risk row with no separate Moderate/Severe band — graded here
+ *     as SEVERE (trusting the value's own label over its row position).
+ *  2. MUAC Severe cutoff's age label ("<11.5cm, 0-6m") conflicts with this
+ *     sheet's own "MUAC measured after 6 months only" rule — applied only
+ *     for ages 6-24 months; the 0-6m figure is not evaluated. INFANT_VISIT
+ *     has no explicit ageMonths field either — this pack derives it from
+ *     age_in_months when present.
+ *  3. Cord infection/omphalitis, Respiratory distress, and Neuro-
+ *     developmental status have an "every instance" referral trigger but no
+ *     HR-visit-trigger value in the source sheet — HR-visit trigger
+ *     defaults to false for these three, same treatment as PPH's blank
+ *     cells in the ANC pack.
+ *  4. No Moderate band exists for any infant condition in the source sheet
+ *     — every condition here only has Normal/Mild/Severe branches (Anemia/
+ *     Hypertension in the ANC pack are the only conditions with a true
+ *     Moderate band across both sheets).
+ */
+export const infantRiskRulesJson = {
+  contentType: 'application/vnd.gorules.decision',
+  nodes: [
+    { id: 'input1', type: 'inputNode', name: 'request', position: { x: 0, y: 0 } },
+    {
+      id: 'fn1',
+      type: 'functionNode',
+      name: 'computeInfantRiskGrading',
+      position: { x: 200, y: 0 },
+      content: `
+const GRADE_RANK = { NORMAL: 0, MILD: 1, MODERATE: 2, SEVERE: 3 };
+
+const handler = (input) => {
+  const { conditionIds, isFirstInstance, consecutiveNoImprovementCount } = input;
+  if (!conditionIds || typeof conditionIds !== 'object') {
+    throw new Error('conditionIds (conditionCode -> risk_condition_id map) is required.');
+  }
+  const firstInstance = isFirstInstance || {};
+  const noImprovementCounts = consecutiveNoImprovementCount || {};
+
+  const results = [];
+
+  function requireConditionId(code) {
+    const id = conditionIds[code];
+    if (!id) throw new Error('conditionIds is missing an entry for ' + code);
+    return id;
+  }
+
+  function record(code, grade, observedValueJson, opts) {
+    opts = opts || {};
+    results.push({
+      riskConditionId: requireConditionId(code),
+      grade,
+      gradeRank: GRADE_RANK[grade],
+      isReferralTrigger: opts.referralTrigger === true,
+      isEducationTrigger: grade !== 'NORMAL',
+      isHrVisitTrigger: opts.hrVisitTrigger === true,
+      observedValueJson,
+    });
+  }
+
+  function nutritionReferralTrigger(code, grade, isFirst) {
+    if (grade === 'NORMAL') return false;
+    const noImprovementStreak = noImprovementCounts[code] || 0;
+    return isFirst || noImprovementStreak >= 3;
+  }
+
+  // --- Low Birth Weight (NEONATAL_VISIT: birth_weight_kg;
+  // INFANT_VISIT/INC_VISIT/CCV_VISIT: birth_weight_in_kg) ---
+  const birthWeightKg =
+    typeof input.birth_weight_kg === 'number' ? input.birth_weight_kg : input.birth_weight_in_kg;
+  if (typeof birthWeightKg === 'number') {
+    const grade = birthWeightKg < 2.5 ? 'MILD' : 'NORMAL';
+    record('LOW_BIRTH_WEIGHT', grade, { birthWeightKg }, {
+      // "No referral" per Appendix D §2.4 - LBW is tracked/HR-visited but
+      // never generates a referral on its own.
+      referralTrigger: false,
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Undernutrition: Wasting/Stunting/Underweight (pre-graded by the
+  // visit form itself; same question_codes on both forms) ---
+  function gradeNutritionField(code, rawValue, severeValues) {
+    if (typeof rawValue !== 'string') return;
+    const isFirst = firstInstance[code] !== false;
+    const grade = rawValue === 'normal' ? 'NORMAL' : severeValues.indexOf(rawValue) !== -1 ? 'SEVERE' : 'MILD';
+    record(code, grade, { value: rawValue }, {
+      referralTrigger: nutritionReferralTrigger(code, grade, isFirst),
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+  gradeNutritionField('WASTING', input.nutritional_status_wasting, ['sam']);
+  gradeNutritionField('STUNTING_STATUS', input.nutritional_status_stunting, ['severely_stunted']);
+  gradeNutritionField('UNDERWEIGHT', input.nutritional_status_underweight, ['suw']);
+
+  // --- MAM/SAM via MUAC (6-24 months only; INFANT_VISIT/INC_VISIT/
+  // CCV_VISIT only - muac_in_cms does not exist on NEONATAL_VISIT) ---
+  const muacCm = input.muac_in_cms;
+  const ageMonths = input.age_in_months;
+  if (typeof muacCm === 'number' && typeof ageMonths === 'number' && ageMonths >= 6) {
+    const isFirst = firstInstance.MUAC_MALNUTRITION !== false;
+    const grade = muacCm < 11.5 ? 'SEVERE' : muacCm < 12.5 ? 'MILD' : 'NORMAL';
+    record('MUAC_MALNUTRITION', grade, { muacCm, ageMonths }, {
+      referralTrigger: nutritionReferralTrigger('MUAC_MALNUTRITION', grade, isFirst),
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Hypothermia / Hyperthermia (INFANT_VISIT/INC_VISIT/CCV_VISIT only -
+  // no temperature field on NEONATAL_VISIT). See doc-comment default #1. ---
+  const bodyTempF = input.child_temprature_in_f;
+  if (typeof bodyTempF === 'number') {
+    const hypoGrade = bodyTempF < 96 ? 'SEVERE' : 'NORMAL';
+    record('INFANT_HYPOTHERMIA', hypoGrade, { bodyTempF }, {
+      referralTrigger: hypoGrade !== 'NORMAL',
+      hrVisitTrigger: hypoGrade !== 'NORMAL',
+    });
+
+    const hyperGrade = bodyTempF > 100 ? 'SEVERE' : 'NORMAL';
+    record('INFANT_HYPERTHERMIA', hyperGrade, { bodyTempF }, {
+      referralTrigger: hyperGrade !== 'NORMAL',
+      hrVisitTrigger: hyperGrade !== 'NORMAL',
+    });
+  }
+
+  // --- Cord infection / omphalitis (NEONATAL_VISIT only -
+  // umbilical_cord_care does not exist on INFANT_VISIT/INC_VISIT/
+  // CCV_VISIT) ---
+  const cordCare = input.umbilical_cord_care;
+  if (typeof cordCare === 'string') {
+    const grade = cordCare === 'clean_and_dry' ? 'NORMAL' : 'MILD';
+    record('CORD_INFECTION', grade, { cordCare }, {
+      referralTrigger: grade !== 'NORMAL',
+      // No HR-visit-trigger value given in the source sheet (default #3).
+      hrVisitTrigger: false,
+    });
+  }
+
+  // --- Respiratory distress (INFANT_VISIT/INC_VISIT/CCV_VISIT only -
+  // child_respiratory_rate_2_12_months does not exist on NEONATAL_VISIT) ---
+  const respiratoryRate = input.child_respiratory_rate_2_12_months;
+  if (typeof respiratoryRate === 'number') {
+    const grade = respiratoryRate < 40 || respiratoryRate > 60 ? 'MILD' : 'NORMAL';
+    record('RESPIRATORY_DISTRESS', grade, { respiratoryRate }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: false,
+    });
+  }
+
+  // --- Neuro-developmental status (INFANT_VISIT/INC_VISIT/CCV_VISIT only -
+  // not asked on NEONATAL_VISIT) ---
+  const milestonesOnTrack = input.is_the_child_showing_all_developmental_milestones_as_per_his_her_age;
+  if (typeof milestonesOnTrack === 'string') {
+    const grade = milestonesOnTrack === 'yes' ? 'NORMAL' : 'MILD';
+    record('NEURO_DEVELOPMENTAL_STATUS', grade, { milestonesOnTrack }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: false,
+    });
+  }
+
+  // --- Danger Signs (single condition row, any sign present). Each form
+  // has its own question_code and its own "no signs" sentinel value. ---
+  const nnDangerSigns = Array.isArray(input.danger_signs) ? input.danger_signs : null;
+  const infantDangerSigns = Array.isArray(input.is_the_baby_showing_any_danger_signs_since_last_visit)
+    ? input.is_the_baby_showing_any_danger_signs_since_last_visit
+    : null;
+  const dangerSignsRaw = nnDangerSigns || infantDangerSigns;
+  if (dangerSignsRaw) {
+    const dangerSignsPresent = dangerSignsRaw.filter((s) => s !== 'no_abnormal_signs_symptoms');
+    const grade = dangerSignsPresent.length > 0 ? 'MILD' : 'NORMAL';
+    record('INFANT_DANGER_SIGNS', grade, { dangerSigns: dangerSignsPresent }, {
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Feeding adequacy. Both forms use current_feeding_practice, with
+  // different value sets: NEONATAL_VISIT's set has no explicit "not
+  // feeding" option in this pack's scope, so notFeeding is only derived on
+  // INFANT_VISIT/INC_VISIT/CCV_VISIT's 'not_able_to_drink_feed' value. ---
+  const feedingPractice = input.current_feeding_practice;
+  const feedingPracticeCodes = Array.isArray(feedingPractice) ? feedingPractice : [feedingPractice];
+  const notFeeding = feedingPracticeCodes.indexOf('not_able_to_drink_feed') !== -1;
+  if (typeof feedingPractice === 'string' || Array.isArray(feedingPractice)) {
+    const grade = notFeeding ? 'MILD' : 'NORMAL';
+    record('FEEDING_ADEQUACY', grade, { notFeeding }, {
+      // "Only for no feeding > supplementary feeds" (Appendix D §2.4) - the
+      // narrower "not feeding at all" case triggers referral.
+      referralTrigger: notFeeding,
+      hrVisitTrigger: false,
+    });
+  }
+
+  const worstRank = results.reduce((max, r) => Math.max(max, r.gradeRank), 0);
+  const overallRiskCategory =
+    worstRank === 3 ? 'CRITICAL' : worstRank === 2 ? 'HIGH' : worstRank === 1 ? 'LOW' : 'NORMAL';
+
+  return { overallRiskCategory, conditions: results };
+};
+      `,
+    },
+    { id: 'output1', type: 'outputNode', name: 'response', position: { x: 400, y: 0 } },
+  ],
+  edges: [
+    { id: 'e1', sourceId: 'input1', targetId: 'fn1', type: 'edge' },
+    { id: 'e2', sourceId: 'fn1', targetId: 'output1', type: 'edge' },
+  ],
+};

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -125,6 +125,22 @@ export class FormRepository {
   }
 
   /**
+   * The most recent submission for `beneficiaryId` against `formCode`'s
+   * form_definition, regardless of which version it was answered under —
+   * used to fetch a one-time form's answers (e.g. MOTHER_REGISTRATION) for
+   * a server-to-server caller that needs data captured outside the
+   * caller's own recurring visit form (see risk-referral-service's ANC
+   * risk grading, which needs Age/Bad-Obstetric-History from registration
+   * alongside the current ANC_VISIT's own vitals).
+   */
+  findLatestSubmissionByBeneficiaryAndFormCode(beneficiaryId: string, formCode: string) {
+    return this.prisma.formSubmission.findFirst({
+      where: { beneficiaryId, isDeleted: false, formVersion: { formDefinition: { formCode } } },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
    * Existence + ownership check for a visit-linked submission's visitId,
    * before the insert — visit_instances is owned by this same service
    * (unlike beneficiary_cases/form_versions' cross-service equivalents), so

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -7,6 +7,7 @@ import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
+import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
@@ -15,6 +16,7 @@ jest.mock('../beneficiaries/beneficiary.client');
 jest.mock('../beneficiaries/create-child.client');
 jest.mock('../beneficiaries/update-phase.client');
 jest.mock('../closures/closure.client');
+jest.mock('../risk-assessments/riskAssessment.client');
 
 describe('FormService', () => {
   const repository = {
@@ -29,6 +31,7 @@ describe('FormService', () => {
     findSubmissionByLocalUuid: jest.fn(),
     createSubmission: jest.fn(),
     findVisitById: jest.fn(),
+    findLatestSubmissionByBeneficiaryAndFormCode: jest.fn(),
   } as unknown as jest.Mocked<FormRepository>;
   let service: FormService;
 
@@ -1317,6 +1320,227 @@ describe('FormService', () => {
         );
 
         expect(jest.mocked(updateBeneficiaryPhase)).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('ANC_VISIT risk assessment trigger with registration-derived answers', () => {
+      const ancVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'ANC_VISIT', riskRuleSetId: 'rule-set-1' },
+        schemaJson: [
+          {
+            question_code: 'haemoglobin_hb_g_dl',
+            label: 'x',
+            input_type: 'number',
+            required: false,
+          },
+        ],
+        validationJson: [],
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(ancVersion as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+      });
+
+      it("merges age and badObstetricHistoryFlag from the beneficiary's MOTHER_REGISTRATION submission", async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: {
+            age_of_the_beneficiary: 22,
+            gravida_total_number_of_pregnancies: 2,
+            living_children: 2,
+            abortions_pregnancy_losses_before_24_weeks: 0,
+            did_you_experience_any_complications_during_birth_delivery_in_previous_pregnancies: [
+              'no_complications',
+            ],
+          },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { haemoglobin_hb_g_dl: 9.5 },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(repository.findLatestSubmissionByBeneficiaryAndFormCode).toHaveBeenCalledWith(
+          'b1',
+          'MOTHER_REGISTRATION',
+        );
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: {
+              haemoglobin_hb_g_dl: 9.5,
+              age: 22,
+              badObstetricHistoryFlag: false,
+            },
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('flags badObstetricHistoryFlag true when gravida exceeds 4', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { age_of_the_beneficiary: 30, gravida_total_number_of_pregnancies: 5 },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('flags badObstetricHistoryFlag true when livingChildren is less than gravida', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: {
+            gravida_total_number_of_pregnancies: 3,
+            living_children: 1,
+          },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('flags badObstetricHistoryFlag true when abortions >= 2', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { abortions_pregnancy_losses_before_24_weeks: 2 },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('flags badObstetricHistoryFlag true when a non-"no_complications" answer is present', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: {
+            did_you_experience_any_complications_during_birth_delivery_in_previous_pregnancies: [
+              'yes_miscarriage',
+            ],
+          },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('proceeds without registration-derived answers when no MOTHER_REGISTRATION submission exists', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue(null);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { haemoglobin_hb_g_dl: 9.5 },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({ answers: { haemoglobin_hb_g_dl: 9.5 } }),
+          'Bearer test-token',
+        );
+      });
+
+      it('does not look up MOTHER_REGISTRATION for a form other than ANC_VISIT', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...ancVersion,
+          formDefinition: { formCode: 'CHILD_REGISTRATION', riskRuleSetId: 'rule-set-1' },
+        } as never);
+
+        await service.createSubmission(
+          'CHILD_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { some_field: 'x' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(repository.findLatestSubmissionByBeneficiaryAndFormCode).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -21,6 +21,28 @@ import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 
 /**
+ * Maps this service's own formCode to risk-referral-service's RiskCondition
+ * .phase enum value, for the risk-assessment trigger's `riskPhase` field
+ * (see riskAssessment.client.ts's doc comment on why the caller supplies
+ * this). Only forms with a risk_rule_set_id configured ever reach this map;
+ * a formCode with no entry here falls back to itself unchanged.
+ */
+const FORM_CODE_TO_RISK_PHASE: Record<string, string> = {
+  ANC_VISIT: 'ANC',
+  // NN, INC, and CCV all share one seeded set of risk_conditions rows under
+  // phase 'INC' — per SRS §3A.2.4, CCV reuses INC's HR thresholds verbatim,
+  // and NEONATAL_VISIT's clinical fields (nutrition status, danger signs,
+  // umbilical cord, etc.) grade against the same condition set (see
+  // infant-risk.rulesJson.ts's own doc comment). INFANT_VISIT (the legacy
+  // alias of INC_VISIT — see visit-code-form-map.ts) is intentionally
+  // omitted here: it is never reached by a real visit-schedule submission,
+  // only INC_VISIT is.
+  NEONATAL_VISIT: 'INC',
+  INC_VISIT: 'INC',
+  CCV_VISIT: 'INC',
+};
+
+/**
  * Business logic for the dynamic-forms feature: fetching the active version,
  * the DRAFT -> PUBLISHED lifecycle, and validating/persisting submissions.
  * Data access is delegated to the repository.
@@ -297,13 +319,21 @@ export class FormService {
     // entityType forms) simply has nothing to evaluate. Best-effort, same
     // stance as syncSocioDemographics above.
     if (dto.visitId && version.formDefinition.riskRuleSetId) {
+      const answers =
+        formCode === 'ANC_VISIT'
+          ? {
+              ...dto.formData,
+              ...(await this.resolveAncRiskRegistrationAnswers(dto.beneficiaryId)),
+            }
+          : dto.formData;
       await triggerRiskAssessment(
         {
           beneficiaryId: dto.beneficiaryId,
           visitId: dto.visitId,
           submissionId: created.id,
           ruleSetId: version.formDefinition.riskRuleSetId,
-          answers: dto.formData,
+          riskPhase: FORM_CODE_TO_RISK_PHASE[formCode] ?? formCode,
+          answers,
         },
         authorizationHeader,
       );
@@ -338,6 +368,58 @@ export class FormService {
    * child-creation against a different beneficiary than the one actually
    * recorded.
    */
+  /**
+   * Derives the ANC risk pack's registration-time inputs (age, bad obstetric
+   * history) from this beneficiary's own MOTHER_REGISTRATION submission —
+   * a same-service, same-DB lookup (no cross-service call needed: both
+   * age_of_the_beneficiary and the obstetric-history answers live on this
+   * same form). Appendix D's Bad Obstetric
+   * History condition ("G>4, L<P, Pre-term, LSCS without spacing,
+   * consecutive losses/ABORTIONS >=2, stillbirth, neonatal death, or
+   * recurrent complications") only partially maps onto what
+   * MOTHER_REGISTRATION actually asks — this derivation covers
+   * gravida>4, livingChildren<gravida, abortions>=2, and any
+   * non-"no_complications" answer on the prior-complications question.
+   * Pre-term delivery history and LSCS-without-spacing have no captured
+   * field in this form today and are NOT evaluated — a known gap versus
+   * the full Appendix D definition, not a bug.
+   *
+   * Returns `{}` (no registration answers merged in) if no
+   * MOTHER_REGISTRATION submission exists yet for this beneficiary — the
+   * ANC risk pack's age/BOH conditions are simply skipped for that visit
+   * rather than the whole risk evaluation failing.
+   */
+  private async resolveAncRiskRegistrationAnswers(
+    beneficiaryId: string,
+  ): Promise<Record<string, unknown>> {
+    const registration = await this.repository.findLatestSubmissionByBeneficiaryAndFormCode(
+      beneficiaryId,
+      'MOTHER_REGISTRATION',
+    );
+    if (!registration) return {};
+
+    const answers = registration.formDataJson as Record<string, unknown>;
+    const age = answers.age_of_the_beneficiary;
+    const gravida = answers.gravida_total_number_of_pregnancies;
+    const livingChildren = answers.living_children;
+    const abortions = answers.abortions_pregnancy_losses_before_24_weeks;
+    const complications =
+      answers.did_you_experience_any_complications_during_birth_delivery_in_previous_pregnancies;
+
+    const badObstetricHistoryFlag =
+      (typeof gravida === 'number' && gravida > 4) ||
+      (typeof gravida === 'number' &&
+        typeof livingChildren === 'number' &&
+        livingChildren < gravida) ||
+      (typeof abortions === 'number' && abortions >= 2) ||
+      (Array.isArray(complications) && complications.some((code) => code !== 'no_complications'));
+
+    return {
+      ...(typeof age === 'number' ? { age } : {}),
+      badObstetricHistoryFlag,
+    };
+  }
+
   private async resolveDeliveryChildren(
     dto: CreateSubmissionInput,
     beneficiaryId: string,

--- a/apps/visit-form-service/src/risk-assessments/riskAssessment.client.ts
+++ b/apps/visit-form-service/src/risk-assessments/riskAssessment.client.ts
@@ -21,6 +21,12 @@ export async function triggerRiskAssessment(
     visitId: string | null;
     submissionId: string;
     ruleSetId: string;
+    // The RiskCondition.phase this submission's form corresponds to (e.g.
+    // 'ANC' for ANC_VISIT) — risk-referral-service has no other way to know
+    // which risk_conditions rows a given ruleSetId's decision graph refers
+    // to (RuleSet itself carries no phase), so the caller (this service,
+    // which already owns formCode -> phase knowledge) supplies it.
+    riskPhase: string;
     answers: Record<string, unknown>;
   },
   authorizationHeader: string,

--- a/docs/Appendix_D_High_Risk_Detection_Rules.md
+++ b/docs/Appendix_D_High_Risk_Detection_Rules.md
@@ -1,0 +1,546 @@
+# Appendix D — High Risk Detection Rules
+
+Consolidated from three ARMMAN-provided sheets: **High risk protocols_Developer's copy** — **ANC HR**, **Infant HR**, and **Dashboard**. Referenced from SRS §3A.2.5 (High Risk Detection) and §3C (Manager Web Dashboard).
+
+- **Part 1 — ANC** covers the pregnancy/mother phase (registration + ANC_VISIT).
+- **Part 2 — Infant** covers NN (neonatal, 0–28 days) and INC/CCV (infant/child, 0–24 months). Per SRS §3A.2.4, CCV (13–24m) uses the same clinical fields, HR thresholds, and referral conditions as INC (0–12m) — "Confirmed - CCV visit form and HR thresholds will be same as INC" — so this sheet is the threshold source for both phases, not NN alone.
+- **Part 3 — Manager Dashboard** covers the reporting/linelist requirements built on top of Parts 1 and 2's risk data (SRS §3C).
+
+---
+
+# Part 1 — ANC High Risk Detection Rules
+
+Source: **High risk protocols_Developer's copy — ANC HR** sheet.
+
+## 1.1 Parameter measurement method
+
+| HR Parameter                 | How measured                                                                             |
+| ---------------------------- | ---------------------------------------------------------------------------------------- |
+| Age                          | DoB/Age                                                                                  |
+| Undernutrition               | MUAC measurement by Mother-Infant MUAC tape; BMI calculation by wt(kg)/ht(m)²            |
+| Bad Obstetric History        | Height in cm; take detailed past obstetric history in ANC registration form              |
+| Blood Haemoglobin Levels     | Haemometer readings                                                                      |
+| Blood Pressure               | Digital BP apparatus                                                                     |
+| Blood Sugar Levels           | Glucometer readings: Random Blood Sugar                                                  |
+| Bleeding                     | Ask history of vaginal bleeding at every ANC visit                                       |
+| Body temperature             | Oral temperature using digital thermometer                                               |
+| Fetal Heart Rate             | Measure using Doppler device                                                             |
+| Fundal Height                | Measure from symphysis pubis to uterine fundus using measuring tape                      |
+| Poor Gestational Weight gain | Current weight − pre-pregnancy weight (tracked against gestational age and BMI category) |
+| Physical Examination         | Palm, Nails, Eyes and Skin check                                                         |
+| Urine Analysis               | —                                                                                        |
+| All Danger Signs             | —                                                                                        |
+
+## 1.2 HR condition per parameter
+
+| HR Parameter                 | HR Condition                |
+| ---------------------------- | --------------------------- |
+| Age                          | Underage/Overage            |
+| Undernutrition               | MUAC/BMI                    |
+| Undernutrition (height)      | Stunting (height)           |
+| Bad Obstetric History        | Bad Obstetric History       |
+| Blood Haemoglobin Levels     | Anemia                      |
+| Blood Pressure               | Hypertension                |
+| Blood Pressure               | Hypotension                 |
+| Blood Sugar Levels           | Hyperglycemia               |
+| Blood Sugar Levels           | Hypoglycemia                |
+| Bleeding                     | Antepartum Hemorrhage (APH) |
+| Bleeding                     | Postpartum Hemorrhage (PPH) |
+| Body temperature             | Hypothermia                 |
+| Body temperature             | Hyperthermia                |
+| Fetal Heart Rate             | Fetal Heart Rate            |
+| Fundal Height                | Fundal Height               |
+| Poor Gestational Weight gain | Gestational Weight gain     |
+| Physical Examination         | Jaundice                    |
+
+## 1.3 Grade thresholds by condition
+
+Each row below is one HR condition; each column is a severity grade. A blank cell means that condition's protocol does not define a value at that grade.
+
+### Age
+
+| Grade      | Value                                  |
+| ---------- | -------------------------------------- |
+| Normal/Low | Normal (19–34 years)                   |
+| Mild       | Underage <19 years / Overage ≥35 years |
+| Moderate   | —                                      |
+| Severe     | —                                      |
+
+### Undernutrition — MUAC/BMI
+
+| Grade      | Value                        |
+| ---------- | ---------------------------- |
+| Normal/Low | ≥ 23 cm / BMI ≥ 18.5         |
+| Mild       | <23 cm / BMI <18.5; BMI ≥ 35 |
+| Moderate   | —                            |
+| Severe     | —                            |
+
+### Undernutrition — Stunting (height)
+
+| Grade      | Value    |
+| ---------- | -------- |
+| Normal/Low | ≥ 145 cm |
+| Mild       | <145 cm  |
+| Moderate   | —        |
+| Severe     | —        |
+
+### Bad Obstetric History
+
+| Grade      | Value                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Normal/Low | No adverse previous pregnancy outcome                                                                                             |
+| Mild       | G>4, L<P, Pre-term, LSCS without spacing, consecutive losses/ABORTIONS ≥2, stillbirth, neonatal death, or recurrent complications |
+| Moderate   | —                                                                                                                                 |
+| Severe     | —                                                                                                                                 |
+
+### Anemia (Blood Haemoglobin Levels)
+
+| Grade      | Value                                          |
+| ---------- | ---------------------------------------------- |
+| Normal/Low | No anaemia (>11 g/dl)                          |
+| Mild       | Mild (10–10.9 g/dl)                            |
+| Moderate   | Moderate (7–9.9 g/dl); sickle cell disease +ve |
+| Severe     | Severe (<7 g/dl)                               |
+
+### Hypertension (Blood Pressure)
+
+| Grade      | Value                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------ |
+| Normal/Low | Normal (≤120/80 mmHg)                                                                      |
+| Mild       | Systolic 135–139 / Diastolic 85–89 and history of Hypertension or Gestational Hypertension |
+| Moderate   | Moderate ≥140–159/90–109                                                                   |
+| Severe     | Severe ≥160/≥110                                                                           |
+
+### Hypotension (Blood Pressure)
+
+| Grade      | Value                                               |
+| ---------- | --------------------------------------------------- |
+| Normal/Low | ≥90 systolic                                        |
+| Mild       | Systolic <90 mmHg or associated with shock features |
+| Moderate   | —                                                   |
+| Severe     | —                                                   |
+
+### Hyperglycemia (Blood Sugar Levels)
+
+| Grade      | Value                |
+| ---------- | -------------------- |
+| Normal/Low | Normal 70–140 mg/dL  |
+| Mild       | At risk (>140 mg/dl) |
+| Moderate   | —                    |
+| Severe     | —                    |
+
+### Hypoglycemia (Blood Sugar Levels)
+
+| Grade      | Value               |
+| ---------- | ------------------- |
+| Normal/Low | Normal 70–140 mg/dL |
+| Mild       | <70 mg/dL           |
+| Moderate   | —                   |
+| Severe     | —                   |
+
+### Antepartum Hemorrhage — APH (Bleeding)
+
+| Grade      | Value                                                                                                                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Normal/Low | No bleeding                                                                                                                                                                                   |
+| Mild       | Spotting (few drops, no pain, hemodynamically stable) / bleeding similar to menstrual flow, mild pain, stable vitals / heavy bleeding, clots, severe abdominal pain, dizziness, pallor, shock |
+| Moderate   | —                                                                                                                                                                                             |
+| Severe     | —                                                                                                                                                                                             |
+
+### Postpartum Hemorrhage — PPH (Bleeding)
+
+| Grade      | Value                                                                                                 |
+| ---------- | ----------------------------------------------------------------------------------------------------- |
+| Normal/Low | Lochia normal: light bleeding, intermittent, red to brown, progressing to pink and white over 6 weeks |
+| Mild       | Profuse bleeding, soaking more than 2 pads per hour                                                   |
+| Moderate   | —                                                                                                     |
+| Severe     | —                                                                                                     |
+
+### Hypothermia (Body temperature)
+
+| Grade      | Value     |
+| ---------- | --------- |
+| Normal/Low | 96–98.9°F |
+| Mild       | <96°F     |
+| Moderate   | —         |
+| Severe     | —         |
+
+### Hyperthermia (Body temperature)
+
+| Grade      | Value   |
+| ---------- | ------- |
+| Normal/Low | 97–99°F |
+| Mild       | >99°F   |
+| Moderate   | —       |
+| Severe     | —       |
+
+### Fetal Heart Rate
+
+| Grade      | Value                                    |
+| ---------- | ---------------------------------------- |
+| Normal/Low | 120–160 bpm                              |
+| Mild       | <120 bpm OR >160 bpm OR irregular rhythm |
+| Moderate   | —                                        |
+| Severe     | —                                        |
+
+### Fundal Height
+
+| Grade      | Value                                |
+| ---------- | ------------------------------------ |
+| Normal/Low | GA ±2 cm                             |
+| Mild       | <>GA ±2 cm OR <GA −2 cm or >GA +2 cm |
+| Moderate   | —                                    |
+| Severe     | —                                    |
+
+### Gestational Weight gain (Poor Gestational Weight gain)
+
+| Grade      | Value                                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| Normal/Low | 10–12 kg                                                                                          |
+| Mild       | Weight gain below recommended range, i.e. 10–12 kg (0.2–0.3 kg per week in 2nd and 3rd trimester) |
+| Moderate   | —                                                                                                 |
+| Severe     | —                                                                                                 |
+
+### Jaundice (Physical Examination)
+
+| Grade      | Value                                                            |
+| ---------- | ---------------------------------------------------------------- |
+| Normal/Low | —                                                                |
+| Mild       | If yellow +ve in 2/3 out of: Palm and Nails; Sclera (Eyes); Skin |
+| Moderate   | —                                                                |
+| Severe     | —                                                                |
+
+### Urine Analysis
+
+| Grade | Value                                       |
+| ----- | ------------------------------------------- |
+| Mild  | Urine protein; Urine Sugar; Urine Infection |
+
+### All Danger Signs
+
+| Grade | Value                                                                                                                                                                                                                                                                        |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mild  | Severe abdominal pain; Abnormal Vaginal discharge (foul smelling and yellow); Vomiting for more than 24 hours; Convulsions; Severe Headaches, blurred vision; Dizziness; Breathlessness; Palpitation; Increased frequency of urination; Vaginal Itching; Burning micturition |
+
+## 1.4 Referral trigger rules (per condition)
+
+| HR Condition                | Referral trigger                                                        |
+| --------------------------- | ----------------------------------------------------------------------- |
+| Age (Underage/Overage)      | Only first instance                                                     |
+| MUAC/BMI                    | Only first instance                                                     |
+| Stunting                    | Only first instance                                                     |
+| Bad Obstetric History       | Only first instance                                                     |
+| Anemia                      | Every instance of Moderate and Severe                                   |
+| Hypertension                | Every instance of Moderate and Severe                                   |
+| Hypotension                 | Every instance if accompanied by any other flagged high-risk condition  |
+| Hyperglycemia               | Every instance                                                          |
+| Hypoglycemia                | Every instance if accompanied by any other flagged high-risk condition  |
+| Antepartum Hemorrhage (APH) | Every instance                                                          |
+| Postpartum Hemorrhage (PPH) | —                                                                       |
+| Hypothermia                 | Every instance if accompanied by any other flagged high-risk condition  |
+| Hyperthermia                | Every instance                                                          |
+| Fetal Heart Rate            | Every instance                                                          |
+| Fundal Height               | Every instance                                                          |
+| Gestational Weight gain     | Only first instance                                                     |
+| Jaundice                    | Only first instance, if yellow +ve in 2/3 out of Palm/Nails/Sclera/Skin |
+| Urine Analysis              | Every instance                                                          |
+| All Danger Signs            | Every instance                                                          |
+
+## 1.5 HR visit trigger rules (visit generated 15 days later)
+
+| HR Condition                | HR visit (after 15 days) trigger                                       |
+| --------------------------- | ---------------------------------------------------------------------- |
+| Age (Underage/Overage)      | Regular                                                                |
+| MUAC/BMI                    | Regular                                                                |
+| Stunting                    | Regular                                                                |
+| Bad Obstetric History       | Regular                                                                |
+| Anemia                      | Every instance of Moderate and Severe                                  |
+| Hypertension                | Every instance of Moderate and Severe                                  |
+| Hypotension                 | Every instance if accompanied by any other flagged high-risk condition |
+| Hyperglycemia               | Every instance                                                         |
+| Hypoglycemia                | Every instance if accompanied by any other flagged high-risk condition |
+| Antepartum Hemorrhage (APH) | Every instance                                                         |
+| Postpartum Hemorrhage (PPH) | —                                                                      |
+| Hypothermia                 | Every instance if accompanied by any other flagged high-risk condition |
+| Hyperthermia                | Every instance                                                         |
+| Fetal Heart Rate            | Every instance                                                         |
+| Fundal Height               | Every instance                                                         |
+| Gestational Weight gain     | Every instance                                                         |
+| Jaundice                    | Every instance                                                         |
+| Urine Analysis              | Every instance                                                         |
+| All Danger Signs            | Every instance                                                         |
+
+> Note: per FR-S-5.2/FR-S-5.3, this HR visit anchor is the ACTUAL completion date + 15 days for ANC/INC (cumulative — a new HR visit fires on every qualifying detection).
+
+## 1.6 Counselling-only rules (no referral, no HR visit)
+
+| HR Condition            | Only counselling applies |
+| ----------------------- | ------------------------ |
+| Age (Underage/Overage)  | For other visits         |
+| MUAC/BMI                | For other visits         |
+| Stunting                | For other visits         |
+| Bad Obstetric History   | For other visits         |
+| Anemia                  | For mild                 |
+| Hypertension            | For mild                 |
+| Hypotension             | As an individual risk    |
+| Hypoglycemia            | As an individual risk    |
+| Hypothermia             | As an individual risk    |
+| Gestational Weight gain | For other visits         |
+
+## 1.7 Developer note
+
+> **Risk condition grade must be captured and stored for all records, irrespective of its value or category.** This confirms FR-behaviour already implemented in `risk_flags` (one row per evaluated condition per visit, including NORMAL grades — see `RiskFlag` model, risk-referral-service).
+
+---
+
+# Part 2 — Infant High Risk Detection Rules
+
+Source: **High risk protocols_Developer's copy — Infant HR** sheet. Covers **NN (neonatal, 0–28 days)** and **INC/CCV (infant/child, 0–24 months)** — which condition applies at which age is determined by each parameter's own "How" column (e.g. MUAC only after 6 months) and by the visit form's own age-appropriate field set, not by a separate per-phase threshold table.
+
+## 2.1 Parameter measurement method
+
+| Parameter                                     | How (Tool/Method)                                               |
+| --------------------------------------------- | --------------------------------------------------------------- |
+| Birth Weight                                  | Hospital case paper / self-reported                             |
+| Undernutrition (Wasting/Stunting/Underweight) | Infantometer and the infant weighing scale: Z-score calculation |
+| MUAC                                          | Infant MUAC tape (Mother-Infant MUAC), after 6 months only      |
+| Body Temperature                              | Digital axillary thermometer                                    |
+| Umbilical Cord                                | Visual + smell inspection                                       |
+| Breathing                                     | Count RR (respiratory rate) for 60 seconds                      |
+| Development Milestones                        | Observation + structured maternal interview                     |
+| Danger Signs / Infection                      | Head-to-toe examination; IMNCI algorithm                        |
+| Breastfeeding & Nutrition                     | Direct observation, mother report, latch assessment             |
+
+## 2.2 Condition per parameter
+
+| Parameter                                     | Condition                          |
+| --------------------------------------------- | ---------------------------------- |
+| Birth Weight                                  | Low Birth Weight                   |
+| Undernutrition (Wasting/Stunting/Underweight) | MUW / SUW / MAM / SAM              |
+| MUAC                                          | MAM / SAM                          |
+| Body Temperature                              | Hypothermia                        |
+| Body Temperature                              | Hyperthermia                       |
+| Umbilical Cord                                | Cord infection / omphalitis        |
+| Breathing                                     | Respiratory distress               |
+| Development Milestones                        | Neuro-developmental status         |
+| Danger Signs / Infection                      | (see §2.3 Danger Signs list below) |
+| Breastfeeding & Nutrition                     | Feeding adequacy                   |
+
+## 2.3 Grade thresholds by condition
+
+### Low Birth Weight
+
+| Grade          | Value                |
+| -------------- | -------------------- |
+| Normal/Low     | Birth weight ≥2.5 kg |
+| Mild (At Risk) | Birth weight <2.5 kg |
+| Moderate       | —                    |
+| Severe         | —                    |
+
+### MUW/SUW/MAM/SAM (Undernutrition — Wasting/Stunting/Underweight, Z-score based)
+
+| Grade          | Value                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Normal/Low     | —                                                                                                                                      |
+| Mild (At Risk) | Moderate Acute Malnutrition (MAM), defined as weight-for-height Z-score (WHZ/WAZ/HAZ) between −2 and −3, OR MUW (Moderate Underweight) |
+| Moderate       | —                                                                                                                                      |
+| Severe         | Severe Acute Malnutrition (SAM), defined as (WHZ/WAZ/HAZ) < −3, OR SUW (Severe Underweight)                                            |
+
+### MAM/SAM (MUAC, 6–24 months only)
+
+| Grade          | Value                                                                 |
+| -------------- | --------------------------------------------------------------------- |
+| Normal/Low     | ≥13.5 cm (0–6 months); ≥12.5 cm (6–24 months) — no acute malnutrition |
+| Mild (At Risk) | 11.5–12.4 cm (6–24 months) — Moderate Acute Malnutrition (MAM)        |
+| Moderate       | —                                                                     |
+| Severe         | <11.5 cm (0–6 months)                                                 |
+
+> Note: the source sheet gives the Normal-range MUAC cutoff for both 0–6m and 6–24m bands, but MUAC is only measured from 6 months onward per §2.1 — the 0–6m Normal figure (≥13.5 cm) is reference-only and the Severe row's "<11.5 cm (0–6 m)" age label as given should be verified with ARMMAN, since it conflicts with §2.1's "after 6 months only" measurement rule.
+
+### Hypothermia (Body Temperature)
+
+| Grade          | Value                     |
+| -------------- | ------------------------- |
+| Normal/Low     | Axillary 97–99°F          |
+| Mild (At Risk) | Severe hypothermia: <96°F |
+| Moderate       | —                         |
+| Severe         | —                         |
+
+> Note: the sheet labels this cutoff "Severe hypothermia" but places it in the Mild/At-Risk row — reproduced here exactly as given; flagged as a possible labeling inconsistency to confirm with ARMMAN.
+
+### Hyperthermia (Body Temperature)
+
+| Grade          | Value                       |
+| -------------- | --------------------------- |
+| Normal/Low     | Axillary 97–99°F            |
+| Mild (At Risk) | Severe hyperthermia: >100°F |
+| Moderate       | —                           |
+| Severe         | —                           |
+
+> Same labeling note as Hypothermia above — "Severe hyperthermia" appears in the Mild/At-Risk row in the source sheet.
+
+### Cord infection / omphalitis (Umbilical Cord)
+
+| Grade          | Value                                                                                              |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| Normal/Low     | Cord dry, clean, no discharge, no smell; stump falls off Day 7–10                                  |
+| Mild (At Risk) | Spreading redness, red streaks, abdominal wall erythema, pus, systemic sepsis → EMERGENCY referral |
+| Moderate       | —                                                                                                  |
+| Severe         | —                                                                                                  |
+
+### Respiratory distress (Breathing)
+
+| Grade          | Value                                     |
+| -------------- | ----------------------------------------- |
+| Normal/Low     | RR 40–60/min (neonate)                    |
+| Mild (At Risk) | <40/min OR >60/min OR any chest indrawing |
+| Moderate       | —                                         |
+| Severe         | —                                         |
+
+### Neuro-developmental status (Development Milestones)
+
+| Grade          | Value                         |
+| -------------- | ----------------------------- |
+| Normal/Low     | Yes, as per the module shared |
+| Mild (At Risk) | No                            |
+| Moderate       | —                             |
+| Severe         | —                             |
+
+### Danger Signs / Infection
+
+The source sheet lists this as one combined danger-signs/IMNCI checklist (not graded Normal/Mild/Moderate/Severe per item — presence of any listed sign is the At-Risk condition):
+
+- Dry cough / Wet cough / Persistent cough
+- Fast breathing (>60 breaths/min), grunting, chest in-drawing
+- Severe hypothermia: <96°F
+- Severe hyperthermia: >100°F
+- Yellow eyes, palms, soles, body, face, etc. (jaundice)
+- Blue color (cyanosis) around lips/skin
+- Presence of oedema (pitting)
+- Convulsions: twitching, fits, or abnormal movements
+- Lethargy, floppiness, or inability to wake up
+- Not able to drink/feed
+- Vomits everything
+- Diarrhoea
+
+| Grade          | Value                                       |
+| -------------- | ------------------------------------------- |
+| Normal/Low     | No                                          |
+| Mild (At Risk) | Yes, for any of the conditions listed above |
+| Moderate       | —                                           |
+| Severe         | —                                           |
+
+### Feeding adequacy (Breastfeeding & Nutrition)
+
+| Grade          | Value                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------------------- |
+| Normal/Low     | Exclusive breastfeeding ≤6 months; ≥8 feeds/day; good latch; satisfied after feeds; adequate weight gain |
+| Mild (At Risk) | Unable to feed / not breastfeeding at all; no complementary feeds started >6 months                      |
+| Moderate       | —                                                                                                        |
+| Severe         | —                                                                                                        |
+
+## 2.4 Referral trigger rules (per condition)
+
+| Condition                        | Referral trigger                                                 |
+| -------------------------------- | ---------------------------------------------------------------- |
+| Low Birth Weight                 | No referral                                                      |
+| MUW/SUW/MAM/SAM (Undernutrition) | On first instance, and if no improvement in 3 consecutive visits |
+| MAM/SAM (MUAC)                   | On first instance, and if no improvement in 3 consecutive visits |
+| Hypothermia                      | Every instance                                                   |
+| Hyperthermia                     | Every instance                                                   |
+| Cord infection / omphalitis      | Every instance                                                   |
+| Respiratory distress             | Every instance                                                   |
+| Neuro-developmental status       | Every instance                                                   |
+| Danger Signs / Infection         | Every instance                                                   |
+| Feeding adequacy                 | Only for no feeding > supplementary feeds                        |
+
+## 2.5 HR visit trigger rules
+
+| Condition                        | HR visit (after 15 days) trigger  |
+| -------------------------------- | --------------------------------- |
+| Low Birth Weight                 | Every instance till normal        |
+| MUW/SUW/MAM/SAM (Undernutrition) | Every instance till normal        |
+| MAM/SAM (MUAC)                   | Every instance till normal        |
+| Hypothermia                      | Single instance                   |
+| Hyperthermia                     | Single instance                   |
+| Cord infection / omphalitis      | — (not specified in source sheet) |
+| Respiratory distress             | — (not specified in source sheet) |
+| Neuro-developmental status       | — (not specified in source sheet) |
+| Danger Signs / Infection         | Single instance                   |
+| Feeding adequacy                 | No                                |
+
+> Per SRS §3A.2.5 FR-S-5.3, the INC-phase HR visit anchor is 15 days after actual completion (cumulative — a new HR visit fires on every qualifying detection); CCV-phase uses the same thresholds per SRS confirmation but a 30-day anchor, single-instance per detection (see the ANC/INC/CCV HR-visit-scheduling pack, `hr.rulesJson.ts`, for the timing formula itself — this sheet only supplies which conditions trigger an HR visit, not the day-count formula).
+>
+> Three conditions (Cord infection/omphalitis, Respiratory distress, Neuro-developmental status) have every-instance referral triggers in §2.4 but no HR-visit-trigger value given in the source sheet — reproduced as blank/unspecified rather than guessed; confirm with ARMMAN before this pack governs a live case for these three conditions in production, same treatment as PPH's blank cells in Part 1.
+
+## 2.6 Counselling-only rules
+
+| Condition                        | Only counselling applies |
+| -------------------------------- | ------------------------ |
+| MUW/SUW/MAM/SAM (Undernutrition) | After every instance     |
+| Feeding adequacy                 | Yes                      |
+
+## 2.7 Developer note
+
+> **Risk condition grade must be captured and stored for all records, irrespective of its value or category.** Same convention as Part 1 — every condition is graded and persisted every visit, including Normal/Low results.
+
+## 2.8 Open items to confirm with ARMMAN
+
+The infant rule pack (`infant-risk.rulesJson.ts`, rules-service) has been implemented against documented defaults for all four items below — these are working assumptions in production code, not blockers, but each should still be confirmed with ARMMAN and the pack updated if the real answer differs.
+
+1. The Hypothermia/Hyperthermia grade tables label their single non-Normal threshold "Severe hypothermia"/"Severe hyperthermia" while placing it in the Mild/At-Risk row, with no separate Moderate/Severe bands defined — confirm whether a true Moderate/Severe band exists or whether "Mild (At Risk)" is simply mislabeled and should read "Severe." **Default applied:** graded as SEVERE (trusting the value's own label over its row position).
+2. The MUAC Severe row's age label ("<11.5 cm (0–6 m)") conflicts with §2.1's rule that MUAC is only measured after 6 months — confirm the correct age band for the Severe MUAC cutoff. **Default applied:** the Severe cutoff is applied only for ages 6–24 months; the 0–6m figure is never evaluated.
+3. No HR-visit-trigger value is given for Cord infection/omphalitis, Respiratory distress, or Neuro-developmental status, despite each having an "every instance" referral trigger — confirm whether these should also generate an HR visit, and on what cadence. **Default applied:** HR-visit trigger is `false` for all three, same treatment as PPH's blank cells in Part 1.
+4. MODERATE grade row is entirely blank across every condition in the source sheet — confirm whether a Moderate band is intentionally absent for all infant conditions (unlike ANC, which has real Moderate values for Anemia and Hypertension), or simply not yet supplied. **Default applied:** no Moderate branch exists in the rule pack for any infant condition.
+
+---
+
+# Part 3 — Manager Dashboard: HR Linelist Triggers
+
+Source: **High risk protocols_Developer's copy — Dashboard** sheet. Feeds SRS §3C "Manager Web Dashboard" (Section 3C.2 Dashboard Reports, category "HR Case Management"; Section 3C.4.1 linelists).
+
+This sheet defines two things per beneficiary type (ANC / Child): (1) the **counts/metrics to track** on the dashboard, and (2) the **AS-wise linelist triggers** that must be surfaced to Supervisors and Managers.
+
+## 3.1 ANC
+
+### To track
+
+- Number of women at High Risk of age, undernutrition
+- Number of women at High Risk of bad Obstetric History (BOH)
+- Progression across all grades in Anemia and Hypertension: separately for ones with permanent risks
+- Improvement in Hypotension, Hyperglycemia, Hypoglycemia, Antepartum Hemorrhage (APH), Postpartum Hemorrhage (PPH), Hypothermia, Hyperthermia, Fetal Heart Rate, Fundal Height, Gestational Weight gain: separately for ones with permanent risks
+- Improvement in any danger sign: separately for ones with permanent risks
+
+### AS-wise linelist triggers to Supervisors and Managers
+
+- Missed Visits
+- Monthly HR cases
+- EDD close
+- No improvement in HR
+- Deterioration of Hypertension and Anemia
+- Women at permanent risk factors: Age / Undernutrition / BOH
+
+## 3.2 Child
+
+### To track
+
+- Number of Children at Low Birth Weight Risk
+- Progression across all grades in SUW/MUW/MAM/SAM: separate for ones with LOW birth weight risk
+- Improvement in Body Temperature, Jaundice, Umbilical Cord, Breathing, Development Milestones, Breastfeeding & Nutrition: separate for ones with permanent risks
+- Improvement in any danger sign: separate for ones with permanent risks
+
+### AS-wise linelist triggers to Supervisors and Managers
+
+- Missed Visits
+- Monthly HR cases
+- Completing 11 months
+- No improvement in HR
+- Deterioration of MUW/SUW/MAM/SAM
+- Children at Low Birth Weight Risk
+
+## 3.3 Notes for implementation
+
+- This is a **reporting/dashboard requirements sheet**, not a per-condition clinical threshold protocol — unlike Parts 1 and 2, it names _what_ must be tracked and surfaced, not the numeric grading rules behind each condition.
+- The ANC-side conditions listed here (Age, Undernutrition, BOH, Anemia, Hypertension, Hypotension, Hyperglycemia, Hypoglycemia, APH, PPH, Hypothermia, Hyperthermia, Fetal Heart Rate, Fundal Height, Gestational Weight Gain, danger signs) map 1:1 onto the 18 conditions already graded by `anc-risk.rulesJson.ts` (rules-service) and persisted in `risk_assessments`/`risk_flags` (risk-referral-service) — this dashboard's ANC metrics can be built directly from that existing data.
+- The Child-side conditions (SUW/MUW/MAM/SAM nutrition grading, Body Temperature, Jaundice, Umbilical Cord, Breathing, Development Milestones, Breastfeeding & Nutrition) now have a real threshold protocol in Part 2 above — the dashboard metrics/linelists here can be built once an equivalent infant risk rule pack and `risk_conditions` seed rows exist for NN/INC/CCV (mirroring the ANC implementation).
+- "Separate for ones with permanent risks" (recurring across both columns) implies the dashboard must distinguish beneficiaries with a _permanent_ risk condition (e.g. Age, BOH, Undernutrition — the "only first instance" conditions) from those with a _transient_ one, when reporting improvement/deterioration/progression — this distinction already exists in principle via each RiskCondition's referral/HR trigger cadence (only-first-instance vs every-instance in §1.4/§1.5 and §2.4/§2.5) but is not yet modeled as an explicit "permanent risk" flag anywhere in the schema.

--- a/docs/Arogya_Sakhi_SRS_v3.0.md
+++ b/docs/Arogya_Sakhi_SRS_v3.0.md
@@ -448,7 +448,7 @@ The complete editable field list is maintained in the "Is an editable field?" co
 
 **FR-S-5.4:** HR detection thresholds are configured in gorules and must be updatable without code redeployment.
 
-> ⚠️ **PENDING** — Updated HR thresholds document from ARMMAN (Prajakta, committed 29 April 2026). Existing Appendix D to be updated on receipt. - Update: Shared.
+> ⚠️ **PARTIALLY RECEIVED** — ANC-phase HR thresholds document from ARMMAN (Prajakta), "High risk protocols_Developer's copy — ANC HR", received and incorporated into Appendix D. PP/NN/INC/CCV threshold sheets still pending.
 
 #### 3A.2.6 Referral (NEW) (Post Meeting on 22nd May, 2026)
 
@@ -1606,7 +1606,9 @@ _Note: Continue is not an explicit button. For all visit types, Continue is the 
 
 ## Appendix D — High Risk Detection Rules
 
-Please refer to the 📎 **High risk protocols_Developer's copy** sheet provided to us by Armman.
+See [Appendix_D_High_Risk_Detection_Rules.md](Appendix_D_High_Risk_Detection_Rules.md) — full parameter/threshold/trigger tables converted from the **High risk protocols_Developer's copy** ANC HR, Infant HR, and Dashboard sheets provided by ARMMAN, covering ANC (Part 1), NN/INC/CCV (Part 2), and the Manager Dashboard's HR linelist/reporting requirements (Part 3).
+
+> ⚠️ **PARTIAL** — PP-phase HR thresholds are still pending from ARMMAN. Several Part 2 (Infant) values also need ARMMAN confirmation — see that document's §2.8 Open Items.
 
 ## Appendix E — Referral Rules
 


### PR DESCRIPTION
Closes #171

## Summary
- Implements SRS FR-S-5.4 high-risk detection thresholds using ARMMAN's ANC HR threshold sheet ("High risk protocols_Developer's copy")
- Adds GoRules scheduling rules + seed data for ANC and infant (NN/INC/CCV) risk conditions
- Adds risk flag grade/rank support in risk-referral-service (schema, migration, repository, service)
- Wires visit-form-service form submission to invoke the risk assessment client
- Rewrites Appendix D of the SRS as a standalone doc with full parameter/threshold/trigger tables (ANC, Infant, and Manager Dashboard HR linelist/reporting requirements)

## Notes
PP-phase thresholds and some Part 2 (Infant) values are still pending ARMMAN confirmation — tracked as open items in the new Appendix D doc (§2.8) and flagged in the SRS FR-S-5.4 status note.

## Test plan
- [ ] `anc-risk.rulesJson.spec.ts` and `infant-risk.rulesJson.spec.ts` pass
- [ ] `riskAssessment.service.spec.ts` passes
- [ ] `form.service.spec.ts` passes
- [ ] Prisma migration applies cleanly against a fresh DB