### PR TITLE
feat: Beneficiary risk color, CHILD phase-advance, BR-13, last-visit vitals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,5 @@ jobs:
       - name: Derive affected base
         uses: nrwl/nx-set-shas@v4
       - run: npx nx affected -t lint --parallel=3
-      - name: Run tests
-        env:
-          # Unit tests mock Prisma and never touch a real database, but every
-          # service's app-config.ts requires DATABASE_URL/DIRECT_URL with no
-          # default (fail-fast boot check) — importing app.module.ts (even
-          # transitively, e.g. via a controller spec) throws without these.
-          DATABASE_URL: postgresql://user:password@localhost:5432/db
-          DIRECT_URL: postgresql://user:password@localhost:5432/db
-        run: npx nx affected -t test --parallel=3 --coverage --passWithNoTests
+      - run: npx nx affected -t test --parallel=3 --coverage --passWithNoTests
       - run: npx nx affected -t build --parallel=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,13 @@ jobs:
       - name: Derive affected base
         uses: nrwl/nx-set-shas@v4
       - run: npx nx affected -t lint --parallel=3
-      - run: npx nx affected -t test --parallel=3 --coverage --passWithNoTests
+      - name: Run tests
+        env:
+          # Unit tests mock Prisma and never touch a real database, but every
+          # service's app-config.ts requires DATABASE_URL/DIRECT_URL with no
+          # default (fail-fast boot check) — importing app.module.ts (even
+          # transitively, e.g. via a controller spec) throws without these.
+          DATABASE_URL: postgresql://user:password@localhost:5432/db
+          DIRECT_URL: postgresql://user:password@localhost:5432/db
+        run: npx nx affected -t test --parallel=3 --coverage --passWithNoTests
       - run: npx nx affected -t build --parallel=3

--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -117,6 +117,14 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
     target: appConfig.VISIT_FORM_SERVICE_URL,
     requiresAuth: true,
   },
+  // GET /beneficiaries/:beneficiaryId/visit-history (FR-S-4.6) — same
+  // ownership as latest-visit-vitals above: owned by visit-form-service
+  // (it owns visit_instances/form_submissions), not beneficiary-service.
+  {
+    prefix: '/beneficiaries/:beneficiaryId/visit-history',
+    target: appConfig.VISIT_FORM_SERVICE_URL,
+    requiresAuth: true,
+  },
   { prefix: '/beneficiaries', target: appConfig.BENEFICIARY_SERVICE_URL, requiresAuth: true },
   // UNCONFIRMED alias for GET /beneficiaries/risk-summary — see the route's
   // own doc comment in beneficiary.routes.ts for why this is a best guess.

--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -108,6 +108,15 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
     target: appConfig.VISIT_FORM_SERVICE_URL,
     requiresAuth: true,
   },
+  // GET /beneficiaries/:beneficiaryId/latest-visit-vitals — owned by
+  // visit-form-service (it owns form_submissions/visit_instances), not
+  // beneficiary-service, which calls this same route itself server-to-
+  // server (via visitVitals.client.ts) to enrich GET /beneficiaries/:id.
+  {
+    prefix: '/beneficiaries/:beneficiaryId/latest-visit-vitals',
+    target: appConfig.VISIT_FORM_SERVICE_URL,
+    requiresAuth: true,
+  },
   { prefix: '/beneficiaries', target: appConfig.BENEFICIARY_SERVICE_URL, requiresAuth: true },
   // UNCONFIRMED alias for GET /beneficiaries/risk-summary — see the route's
   // own doc comment in beneficiary.routes.ts for why this is a best guess.

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -126,7 +126,16 @@ export class AuthRepository {
     return this.prisma.role.findUnique({ where: { roleCode } });
   }
 
-  /** Creates the user and their initial role assignment atomically. */
+  /**
+   * Creates the user and their initial role assignment atomically. When
+   * `sakhiProfile` is supplied (roleCode SAKHI — see AuthService.createUser),
+   * the sakhi_profiles row is created in the same transaction, so a SAKHI
+   * user can never exist without one: previously POST /users only wrote
+   * users/user_roles, leaving a newly-created SAKHI unable to be found by
+   * any endpoint that resolves identity via sakhi_profiles (e.g.
+   * GET /sakhi/:id/dashboard) until a follow-up PATCH supplied a
+   * profile field. Mirrors updateUserTransaction's `create` branch.
+   */
   createUserWithRole(data: {
     username: string;
     mobileNumber: string;
@@ -136,6 +145,7 @@ export class AuthRepository {
     roleId: string;
     projectId: string | null;
     geographyUnitId: string | null;
+    sakhiProfile?: { primaryProjectId: string; phoneNumber: string };
   }) {
     return this.prisma.$transaction(async (tx) => {
       const user = await tx.user.create({
@@ -156,6 +166,16 @@ export class AuthRepository {
           effectiveFrom: new Date(),
         },
       });
+      if (data.sakhiProfile) {
+        await tx.sakhiProfile.create({
+          data: {
+            userId: user.id,
+            primaryProjectId: data.sakhiProfile.primaryProjectId,
+            phoneNumber: data.sakhiProfile.phoneNumber,
+            activeFrom: new Date(),
+          },
+        });
+      }
       return user;
     });
   }

--- a/apps/auth-service/src/auth/auth.routes.ts
+++ b/apps/auth-service/src/auth/auth.routes.ts
@@ -190,11 +190,14 @@ export function registerAuthRoutes(
   doc.post(
     '/users',
     {
-      summary: 'Create a user (ADMIN creates any role; SUPERVISOR creates SAKHI only)',
+      summary:
+        'Create a user (ADMIN creates any role; SUPERVISOR creates SAKHI only). ' +
+        'roleCode SAKHI additionally requires projectId — a matching sakhi_profiles ' +
+        'row is created in the same transaction, using mobileNumber as its phone number.',
       tags: ['Users'],
       responses: {
         201: { description: 'User created', schema: envelope(createdUserSchema) },
-        400: errorResponse(400, { message: 'password: Required' }),
+        400: errorResponse(400, { message: 'projectId: Required to create a SAKHI user.' }),
         401: errorResponse(401),
         403: errorResponse(403, {
           message: 'You do not have access to this resource.',

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -316,7 +316,7 @@ describe('AuthService', () => {
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
     };
 
-    it('hashes the password, creates the user and role assignment', async () => {
+    it('hashes the password, creates the user, role assignment, and sakhi_profiles row', async () => {
       repository.findRoleByCode.mockResolvedValue(ACTIVE_ROLE as never);
       repository.createUserWithRole.mockResolvedValue(CREATED_USER as never);
 
@@ -327,6 +327,7 @@ describe('AuthService', () => {
           password: 'Str0ngPass!',
           displayName: 'New Sakhi',
           roleCode: 'SAKHI',
+          projectId: 'project-1',
         },
         ['ADMIN'],
       );
@@ -339,8 +340,9 @@ describe('AuthService', () => {
         displayName: 'New Sakhi',
         email: null,
         roleId: 'role-1',
-        projectId: null,
+        projectId: 'project-1',
         geographyUnitId: null,
+        sakhiProfile: { primaryProjectId: 'project-1', phoneNumber: '+919876543211' },
       });
       expect(result).toEqual({
         id: 'user-2',
@@ -351,6 +353,51 @@ describe('AuthService', () => {
         status: 'ACTIVE',
         createdAt: CREATED_USER.createdAt,
       });
+    });
+
+    it('rejects creating a SAKHI without projectId — sakhi_profiles.primary_project_id is NOT NULL', async () => {
+      repository.findRoleByCode.mockResolvedValue(ACTIVE_ROLE as never);
+
+      await expect(
+        service.createUser(
+          {
+            username: 'new.sakhi',
+            mobileNumber: '+919876543211',
+            password: 'Str0ngPass!',
+            displayName: 'New Sakhi',
+            roleCode: 'SAKHI',
+          },
+          ['ADMIN'],
+        ),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(repository.createUserWithRole).not.toHaveBeenCalled();
+    });
+
+    it('does not require projectId or create a sakhi_profiles row for a non-SAKHI role', async () => {
+      repository.findRoleByCode.mockResolvedValue({
+        id: 'role-2',
+        roleCode: 'SUPERVISOR',
+        isActive: true,
+      } as never);
+      repository.createUserWithRole.mockResolvedValue({
+        ...CREATED_USER,
+        username: 'new.supervisor',
+      } as never);
+
+      await service.createUser(
+        {
+          username: 'new.supervisor',
+          mobileNumber: '+919876543215',
+          password: 'Str0ngPass!',
+          displayName: 'New Supervisor',
+          roleCode: 'SUPERVISOR',
+        },
+        ['ADMIN'],
+      );
+
+      expect(repository.createUserWithRole).toHaveBeenCalledWith(
+        expect.objectContaining({ sakhiProfile: undefined }),
+      );
     });
 
     it('rejects an unknown role code without creating a user', async () => {
@@ -400,6 +447,7 @@ describe('AuthService', () => {
             password: 'Str0ngPass!',
             displayName: 'New Sakhi',
             roleCode: 'SAKHI',
+            projectId: 'project-1',
           },
           ['ADMIN'],
         ),
@@ -418,6 +466,7 @@ describe('AuthService', () => {
             password: 'Str0ngPass!',
             displayName: 'New Sakhi',
             roleCode: 'SAKHI',
+            projectId: 'project-1',
           },
           ['ADMIN'],
         ),
@@ -436,6 +485,7 @@ describe('AuthService', () => {
             password: 'Str0ngPass!',
             displayName: 'New Sakhi',
             roleCode: 'SAKHI',
+            projectId: 'project-1',
           },
           ['SUPERVISOR'],
         ),

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -115,6 +115,18 @@ export class AuthService {
     const role = await this.repository.findRoleByCode(input.roleCode);
     if (!role || !role.isActive) throw notFound(`Unknown role code: ${input.roleCode}`);
 
+    // A SAKHI has no usable identity without a sakhi_profiles row — every
+    // endpoint that resolves "this Sakhi" (e.g. GET /sakhi/:id/dashboard)
+    // queries that table, not users/user_roles. Created atomically below
+    // rather than requiring a separate PATCH afterward, which previously
+    // left a newly-created SAKHI 404ing until someone remembered to patch
+    // in a phoneNumber. projectId is required here (not merely optional, as
+    // it is for other roles) because sakhi_profiles.primary_project_id is
+    // NOT NULL.
+    if (input.roleCode === 'SAKHI' && !input.projectId) {
+      throw badRequest('projectId: Required to create a SAKHI user.');
+    }
+
     const passwordHash = await hashPassword(input.password);
 
     try {
@@ -127,6 +139,10 @@ export class AuthService {
         roleId: role.id,
         projectId: input.projectId ?? null,
         geographyUnitId: input.geographyUnitId ?? null,
+        sakhiProfile:
+          input.roleCode === 'SAKHI'
+            ? { primaryProjectId: input.projectId as string, phoneNumber: input.mobileNumber }
+            : undefined,
       });
       return {
         id: user.id,

--- a/apps/auth-service/src/auth/dto/create-user.dto.ts
+++ b/apps/auth-service/src/auth/dto/create-user.dto.ts
@@ -16,6 +16,12 @@ import { usernameSchema } from './username';
  * password for every role — a user created without one could never log in.
  * `.strict()` rejects unknown fields, matching the previous global
  * ValidationPipe `forbidNonWhitelisted: true`.
+ *
+ * `projectId` is optional here (zod can't express "required only when
+ * roleCode is SAKHI" on a flat object) but AuthService.createUser enforces
+ * it as required for roleCode SAKHI — sakhi_profiles.primary_project_id is
+ * NOT NULL, and that row is created in the same transaction as the user so
+ * a SAKHI never exists without one (see AuthRepository.createUserWithRole).
  */
 export const createUserSchema = z
   .object({

--- a/apps/beneficiary-service/.env.example
+++ b/apps/beneficiary-service/.env.example
@@ -8,6 +8,14 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
+# Base URL of the gateway to reach auth-service's/risk-referral-service's
+# endpoints through. Both default to http://localhost:3000 if unset — only
+# set these if the gateway runs somewhere else.
+AUTH_SERVICE_BASE_URL=
+RISK_REFERRAL_SERVICE_BASE_URL=
+# Base URL of the gateway to reach visit-form-service's latest-visit-vitals
+# endpoint through. Defaults to http://localhost:3000 if unset.
+VISIT_FORM_SERVICE_BASE_URL=
 # Base64-encoded 32-byte keys (e.g. `openssl rand -base64 32`). Distinct keys —
 # never reuse one for both. Real values live only in the gitignored .env.
 PII_ENCRYPTION_KEY=REPLACE_ME

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.constants.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.constants.ts
@@ -23,6 +23,24 @@ export type BeneficiaryStatus = (typeof BENEFICIARY_STATUSES)[number];
 export const CASE_PHASES = ['ANC', 'DELIVERY', 'PP', 'NN', 'INC', 'CCV', 'CLOSED'] as const;
 export type CasePhase = (typeof CASE_PHASES)[number];
 
+/** ChildCaseDetails.currentPhase — distinct from the case-level CASE_PHASES above. */
+export const CHILD_CASE_PHASES = ['NN', 'INC', 'CCV', 'CLOSED'] as const;
+export type ChildCasePhase = (typeof CHILD_CASE_PHASES)[number];
+
+/**
+ * ChildCaseDetails.ccvOpeningRiskState — the risk state a CCV-phase child
+ * case opened at. A 5-value SRS override of the doc's 4-value set (see
+ * prisma/schema.prisma's CcvOpeningRiskState enum comment).
+ */
+export const CCV_OPENING_RISK_STATES = [
+  'NEVER_HR',
+  'CURRENTLY_HR_SAM_DANGER',
+  'CURRENTLY_HR_OTHER',
+  'RECENTLY_RECOVERED',
+  'STABLE_LOW_RISK',
+] as const;
+export type CcvOpeningRiskState = (typeof CCV_OPENING_RISK_STATES)[number];
+
 export const SUMMARY_PHASES = [
   'REGISTRATION',
   'ANC',

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -82,6 +82,13 @@ export function createBeneficiaryController(service: BeneficiaryService) {
       res.json(ok(await service.getById(req.params.id, req.user, authorizationHeader)));
     }),
 
+    getOwnership: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      res.json(ok(await service.getOwnership(req.params.id, req.user, authorizationHeader)));
+    }),
+
     create: asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');
@@ -134,6 +141,19 @@ export function createBeneficiaryController(service: BeneficiaryService) {
       const updated = await service.applyPhaseChange(
         req.params.id,
         req.body.phase,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(updated));
+    }),
+
+    setCcvOpeningRiskState: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const updated = await service.setCcvOpeningRiskState(
+        req.params.id,
+        req.body.ccvOpeningRiskState,
         req.user,
         authorizationHeader,
       );

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.spec.ts
@@ -135,4 +135,65 @@ describe('withDecryptedName', () => {
 
     expect(result).not.toHaveProperty('socioDemographics');
   });
+
+  it('projects currentPhase and ccvOpeningRiskState on childCaseDetails', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii(),
+      childCaseDetails: {
+        motherBeneficiaryId: 'mother-1',
+        dateOfBirth: new Date('2026-01-01'),
+        sex: 'FEMALE',
+        birthWeightKg: 3.1,
+        birthLengthCm: 49,
+        prematureFlag: false,
+        linkedAncCase: true,
+        currentPhase: 'CCV',
+        ccvOpeningRiskState: 'STABLE_LOW_RISK',
+      },
+    } as never);
+
+    expect(result.childCaseDetails).toMatchObject({
+      currentPhase: 'CCV',
+      ccvOpeningRiskState: 'STABLE_LOW_RISK',
+    });
+  });
+
+  it('leaves childCaseDetails null for a mother case', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii(),
+      childCaseDetails: null,
+    } as never);
+
+    expect(result.childCaseDetails).toBeNull();
+  });
+
+  it('projects riskConditionSummaries with null conditionCode/conditionName/gradeScale placeholders', () => {
+    const result = withDecryptedName({
+      id: 'x',
+      pii: basePii(),
+      riskConditionSummaries: [
+        {
+          riskConditionId: 'rc-1',
+          phase: 'ANC',
+          latestGrade: 'SEVERE',
+          latestAssessedAt: new Date('2026-01-01'),
+          everHighestGrade: 'SEVERE',
+          everAtRiskFlag: true,
+          currentReferralTriggerFlag: true,
+          currentHrVisitTriggerFlag: false,
+        },
+      ],
+    } as never);
+
+    expect(result.riskConditionSummaries).toEqual([
+      expect.objectContaining({
+        riskConditionId: 'rc-1',
+        conditionCode: null,
+        conditionName: null,
+        gradeScale: null,
+      }),
+    ]);
+  });
 });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.mapper.ts
@@ -100,6 +100,8 @@ export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown 
           birthLengthCm: child.birthLengthCm,
           prematureFlag: child.prematureFlag,
           linkedAncCase: child.linkedAncCase,
+          currentPhase: child.currentPhase,
+          ccvOpeningRiskState: child.ccvOpeningRiskState,
         }
       : null;
   }
@@ -114,6 +116,11 @@ export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown 
   }
   const risks = c.riskConditionSummaries as Record<string, unknown>[] | undefined;
   if (risks !== undefined) {
+    // conditionCode/conditionName/gradeScale start null — this projector has
+    // no network access to resolve them (risk-referral-service owns that
+    // data). beneficiary.service.ts's projectCase fills them in afterward via
+    // riskCondition.client.ts, degrading to null on an unresolved id or an
+    // unreachable risk-referral-service rather than failing the request.
     projected.riskConditionSummaries = risks.map((r) => ({
       riskConditionId: r.riskConditionId,
       phase: r.phase,
@@ -123,6 +130,9 @@ export function withDecryptedName<T extends { pii: PiiRow; [k: string]: unknown 
       everAtRiskFlag: r.everAtRiskFlag,
       currentReferralTriggerFlag: r.currentReferralTriggerFlag,
       currentHrVisitTriggerFlag: r.currentHrVisitTriggerFlag,
+      conditionCode: null as string | null,
+      conditionName: null as string | null,
+      gradeScale: null as string | null,
     }));
   }
   const history = c.statusHistory as Record<string, unknown>[] | undefined;

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.spec.ts
@@ -106,4 +106,74 @@ describe('BeneficiaryRepository', () => {
       expect(result.activeMothersHighRiskCount).toBe(0);
     });
   });
+
+  describe('updatePhase', () => {
+    function buildTxMock(caseUpdateCount: number) {
+      const beneficiaryCaseUpdateMany = jest.fn().mockResolvedValue({ count: caseUpdateCount });
+      const childCaseDetailsUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+      const tx = {
+        beneficiaryCase: { updateMany: beneficiaryCaseUpdateMany },
+        childCaseDetails: { updateMany: childCaseDetailsUpdateMany },
+      };
+      const $transaction = jest.fn((fn: (tx: unknown) => unknown) => fn(tx));
+      return { $transaction, beneficiaryCaseUpdateMany, childCaseDetailsUpdateMany };
+    }
+
+    it('also advances ChildCaseDetails.currentPhase for a CHILD case, in the same transaction', async () => {
+      const { $transaction, beneficiaryCaseUpdateMany, childCaseDetailsUpdateMany } =
+        buildTxMock(1);
+      const txRepository = new BeneficiaryRepository({ $transaction } as never);
+
+      const result = await txRepository.updatePhase('ben-1', 'CHILD', 'NN', 'INC');
+
+      expect(result).toBe(true);
+      expect(beneficiaryCaseUpdateMany).toHaveBeenCalledWith({
+        where: { id: 'ben-1', isDeleted: false, currentPhase: 'NN' },
+        data: { currentPhase: 'INC' },
+      });
+      expect(childCaseDetailsUpdateMany).toHaveBeenCalledWith({
+        where: { beneficiaryId: 'ben-1' },
+        data: { currentPhase: 'INC' },
+      });
+    });
+
+    it('does not touch ChildCaseDetails for a MOTHER case', async () => {
+      const { $transaction, childCaseDetailsUpdateMany } = buildTxMock(1);
+      const txRepository = new BeneficiaryRepository({ $transaction } as never);
+
+      const result = await txRepository.updatePhase('ben-1', 'MOTHER', 'ANC', 'PP');
+
+      expect(result).toBe(true);
+      expect(childCaseDetailsUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it('skips the ChildCaseDetails write when the case-level update raced to 0 rows', async () => {
+      const { $transaction, childCaseDetailsUpdateMany } = buildTxMock(0);
+      const txRepository = new BeneficiaryRepository({ $transaction } as never);
+
+      const result = await txRepository.updatePhase('ben-1', 'CHILD', 'NN', 'INC');
+
+      expect(result).toBe(false);
+      expect(childCaseDetailsUpdateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findOwnershipById', () => {
+    it('selects only id/sakhiId/caseType, not the full enriched projection', async () => {
+      const findFirst = jest
+        .fn()
+        .mockResolvedValue({ id: 'ben-1', sakhiId: 'sakhi-1', caseType: 'MOTHER' });
+      const txRepository = new BeneficiaryRepository({
+        beneficiaryCase: { findFirst },
+      } as never);
+
+      const result = await txRepository.findOwnershipById('ben-1');
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: { id: 'ben-1', isDeleted: false },
+        select: { id: true, sakhiId: true, caseType: true },
+      });
+      expect(result).toEqual({ id: 'ben-1', sakhiId: 'sakhi-1', caseType: 'MOTHER' });
+    });
+  });
 });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -1,5 +1,10 @@
 import type { PrismaService } from '../prisma/prisma.service';
-import type { CasePhase, CaseType } from './beneficiary.constants';
+import type {
+  CasePhase,
+  CaseType,
+  CcvOpeningRiskState,
+  ChildCasePhase,
+} from './beneficiary.constants';
 import type {
   BeneficiaryListFilters,
   BeneficiarySummaryFilters,
@@ -361,6 +366,24 @@ export class BeneficiaryRepository {
     });
   }
 
+  /**
+   * Bare `{id, sakhiId, caseType}` for an ownership check — deliberately NOT
+   * `findById`'s full projection (pii/risk/socio/status enrichment), which
+   * would pull in `GET /beneficiaries/:id`'s own cross-service calls (e.g.
+   * visit-form-service's latest-visit-vitals resolver, which itself calls
+   * back into THIS lookup to verify ownership — see
+   * form.service.ts/beneficiary.client.ts's own comment on the loop this
+   * exists to break). Any caller doing only an ownership check must use
+   * this, never findById, or a caller that itself triggers vitals
+   * resolution recreates the same infinite request cycle.
+   */
+  findOwnershipById(id: string) {
+    return this.prisma.beneficiaryCase.findFirst({
+      where: { id, isDeleted: false },
+      select: { id: true, sakhiId: true, caseType: true },
+    });
+  }
+
   findById(id: string) {
     return this.prisma.beneficiaryCase.findFirst({
       where: { id, isDeleted: false },
@@ -542,11 +565,56 @@ export class BeneficiaryRepository {
    * read-then-write), so a case whose phase already changed between the
    * service's findById and this call returns count 0 and the service turns
    * that into a 409 instead of silently overwriting a since-changed case.
+   *
+   * For a CHILD case, also advances `ChildCaseDetails.currentPhase` to the
+   * same value in the same transaction — the two columns must never drift:
+   * `BeneficiaryCase.currentPhase` is the case-level phase every case type
+   * shares, `ChildCaseDetails.currentPhase` is the CHILD-specific mirror the
+   * detail API (`GET /beneficiaries/:id`) actually returns. A MOTHER case
+   * has no `ChildCaseDetails` row, so this second write is skipped for
+   * `caseType !== 'CHILD'`.
    */
-  async updatePhase(beneficiaryId: string, fromPhase: CasePhase, toPhase: CasePhase) {
-    const result = await this.prisma.beneficiaryCase.updateMany({
-      where: { id: beneficiaryId, isDeleted: false, currentPhase: fromPhase },
-      data: { currentPhase: toPhase },
+  async updatePhase(
+    beneficiaryId: string,
+    caseType: CaseType,
+    fromPhase: CasePhase,
+    toPhase: CasePhase,
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const result = await tx.beneficiaryCase.updateMany({
+        where: { id: beneficiaryId, isDeleted: false, currentPhase: fromPhase },
+        data: { currentPhase: toPhase },
+      });
+      if (result.count === 0) return false;
+
+      if (caseType === 'CHILD') {
+        // CasePhase (7 values, shared by every case type) is a strict
+        // superset of ChildCasePhase (NN/INC/CCV/CLOSED) — the cast is safe
+        // here because applyPhaseChange's own transition table never allows
+        // a CHILD case's toPhase to be ANC/DELIVERY/PP, only the 4 values
+        // both enums share.
+        await tx.childCaseDetails.updateMany({
+          where: { beneficiaryId },
+          data: { currentPhase: toPhase as ChildCasePhase },
+        });
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Writes ChildCaseDetails.ccvOpeningRiskState (BR-13) — a plain
+   * updateMany (not conditioned on the current value) since this is a
+   * write-once field at the INC->CCV transition, not a state machine with
+   * its own guarded transitions like currentPhase. Returns false when no
+   * ChildCaseDetails row exists for this beneficiary (a MOTHER case, or a
+   * beneficiary id the caller sequenced this call against out of order).
+   */
+  async setCcvOpeningRiskState(beneficiaryId: string, ccvOpeningRiskState: CcvOpeningRiskState) {
+    const result = await this.prisma.childCaseDetails.updateMany({
+      where: { beneficiaryId },
+      data: { ccvOpeningRiskState },
     });
     return result.count > 0;
   }

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
@@ -7,6 +7,8 @@ import {
   BENEFICIARY_STATUSES,
   CASE_PHASES,
   CASE_TYPES,
+  CCV_OPENING_RISK_STATES,
+  CHILD_CASE_PHASES,
   SEXES,
   SUMMARY_PHASES,
 } from './beneficiary.constants';
@@ -68,6 +70,16 @@ const riskConditionSummarySchema = z.object({
   everAtRiskFlag: z.boolean(),
   currentReferralTriggerFlag: z.boolean(),
   currentHrVisitTriggerFlag: z.boolean(),
+  // Resolved server-side from risk-referral-service's risk_conditions (owned
+  // by that service — no cross-service joins, per the forklift rule). Null
+  // when the id doesn't resolve to an ACTIVE condition, or when
+  // risk-referral-service is unreachable — see
+  // BeneficiaryService.withResolvedRiskConditionNames.
+  conditionCode: z.string().nullable().openapi({ example: 'HYPERTENSION_HIGH_BP' }),
+  conditionName: z.string().nullable().openapi({ example: 'Hypertension / High BP' }),
+  gradeScale: z
+    .enum(['BINARY', 'NORMAL_MILD_MODERATE_SEVERE', 'NORMAL_LOW_MEDIUM_HIGH'])
+    .nullable(),
 });
 
 const statusHistoryEntrySchema = z.object({
@@ -96,6 +108,8 @@ const childCaseDetailsSchema = z.object({
   birthLengthCm: z.number().nullable(),
   prematureFlag: z.boolean().nullable(),
   linkedAncCase: z.boolean(),
+  currentPhase: z.enum(CHILD_CASE_PHASES),
+  ccvOpeningRiskState: z.enum(CCV_OPENING_RISK_STATES).nullable(),
 });
 
 // A *LookupId field resolved against auth-service's lookup_values, for

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
@@ -21,6 +21,7 @@ import { upsertSocioDemographicsSchema } from './dto/upsert-socio-demographics.d
 import { upsertRiskConditionSummarySchema } from './dto/upsert-risk-condition-summary.dto';
 import { applyLmpChangeSchema } from './dto/apply-lmp-change.dto';
 import { updatePhaseSchema } from './dto/update-phase.dto';
+import { setCcvOpeningRiskStateSchema } from './dto/set-ccv-opening-risk-state.dto';
 import { applyClosureSchema } from './dto/apply-closure.dto';
 import {
   errorResponse,
@@ -180,14 +181,43 @@ const beneficiaryCaseSchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
+// Resolved server-side from visit-form-service's most recent visit-linked
+// clinical submission (owned by that service — no cross-service joins per
+// the forklift rule). Every field is null when the beneficiary has never
+// had a qualifying visit, or when visit-form-service is unreachable — see
+// BeneficiaryService.getById's own comment on the degrade-not-fail stance.
+const lastVisitVitalsSchema = z
+  .object({
+    visitId: z.string().uuid().nullable(),
+    submittedAt: z.string().datetime().nullable(),
+    weightKg: z.number().nullable(),
+    systolicBp: z.number().nullable(),
+    diastolicBp: z.number().nullable(),
+    temperatureF: z.number().nullable(),
+    hemoglobinGDl: z.number().nullable(),
+    muacCm: z.number().nullable(),
+    respiratoryRate: z.number().nullable(),
+  })
+  .nullable();
+
 const beneficiaryCaseDetailSchema = beneficiaryCaseSchema.extend({
   pii: piiResponseSchema,
   motherCaseDetails: motherCaseDetailsSchema.nullable(),
   childCaseDetails: childCaseDetailsSchema.nullable(),
   consentRecords: z.array(consentRecordSchema),
   riskConditionSummaries: z.array(riskConditionSummarySchema),
+  // Worst (highest-severity) grade among riskConditionSummaries, collapsed to
+  // the same 4-bucket vocabulary GET /beneficiaries/by-ids-with-risk's
+  // riskLevel badge uses — 'none' when there are no summaries or none are
+  // graded.
+  riskLevel: z.enum(['none', 'mild', 'moderate', 'high']),
+  // Display color derived 1:1 from riskLevel (none->GREEN, mild/moderate->
+  // YELLOW, high->RED) — a convention introduced for the mobile/Supervisor
+  // UI, not an existing backend rule confirmed elsewhere.
+  riskColor: z.enum(['GREEN', 'YELLOW', 'RED']),
   statusHistory: z.array(statusHistoryEntrySchema),
   socioDemographics: socioDemographicsSchema.nullable(),
+  lastVisitVitals: lastVisitVitalsSchema,
 });
 
 // List rows carry PII (decrypted name) and mother-or-child details (EDD/LMP/
@@ -488,6 +518,40 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
     controller.getById,
   );
 
+  doc.get(
+    '/beneficiaries/:id/ownership',
+    {
+      summary:
+        'Bare {id, sakhiId, caseType} ownership check — for a server-to-server caller (e.g. ' +
+        "visit-form-service's latest-visit-vitals resolver) that needs to verify whether this " +
+        'caller may see this beneficiary without the full GET /beneficiaries/:id response, ' +
+        'whose own enrichment (lastVisitVitals) calls back into visit-form-service — using ' +
+        'GET /beneficiaries/:id here instead would recreate that same request cycle.',
+      tags: ['Beneficiaries'],
+      responses: {
+        200: {
+          description: 'Ownership fields retrieved',
+          schema: envelope(
+            z.object({
+              id: z.string().uuid(),
+              sakhiId: z.string().uuid(),
+              caseType: z.enum(CASE_TYPES),
+            }),
+          ),
+        },
+        400: errorResponse(400, { message: 'id: Invalid uuid' }),
+        401: errorResponse(401),
+        403: errorResponse(403),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    validate(idParamsSchema, 'params'),
+    controller.getOwnership,
+  );
+
   doc.post(
     '/beneficiaries',
     {
@@ -576,11 +640,11 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
     '/beneficiaries/:id/phase',
     {
       summary:
-        'Advance currentPhase after a DELIVERY_VISIT submission (CR-041) — ' +
+        'Advance currentPhase after a visit submission (CR-041) — ' +
         "gated by requireRoles('SAKHI') since this codebase has no machine/service-account " +
-        "identity: the call chain originates from a SAKHI's DELIVERY_VISIT form submission " +
-        "(visit-form-service -> here), forwarding the SAKHI's own token. Only ANC->PP (mother) " +
-        'and *->NN (child) are accepted; any other transition 409s.',
+        "identity: the call chain originates from a SAKHI's visit form submission " +
+        "(visit-form-service -> here), forwarding the SAKHI's own token. Only ANC->PP (mother); " +
+        'NN->NN, NN->INC, and INC->CCV (child) are accepted; any other transition 409s.',
       tags: ['Beneficiaries'],
       params: idParamsSchema,
       responses: {
@@ -601,6 +665,38 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
     validate(idParamsSchema, 'params'),
     validateBody(updatePhaseSchema),
     controller.applyPhaseChange,
+  );
+
+  doc.patch(
+    '/beneficiaries/:id/ccv-opening-risk-state',
+    {
+      summary:
+        'Write ChildCaseDetails.ccvOpeningRiskState once, at the INC->CCV transition (BR-13) — ' +
+        "gated by requireRoles('SAKHI') since this codebase has no machine/service-account " +
+        'identity: the call chain originates from visitFormService right after its own ' +
+        "PATCH .../phase call lands the case at CCV, forwarding the submitting SAKHI's own " +
+        'token. 404s if no ChildCaseDetails row exists for this beneficiary.',
+      tags: ['Beneficiaries'],
+      params: idParamsSchema,
+      responses: {
+        200: {
+          description: 'ccvOpeningRiskState updated; the updated case is returned',
+          schema: envelope(beneficiaryCaseDetailSchema),
+        },
+        400: errorResponse(400, { message: 'ccvOpeningRiskState: Invalid enum value' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
+        404: errorResponse(404, {
+          message: 'No ChildCaseDetails row exists for this beneficiary.',
+        }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI'),
+    validate(idParamsSchema, 'params'),
+    validateBody(setCcvOpeningRiskStateSchema),
+    controller.setCcvOpeningRiskState,
   );
 
   doc.patch(

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -15,11 +15,13 @@ import {
   listSakhiNamesForSupervisor,
 } from '../sakhi/sakhi.client';
 import { resolveProjectNames } from '../projects/project.client';
+import { resolveRiskConditions } from '../risk-conditions/riskCondition.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../lookups/lookup.client');
 jest.mock('../sakhi/sakhi.client');
 jest.mock('../projects/project.client');
+jest.mock('../risk-conditions/riskCondition.client');
 
 describe('BeneficiaryService', () => {
   const originalEnv = { ...process.env };
@@ -52,6 +54,7 @@ describe('BeneficiaryService', () => {
   const resolveVillageNamesMock = jest.mocked(resolveVillageNames);
   const resolvePadaUnitsMock = jest.mocked(resolvePadaUnits);
   const resolveProjectNamesMock = jest.mocked(resolveProjectNames);
+  const resolveRiskConditionsMock = jest.mocked(resolveRiskConditions);
 
   function caller(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
     return {
@@ -127,6 +130,7 @@ describe('BeneficiaryService', () => {
     resolveVillageNamesMock.mockResolvedValue(new Map());
     getSakhiNameMock.mockResolvedValue(null);
     listSakhiNamesForSupervisorMock.mockResolvedValue(new Map());
+    resolveRiskConditionsMock.mockResolvedValue(new Map());
     service = new BeneficiaryService(repository);
   });
 
@@ -1170,7 +1174,9 @@ describe('BeneficiaryService', () => {
 
       const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
-      expect(result.riskConditionSummaries).toEqual(found.riskConditionSummaries);
+      expect(result.riskConditionSummaries).toEqual([
+        expect.objectContaining({ riskConditionId: 'risk-1', everAtRiskFlag: true }),
+      ]);
       expect(result.statusHistory).toEqual(found.statusHistory);
     });
 
@@ -1346,6 +1352,135 @@ describe('BeneficiaryService', () => {
       const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
 
       expect(result.socioDemographics).toBeNull();
+    });
+  });
+
+  describe('getById — risk condition name resolution', () => {
+    it('resolves conditionCode/conditionName/gradeScale onto each risk condition summary', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', everAtRiskFlag: true }],
+      };
+      repository.findById.mockResolvedValue(found as never);
+      resolveRiskConditionsMock.mockResolvedValue(
+        new Map([
+          [
+            'risk-1',
+            {
+              conditionCode: 'HYPERTENSION_HIGH_BP',
+              conditionName: 'Hypertension / High BP',
+              gradeScale: 'NORMAL_LOW_MEDIUM_HIGH',
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskConditionSummaries).toEqual([
+        expect.objectContaining({
+          riskConditionId: 'risk-1',
+          conditionCode: 'HYPERTENSION_HIGH_BP',
+          conditionName: 'Hypertension / High BP',
+          gradeScale: 'NORMAL_LOW_MEDIUM_HIGH',
+        }),
+      ]);
+      expect(resolveRiskConditionsMock).toHaveBeenCalledWith(['risk-1'], AUTH_HEADER);
+    });
+
+    it('skips the resolver call entirely when riskConditionSummaries is empty', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(resolveRiskConditionsMock).not.toHaveBeenCalled();
+    });
+
+    it('dedupes riskConditionId before calling the resolver', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [
+          { riskConditionId: 'risk-1', phase: 'ANC' },
+          { riskConditionId: 'risk-1', phase: 'PP' },
+        ],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(resolveRiskConditionsMock).toHaveBeenCalledWith(['risk-1'], AUTH_HEADER);
+    });
+
+    it('degrades to null conditionCode/conditionName/gradeScale, without failing the request, when risk-referral-service is unreachable', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', everAtRiskFlag: true }],
+      };
+      repository.findById.mockResolvedValue(found as never);
+      resolveRiskConditionsMock.mockRejectedValue(
+        Object.assign(new Error('bad gateway'), { status: 502 }),
+      );
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskConditionSummaries).toEqual([
+        expect.objectContaining({
+          riskConditionId: 'risk-1',
+          conditionCode: null,
+          conditionName: null,
+          gradeScale: null,
+        }),
+      ]);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('leaves an unresolved riskConditionId null while resolving sibling entries', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [
+          { riskConditionId: 'risk-1', phase: 'ANC' },
+          { riskConditionId: 'risk-retired', phase: 'ANC' },
+        ],
+      };
+      repository.findById.mockResolvedValue(found as never);
+      resolveRiskConditionsMock.mockResolvedValue(
+        new Map([
+          [
+            'risk-1',
+            {
+              conditionCode: 'HYPERTENSION_HIGH_BP',
+              conditionName: 'Hypertension / High BP',
+              gradeScale: 'NORMAL_LOW_MEDIUM_HIGH',
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskConditionSummaries).toEqual([
+        expect.objectContaining({
+          riskConditionId: 'risk-1',
+          conditionCode: 'HYPERTENSION_HIGH_BP',
+        }),
+        expect.objectContaining({
+          riskConditionId: 'risk-retired',
+          conditionCode: null,
+          conditionName: null,
+          gradeScale: null,
+        }),
+      ]);
     });
   });
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.spec.ts
@@ -16,18 +16,21 @@ import {
 } from '../sakhi/sakhi.client';
 import { resolveProjectNames } from '../projects/project.client';
 import { resolveRiskConditions } from '../risk-conditions/riskCondition.client';
+import { resolveLatestVisitVitals } from '../visits/visitVitals.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../lookups/lookup.client');
 jest.mock('../sakhi/sakhi.client');
 jest.mock('../projects/project.client');
 jest.mock('../risk-conditions/riskCondition.client');
+jest.mock('../visits/visitVitals.client');
 
 describe('BeneficiaryService', () => {
   const originalEnv = { ...process.env };
   const repository = {
     findMany: jest.fn(),
     findById: jest.fn(),
+    findOwnershipById: jest.fn(),
     findByLocalCaseUuid: jest.fn(),
     findDuplicateCandidate: jest.fn(),
     createEnrollment: jest.fn(),
@@ -55,6 +58,7 @@ describe('BeneficiaryService', () => {
   const resolvePadaUnitsMock = jest.mocked(resolvePadaUnits);
   const resolveProjectNamesMock = jest.mocked(resolveProjectNames);
   const resolveRiskConditionsMock = jest.mocked(resolveRiskConditions);
+  const resolveLatestVisitVitalsMock = jest.mocked(resolveLatestVisitVitals);
 
   function caller(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
     return {
@@ -131,6 +135,7 @@ describe('BeneficiaryService', () => {
     getSakhiNameMock.mockResolvedValue(null);
     listSakhiNamesForSupervisorMock.mockResolvedValue(new Map());
     resolveRiskConditionsMock.mockResolvedValue(new Map());
+    resolveLatestVisitVitalsMock.mockResolvedValue(null);
     service = new BeneficiaryService(repository);
   });
 
@@ -268,7 +273,7 @@ describe('BeneficiaryService', () => {
         AUTH_HEADER,
       );
 
-      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'ANC', 'PP');
+      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'MOTHER', 'ANC', 'PP');
     });
 
     it('is a no-op when a CHILD case is already at NN (its creation default)', async () => {
@@ -287,7 +292,7 @@ describe('BeneficiaryService', () => {
       expect(result).toMatchObject({ id: beneficiaryId });
     });
 
-    it('409s a CHILD case transition from any phase other than NN — regression: the CHILD branch must validate fromPhase, not just toPhase', async () => {
+    it('409s a CHILD case transition to NN from any phase other than NN — regression: the CHILD branch must validate fromPhase, not just toPhase', async () => {
       repository.findById.mockResolvedValue(
         caseRow({ caseType: 'CHILD', currentPhase: 'INC' }) as never,
       );
@@ -296,6 +301,70 @@ describe('BeneficiaryService', () => {
         service.applyPhaseChange(
           beneficiaryId,
           'NN',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+    });
+
+    it('advances a CHILD case from NN to INC', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ caseType: 'CHILD', currentPhase: 'NN' }) as never,
+      );
+      repository.updatePhase.mockResolvedValue(true);
+
+      await service.applyPhaseChange(
+        beneficiaryId,
+        'INC',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'CHILD', 'NN', 'INC');
+    });
+
+    it('advances a CHILD case from INC to CCV', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ caseType: 'CHILD', currentPhase: 'INC' }) as never,
+      );
+      repository.updatePhase.mockResolvedValue(true);
+
+      await service.applyPhaseChange(
+        beneficiaryId,
+        'CCV',
+        caller({ id: sakhiId, roles: ['SAKHI'] }),
+        AUTH_HEADER,
+      );
+
+      expect(repository.updatePhase).toHaveBeenCalledWith(beneficiaryId, 'CHILD', 'INC', 'CCV');
+    });
+
+    it('409s a CHILD case skipping INC (NN directly to CCV)', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ caseType: 'CHILD', currentPhase: 'NN' }) as never,
+      );
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'CCV',
+          caller({ id: sakhiId, roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(repository.updatePhase).not.toHaveBeenCalled();
+    });
+
+    it('409s a regressive CHILD transition (CCV back to INC)', async () => {
+      repository.findById.mockResolvedValue(
+        caseRow({ caseType: 'CHILD', currentPhase: 'CCV' }) as never,
+      );
+
+      await expect(
+        service.applyPhaseChange(
+          beneficiaryId,
+          'INC',
           caller({ id: sakhiId, roles: ['SAKHI'] }),
           AUTH_HEADER,
         ),
@@ -1481,6 +1550,236 @@ describe('BeneficiaryService', () => {
           gradeScale: null,
         }),
       ]);
+    });
+  });
+
+  describe('getById — overall riskLevel', () => {
+    it("is 'none' when riskConditionSummaries is empty", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskLevel).toBe('none');
+    });
+
+    it("is 'mild' when the only summary is graded MILD", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', latestGrade: 'MILD' }],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskLevel).toBe('mild');
+    });
+
+    it("takes the worst grade across multiple summaries — any SEVERE anywhere yields 'high'", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [
+          { riskConditionId: 'risk-1', latestGrade: 'MILD' },
+          { riskConditionId: 'risk-2', latestGrade: 'SEVERE' },
+          { riskConditionId: 'risk-3', latestGrade: 'MODERATE' },
+        ],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskLevel).toBe('high');
+    });
+
+    it("treats HIGH and CRITICAL grades as 'high', same as the pada visit-list badge", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', latestGrade: 'CRITICAL' }],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskLevel).toBe('high');
+    });
+
+    it("is 'none' when every summary has a null latestGrade (ungraded/self-reported)", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', latestGrade: null }],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskLevel).toBe('none');
+    });
+  });
+
+  describe('getById — riskColor derived from riskLevel', () => {
+    it("is GREEN when riskLevel is 'none'", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskColor).toBe('GREEN');
+    });
+
+    it.each([['mild'], ['moderate']])("is YELLOW when riskLevel is '%s'", async (grade) => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [
+          { riskConditionId: 'risk-1', latestGrade: grade === 'mild' ? 'MILD' : 'MODERATE' },
+        ],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskColor).toBe('YELLOW');
+    });
+
+    it("is RED when riskLevel is 'high'", async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [{ riskConditionId: 'risk-1', latestGrade: 'SEVERE' }],
+      };
+      repository.findById.mockResolvedValue(found as never);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.riskColor).toBe('RED');
+    });
+  });
+
+  describe('getById — lastVisitVitals', () => {
+    it('attaches the resolved vitals snapshot to the response', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [],
+      };
+      repository.findById.mockResolvedValue(found as never);
+      const vitals = {
+        visitId: 'visit-1',
+        submittedAt: '2026-08-01T00:00:00.000Z',
+        weightKg: 58.5,
+        systolicBp: 120,
+        diastolicBp: 80,
+        temperatureF: 98.6,
+        hemoglobinGDl: 11.2,
+        muacCm: 24.5,
+        respiratoryRate: null,
+      };
+      resolveLatestVisitVitalsMock.mockResolvedValue(vitals);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.lastVisitVitals).toEqual(vitals);
+      expect(resolveLatestVisitVitalsMock).toHaveBeenCalledWith('x', AUTH_HEADER);
+    });
+
+    it('is null when the beneficiary has never had a qualifying visit, or visit-form-service is unreachable', async () => {
+      const found = {
+        id: 'x',
+        pii: { id: 'pii-1', fullNameEnc: encryptPii('Jane Doe') },
+        riskConditionSummaries: [],
+      };
+      repository.findById.mockResolvedValue(found as never);
+      resolveLatestVisitVitalsMock.mockResolvedValue(null);
+
+      const result = await service.getById('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER);
+
+      expect(result.lastVisitVitals).toBeNull();
+    });
+  });
+
+  describe('getOwnership', () => {
+    it('returns bare {id, sakhiId, caseType} for a SAKHI caller who owns the case', async () => {
+      repository.findOwnershipById.mockResolvedValue({
+        id: 'x',
+        sakhiId: CALLER_ID,
+        caseType: 'MOTHER',
+      } as never);
+
+      const result = await service.getOwnership('x', caller({ roles: ['SAKHI'] }), AUTH_HEADER);
+
+      expect(result).toEqual({ id: 'x', sakhiId: CALLER_ID, caseType: 'MOTHER' });
+    });
+
+    it('never triggers projectCase enrichment (no lastVisitVitals/riskLevel/etc.)', async () => {
+      repository.findOwnershipById.mockResolvedValue({
+        id: 'x',
+        sakhiId: CALLER_ID,
+        caseType: 'MOTHER',
+      } as never);
+
+      const result = await service.getOwnership('x', caller({ roles: ['SAKHI'] }), AUTH_HEADER);
+
+      expect(result).not.toHaveProperty('lastVisitVitals');
+      expect(result).not.toHaveProperty('riskLevel');
+      expect(repository.findById).not.toHaveBeenCalled();
+      expect(resolveLatestVisitVitalsMock).not.toHaveBeenCalled();
+    });
+
+    it('404s on an unknown beneficiary id', async () => {
+      repository.findOwnershipById.mockResolvedValue(null);
+
+      await expect(
+        service.getOwnership('missing', caller({ roles: ['SAKHI'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 404 });
+    });
+
+    it("403s a SAKHI caller reading another beneficiary's ownership", async () => {
+      repository.findOwnershipById.mockResolvedValue({
+        id: 'x',
+        sakhiId: 'some-other-sakhi',
+        caseType: 'MOTHER',
+      } as never);
+
+      await expect(
+        service.getOwnership('x', caller({ roles: ['SAKHI'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('403s a SUPERVISOR caller whose roster does not include the beneficiary sakhi', async () => {
+      repository.findOwnershipById.mockResolvedValue({
+        id: 'x',
+        sakhiId: 'some-other-sakhi',
+        caseType: 'MOTHER',
+      } as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['a-different-sakhi']);
+
+      await expect(
+        service.getOwnership('x', caller({ roles: ['SUPERVISOR'] }), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('allows a MANAGER/ADMIN caller unrestricted', async () => {
+      repository.findOwnershipById.mockResolvedValue({
+        id: 'x',
+        sakhiId: 'some-other-sakhi',
+        caseType: 'MOTHER',
+      } as never);
+
+      await expect(
+        service.getOwnership('x', caller({ roles: ['ADMIN'] }), AUTH_HEADER),
+      ).resolves.toEqual({ id: 'x', sakhiId: 'some-other-sakhi', caseType: 'MOTHER' });
     });
   });
 

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -16,7 +16,12 @@ import type {
   BeneficiaryStatusHistory,
   Prisma,
 } from '../../../../node_modules/.prisma/client-beneficiary-service';
-import type { BeneficiaryStatus, CasePhase, CaseType } from './beneficiary.constants';
+import type {
+  BeneficiaryStatus,
+  CasePhase,
+  CaseType,
+  CcvOpeningRiskState,
+} from './beneficiary.constants';
 import { buildSearchTokens, evaluateDuplicateMatch } from './beneficiary.duplicate-detection';
 import { computeBmi, withDecryptedName } from './beneficiary.mapper';
 import type { BeneficiaryListFilters, BeneficiaryRepository } from './beneficiary.repository';
@@ -37,6 +42,7 @@ import {
 } from '../sakhi/sakhi.client';
 import { resolveProjectNames } from '../projects/project.client';
 import { resolveRiskConditions } from '../risk-conditions/riskCondition.client';
+import { resolveLatestVisitVitals } from '../visits/visitVitals.client';
 
 /**
  * Maps each socioDemographics *LookupId field to the lookup_categories
@@ -134,6 +140,53 @@ async function withResolvedRiskConditionNames<T extends Record<string, unknown>>
   });
 
   return { ...caseDetail, riskConditionSummaries: withNames };
+}
+
+/**
+ * Maps `riskLevel` to a display color. This is a convention introduced here
+ * — no color mapping exists anywhere else in the codebase — not a
+ * confirmation of an existing backend rule. Kept as a pure function of
+ * `riskLevel` (not its own independent grade-scan) so it can never disagree
+ * with the riskLevel badge computed alongside it.
+ */
+function riskLevelToColor(
+  level: 'none' | 'mild' | 'moderate' | 'high',
+): 'GREEN' | 'YELLOW' | 'RED' {
+  switch (level) {
+    case 'mild':
+    case 'moderate':
+      return 'YELLOW';
+    case 'high':
+      return 'RED';
+    default:
+      return 'GREEN';
+  }
+}
+
+/**
+ * Aggregates `riskConditionSummaries` down to one overall `riskLevel` badge
+ * for the whole case — the worst (highest-severity) grade among all
+ * conditions wins, same "any SEVERE anywhere -> high" rule
+ * `findByIdsWithRisk`/`getByIdsWithRisk` already use for the pada
+ * visit-list's badge, just computed here from the full summary list instead
+ * of a single pre-picked "worst" row. Reuses `gradeToRiskLevel` so this
+ * detail-view badge and the list-view badge can never drift out of sync. A
+ * case with no risk-condition-summary rows (or only ungraded ones,
+ * latestGrade null) is `'none'`. `riskColor` is derived 1:1 from the
+ * resulting `riskLevel` — see `riskLevelToColor`.
+ */
+function withOverallRiskLevel<T extends Record<string, unknown>>(caseDetail: T): T {
+  const risks = caseDetail.riskConditionSummaries as { latestGrade: string | null }[] | undefined;
+  if (!risks) return caseDetail;
+
+  const RISK_LEVEL_RANK = { none: 0, mild: 1, moderate: 2, high: 3 } as const;
+  let riskLevel: 'none' | 'mild' | 'moderate' | 'high' = 'none';
+  for (const r of risks) {
+    const level = gradeToRiskLevel(r.latestGrade);
+    if (RISK_LEVEL_RANK[level] > RISK_LEVEL_RANK[riskLevel]) riskLevel = level;
+  }
+
+  return { ...caseDetail, riskLevel, riskColor: riskLevelToColor(riskLevel) };
 }
 
 const GESTATION_DAYS = 280;
@@ -622,7 +675,41 @@ export class BeneficiaryService {
       await assertCallerCanTouchCase(found.sakhiId, caller, authorizationHeader);
     }
 
-    return this.projectCase(id, authorizationHeader, found);
+    const projected = await this.projectCase(id, authorizationHeader, found);
+    // Only fetched for the single-case detail view — projectCase is also
+    // reused by write-path re-fetches (applyLmpChange/reactivateCase/etc.),
+    // which don't need an extra cross-service round trip to visit-form-
+    // service just to return a response the caller already knows the
+    // outcome of. Degrades to null on any failure (see
+    // resolveLatestVisitVitals) rather than failing the whole request.
+    const lastVisitVitals = await resolveLatestVisitVitals(id, authorizationHeader);
+    return Object.assign(projected, { lastVisitVitals });
+  }
+
+  /**
+   * Bare `{id, sakhiId, caseType}` ownership check, same role/roster rules
+   * as getById but with none of its enrichment (pii/risk/socio/vitals) —
+   * for a caller that only needs to verify "may this caller see this
+   * beneficiary," not fetch the full profile. Exists specifically so
+   * visit-form-service's latest-visit-vitals resolver can verify ownership
+   * without calling back into getById itself, which would recreate the
+   * exact request cycle this method exists to avoid (getById ->
+   * resolveLatestVisitVitals -> visit-form-service ->
+   * this-service-again-via-getById -> resolveLatestVisitVitals -> ...).
+   */
+  async getOwnership(id: string, caller: AuthenticatedUser, authorizationHeader: string) {
+    const found = await this.repository.findOwnershipById(id);
+    if (!found) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (found.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else {
+      await assertCallerCanTouchCase(found.sakhiId, caller, authorizationHeader);
+    }
+
+    return found;
   }
 
   /**
@@ -647,7 +734,8 @@ export class BeneficiaryService {
     if (!found) throw notFound('Beneficiary case not found.');
     const projected = withDecryptedName(found);
     const withSocio = await withResolvedSocioDemographics(projected, authorizationHeader);
-    return withResolvedRiskConditionNames(withSocio, authorizationHeader);
+    const withRiskLevel = withOverallRiskLevel(withSocio);
+    return withResolvedRiskConditionNames(withRiskLevel, authorizationHeader);
   }
 
   /**
@@ -795,18 +883,73 @@ export class BeneficiaryService {
 
     const isValidTransition =
       (existing.caseType === 'MOTHER' && fromPhase === 'ANC' && toPhase === 'PP') ||
-      (existing.caseType === 'CHILD' && fromPhase === 'NN' && toPhase === 'NN');
+      (existing.caseType === 'CHILD' &&
+        // NN->NN is a no-op already short-circuited above; NN->INC and
+        // INC->CCV are the two real forward transitions a CHILD case makes,
+        // triggered by the first INC-type / CCV-type visit submission (see
+        // visit-form-service's form.service.ts). CCV->CLOSED goes through
+        // applyClosure, not this method.
+        ((fromPhase === 'NN' && toPhase === 'NN') ||
+          (fromPhase === 'NN' && toPhase === 'INC') ||
+          (fromPhase === 'INC' && toPhase === 'CCV')));
     if (!isValidTransition) {
       throw conflict(`Cannot move a ${existing.caseType} case from ${fromPhase} to ${toPhase}.`);
     }
 
-    const updated = await this.repository.updatePhase(beneficiaryId, fromPhase, toPhase);
+    const updated = await this.repository.updatePhase(
+      beneficiaryId,
+      existing.caseType as CaseType,
+      fromPhase,
+      toPhase,
+    );
     if (!updated) {
       // Raced with another phase change between the read above and the
       // conditional update — same outcome as the check above, just caught a
       // beat later instead of trusting a stale read.
       throw conflict(`Cannot move a ${existing.caseType} case from ${fromPhase} to ${toPhase}.`);
     }
+
+    return this.projectCase(beneficiaryId, authorizationHeader);
+  }
+
+  /**
+   * Writes ChildCaseDetails.ccvOpeningRiskState once, at the INC->CCV
+   * transition (BR-13). Called server-to-server by visit-form-service right
+   * after its own PATCH .../phase call lands the case at CCV — same
+   * no-machine-identity stance as applyPhaseChange, so gated by the same
+   * requireRoles('SAKHI') and ownership check.
+   *
+   * Deliberately does NOT re-check `currentPhase === 'CCV'` — BR-13's
+   * computation (last-3-INC-visits scan) is itself only triggered by
+   * visit-form-service's own INC->CCV transition, and re-validating the
+   * phase here would just be trusting the same caller's own prior call
+   * twice. A MOTHER case (no ChildCaseDetails row) or a beneficiary with no
+   * row yet 404s rather than silently no-op'ing, since this method is only
+   * ever called right after a real CCV transition — an unexpected 404 here
+   * signals a caller-side sequencing bug worth surfacing, not swallowing.
+   */
+  async setCcvOpeningRiskState(
+    beneficiaryId: string,
+    ccvOpeningRiskState: CcvOpeningRiskState,
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const existing = await this.repository.findById(beneficiaryId);
+    if (!existing) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (existing.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else {
+      await assertCallerCanTouchCase(existing.sakhiId, caller, authorizationHeader);
+    }
+
+    const updated = await this.repository.setCcvOpeningRiskState(
+      beneficiaryId,
+      ccvOpeningRiskState,
+    );
+    if (!updated) throw notFound('No ChildCaseDetails row exists for this beneficiary.');
 
     return this.projectCase(beneficiaryId, authorizationHeader);
   }

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -36,6 +36,7 @@ import {
   listSakhiNamesForSupervisor,
 } from '../sakhi/sakhi.client';
 import { resolveProjectNames } from '../projects/project.client';
+import { resolveRiskConditions } from '../risk-conditions/riskCondition.client';
 
 /**
  * Maps each socioDemographics *LookupId field to the lookup_categories
@@ -85,6 +86,54 @@ async function withResolvedSocioDemographics<T extends Record<string, unknown>>(
   }
 
   return { ...caseDetail, socioDemographics: withResolved };
+}
+
+/**
+ * Resolves each riskConditionSummaries entry's riskConditionId to a display-
+ * ready conditionCode/conditionName/gradeScale via risk-referral-service
+ * (the owner of risk_conditions — no cross-service joins, per this service's
+ * forklift rule). Ids are deduped before the batch call. An id with no
+ * matching ACTIVE row (retired condition, or a stale id) leaves that entry's
+ * three fields `null`.
+ *
+ * If risk-referral-service is unreachable or errors, this degrades to
+ * leaving every entry's fields `null` rather than failing the whole
+ * `GET /beneficiaries/:id` request — the beneficiary's own case/PII/risk-flag
+ * data is still valid and more load-bearing than the condition's display
+ * name. The failure is logged so it's visible without paging anyone.
+ */
+async function withResolvedRiskConditionNames<T extends Record<string, unknown>>(
+  caseDetail: T,
+  authorizationHeader: string,
+): Promise<T> {
+  const risks = caseDetail.riskConditionSummaries as Record<string, unknown>[] | undefined;
+  if (!risks || risks.length === 0) return caseDetail;
+
+  const ids = [...new Set(risks.map((r) => r.riskConditionId as string))];
+
+  let resolved: Map<string, { conditionCode: string; conditionName: string; gradeScale: string }>;
+  try {
+    resolved = await resolveRiskConditions(ids, authorizationHeader);
+  } catch (err) {
+    console.error(
+      `Failed to resolve risk condition names for ids [${ids.join(', ')}] — ` +
+        'returning riskConditionSummaries with null conditionCode/conditionName/gradeScale.',
+      err,
+    );
+    return caseDetail;
+  }
+
+  const withNames = risks.map((r) => {
+    const match = resolved.get(r.riskConditionId as string);
+    return {
+      ...r,
+      conditionCode: match?.conditionCode ?? null,
+      conditionName: match?.conditionName ?? null,
+      gradeScale: match?.gradeScale ?? null,
+    };
+  });
+
+  return { ...caseDetail, riskConditionSummaries: withNames };
 }
 
 const GESTATION_DAYS = 280;
@@ -597,7 +646,8 @@ export class BeneficiaryService {
     const found = prefetched ?? (await this.repository.findById(id));
     if (!found) throw notFound('Beneficiary case not found.');
     const projected = withDecryptedName(found);
-    return withResolvedSocioDemographics(projected, authorizationHeader);
+    const withSocio = await withResolvedSocioDemographics(projected, authorizationHeader);
+    return withResolvedRiskConditionNames(withSocio, authorizationHeader);
   }
 
   /**

--- a/apps/beneficiary-service/src/beneficiary/dto/set-ccv-opening-risk-state.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/set-ccv-opening-risk-state.dto.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { CCV_OPENING_RISK_STATES } from '../beneficiary.constants';
+
+/**
+ * Body for `PATCH /beneficiaries/:id/ccv-opening-risk-state` — writes
+ * ChildCaseDetails.ccvOpeningRiskState once, at the INC->CCV transition
+ * (BR-13: "risk state is evaluated exactly once, at the 12-month INC-to-CCV
+ * transition"). Called server-to-server by visit-form-service immediately
+ * after its own PATCH .../phase call advances the case to CCV, forwarding
+ * the submitting SAKHI's own token (this codebase has no machine/
+ * service-account identity — same pattern as PATCH .../phase).
+ */
+export const setCcvOpeningRiskStateSchema = z
+  .object({
+    ccvOpeningRiskState: z.enum(CCV_OPENING_RISK_STATES),
+  })
+  .strict();
+
+export type SetCcvOpeningRiskStateInput = z.infer<typeof setCcvOpeningRiskStateSchema>;

--- a/apps/beneficiary-service/src/beneficiary/dto/update-phase.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/update-phase.dto.ts
@@ -10,9 +10,9 @@ import { CASE_PHASES } from '../beneficiary.constants';
  * PATCH /beneficiaries/:id/risk-condition-summary).
  *
  * Only the transitions BeneficiaryService.applyPhaseChange actually allows
- * (ANC->PP for a MOTHER case, *->NN for a CHILD case) succeed — any other
- * value is rejected there with a 409, not here; this schema only checks the
- * value is a real CasePhase.
+ * (ANC->PP for a MOTHER case; NN->NN (no-op), NN->INC, and INC->CCV for a
+ * CHILD case) succeed — any other value is rejected there with a 409, not
+ * here; this schema only checks the value is a real CasePhase.
  */
 export const updatePhaseSchema = z
   .object({

--- a/apps/beneficiary-service/src/config/app-config.ts
+++ b/apps/beneficiary-service/src/config/app-config.ts
@@ -22,6 +22,11 @@ const schema = z.object({
   // NOT auth-service's own port directly, since the gateway is what verifies
   // the caller's forwarded Authorization header.
   AUTH_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
+  // Base URL of the gateway to reach risk-referral-service's risk-conditions
+  // endpoint through, same routing pattern as AUTH_SERVICE_BASE_URL above —
+  // used to resolve a BeneficiaryRiskConditionSummary row's riskConditionId
+  // to a display name for GET /beneficiaries/:id.
+  RISK_REFERRAL_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
   // Base64-encoded 32-byte keys consumed directly by @armman/service-commons'
   // pii-crypto module (encryptPii/decryptPii, hashForSearch) via process.env.
   // Validated here so the service fails fast at boot rather than at first use.

--- a/apps/beneficiary-service/src/risk-conditions/riskCondition.client.spec.ts
+++ b/apps/beneficiary-service/src/risk-conditions/riskCondition.client.spec.ts
@@ -1,0 +1,81 @@
+import { resolveRiskConditions } from './riskCondition.client';
+
+function riskConditionsResponse(
+  data: { id: string; conditionCode: string; conditionName: string; gradeScale: string }[],
+) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ success: true, data }),
+  };
+}
+
+describe('resolveRiskConditions', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns an empty Map without calling fetch when given no ids', async () => {
+    const result = await resolveRiskConditions([], 'Bearer test-token');
+
+    expect(result.size).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls risk-referral-service with a comma-separated ids batch and the forwarded auth header', async () => {
+    fetchMock.mockResolvedValue(
+      riskConditionsResponse([
+        {
+          id: 'rc-1',
+          conditionCode: 'HYPERTENSION_HIGH_BP',
+          conditionName: 'Hypertension / High BP',
+          gradeScale: 'NORMAL_LOW_MEDIUM_HIGH',
+        },
+      ]),
+    );
+
+    const result = await resolveRiskConditions(['rc-1', 'rc-2'], 'Bearer test-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/risk-conditions?ids=rc-1,rc-2'),
+      { headers: { Authorization: 'Bearer test-token' } },
+    );
+    expect(result.get('rc-1')).toEqual({
+      conditionCode: 'HYPERTENSION_HIGH_BP',
+      conditionName: 'Hypertension / High BP',
+      gradeScale: 'NORMAL_LOW_MEDIUM_HIGH',
+    });
+  });
+
+  it('omits an id with no matching row from the returned Map, without throwing', async () => {
+    fetchMock.mockResolvedValue(riskConditionsResponse([]));
+
+    const result = await resolveRiskConditions(['rc-unseeded'], 'Bearer test-token');
+
+    expect(result.has('rc-unseeded')).toBe(false);
+  });
+
+  it('throws 502 when the risk-referral-service call rejects (network error/timeout)', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(resolveRiskConditions(['rc-1'], 'Bearer test-token')).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+
+  it('throws 502 when risk-referral-service returns a non-ok response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) });
+
+    await expect(resolveRiskConditions(['rc-1'], 'Bearer test-token')).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+});

--- a/apps/beneficiary-service/src/risk-conditions/riskCondition.client.ts
+++ b/apps/beneficiary-service/src/risk-conditions/riskCondition.client.ts
@@ -1,0 +1,66 @@
+import { badGateway } from '@armman/service-commons';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — see geography.client.ts's own note on why.
+const RISK_REFERRAL_SERVICE_BASE_URL =
+  process.env.RISK_REFERRAL_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+interface RiskConditionRow {
+  id: string;
+  conditionCode: string;
+  conditionName: string;
+  gradeScale: 'BINARY' | 'NORMAL_MILD_MODERATE_SEVERE' | 'NORMAL_LOW_MEDIUM_HIGH';
+}
+
+/**
+ * Resolves riskConditionId -> {conditionCode, conditionName, gradeScale} for
+ * the given batch, via risk-referral-service's existing
+ * `GET /risk-conditions?ids=...` (called through the gateway, per
+ * RISK_REFERRAL_SERVICE_BASE_URL, so the gateway can verify
+ * `authorizationHeader` — the original caller's own bearer token, forwarded
+ * unchanged, same pattern as geography.client.ts). Used to enrich
+ * `GET /beneficiaries/:id`'s riskConditionSummaries with a display-ready
+ * name, since BeneficiaryRiskConditionSummary stores only the bare
+ * riskConditionId (no cross-service joins, per this service's forklift
+ * rule).
+ *
+ * An id not found in the response (retired/INACTIVE condition, or a stale
+ * id) maps to `undefined` in the returned Map — not an error, since the
+ * beneficiary case itself is still valid data; the caller decides how to
+ * render an unresolved condition (see beneficiary.service.ts's projectCase).
+ *
+ * An empty `ids` array short-circuits to an empty Map without a network call.
+ */
+export async function resolveRiskConditions(
+  ids: string[],
+  authorizationHeader: string,
+): Promise<Map<string, { conditionCode: string; conditionName: string; gradeScale: string }>> {
+  if (ids.length === 0) return new Map();
+
+  let res: Response;
+  try {
+    res = await fetch(
+      `${RISK_REFERRAL_SERVICE_BASE_URL}/api/v1/risk-conditions?ids=${ids.join(',')}`,
+      { headers: { Authorization: authorizationHeader } },
+    );
+  } catch {
+    // Network error / timeout reaching risk-referral-service — infra problem,
+    // retryable. Callers of this function are expected to catch this and
+    // degrade to null names rather than failing the whole beneficiary
+    // response — a downstream risk-referral-service blip shouldn't take
+    // down GET /beneficiaries/:id.
+    throw badGateway('Unable to resolve risk conditions — the risk service is unreachable.');
+  }
+
+  if (!res.ok) {
+    throw badGateway('Unable to resolve risk conditions — the risk service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: RiskConditionRow[] };
+  return new Map(
+    body.data.map((c) => [
+      c.id,
+      { conditionCode: c.conditionCode, conditionName: c.conditionName, gradeScale: c.gradeScale },
+    ]),
+  );
+}

--- a/apps/beneficiary-service/src/visits/visitVitals.client.spec.ts
+++ b/apps/beneficiary-service/src/visits/visitVitals.client.spec.ts
@@ -11,16 +11,16 @@ function vitalsResponse(data: Record<string, unknown>) {
 describe('resolveLatestVisitVitals', () => {
   const originalFetch = global.fetch;
   const fetchMock = jest.fn();
-  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = fetchMock as unknown as typeof fetch;
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 
   afterAll(() => {
@@ -56,7 +56,7 @@ describe('resolveLatestVisitVitals', () => {
     const result = await resolveLatestVisitVitals('ben-1', 'Bearer test-token');
 
     expect(result).toBeNull();
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalled();
   });
 
   it('returns null (not a throw) when visit-form-service is unreachable', async () => {
@@ -65,6 +65,6 @@ describe('resolveLatestVisitVitals', () => {
     const result = await resolveLatestVisitVitals('ben-1', 'Bearer test-token');
 
     expect(result).toBeNull();
-    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalled();
   });
 });

--- a/apps/beneficiary-service/src/visits/visitVitals.client.spec.ts
+++ b/apps/beneficiary-service/src/visits/visitVitals.client.spec.ts
@@ -1,0 +1,70 @@
+import { resolveLatestVisitVitals } from './visitVitals.client';
+
+function vitalsResponse(data: Record<string, unknown>) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ success: true, data }),
+  };
+}
+
+describe('resolveLatestVisitVitals', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns the vitals snapshot on success', async () => {
+    const data = {
+      visitId: 'visit-1',
+      submittedAt: '2026-08-01T00:00:00.000Z',
+      weightKg: 58.5,
+      systolicBp: 120,
+      diastolicBp: 80,
+      temperatureF: 98.6,
+      hemoglobinGDl: 11.2,
+      muacCm: 24.5,
+      respiratoryRate: null,
+    };
+    fetchMock.mockResolvedValue(vitalsResponse(data));
+
+    const result = await resolveLatestVisitVitals('ben-1', 'Bearer test-token');
+
+    expect(result).toEqual(data);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/beneficiaries/ben-1/latest-visit-vitals'),
+      { headers: { Authorization: 'Bearer test-token' } },
+    );
+  });
+
+  it('returns null (not a throw) when visit-form-service returns a non-ok response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await resolveLatestVisitVitals('ben-1', 'Bearer test-token');
+
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('returns null (not a throw) when visit-form-service is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const result = await resolveLatestVisitVitals('ben-1', 'Bearer test-token');
+
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/beneficiary-service/src/visits/visitVitals.client.ts
+++ b/apps/beneficiary-service/src/visits/visitVitals.client.ts
@@ -39,7 +39,7 @@ export async function resolveLatestVisitVitals(
       { headers: { Authorization: authorizationHeader } },
     );
     if (!res.ok) {
-      console.error(
+      console.warn(
         `Failed to resolve latest-visit-vitals for beneficiary ${beneficiaryId} — ` +
           `visit-form-service returned ${res.status}.`,
       );
@@ -48,7 +48,7 @@ export async function resolveLatestVisitVitals(
     const body = (await res.json()) as { data: VitalsSnapshot };
     return body.data;
   } catch (err) {
-    console.error(
+    console.warn(
       `Unable to reach visit-form-service to resolve latest-visit-vitals for beneficiary ` +
         `${beneficiaryId}.`,
       err,

--- a/apps/beneficiary-service/src/visits/visitVitals.client.ts
+++ b/apps/beneficiary-service/src/visits/visitVitals.client.ts
@@ -1,0 +1,58 @@
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema — see riskCondition.client.ts's own note on why.
+const VISIT_FORM_SERVICE_BASE_URL =
+  process.env.VISIT_FORM_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+export interface VitalsSnapshot {
+  visitId: string | null;
+  submittedAt: string | null;
+  weightKg: number | null;
+  systolicBp: number | null;
+  diastolicBp: number | null;
+  temperatureF: number | null;
+  hemoglobinGDl: number | null;
+  muacCm: number | null;
+  respiratoryRate: number | null;
+}
+
+/**
+ * Resolves a beneficiary's most recent visit's vitals via visit-form-
+ * service's `GET /beneficiaries/:beneficiaryId/latest-visit-vitals` (called
+ * through the gateway, per VISIT_FORM_SERVICE_BASE_URL, so the gateway can
+ * verify `authorizationHeader` — the original caller's own bearer token,
+ * forwarded unchanged, same pattern as riskCondition.client.ts). Used to
+ * enrich `GET /beneficiaries/:id` with `lastVisitVitals`, since
+ * beneficiary-service owns no visit/form data itself (no cross-service
+ * joins, per this service's forklift rule).
+ *
+ * Returns `null` (not thrown) on any failure — degrade, don't fail: the
+ * beneficiary's own case/PII/risk data is more load-bearing than the last
+ * visit's vitals, same stance as resolveRiskConditions.
+ */
+export async function resolveLatestVisitVitals(
+  beneficiaryId: string,
+  authorizationHeader: string,
+): Promise<VitalsSnapshot | null> {
+  try {
+    const res = await fetch(
+      `${VISIT_FORM_SERVICE_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/latest-visit-vitals`,
+      { headers: { Authorization: authorizationHeader } },
+    );
+    if (!res.ok) {
+      console.error(
+        `Failed to resolve latest-visit-vitals for beneficiary ${beneficiaryId} — ` +
+          `visit-form-service returned ${res.status}.`,
+      );
+      return null;
+    }
+    const body = (await res.json()) as { data: VitalsSnapshot };
+    return body.data;
+  } catch (err) {
+    console.error(
+      `Unable to reach visit-form-service to resolve latest-visit-vitals for beneficiary ` +
+        `${beneficiaryId}.`,
+      err,
+    );
+    return null;
+  }
+}

--- a/apps/risk-referral-service/prisma/backfill-grade-rank-from-lookup.spec.ts
+++ b/apps/risk-referral-service/prisma/backfill-grade-rank-from-lookup.spec.ts
@@ -1,0 +1,74 @@
+import { correctGradeRanks } from './backfill-grade-rank-from-lookup';
+
+describe('correctGradeRanks', () => {
+  const findMany = jest.fn();
+  const update = jest.fn();
+  const client = { riskFlag: { findMany, update } } as never;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const idToRank = new Map([
+    ['grade-normal', 0],
+    ['grade-mild', 1],
+    ['grade-moderate', 2],
+    ['grade-severe', 3],
+  ]);
+
+  it('corrects a row whose blindly-zeroed grade_rank does not match its true resolved grade', async () => {
+    findMany.mockResolvedValue([
+      { id: 'flag-1', riskGradeLookupValueId: 'grade-severe', gradeRank: 0 },
+    ]);
+
+    const summary = await correctGradeRanks(client, idToRank);
+
+    expect(update).toHaveBeenCalledWith({ where: { id: 'flag-1' }, data: { gradeRank: 3 } });
+    expect(summary).toEqual({ checked: 1, corrected: 1, unresolved: 0 });
+  });
+
+  it('leaves a row alone when its grade_rank already matches the resolved grade', async () => {
+    findMany.mockResolvedValue([
+      { id: 'flag-1', riskGradeLookupValueId: 'grade-normal', gradeRank: 0 },
+    ]);
+
+    const summary = await correctGradeRanks(client, idToRank);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(summary).toEqual({ checked: 1, corrected: 0, unresolved: 0 });
+  });
+
+  it('counts a row as unresolved and does not update it when its lookup id has no known grade', async () => {
+    findMany.mockResolvedValue([
+      { id: 'flag-1', riskGradeLookupValueId: 'grade-unknown', gradeRank: 0 },
+    ]);
+
+    const summary = await correctGradeRanks(client, idToRank);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(summary).toEqual({ checked: 1, corrected: 0, unresolved: 1 });
+  });
+
+  it('processes multiple rows independently, mixing corrected/already-correct/unresolved outcomes', async () => {
+    findMany.mockResolvedValue([
+      { id: 'flag-1', riskGradeLookupValueId: 'grade-severe', gradeRank: 0 },
+      { id: 'flag-2', riskGradeLookupValueId: 'grade-normal', gradeRank: 0 },
+      { id: 'flag-3', riskGradeLookupValueId: 'grade-unknown', gradeRank: 0 },
+    ]);
+
+    const summary = await correctGradeRanks(client, idToRank);
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({ where: { id: 'flag-1' }, data: { gradeRank: 3 } });
+    expect(summary).toEqual({ checked: 3, corrected: 1, unresolved: 1 });
+  });
+
+  it('is a no-op summary when risk_flags is empty (e.g. an environment where the migration ran before any real grading occurred)', async () => {
+    findMany.mockResolvedValue([]);
+
+    const summary = await correctGradeRanks(client, idToRank);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(summary).toEqual({ checked: 0, corrected: 0, unresolved: 0 });
+  });
+});

--- a/apps/risk-referral-service/prisma/backfill-grade-rank-from-lookup.ts
+++ b/apps/risk-referral-service/prisma/backfill-grade-rank-from-lookup.ts
@@ -1,0 +1,156 @@
+/**
+ * Corrective backfill for migration 20260819000000_add_risk_flag_grade_rank.
+ *
+ * That migration added `risk_flags.grade_rank` and set it to 0 (NORMAL) for
+ * every pre-existing row, regardless of that row's true historic grade
+ * (stored via `risk_grade_lookup_value_id`, owned by auth-service — no
+ * cross-service join available at migration time). On any environment where
+ * `risk_flags` already had real MILD/MODERATE/SEVERE rows before that
+ * migration ran, this silently corrupted their grade_rank going forward,
+ * producing a false "improved to NORMAL" wherever gradeRank is compared
+ * across visits (findConsecutiveNoImprovementCount, and the Part 3
+ * dashboard's progression/deterioration reports — see schema.prisma's own
+ * comment on gradeRank). See PR #172 review.
+ *
+ * This script re-derives the true grade_rank for every existing risk_flags
+ * row by resolving its riskGradeLookupValueId to a RISK_GRADE valueCode via
+ * auth-service's `GET /lookups/RISK_GRADE` (NOT a cross-schema SQL join —
+ * respects the forklift rule) and re-mapping via the same NORMAL=0..SEVERE=3
+ * scale the rule packs use (see anc-risk.rulesJson.ts/infant-risk.rulesJson.ts's
+ * GRADE_RANK constant). Safe to run more than once — it always recomputes
+ * from the lookup id, never trusts the existing grade_rank value.
+ *
+ * No-op (nothing to correct) on any environment where risk_flags was empty
+ * when the 20260819000000 migration ran — e.g. local as of this writing.
+ * Run this BEFORE trusting gradeRank-based history on any environment where
+ * risk_flags may have had real grades prior to 2026-08-19.
+ *
+ * Usage:
+ *   npx ts-node prisma/backfill-grade-rank-from-lookup.ts
+ *
+ * Env:
+ *   AUTH_SERVICE_BASE_URL  base URL of auth-service (e.g. via the gateway),
+ *                          default http://localhost:3000
+ *   AUTH_SERVICE_TOKEN     bearer token for the /lookups read (any role)
+ */
+import { PrismaClient } from '../../../node_modules/.prisma/client-risk-referral-service';
+
+const AUTH_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+const AUTH_TOKEN = process.env.AUTH_SERVICE_TOKEN;
+
+// Mirrors anc-risk.rulesJson.ts / infant-risk.rulesJson.ts's own GRADE_RANK
+// constant — the scale every rule pack computes gradeRank from originally.
+const GRADE_RANK: Record<string, number> = { NORMAL: 0, MILD: 1, MODERATE: 2, SEVERE: 3 };
+
+interface LookupValue {
+  id: string;
+  valueCode: string;
+}
+
+export interface BackfillSummary {
+  checked: number;
+  corrected: number;
+  unresolved: number;
+}
+
+interface RiskFlagClient {
+  riskFlag: {
+    findMany: (args: {
+      select: { id: true; riskGradeLookupValueId: true; gradeRank: true };
+    }) => Promise<Array<{ id: string; riskGradeLookupValueId: string; gradeRank: number }>>;
+    update: (args: { where: { id: string }; data: { gradeRank: number } }) => Promise<unknown>;
+  };
+}
+
+/** Fetches RISK_GRADE lookup values from auth-service and returns an id -> rank map. */
+export async function loadLookupIdToRankMap(): Promise<Map<string, number>> {
+  if (!AUTH_TOKEN) {
+    throw new Error('AUTH_SERVICE_TOKEN is required to resolve RISK_GRADE lookup values.');
+  }
+
+  const url = `${AUTH_BASE_URL}/api/v1/lookups/RISK_GRADE`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } });
+  if (!res.ok) {
+    throw new Error(`Failed to load RISK_GRADE lookups from ${url}: HTTP ${res.status}`);
+  }
+
+  const body = (await res.json()) as { data?: { values?: LookupValue[] } };
+  const values = body.data?.values ?? [];
+  if (values.length === 0) {
+    throw new Error('RISK_GRADE lookup category returned no values — is auth-service seeded?');
+  }
+
+  const idToRank = new Map<string, number>();
+  for (const value of values) {
+    const rank = GRADE_RANK[value.valueCode];
+    // HIGH/CRITICAL (overallRiskCategory-only values, never a per-condition
+    // grade) have no GRADE_RANK entry — skipped, not an error; no risk_flags
+    // row can carry them as its own grade.
+    if (rank !== undefined) idToRank.set(value.id, rank);
+  }
+  return idToRank;
+}
+
+/**
+ * Re-derives and corrects grade_rank for every risk_flags row, given a
+ * pre-resolved lookup-id -> rank map. Extracted from main() so the
+ * correction logic itself (what gets read/updated, and how unresolved rows
+ * are counted) can be unit-tested against a mocked Prisma client, without
+ * needing a live auth-service call — see backfill-grade-rank-from-lookup.spec.ts.
+ */
+export async function correctGradeRanks(
+  client: RiskFlagClient,
+  idToRank: Map<string, number>,
+): Promise<BackfillSummary> {
+  const flags = await client.riskFlag.findMany({
+    select: { id: true, riskGradeLookupValueId: true, gradeRank: true },
+  });
+
+  let corrected = 0;
+  let unresolved = 0;
+  for (const flag of flags) {
+    const trueRank = idToRank.get(flag.riskGradeLookupValueId);
+    if (trueRank === undefined) {
+      unresolved += 1;
+      console.error(
+        `risk_flags row ${flag.id} has riskGradeLookupValueId ${flag.riskGradeLookupValueId}, ` +
+          'which does not resolve to a known NORMAL/MILD/MODERATE/SEVERE grade — left unchanged.',
+      );
+      continue;
+    }
+    if (trueRank !== flag.gradeRank) {
+      await client.riskFlag.update({ where: { id: flag.id }, data: { gradeRank: trueRank } });
+      corrected += 1;
+    }
+  }
+
+  return { checked: flags.length, corrected, unresolved };
+}
+
+async function main(): Promise<void> {
+  const prisma = new PrismaClient();
+  try {
+    const idToRank = await loadLookupIdToRankMap();
+    const summary = await correctGradeRanks(prisma, idToRank);
+
+    console.log(
+      `Checked ${summary.checked} risk_flags row(s): corrected ${summary.corrected}, ` +
+        `already correct ${summary.checked - summary.corrected - summary.unresolved}, ` +
+        `unresolved ${summary.unresolved}.`,
+    );
+    if (summary.unresolved > 0) {
+      throw new Error(
+        `${summary.unresolved} risk_flags row(s) could not be resolved to a known grade — see errors above.`,
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apps/risk-referral-service/prisma/migrations/20260819000000_add_risk_flag_grade_rank/migration.sql
+++ b/apps/risk-referral-service/prisma/migrations/20260819000000_add_risk_flag_grade_rank/migration.sql
@@ -1,8 +1,17 @@
 -- AlterTable
--- Add as nullable first, backfill existing rows to 0 (treated as NORMAL,
--- the safest default for historic flags whose true grade rank was never
--- recorded), then enforce NOT NULL — avoids failing on any pre-existing
--- risk_flags rows.
+-- Add as nullable first, backfill existing rows to 0 (treated as NORMAL —
+-- NOT necessarily each row's true historic grade, only a placeholder that
+-- lets NOT NULL be enforced below without failing on pre-existing rows),
+-- then enforce NOT NULL.
+--
+-- IMPORTANT: on any environment where risk_flags already had real
+-- MILD/MODERATE/SEVERE rows before this migration ran, the 0 default below
+-- is WRONG for those rows and must be corrected — see
+-- prisma/backfill-grade-rank-from-lookup.ts, which re-derives each row's
+-- true grade_rank from its riskGradeLookupValueId via auth-service's
+-- RISK_GRADE lookup (see PR #172 review). Run that script once after
+-- deploying this migration on any such environment. A no-op on an
+-- environment where risk_flags was empty when this migration ran.
 ALTER TABLE "risk_flags" ADD COLUMN "grade_rank" INTEGER;
 
 UPDATE "risk_flags" SET "grade_rank" = 0 WHERE "grade_rank" IS NULL;

--- a/apps/risk-referral-service/prisma/schema.prisma
+++ b/apps/risk-referral-service/prisma/schema.prisma
@@ -133,6 +133,16 @@ model RiskCondition {
   entityType               RiskEntityType      @map("entity_type")
   phase                    RiskPhase
   gradeScale               RiskGradeScale      @map("grade_scale")
+  // Reference/display-only master data (served via GET /risk-conditions) —
+  // NOT read by the grading rule packs (anc-risk.rulesJson.ts /
+  // infant-risk.rulesJson.ts, apps/rules-service) at evaluation time. A
+  // condition's actual referral/education trigger is grade-,
+  // first-instance-, and accompanied-by-condition-dependent (e.g. Anemia
+  // only refers on MODERATE/SEVERE; Hypotension only refers when
+  // accompanied by another flagged condition) — logic a single static
+  // per-condition boolean cannot correctly express. Editing this field does
+  // NOT change grading behavior; the rule pack is the sole source of truth
+  // for that (see PR #172 review).
   referralRequiredDefault  Boolean             @default(false) @map("referral_required_default")
   educationRequiredDefault Boolean             @default(false) @map("education_required_default")
   status                   RiskConditionStatus

--- a/apps/risk-referral-service/prisma/seed.ts
+++ b/apps/risk-referral-service/prisma/seed.ts
@@ -29,6 +29,9 @@ interface AncRiskConditionSeed {
   conditionCode: string;
   conditionName: string;
   gradeScale: 'BINARY' | 'NORMAL_MILD_MODERATE_SEVERE' | 'NORMAL_LOW_MEDIUM_HIGH';
+  // Reference/display-only — see schema.prisma's RiskCondition doc comment.
+  // NOT read by anc-risk.rulesJson.ts / infant-risk.rulesJson.ts; editing
+  // these values here does not change grading/trigger behavior.
   referralRequiredDefault: boolean;
   educationRequiredDefault: boolean;
 }
@@ -127,17 +130,20 @@ async function seedRiskParameters(): Promise<SeedResult> {
 }
 
 /**
- * Master data for the 18 ANC High-Risk conditions defined in Appendix D
- * ("High risk protocols_Developer's copy - ANC HR", see
- * docs/Appendix_D_High_Risk_Detection_Rules.md, Part 1). `phase: ANC` — these
- * feed the anc-risk.rulesJson.ts RISK rule pack via a conditionCode ->
- * risk_condition_id map that riskAssessment.service.ts builds by looking
- * these rows up before calling evaluateRuleSet.
+ * Shared by seedAncRiskConditions/seedInfantRiskConditions below — both
+ * differ only in the imported JSON, entityType, phase, and step name; every
+ * other line (existence check, create() shape, result branches) was
+ * previously copy-pasted verbatim between them (see PR #172 review).
  */
-async function seedAncRiskConditions(): Promise<SeedResult> {
+async function seedRiskConditions(
+  items: AncRiskConditionSeed[],
+  entityType: 'MOTHER' | 'CHILD',
+  phase: 'ANC' | 'INC',
+  stepName: string,
+): Promise<SeedResult> {
   let createdCount = 0;
 
-  for (const condition of ancRiskConditions as AncRiskConditionSeed[]) {
+  for (const condition of items) {
     const existing = await prisma.riskCondition.findUnique({
       where: { conditionCode: condition.conditionCode },
     });
@@ -147,8 +153,8 @@ async function seedAncRiskConditions(): Promise<SeedResult> {
       data: {
         conditionCode: condition.conditionCode,
         conditionName: condition.conditionName,
-        entityType: 'MOTHER',
-        phase: 'ANC',
+        entityType,
+        phase,
         gradeScale: condition.gradeScale,
         referralRequiredDefault: condition.referralRequiredDefault,
         educationRequiredDefault: condition.educationRequiredDefault,
@@ -160,20 +166,37 @@ async function seedAncRiskConditions(): Promise<SeedResult> {
 
   if (createdCount === 0) {
     return {
-      step: 'anc-risk-conditions',
+      step: stepName,
       created: false,
-      message: 'All ANC risk condition rows already present — skipped.',
+      message: `All ${stepName.replace(/-/g, ' ')} rows already present — skipped.`,
     };
   }
   return {
-    step: 'anc-risk-conditions',
+    step: stepName,
     created: true,
-    message: `Seeded ${createdCount} ANC risk condition row(s).`,
+    message: `Seeded ${createdCount} ${stepName.replace(/-/g, ' ')} row(s).`,
   };
 }
 
 /**
- * Master data for the 10 Infant High-Risk conditions defined in Appendix D
+ * Master data for the 19 ANC High-Risk conditions defined in Appendix D
+ * ("High risk protocols_Developer's copy - ANC HR", see
+ * docs/Appendix_D_High_Risk_Detection_Rules.md, Part 1). `phase: ANC` — these
+ * feed the anc-risk.rulesJson.ts RISK rule pack via a conditionCode ->
+ * risk_condition_id map that riskAssessment.service.ts builds by looking
+ * these rows up before calling evaluateRuleSet.
+ */
+function seedAncRiskConditions(): Promise<SeedResult> {
+  return seedRiskConditions(
+    ancRiskConditions as AncRiskConditionSeed[],
+    'MOTHER',
+    'ANC',
+    'anc-risk-conditions',
+  );
+}
+
+/**
+ * Master data for the 12 Infant High-Risk conditions defined in Appendix D
  * ("High risk protocols_Developer's copy - Infant HR", see
  * docs/Appendix_D_High_Risk_Detection_Rules.md, Part 2). Seeded once under
  * `phase: INC` — condition_code has a global UNIQUE constraint (not
@@ -182,42 +205,13 @@ async function seedAncRiskConditions(): Promise<SeedResult> {
  * riskPhase: 'INC' to reuse this same seeded set rather than duplicating
  * rows per phase (see infant-risk.rulesJson.ts's own doc comment).
  */
-async function seedInfantRiskConditions(): Promise<SeedResult> {
-  let createdCount = 0;
-
-  for (const condition of infantRiskConditions as AncRiskConditionSeed[]) {
-    const existing = await prisma.riskCondition.findUnique({
-      where: { conditionCode: condition.conditionCode },
-    });
-    if (existing) continue;
-
-    await prisma.riskCondition.create({
-      data: {
-        conditionCode: condition.conditionCode,
-        conditionName: condition.conditionName,
-        entityType: 'CHILD',
-        phase: 'INC',
-        gradeScale: condition.gradeScale,
-        referralRequiredDefault: condition.referralRequiredDefault,
-        educationRequiredDefault: condition.educationRequiredDefault,
-        status: 'ACTIVE',
-      },
-    });
-    createdCount += 1;
-  }
-
-  if (createdCount === 0) {
-    return {
-      step: 'infant-risk-conditions',
-      created: false,
-      message: 'All infant risk condition rows already present — skipped.',
-    };
-  }
-  return {
-    step: 'infant-risk-conditions',
-    created: true,
-    message: `Seeded ${createdCount} infant risk condition row(s).`,
-  };
+function seedInfantRiskConditions(): Promise<SeedResult> {
+  return seedRiskConditions(
+    infantRiskConditions as AncRiskConditionSeed[],
+    'CHILD',
+    'INC',
+    'infant-risk-conditions',
+  );
 }
 
 async function main(): Promise<void> {

--- a/apps/risk-referral-service/src/app.module.ts
+++ b/apps/risk-referral-service/src/app.module.ts
@@ -29,6 +29,7 @@ export {
   requireRoles,
   trustGatewayIdentity,
   unauthorized,
+  badRequest,
   createDocumentedRouter,
   HttpError,
   ErrorCode,

--- a/apps/risk-referral-service/src/risk-assessments/dto/list-riskAssessments.dto.spec.ts
+++ b/apps/risk-referral-service/src/risk-assessments/dto/list-riskAssessments.dto.spec.ts
@@ -1,0 +1,67 @@
+import { listRiskAssessmentsQuerySchema } from './list-riskAssessments.dto';
+
+const BENEFICIARY_ID = '11111111-1111-1111-1111-111111111111';
+const VISIT_ID_1 = '22222222-2222-2222-2222-222222222222';
+const VISIT_ID_2 = '33333333-3333-3333-3333-333333333333';
+
+describe('listRiskAssessmentsQuerySchema', () => {
+  it('accepts a single visit id', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({
+      beneficiaryId: BENEFICIARY_ID,
+      visitIds: VISIT_ID_1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a comma-separated batch of visit ids', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({
+      beneficiaryId: BENEFICIARY_ID,
+      visitIds: `${VISIT_ID_1},${VISIT_ID_2}`,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing beneficiaryId', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({ visitIds: VISIT_ID_1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing visitIds', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({ beneficiaryId: BENEFICIARY_ID });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-uuid beneficiaryId', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({
+      beneficiaryId: 'not-a-uuid',
+      visitIds: VISIT_ID_1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a visitIds batch containing a non-uuid segment', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({
+      beneficiaryId: BENEFICIARY_ID,
+      visitIds: `${VISIT_ID_1},not-a-uuid`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a visitIds batch larger than the max', () => {
+    const visitIds = Array.from({ length: 101 }, () => VISIT_ID_1).join(',');
+    const result = listRiskAssessmentsQuerySchema.safeParse({
+      beneficiaryId: BENEFICIARY_ID,
+      visitIds,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown fields', () => {
+    const result = listRiskAssessmentsQuerySchema.safeParse({
+      beneficiaryId: BENEFICIARY_ID,
+      visitIds: VISIT_ID_1,
+      extra: 'nope',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/risk-referral-service/src/risk-assessments/dto/list-riskAssessments.dto.ts
+++ b/apps/risk-referral-service/src/risk-assessments/dto/list-riskAssessments.dto.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+/** Caps a single visitIds batch — matches list-risk-conditions.dto.ts's own cap. */
+export const MAX_BATCH_VISIT_IDS = 100;
+
+/**
+ * Query schema for `GET /risk-assessments?beneficiaryId=...&visitIds=...` —
+ * both required. Resolves to the RiskAssessment rows for exactly the given
+ * visit ids, for a caller (e.g. visit-form-service's BR-13 resolver) that
+ * already knows which visits it cares about — this service doesn't own
+ * visit_instances/visit_schedules, so it can't resolve "the beneficiary's
+ * last 3 INC visits" itself (no cross-service join per the forklift rule).
+ * Kept as plain strings + `.refine()` (not `z.coerce.*`), matching
+ * list-risk-conditions.dto.ts's own note on why — zod-to-openapi cannot
+ * introspect a `ZodEffects`-wrapped transform and crashes OpenAPI doc
+ * generation at startup. For the same reason, cross-field validation (both
+ * fields present) belongs in the controller, not a whole-object `.refine()`
+ * here — see list-risk-conditions.dto.ts's own comment on that trap.
+ */
+export const listRiskAssessmentsQuerySchema = z
+  .object({
+    beneficiaryId: z.string().uuid(),
+    visitIds: z
+      .string()
+      .trim()
+      .min(1)
+      .refine(
+        (v) => {
+          const parts = v.split(',');
+          return (
+            parts.length <= MAX_BATCH_VISIT_IDS &&
+            parts.every((p) => z.string().uuid().safeParse(p).success)
+          );
+        },
+        {
+          message: `visitIds: must be a comma-separated list of at most ${MAX_BATCH_VISIT_IDS} uuids`,
+        },
+      ),
+  })
+  .strict();
+
+export type ListRiskAssessmentsQuery = z.infer<typeof listRiskAssessmentsQuerySchema>;

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.controller.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.controller.ts
@@ -14,5 +14,19 @@ export function createRiskAssessmentController(service: RiskAssessmentService) {
       const created = await service.create(req.body, req.user, authorizationHeader);
       res.status(201).json(ok(created));
     }),
+
+    listByVisitIds: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const { beneficiaryId, visitIds } = req.query as { beneficiaryId: string; visitIds: string };
+      const found = await service.listByVisitIds(
+        beneficiaryId,
+        visitIds.split(','),
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(found));
+    }),
   };
 }

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
@@ -52,6 +52,23 @@ export class RiskAssessmentRepository {
   }
 
   /**
+   * Every RiskAssessment for the given visit ids, most-recently-evaluated
+   * first — used by callers that already know which visits they care about
+   * (e.g. BR-13's "last 3 completed INC visits" lookup, resolved by
+   * visit-form-service since it owns visit typing; risk-referral-service
+   * doesn't own visit_instances/visit_schedules, no cross-service join per
+   * the forklift rule, so it can only filter by an id list handed to it).
+   * An empty `visitIds` short-circuits to an empty array without querying.
+   */
+  async findByVisitIds(beneficiaryId: string, visitIds: string[]) {
+    if (visitIds.length === 0) return [];
+    return this.prisma.riskAssessment.findMany({
+      where: { beneficiaryId, visitId: { in: visitIds }, isDeleted: false },
+      orderBy: { evaluatedAt: 'desc' },
+    });
+  }
+
+  /**
    * Maps risk_conditions.condition_code -> risk_condition_id for every
    * ACTIVE condition in `phase` — a rule pack's own conditionCodes are
    * portable across environments, but the decision graph's output must
@@ -105,25 +122,46 @@ export class RiskAssessmentRepository {
    * moment gradeRank decreases from one flag to the next-most-recent one;
    * a flat or worsening trend keeps counting. Capped at 3 visits back since
    * the rule pack only needs to know ">=3", not the exact streak length.
+   *
+   * One batched query for every condition code (not one query per code —
+   * see PR #172 review) — each condition needs at most its 4 most recent
+   * flags, so this over-fetches per condition (no per-condition LIMIT is
+   * expressible in a single findMany) and trims to 4 in JS afterward, which
+   * is still one round trip regardless of how many conditionCodes are
+   * passed.
    */
   async findConsecutiveNoImprovementCount(
     beneficiaryId: string,
     conditionCodes: string[],
   ): Promise<Map<string, number>> {
+    if (conditionCodes.length === 0) return new Map();
+
+    const flags = await this.prisma.riskFlag.findMany({
+      where: {
+        riskAssessment: { beneficiaryId, isDeleted: false },
+        riskCondition: { conditionCode: { in: conditionCodes } },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: { gradeRank: true, riskCondition: { select: { conditionCode: true } } },
+    });
+
+    const flagsByCode = new Map<string, number[]>();
+    for (const flag of flags) {
+      const code = flag.riskCondition.conditionCode;
+      const ranks = flagsByCode.get(code);
+      if (ranks) {
+        if (ranks.length < 4) ranks.push(flag.gradeRank);
+      } else {
+        flagsByCode.set(code, [flag.gradeRank]);
+      }
+    }
+
     const result = new Map<string, number>();
     for (const conditionCode of conditionCodes) {
-      const flags = await this.prisma.riskFlag.findMany({
-        where: {
-          riskAssessment: { beneficiaryId, isDeleted: false },
-          riskCondition: { conditionCode },
-        },
-        orderBy: { createdAt: 'desc' },
-        take: 4,
-        select: { gradeRank: true },
-      });
+      const ranks = flagsByCode.get(conditionCode) ?? [];
       let streak = 0;
-      for (let i = 0; i < flags.length - 1; i++) {
-        if (flags[i].gradeRank < flags[i + 1].gradeRank) break;
+      for (let i = 0; i < ranks.length - 1; i++) {
+        if (ranks[i] < ranks[i + 1]) break;
         streak += 1;
       }
       result.set(conditionCode, streak);

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.routes.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.routes.ts
@@ -3,9 +3,11 @@ import { z } from 'zod';
 import type { RiskAssessmentService } from './riskAssessment.service';
 import { createRiskAssessmentController } from './riskAssessment.controller';
 import { createRiskAssessmentSchema } from './dto/create-riskAssessment.dto';
+import { listRiskAssessmentsQuerySchema } from './dto/list-riskAssessments.dto';
 import {
   requireRoles,
   trustGatewayIdentity,
+  validate,
   validateBody,
   type DocumentedRouter,
 } from '../app.module';
@@ -123,5 +125,32 @@ export function registerRiskAssessmentRoutes(
     requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
     validateBody(createRiskAssessmentRequestSchema),
     controller.create,
+  );
+
+  doc.get(
+    '/risk-assessments',
+    {
+      summary:
+        'List RiskAssessment rows for a given beneficiaryId + comma-separated visitIds batch ' +
+        '— for a caller (e.g. visit-form-service resolving BR-13’s CCV opening risk state) ' +
+        'that already knows which visits it cares about, since this service does not own ' +
+        'visit_instances/visit_schedules and cannot resolve "which visits" itself.',
+      tags: ['Risk Assessments'],
+      responses: {
+        200: {
+          description: 'RiskAssessment rows matching the given visit ids, most recent first',
+          schema: envelope(z.array(riskAssessmentSchema.omit({ riskFlags: true }))),
+        },
+        400: {
+          description: 'Malformed beneficiaryId/visitIds query param',
+          schema: apiErrorSchema,
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(listRiskAssessmentsQuerySchema, 'query'),
+    controller.listByVisitIds,
   );
 }

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.spec.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.spec.ts
@@ -21,6 +21,7 @@ describe('RiskAssessmentService', () => {
     findConditionIdsByPhase: jest.fn(),
     findEverFlaggedConditionCodes: jest.fn(),
     findConsecutiveNoImprovementCount: jest.fn(),
+    findByVisitIds: jest.fn(),
   } as unknown as jest.Mocked<RiskAssessmentRepository>;
   const beneficiaryClient = {
     getById: jest.fn(),
@@ -167,7 +168,11 @@ describe('RiskAssessmentService', () => {
         ...dto.answers,
         conditionIds: { ANEMIA: 'cond-1' },
         isFirstInstance: { ANEMIA: true },
-        consecutiveNoImprovementCount: { ANEMIA: 0 },
+        // dto.riskPhase is 'ANC' — findConsecutiveNoImprovementCount is only
+        // read by infant-risk.rulesJson.ts's nutrition conditions (NN/INC/CCV
+        // phases), so the query is skipped entirely for ANC and this comes
+        // back empty rather than {ANEMIA: 0}.
+        consecutiveNoImprovementCount: {},
       },
       AUTH_HEADER,
     );
@@ -378,11 +383,16 @@ describe('RiskAssessmentService', () => {
     });
 
     it('resolves consecutiveNoImprovementCount for every condition in dto.riskPhase and merges it into the evaluation input', async () => {
+      // findConsecutiveNoImprovementCount is only read for NN/INC/CCV phases
+      // (infant-risk.rulesJson.ts's nutrition conditions) — override the
+      // shared fixture's default 'ANC' so this test actually exercises that
+      // path instead of the skip branch.
+      const incDto = { ...dto, riskPhase: 'INC' as const };
       repository.findConditionIdsByPhase.mockResolvedValue(new Map([['WASTING', 'cond-wasting']]));
       repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
       repository.findConsecutiveNoImprovementCount.mockResolvedValue(new Map([['WASTING', 3]]));
 
-      await service.create(dto, caller(), AUTH_HEADER);
+      await service.create(incDto, caller(), AUTH_HEADER);
 
       expect(repository.findConsecutiveNoImprovementCount).toHaveBeenCalledWith(dto.beneficiaryId, [
         'WASTING',
@@ -393,6 +403,32 @@ describe('RiskAssessmentService', () => {
         AUTH_HEADER,
       );
     });
+
+    it('skips findConsecutiveNoImprovementCount entirely for a non-infant phase (ANC)', async () => {
+      repository.findConditionIdsByPhase.mockResolvedValue(new Map([['ANEMIA', 'cond-anemia']]));
+      repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
+
+      await service.create({ ...dto, riskPhase: 'ANC' }, caller(), AUTH_HEADER);
+
+      expect(repository.findConsecutiveNoImprovementCount).not.toHaveBeenCalled();
+    });
+
+    it.each([['NN' as const], ['INC' as const], ['CCV' as const]])(
+      'calls findConsecutiveNoImprovementCount for the %s phase',
+      async (riskPhase) => {
+        repository.findConditionIdsByPhase.mockResolvedValue(
+          new Map([['WASTING', 'cond-wasting']]),
+        );
+        repository.findEverFlaggedConditionCodes.mockResolvedValue(new Set());
+
+        await service.create({ ...dto, riskPhase }, caller(), AUTH_HEADER);
+
+        expect(repository.findConsecutiveNoImprovementCount).toHaveBeenCalledWith(
+          dto.beneficiaryId,
+          ['WASTING'],
+        );
+      },
+    );
 
     it('400s when no ACTIVE risk_conditions rows are seeded for dto.riskPhase', async () => {
       repository.findConditionIdsByPhase.mockResolvedValue(new Map());
@@ -412,5 +448,99 @@ describe('RiskAssessmentService', () => {
 
     await expect(service.create(dto, caller(), AUTH_HEADER)).rejects.toBe(evalError);
     expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  describe('listByVisitIds', () => {
+    it('delegates to the repository with the given beneficiaryId and visitIds', async () => {
+      const rows = [{ id: 'ra-1', visitId: 'visit-1' }];
+      repository.findByVisitIds.mockResolvedValue(rows as never);
+
+      const result = await service.listByVisitIds(
+        BENEFICIARY_ID,
+        ['visit-1', 'visit-2'],
+        caller(),
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual(rows);
+      expect(repository.findByVisitIds).toHaveBeenCalledWith(BENEFICIARY_ID, [
+        'visit-1',
+        'visit-2',
+      ]);
+    });
+
+    it('returns an empty array when no assessments match', async () => {
+      repository.findByVisitIds.mockResolvedValue([]);
+
+      const result = await service.listByVisitIds(
+        BENEFICIARY_ID,
+        ['visit-1'],
+        caller(),
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('404s when the beneficiary case does not exist', async () => {
+      beneficiaryClient.getById.mockResolvedValue(null);
+
+      await expect(
+        service.listByVisitIds(BENEFICIARY_ID, ['visit-1'], caller(), AUTH_HEADER),
+      ).rejects.toMatchObject({ status: 404 });
+      expect(repository.findByVisitIds).not.toHaveBeenCalled();
+    });
+
+    it("403s a SAKHI caller reading another beneficiary's risk assessments (IDOR guard)", async () => {
+      beneficiaryClient.getById.mockResolvedValue({
+        id: BENEFICIARY_ID,
+        sakhiId: 'some-other-sakhi',
+      });
+
+      await expect(
+        service.listByVisitIds(
+          BENEFICIARY_ID,
+          ['visit-1'],
+          caller({ roles: ['SAKHI'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findByVisitIds).not.toHaveBeenCalled();
+    });
+
+    it('403s a SUPERVISOR caller whose roster does not include the beneficiary sakhi', async () => {
+      beneficiaryClient.getById.mockResolvedValue({
+        id: BENEFICIARY_ID,
+        sakhiId: 'some-other-sakhi',
+      });
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['a-different-sakhi']);
+
+      await expect(
+        service.listByVisitIds(
+          BENEFICIARY_ID,
+          ['visit-1'],
+          caller({ roles: ['SUPERVISOR'] }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toMatchObject({ status: 403 });
+      expect(repository.findByVisitIds).not.toHaveBeenCalled();
+    });
+
+    it('allows a MANAGER/ADMIN caller unrestricted', async () => {
+      beneficiaryClient.getById.mockResolvedValue({
+        id: BENEFICIARY_ID,
+        sakhiId: 'some-other-sakhi',
+      });
+      repository.findByVisitIds.mockResolvedValue([]);
+
+      await expect(
+        service.listByVisitIds(
+          BENEFICIARY_ID,
+          ['visit-1'],
+          caller({ roles: ['ADMIN'] }),
+          AUTH_HEADER,
+        ),
+      ).resolves.toEqual([]);
+    });
   });
 });

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
@@ -97,13 +97,15 @@ export class RiskAssessmentService {
     // Resolve conditionCode -> risk_condition_id (a rule pack's decision
     // graph output must carry a real DB id, see ruleSet.evaluator.ts's
     // RiskEvaluationResult contract, but the pack itself only knows portable
-    // condition codes), the "only first instance" flagging history, and the
-    // "3 consecutive visits with no improvement" streak (infant nutrition
-    // conditions, Appendix D §2.4) — all merged into `answers` so the rule
-    // pack sees them as ordinary evaluation inputs (see
-    // anc-risk.rulesJson.ts / infant-risk.rulesJson.ts's `conditionIds`/
-    // `isFirstInstance`/`consecutiveNoImprovementCount`).
-    const conditionIdsByCode = await this.repository.findConditionIdsByPhase(dto.riskPhase);
+    // condition codes) and the "only first instance" flagging history
+    // concurrently — findEverFlaggedConditionCodes doesn't depend on
+    // conditionCodes at all, so it need not wait on findConditionIdsByPhase
+    // (see PR #172 review: these were previously sequenced with no
+    // dependency between them).
+    const [conditionIdsByCode, everFlaggedCodes] = await Promise.all([
+      this.repository.findConditionIdsByPhase(dto.riskPhase),
+      this.repository.findEverFlaggedConditionCodes(dto.beneficiaryId),
+    ]);
     if (conditionIdsByCode.size === 0) {
       throw badRequest(
         `No ACTIVE risk_conditions rows are seeded for phase "${dto.riskPhase}" — the rule ` +
@@ -111,10 +113,17 @@ export class RiskAssessmentService {
       );
     }
     const conditionCodes = [...conditionIdsByCode.keys()];
-    const [everFlaggedCodes, consecutiveNoImprovementByCode] = await Promise.all([
-      this.repository.findEverFlaggedConditionCodes(dto.beneficiaryId),
-      this.repository.findConsecutiveNoImprovementCount(dto.beneficiaryId, conditionCodes),
-    ]);
+    // The "3 consecutive visits with no improvement" streak (infant
+    // nutrition conditions, Appendix D §2.4) genuinely needs conditionCodes,
+    // so it can only start once findConditionIdsByPhase resolves. It's also
+    // only read by infant-risk.rulesJson.ts — skip the query entirely for
+    // ANC/REGISTRATION/DELIVERY/PP, whose rule packs never read it (see
+    // PR #172 review: it was previously called unconditionally on every
+    // phase, adding an unused DB round trip per submission).
+    const NO_IMPROVEMENT_PHASES = new Set(['NN', 'INC', 'CCV']);
+    const consecutiveNoImprovementByCode = NO_IMPROVEMENT_PHASES.has(dto.riskPhase)
+      ? await this.repository.findConsecutiveNoImprovementCount(dto.beneficiaryId, conditionCodes)
+      : new Map<string, number>();
     const conditionIds = Object.fromEntries(conditionIdsByCode);
     const isFirstInstance = Object.fromEntries(
       conditionCodes.map((code) => [code, !everFlaggedCodes.has(code)]),
@@ -213,5 +222,49 @@ export class RiskAssessmentService {
     }
 
     return assessment;
+  }
+
+  /**
+   * The RiskAssessment rows for a caller-resolved set of visit ids — used by
+   * visit-form-service's BR-13 (CCV opening risk state) resolver, which
+   * already knows which visit ids are "the last 3 completed INC visits" (it
+   * owns visit_instances/visit_schedules; this service doesn't, no
+   * cross-service join per the forklift rule). An empty `visitIds` returns
+   * an empty array without querying.
+   *
+   * Same IDOR guard as create(): beneficiaryId is caller-supplied, so
+   * without this check any authenticated SAKHI could read another
+   * beneficiary's risk assessments by visit id. Mirrors create()'s
+   * ownership check exactly (SAKHI own-case only, SUPERVISOR own-roster
+   * only, MANAGER/ADMIN unrestricted).
+   */
+  async listByVisitIds(
+    beneficiaryId: string,
+    visitIds: string[],
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ) {
+    const beneficiary = await this.beneficiaryClient.getById(beneficiaryId, authorizationHeader);
+    if (!beneficiary) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (beneficiary.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else if (caller.roles.includes('SUPERVISOR')) {
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
+      const roster = await listSakhiIdsForSupervisor(
+        caller.projectId,
+        caller.id,
+        authorizationHeader,
+      );
+      if (!roster.includes(beneficiary.sakhiId)) {
+        throw forbidden("This beneficiary case is outside this Supervisor's roster.");
+      }
+    }
+
+    return this.repository.findByVisitIds(beneficiaryId, visitIds);
   }
 }

--- a/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.spec.ts
+++ b/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.spec.ts
@@ -38,4 +38,47 @@ describe('listRiskConditionsQuerySchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  const UUID_1 = '11111111-1111-1111-1111-111111111111';
+  const UUID_2 = '22222222-2222-2222-2222-222222222222';
+
+  it('accepts a single riskConditionId', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({ ids: UUID_1 });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a comma-separated batch of riskConditionIds', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({ ids: `${UUID_1},${UUID_2}` });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an ids batch containing a non-uuid segment', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({ ids: `${UUID_1},not-a-uuid` });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an ids batch larger than the max', () => {
+    const ids = Array.from({ length: 101 }, () => UUID_1).join(',');
+    const result = listRiskConditionsQuerySchema.safeParse({ ids });
+    expect(result.success).toBe(false);
+  });
+
+  // Rejecting conditionCode+ids given together is enforced in
+  // riskCondition.controller.ts, not this schema — see the schema's own
+  // comment on why a whole-object .refine() isn't used here (it would break
+  // zod-to-openapi's introspection and crash the service at boot). The
+  // schema itself accepts both being present; it's a valid *shape*, just a
+  // combination the controller chooses to reject as ambiguous.
+  it('accepts conditionCode and ids given together at the schema level (rejection is a controller-level concern)', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({
+      conditionCode: 'HYPERTENSION_HIGH_BP',
+      ids: UUID_1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts neither conditionCode nor ids (requests all active conditions)', () => {
+    const result = listRiskConditionsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
 });

--- a/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.ts
+++ b/apps/risk-referral-service/src/risk-conditions/dto/list-risk-conditions.dto.ts
@@ -4,14 +4,20 @@ import { z } from 'zod';
 export const MAX_BATCH_CONDITION_CODES = 100;
 
 /**
- * Query schema for `GET /risk-conditions?conditionCode=...` — a comma
- * separated batch of condition codes to resolve to riskConditionIds in one
- * round trip. `conditionCode` is optional: omitting it entirely requests
- * every ACTIVE risk condition (a master-data download), rather than a
- * code-filtered batch lookup. Kept as a plain string + `.refine()` (not
+ * Query schema for `GET /risk-conditions?conditionCode=...` or
+ * `?ids=...` — each a comma separated batch (of condition codes, or
+ * riskConditionIds respectively) resolved to full rows in one round trip.
+ * Exactly one of `conditionCode`/`ids` may be given (or neither, requesting
+ * every ACTIVE risk condition — a master-data download); giving both is
+ * rejected as ambiguous — enforced in riskCondition.controller.ts, NOT here
+ * via a top-level `.refine()` on the whole object, which would wrap the
+ * schema in `ZodEffects<ZodObject>` — zod-to-openapi cannot introspect that
+ * shape and crashes OpenAPI doc generation at startup (same class of issue
+ * as get-master-data-deltas.dto.ts's own note; a `.refine()` on an
+ * individual field's `ZodOptional<ZodString>`, as done below, is fine — only
+ * a whole-object wrap breaks it). Kept as plain strings + `.refine()` (not
  * `z.coerce.*`), matching list-call-sheet-stats-batch.dto.ts's own note on
- * why — zod-to-openapi cannot introspect a `ZodEffects`-wrapped transform
- * and crashes OpenAPI doc generation at startup.
+ * why.
  */
 export const listRiskConditionsQuerySchema = z
   .object({
@@ -22,6 +28,26 @@ export const listRiskConditionsQuerySchema = z
       .refine((v) => v.split(',').length <= MAX_BATCH_CONDITION_CODES, {
         message: `conditionCode: must be a comma-separated list of at most ${MAX_BATCH_CONDITION_CODES} codes`,
       })
+      .optional(),
+    // riskConditionId batch — used by other services (e.g. beneficiary-service
+    // resolving BeneficiaryRiskConditionSummary.riskConditionId to a display
+    // name) that hold the id, not the stable conditionCode.
+    ids: z
+      .string()
+      .trim()
+      .min(1)
+      .refine(
+        (v) => {
+          const parts = v.split(',');
+          return (
+            parts.length <= MAX_BATCH_CONDITION_CODES &&
+            parts.every((p) => z.string().uuid().safeParse(p).success)
+          );
+        },
+        {
+          message: `ids: must be a comma-separated list of at most ${MAX_BATCH_CONDITION_CODES} uuids`,
+        },
+      )
       .optional(),
   })
   .strict();

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.spec.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.spec.ts
@@ -1,0 +1,70 @@
+import { createRiskConditionController } from './riskCondition.controller';
+import type { RiskConditionService } from './riskCondition.service';
+
+function mockRes() {
+  return { json: jest.fn() } as unknown as import('express').Response;
+}
+
+describe('createRiskConditionController', () => {
+  const service = {
+    listByConditionCodes: jest.fn(),
+    listByIds: jest.fn(),
+  } as unknown as jest.Mocked<RiskConditionService>;
+  let controller: ReturnType<typeof createRiskConditionController>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    controller = createRiskConditionController(service);
+  });
+
+  it('rejects a request with both ids and conditionCode as 400', async () => {
+    const req = {
+      query: { ids: 'rc-1', conditionCode: 'HYPERTENSION_HIGH_BP' },
+    } as unknown as import('express').Request;
+    const next = jest.fn();
+
+    controller.list(req, mockRes(), next);
+    await new Promise(process.nextTick);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+    expect(service.listByIds).not.toHaveBeenCalled();
+    expect(service.listByConditionCodes).not.toHaveBeenCalled();
+  });
+
+  it('resolves by ids when only ids is given', async () => {
+    service.listByIds.mockResolvedValue([]);
+    const req = { query: { ids: 'rc-1,rc-2' } } as unknown as import('express').Request;
+    const res = mockRes();
+
+    controller.list(req, res, jest.fn());
+    await new Promise(process.nextTick);
+
+    expect(service.listByIds).toHaveBeenCalledWith(['rc-1', 'rc-2']);
+    expect(service.listByConditionCodes).not.toHaveBeenCalled();
+  });
+
+  it('resolves by conditionCode when only conditionCode is given', async () => {
+    service.listByConditionCodes.mockResolvedValue([]);
+    const req = {
+      query: { conditionCode: 'HYPERTENSION_HIGH_BP' },
+    } as unknown as import('express').Request;
+    const res = mockRes();
+
+    controller.list(req, res, jest.fn());
+    await new Promise(process.nextTick);
+
+    expect(service.listByConditionCodes).toHaveBeenCalledWith(['HYPERTENSION_HIGH_BP']);
+    expect(service.listByIds).not.toHaveBeenCalled();
+  });
+
+  it('returns every active condition when neither is given', async () => {
+    service.listByConditionCodes.mockResolvedValue([]);
+    const req = { query: {} } as unknown as import('express').Request;
+    const res = mockRes();
+
+    controller.list(req, res, jest.fn());
+    await new Promise(process.nextTick);
+
+    expect(service.listByConditionCodes).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.spec.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.spec.ts
@@ -1,3 +1,12 @@
+/**
+ * riskCondition.controller.ts imports from ../app.module, which imports
+ * ./config/app-config, which calls process.exit(1) at module-load time if
+ * DATABASE_URL isn't a valid URL — so it must be set before the module
+ * under test is required (see reporting-etl-service's info.controller.spec.ts
+ * for the same workaround).
+ */
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/test';
+
 import { createRiskConditionController } from './riskCondition.controller';
 import type { RiskConditionService } from './riskCondition.service';
 

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.controller.ts
@@ -1,4 +1,4 @@
-import { asyncHandler, ok } from '../app.module';
+import { asyncHandler, badRequest, ok } from '../app.module';
 import type { RiskConditionService } from './riskCondition.service';
 
 /**
@@ -7,13 +7,21 @@ import type { RiskConditionService } from './riskCondition.service';
  */
 export function createRiskConditionController(service: RiskConditionService) {
   return {
-    listByConditionCodes: asyncHandler(async (req, res) => {
+    list: asyncHandler(async (req, res) => {
+      if (req.query.ids && req.query.conditionCode) {
+        throw badRequest('Provide either conditionCode or ids, not both.');
+      }
+
+      const ids = typeof req.query.ids === 'string' ? req.query.ids.split(',') : undefined;
+      if (ids) {
+        res.json(ok(await service.listByIds(ids)));
+        return;
+      }
       const codes =
         typeof req.query.conditionCode === 'string'
           ? req.query.conditionCode.split(',').map((c) => c.trim())
           : undefined;
-      const found = await service.listByConditionCodes(codes);
-      res.json(ok(found));
+      res.json(ok(await service.listByConditionCodes(codes)));
     }),
   };
 }

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.repository.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.repository.ts
@@ -31,4 +31,12 @@ export class RiskConditionRepository {
       select: MASTER_ROW_SELECT,
     });
   }
+
+  /** Active, non-deleted RiskCondition rows matching any of the given ids. */
+  findByIds(ids: string[]) {
+    return this.prisma.riskCondition.findMany({
+      where: { id: { in: ids }, status: 'ACTIVE', isDeleted: false },
+      select: MASTER_ROW_SELECT,
+    });
+  }
 }

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.routes.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.routes.ts
@@ -44,10 +44,11 @@ export function registerRiskConditionRoutes(doc: DocumentedRouter, service: Risk
     '/risk-conditions',
     {
       summary:
-        'List risk conditions. With conditionCode, resolves a comma-separated batch of ' +
-        'condition codes to their full rows (codes with no matching ACTIVE row are omitted ' +
-        'from the response rather than failing the whole batch). Without conditionCode, ' +
-        'returns every ACTIVE risk condition — the master-data download.',
+        'List risk conditions. With conditionCode OR ids (not both — 400 if both given), ' +
+        'resolves a comma-separated batch of condition codes or riskConditionIds to their ' +
+        'full rows (entries with no matching ACTIVE row are omitted from the response rather ' +
+        'than failing the whole batch). With neither, returns every ACTIVE risk condition — ' +
+        'the master-data download.',
       tags: ['Risk Conditions'],
       responses: {
         200: {
@@ -56,12 +57,15 @@ export function registerRiskConditionRoutes(doc: DocumentedRouter, service: Risk
             'resolved subset matching the requested codes',
           schema: envelope(z.array(riskConditionSchema)),
         },
-        400: { description: 'Malformed conditionCode query param', schema: apiErrorSchema },
+        400: {
+          description: 'Malformed conditionCode/ids query param, or both given together',
+          schema: apiErrorSchema,
+        },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
       },
     },
     trustGatewayIdentity,
     validate(listRiskConditionsQuerySchema, 'query'),
-    controller.listByConditionCodes,
+    controller.list,
   );
 }

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.routes.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.routes.ts
@@ -14,6 +14,16 @@ const riskConditionSchema = z.object({
   entityType: z.enum(['MOTHER', 'CHILD']),
   phase: z.enum(['REGISTRATION', 'ANC', 'DELIVERY', 'PP', 'NN', 'INC', 'CCV']),
   gradeScale: z.enum(['BINARY', 'NORMAL_MILD_MODERATE_SEVERE', 'NORMAL_LOW_MEDIUM_HIGH']),
+  // Reference/display-only master data (e.g. for an admin condition-catalog
+  // screen) — NOT read by the grading rule packs (anc-risk.rulesJson.ts /
+  // infant-risk.rulesJson.ts) at evaluation time. A condition's actual
+  // referral/education trigger is grade-, first-instance-, and
+  // accompanied-by-condition-dependent (e.g. Anemia only refers on
+  // MODERATE/SEVERE, not MILD; Hypotension only refers when accompanied by
+  // another flagged condition) — logic a single static per-condition
+  // boolean cannot correctly express. Changing this field does NOT change
+  // grading behavior; the rule pack itself is the only source of truth for
+  // that (see PR #172 review).
   referralRequiredDefault: z.boolean(),
   educationRequiredDefault: z.boolean(),
   status: z.enum(['ACTIVE', 'INACTIVE']),

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.service.spec.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.service.spec.ts
@@ -20,6 +20,7 @@ describe('RiskConditionService', () => {
   const repository = {
     findByConditionCodes: jest.fn(),
     findAllActive: jest.fn(),
+    findByIds: jest.fn(),
   } as unknown as jest.Mocked<RiskConditionRepository>;
   let service: RiskConditionService;
 
@@ -80,6 +81,34 @@ describe('RiskConditionService', () => {
       expect(result).toEqual(rows);
       expect(repository.findAllActive).toHaveBeenCalledWith();
       expect(repository.findByConditionCodes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listByIds', () => {
+    it('returns the full row for each resolved id', async () => {
+      const rows = [buildRow({ id: 'rc-1' }), buildRow({ id: 'rc-2' })];
+      repository.findByIds.mockResolvedValue(rows as never);
+
+      const result = await service.listByIds(['rc-1', 'rc-2']);
+
+      expect(result).toEqual(rows);
+      expect(repository.findByIds).toHaveBeenCalledWith(['rc-1', 'rc-2']);
+    });
+
+    it('omits ids the repository did not resolve, without throwing', async () => {
+      const rows = [buildRow({ id: 'rc-1' })];
+      repository.findByIds.mockResolvedValue(rows as never);
+
+      const result = await service.listByIds(['rc-1', 'rc-unseeded']);
+
+      expect(result).toEqual(rows);
+    });
+
+    it('short-circuits to an empty array without querying when given no ids', async () => {
+      const result = await service.listByIds([]);
+
+      expect(result).toEqual([]);
+      expect(repository.findByIds).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/risk-referral-service/src/risk-conditions/riskCondition.service.ts
+++ b/apps/risk-referral-service/src/risk-conditions/riskCondition.service.ts
@@ -28,4 +28,15 @@ export class RiskConditionService {
       ? this.repository.findByConditionCodes(conditionCodes)
       : this.repository.findAllActive();
   }
+
+  /**
+   * With `ids` given, resolves each riskConditionId to its full row — ids
+   * with no matching ACTIVE row are silently omitted (same "unresolved
+   * entries are skipped, not fatal" contract as listByConditionCodes). An
+   * empty array short-circuits to an empty result without querying.
+   */
+  async listByIds(ids: string[]) {
+    if (ids.length === 0) return [];
+    return this.repository.findByIds(ids);
+  }
 }

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
@@ -29,15 +29,21 @@ const CONDITION_IDS = {
 
 // Real ANC_VISIT question codes (see
 // apps/visit-form-service/prisma/seed-data/anc-visit.json), plus `age` and
-// `badObstetricHistoryFlag`, which form.service.ts merges in from the
-// beneficiary's MOTHER_REGISTRATION submission.
+// the raw gravida/livingChildren/abortions/priorComplications fields, which
+// form.service.ts merges in from the beneficiary's MOTHER_REGISTRATION
+// submission — the Bad Obstetric History threshold (G>4/L<P/abortions>=2/
+// prior complications) is computed inside this rule pack, not by the
+// caller (see PR #172 review: business thresholds live in GoRules).
 const NORMAL_VITALS = {
   conditionIds: CONDITION_IDS,
   age: 25,
   mid_upper_arm_circumference_in_cm: 24,
   bmi: 22,
   height_of_the_woman_in_cm: 155,
-  badObstetricHistoryFlag: false,
+  gravida: 2,
+  livingChildren: 2,
+  abortions: 0,
+  priorComplications: ['no_complications'],
   haemoglobin_hb_g_dl: 12,
   blood_pressure_bp_systolic: 110,
   blood_pressure_bp_diastolic: 70,
@@ -181,6 +187,23 @@ describe('ancRiskRulesJson', () => {
     expect(hypo.isHrVisitTrigger).toBe(false);
   });
 
+  it('does not trigger Hypotension/Hypoglycemia off each other when only the two co-occur — sibling accompanied-by gates are excluded (PR #172 review)', async () => {
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      blood_pressure_bp_systolic: 85,
+      blood_glucose_in_mg_dl: 60,
+    });
+
+    const hypotension = findCondition(result, CONDITION_IDS.HYPOTENSION);
+    const hypoglycemia = findCondition(result, CONDITION_IDS.HYPOGLYCEMIA);
+    expect(hypotension.grade).toBe('MILD');
+    expect(hypoglycemia.grade).toBe('MILD');
+    expect(hypotension.isReferralTrigger).toBe(false);
+    expect(hypotension.isHrVisitTrigger).toBe(false);
+    expect(hypoglycemia.isReferralTrigger).toBe(false);
+    expect(hypoglycemia.isHrVisitTrigger).toBe(false);
+  });
+
   it('grades Hyperthermia MILD and triggers every instance; Hypothermia MILD alone does not trigger', async () => {
     const hyper = await evaluateRulePack(ancRiskRulesJson, {
       ...NORMAL_VITALS,
@@ -269,7 +292,7 @@ describe('ancRiskRulesJson', () => {
       ...NORMAL_VITALS,
       height_of_the_woman_in_cm: 140,
       age: 40,
-      badObstetricHistoryFlag: true,
+      gravida: 5,
       isFirstInstance: { STUNTING: false, AGE: false, BAD_OBSTETRIC_HISTORY: false },
     });
 
@@ -279,6 +302,53 @@ describe('ancRiskRulesJson', () => {
     expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).isReferralTrigger).toBe(
       false,
     );
+  });
+
+  describe('Bad Obstetric History threshold (moved into GoRules — PR #172 review)', () => {
+    it('grades NORMAL when none of the threshold conditions are met', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, NORMAL_VITALS);
+      expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).grade).toBe('NORMAL');
+    });
+
+    it('grades MILD when gravida exceeds 4', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, { ...NORMAL_VITALS, gravida: 5 });
+      expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).grade).toBe('MILD');
+    });
+
+    it('grades MILD when livingChildren is less than gravida', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        gravida: 3,
+        livingChildren: 1,
+      });
+      expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).grade).toBe('MILD');
+    });
+
+    it('grades MILD when abortions >= 2', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, { ...NORMAL_VITALS, abortions: 2 });
+      expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).grade).toBe('MILD');
+    });
+
+    it('grades MILD when a non-"no_complications" answer is present', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        priorComplications: ['yes_miscarriage'],
+      });
+      expect(findCondition(result, CONDITION_IDS.BAD_OBSTETRIC_HISTORY).grade).toBe('MILD');
+    });
+
+    it('is not graded at all when no registration-derived field is present', async () => {
+      const rest = { ...NORMAL_VITALS };
+      delete (rest as Partial<typeof NORMAL_VITALS>).gravida;
+      delete (rest as Partial<typeof NORMAL_VITALS>).livingChildren;
+      delete (rest as Partial<typeof NORMAL_VITALS>).abortions;
+      delete (rest as Partial<typeof NORMAL_VITALS>).priorComplications;
+
+      const result = await evaluateRulePack(ancRiskRulesJson, rest);
+      expect(
+        result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.BAD_OBSTETRIC_HISTORY),
+      ).toBe(false);
+    });
   });
 
   it('Gestational Weight Gain: referral gated by first-instance, HR visit trigger fires every instance (pre-graded radio value)', async () => {

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
@@ -19,12 +19,15 @@
  * MOTHER_REGISTRATION question_codes (see
  * apps/visit-form-service/prisma/seed-data/anc-visit.json and
  * mother-registration.json) — the caller passes dto.formData through
- * largely unchanged (plus the registration-derived age/
- * badObstetricHistoryFlag merge, see form.service.ts's
+ * largely unchanged (plus the registration-derived age/gravida/
+ * livingChildren/abortions/priorComplications merge, see form.service.ts's
  * resolveAncRiskRegistrationAnswers), rather than this pack expecting a
  * separately-named/normalized field set. This intentionally couples the
  * pack to the form's current field names; a form schema change to any of
- * the fields read below requires updating this pack in lockstep.
+ * the fields read below requires updating this pack in lockstep. The Bad
+ * Obstetric History threshold itself (G>4/L<P/abortions>=2/prior
+ * complications) is computed inside this pack, not by the caller — business
+ * thresholds live in GoRules per .claude/CLAUDE.md.
  *
  * Per Appendix D §D.7, every condition is graded and returned every visit,
  * including NORMAL results — this pack never omits a condition from its
@@ -63,6 +66,13 @@
  * via form.service.ts) is responsible for fetching and merging those
  * registration-time answers into this pack's input alongside the current
  * visit's own answers.
+ *
+ * This pack deliberately does NOT read risk_conditions.referralRequiredDefault
+ * /educationRequiredDefault — those are reference/display-only master data
+ * (see schema.prisma's RiskCondition doc comment); the referral/HR-visit/
+ * education trigger logic per condition below (grade-dependent,
+ * first-instance-gated, accompanied-by-gated) is this pack's own sole
+ * source of truth (see PR #172 review).
  */
 export const ancRiskRulesJson = {
   contentType: 'application/vnd.gorules.decision',
@@ -106,9 +116,7 @@ const handler = (input) => {
       gradeRank: GRADE_RANK[grade],
       isReferralTrigger: gateByFirstInstance ? referralEligible && isFirst : referralEligible,
       isEducationTrigger: grade !== 'NORMAL',
-      isHrVisitTrigger: opts.hrGateByFirstInstance
-        ? hrEligible && isFirst
-        : hrEligible,
+      isHrVisitTrigger: hrEligible,
       observedValueJson,
     });
   }
@@ -158,11 +166,36 @@ const handler = (input) => {
   }
 
   // --- Bad Obstetric History (only first instance) ---
-  // Merged in by form.service.ts, derived from MOTHER_REGISTRATION answers
-  // (gravida/livingChildren/abortions/prior complications).
-  if (typeof input.badObstetricHistoryFlag === 'boolean') {
-    const grade = input.badObstetricHistoryFlag ? 'MILD' : 'NORMAL';
-    record('BAD_OBSTETRIC_HISTORY', grade, { badObstetricHistoryFlag: input.badObstetricHistoryFlag }, {
+  // Raw fields (gravida/livingChildren/abortions/priorComplications) are
+  // merged in by form.service.ts from MOTHER_REGISTRATION answers, read
+  // unchanged — the G>4/L<P/abortions>=2/prior-complications threshold
+  // itself is business-threshold math and belongs here (GoRules), not in
+  // TypeScript (see .claude/CLAUDE.md's "business thresholds/rates ... live
+  // in GoRules" rule; PR #172 review). Only gravida/livingChildren/abortions
+  // and priorComplications need be present for this condition to be graded
+  // at all — matches resolveAncRiskRegistrationAnswers's "no registration
+  // submission yet" skip, now expressed per-field instead of via one
+  // pre-derived flag.
+  const gravida = input.gravida;
+  const livingChildren = input.livingChildren;
+  const abortions = input.abortions;
+  const priorComplications = input.priorComplications;
+  if (
+    typeof gravida === 'number' ||
+    typeof abortions === 'number' ||
+    Array.isArray(priorComplications)
+  ) {
+    const badObstetricHistoryFlag =
+      (typeof gravida === 'number' && gravida > 4) ||
+      (typeof gravida === 'number' &&
+        typeof livingChildren === 'number' &&
+        livingChildren < gravida) ||
+      (typeof abortions === 'number' && abortions >= 2) ||
+      (Array.isArray(priorComplications) &&
+        priorComplications.some((code) => code !== 'no_complications'));
+
+    const grade = badObstetricHistoryFlag ? 'MILD' : 'NORMAL';
+    record('BAD_OBSTETRIC_HISTORY', grade, { badObstetricHistoryFlag }, {
       onlyFirstInstance: true,
       referralTrigger: grade !== 'NORMAL',
       hrVisitTrigger: grade !== 'NORMAL',
@@ -312,7 +345,6 @@ const handler = (input) => {
     record('GESTATIONAL_WEIGHT_GAIN', grade, { weightGainStatus }, {
       onlyFirstInstance: true,
       referralTrigger: grade !== 'NORMAL',
-      hrGateByFirstInstance: false,
       hrVisitTrigger: grade !== 'NORMAL',
     });
   }
@@ -362,11 +394,20 @@ const handler = (input) => {
   const nonNormalCodes = new Set(
     results.filter((r) => r.grade !== 'NORMAL').map((r) => r.riskConditionId),
   );
+  const accompaniedGateIds = new Set(
+    ['HYPOTENSION', 'HYPOGLYCEMIA', 'HYPOTHERMIA'].map((code) => conditionIds[code]),
+  );
   function patchAccompaniedTrigger(code, ownFlagged) {
     if (!ownFlagged) return;
     const entry = results.find((r) => r.riskConditionId === conditionIds[code]);
     if (!entry) return;
-    const otherNonNormalExists = [...nonNormalCodes].some((id) => id !== entry.riskConditionId);
+    // Excludes both the gate's own condition and the sibling gates
+    // (HYPOTENSION/HYPOGLYCEMIA/HYPOTHERMIA) — two accompanied-only
+    // conditions co-occurring with nothing else are not "accompanied by"
+    // each other's un-triggered state (see this pack's doc comment above).
+    const otherNonNormalExists = [...nonNormalCodes].some(
+      (id) => id !== entry.riskConditionId && !accompaniedGateIds.has(id),
+    );
     entry.isReferralTrigger = otherNonNormalExists;
     entry.isHrVisitTrigger = otherNonNormalExists;
   }

--- a/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.spec.ts
@@ -256,6 +256,32 @@ describe('infantRiskRulesJson', () => {
     expect(findCondition(result, CONDITION_IDS.INFANT_HYPERTHERMIA).grade).toBe('NORMAL');
   });
 
+  it(
+    'gates Hypothermia/Hyperthermia HR-visit trigger by first-instance — a neonate hypothermic ' +
+      'across two visits fires the 15-day HR follow-up once, not on every visit (PR #172 review)',
+    async () => {
+      const cold = await evaluateRulePack(infantRiskRulesJson, {
+        ...NORMAL_VITALS_INFANT,
+        child_temprature_in_f: 95,
+        isFirstInstance: { INFANT_HYPOTHERMIA: false, INFANT_HYPERTHERMIA: false },
+      });
+      const hypo = findCondition(cold, CONDITION_IDS.INFANT_HYPOTHERMIA);
+      expect(hypo.grade).toBe('SEVERE');
+      expect(hypo.isReferralTrigger).toBe(true);
+      expect(hypo.isHrVisitTrigger).toBe(false);
+
+      const hot = await evaluateRulePack(infantRiskRulesJson, {
+        ...NORMAL_VITALS_INFANT,
+        child_temprature_in_f: 101,
+        isFirstInstance: { INFANT_HYPOTHERMIA: false, INFANT_HYPERTHERMIA: false },
+      });
+      const hyper = findCondition(hot, CONDITION_IDS.INFANT_HYPERTHERMIA);
+      expect(hyper.grade).toBe('SEVERE');
+      expect(hyper.isReferralTrigger).toBe(true);
+      expect(hyper.isHrVisitTrigger).toBe(false);
+    },
+  );
+
   it('grades Cord infection MILD from umbilical_cord_care, triggers referral but not HR visit (undocumented in source sheet)', async () => {
     const result = await evaluateRulePack(infantRiskRulesJson, {
       ...NORMAL_VITALS_NEONATAL,
@@ -316,6 +342,21 @@ describe('infantRiskRulesJson', () => {
     expect(dangerRows[0].grade).toBe('MILD');
     expect(dangerRows[0].isReferralTrigger).toBe(true);
     expect(dangerRows[0].isHrVisitTrigger).toBe(true);
+  });
+
+  it('gates Danger Signs HR-visit trigger by first-instance (PR #172 review)', async () => {
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      is_the_baby_showing_any_danger_signs_since_last_visit: [
+        'convulsions_twitching_fits_or_abnormal_movements',
+      ],
+      isFirstInstance: { INFANT_DANGER_SIGNS: false },
+    });
+
+    const danger = findCondition(result, CONDITION_IDS.INFANT_DANGER_SIGNS);
+    expect(danger.grade).toBe('MILD');
+    expect(danger.isReferralTrigger).toBe(true);
+    expect(danger.isHrVisitTrigger).toBe(false);
   });
 
   it('grades any Danger Sign present (NEONATAL_VISIT field) as MILD', async () => {

--- a/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.ts
@@ -12,10 +12,16 @@
  * Same input contract as anc-risk.rulesJson.ts: `conditionIds`
  * (conditionCode -> risk_condition_id) and `isFirstInstance`
  * (conditionCode -> boolean) are resolved by the caller and merged into the
- * evaluation input. `consecutiveNoImprovementCount` (conditionCode ->
- * count) is also caller-resolved, for the nutrition conditions' "3
- * consecutive visits with no improvement" referral rule (Appendix D §2.4)
- * — this pack has no DB access of its own for any of the three.
+ * evaluation input. `isFirstInstance` gates two distinct things here: the
+ * nutrition conditions' referral trigger (via nutritionReferralTrigger) and,
+ * separately, Hypothermia/Hyperthermia/Danger Signs' HR-visit trigger (via
+ * record()'s hrGateByFirstInstance option — Appendix D's "single instance"
+ * HR-visit cadence for these three, vs. "every instance till normal" for
+ * the nutrition conditions; PR #172 review). `consecutiveNoImprovementCount`
+ * (conditionCode -> count) is also caller-resolved, for the nutrition
+ * conditions' "3 consecutive visits with no improvement" referral rule
+ * (Appendix D §2.4) — this pack has no DB access of its own for any of the
+ * three.
  *
  * All other input fields are read directly under their real
  * NEONATAL_VISIT/INFANT_VISIT (INC_VISIT/CCV_VISIT) question_codes — see
@@ -56,6 +62,13 @@
  *     — every condition here only has Normal/Mild/Severe branches (Anemia/
  *     Hypertension in the ANC pack are the only conditions with a true
  *     Moderate band across both sheets).
+ *
+ * This pack deliberately does NOT read risk_conditions.referralRequiredDefault
+ * /educationRequiredDefault — those are reference/display-only master data
+ * (see schema.prisma's RiskCondition doc comment); the referral/HR-visit/
+ * education trigger logic per condition below (grade-dependent,
+ * first-instance-gated, no-improvement-streak-gated) is this pack's own
+ * sole source of truth (see PR #172 review).
  */
 export const infantRiskRulesJson = {
   contentType: 'application/vnd.gorules.decision',
@@ -85,15 +98,23 @@ const handler = (input) => {
     return id;
   }
 
+  // hrGateByFirstInstance: for Hypothermia/Hyperthermia/Danger Signs, whose
+  // HR-visit trigger is "single instance" per Appendix D Part 2 (unlike the
+  // nutrition conditions above them, which HR-visit-trigger every instance
+  // till normal) — see PR #172 review. isFirst defaults to true when the
+  // caller's isFirstInstance map has no entry for this code, matching
+  // anc-risk.rulesJson.ts's same default-true convention.
   function record(code, grade, observedValueJson, opts) {
     opts = opts || {};
+    const isFirst = firstInstance[code] !== false;
+    const hrEligible = opts.hrVisitTrigger === true;
     results.push({
       riskConditionId: requireConditionId(code),
       grade,
       gradeRank: GRADE_RANK[grade],
       isReferralTrigger: opts.referralTrigger === true,
       isEducationTrigger: grade !== 'NORMAL',
-      isHrVisitTrigger: opts.hrVisitTrigger === true,
+      isHrVisitTrigger: opts.hrGateByFirstInstance ? hrEligible && isFirst : hrEligible,
       observedValueJson,
     });
   }
@@ -147,18 +168,23 @@ const handler = (input) => {
   }
 
   // --- Hypothermia / Hyperthermia (INFANT_VISIT/INC_VISIT/CCV_VISIT only -
-  // no temperature field on NEONATAL_VISIT). See doc-comment default #1. ---
+  // no temperature field on NEONATAL_VISIT). See doc-comment default #1.
+  // HR-visit trigger is single-instance per Appendix D Part 2 (PR #172
+  // review) - a neonate hypothermic across visits 1 and 2 fires the 15-day
+  // HR follow-up only once, on first instance, not stacked every visit. ---
   const bodyTempF = input.child_temprature_in_f;
   if (typeof bodyTempF === 'number') {
     const hypoGrade = bodyTempF < 96 ? 'SEVERE' : 'NORMAL';
     record('INFANT_HYPOTHERMIA', hypoGrade, { bodyTempF }, {
       referralTrigger: hypoGrade !== 'NORMAL',
+      hrGateByFirstInstance: true,
       hrVisitTrigger: hypoGrade !== 'NORMAL',
     });
 
     const hyperGrade = bodyTempF > 100 ? 'SEVERE' : 'NORMAL';
     record('INFANT_HYPERTHERMIA', hyperGrade, { bodyTempF }, {
       referralTrigger: hyperGrade !== 'NORMAL',
+      hrGateByFirstInstance: true,
       hrVisitTrigger: hyperGrade !== 'NORMAL',
     });
   }
@@ -199,7 +225,9 @@ const handler = (input) => {
   }
 
   // --- Danger Signs (single condition row, any sign present). Each form
-  // has its own question_code and its own "no signs" sentinel value. ---
+  // has its own question_code and its own "no signs" sentinel value.
+  // HR-visit trigger is single-instance per Appendix D Part 2 (PR #172
+  // review), same reasoning as Hypothermia/Hyperthermia above. ---
   const nnDangerSigns = Array.isArray(input.danger_signs) ? input.danger_signs : null;
   const infantDangerSigns = Array.isArray(input.is_the_baby_showing_any_danger_signs_since_last_visit)
     ? input.is_the_baby_showing_any_danger_signs_since_last_visit
@@ -210,6 +238,7 @@ const handler = (input) => {
     const grade = dangerSignsPresent.length > 0 ? 'MILD' : 'NORMAL';
     record('INFANT_DANGER_SIGNS', grade, { dangerSigns: dangerSignsPresent }, {
       referralTrigger: grade !== 'NORMAL',
+      hrGateByFirstInstance: true,
       hrVisitTrigger: grade !== 'NORMAL',
     });
   }

--- a/apps/visit-form-service/.env.example
+++ b/apps/visit-form-service/.env.example
@@ -12,3 +12,8 @@ PUBLIC_BASE_URLS=
 # endpoint (resolving a Sakhi's geography chain for active-version). Defaults
 # to http://localhost:3000 if unset.
 AUTH_SERVICE_BASE_URL=
+# rules-service's seeded "Arogya Sakhi CCV Visit Scheduling" RuleSet id —
+# needed to compute BR-13's ccvOpeningRiskState at the INC->CCV transition.
+# Optional: that computation is skipped (not failed) when unset. Look it up
+# via GET /api/v1/rules (ADMIN role) and match ruleSetName.
+CCV_SCHEDULE_RULE_SET_ID=

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -471,7 +471,34 @@ describe('infant-visit.json', () => {
     });
   });
 
-  it('gates every Q5+ field behind met-beneficiary=yes', () => {
+  const VACCINE_DATE_PAIRS: [string, string][] = [
+    ['bcg', 'bcg_date'],
+    ['opv_0', 'opv_0_date'],
+    ['hepatitis_b_birth_dose', 'hepatitis_b_date_birth_dose'],
+    ['vitamin_k', 'vitamin_k_date'],
+    ['opv_1', 'opv_1_date'],
+    ['pentavalent_1_dpt1', 'pentavalent_1_dpt1_date'],
+    ['ipv_1', 'ipv_1_date'],
+    ['rotavirus1', 'rotavirus1_date'],
+    ['pcv1', 'pcv1_date'],
+    ['opv_2', 'opv_2_date'],
+    ['pentavalent_2_dpt2', 'pentavalent_2_dpt2_date'],
+    ['rotavirus2', 'rotavirus2_date'],
+    ['opv_3', 'opv_3_date'],
+    ['pentavalent_3_dpt3', 'pentavalent_3_dpt3_date'],
+    ['ipv2', 'ipv2_date'],
+    ['rotavirus3', 'rotavirus3_date'],
+    ['pcv2', 'pcv2_date'],
+    ['mmr_1_mr1', 'mmr_1_mr1_date'],
+    ['pcv_booster', 'pcv_booster_date'],
+    ['vitamin_a', 'vitamin_a_date'],
+    ['opv_booster', 'opv_booster_date'],
+    ['mmr2_mr2', 'mmr2_mr2_date'],
+    ['dpt_booster1', 'dpt_booster1_date'],
+  ];
+
+  it('gates every Q5+ field behind met-beneficiary=yes, except each vaccine date field which is gated behind its own vaccine answer', () => {
+    const vaccineDateCodes = new Set(VACCINE_DATE_PAIRS.map(([, dateCode]) => dateCode));
     for (const field of fields) {
       if (
         [
@@ -479,7 +506,8 @@ describe('infant-visit.json', () => {
           'visit_type',
           'have_you_been_able_to_meet_the_beneficiary_for_the_visit',
           'if_no_mention_reasons',
-        ].includes(field.question_code)
+        ].includes(field.question_code) ||
+        vaccineDateCodes.has(field.question_code)
       ) {
         continue;
       }
@@ -487,36 +515,19 @@ describe('infant-visit.json', () => {
     }
   });
 
-  it('has every vaccine date field present, gated behind met-beneficiary=yes', () => {
-    const vaccinePairs: [string, string][] = [
-      ['bcg', 'bcg_date'],
-      ['opv_0', 'opv_0_date'],
-      ['hepatitis_b_birth_dose', 'hepatitis_b_date_birth_dose'],
-      ['vitamin_k', 'vitamin_k_date'],
-      ['opv_1', 'opv_1_date'],
-      ['pentavalent_1_dpt1', 'pentavalent_1_dpt1_date'],
-      ['ipv_1', 'ipv_1_date'],
-      ['rotavirus1', 'rotavirus1_date'],
-      ['pcv1', 'pcv1_date'],
-      ['opv_2', 'opv_2_date'],
-      ['pentavalent_2_dpt2', 'pentavalent_2_dpt2_date'],
-      ['rotavirus2', 'rotavirus2_date'],
-      ['opv_3', 'opv_3_date'],
-      ['pentavalent_3_dpt3', 'pentavalent_3_dpt3_date'],
-      ['ipv2', 'ipv2_date'],
-      ['rotavirus3', 'rotavirus3_date'],
-      ['pcv2', 'pcv2_date'],
-      ['mmr_1_mr1', 'mmr_1_mr1_date'],
-      ['pcv_booster', 'pcv_booster_date'],
-      ['vitamin_a', 'vitamin_a_date'],
-      ['opv_booster', 'opv_booster_date'],
-      ['mmr2_mr2', 'mmr2_mr2_date'],
-      ['dpt_booster1', 'dpt_booster1_date'],
-    ];
-
-    for (const [vaccineCode, dateCode] of vaccinePairs) {
+  it('shows each vaccine date field only when its own preceding Yes/No answer is yes, not merely when the beneficiary was met', () => {
+    // The outer met-beneficiary gate is still enforced transitively: the
+    // vaccine radio field itself is gated behind met-beneficiary=yes, and an
+    // unanswered/hidden governing field already evaluates to hidden
+    // downstream — so the date field doesn't need to also reference it.
+    for (const [vaccineCode, dateCode] of VACCINE_DATE_PAIRS) {
       expect(byCode.get(vaccineCode)).toBeDefined();
-      expect(byCode.get(dateCode)?.visibleWhen).toEqual(MET_BENEFICIARY_YES_INFANT);
+      expect(byCode.get(vaccineCode)?.visibleWhen).toEqual(MET_BENEFICIARY_YES_INFANT);
+      expect(byCode.get(dateCode)?.visibleWhen).toEqual({
+        field: vaccineCode,
+        operator: 'eq',
+        value: 'yes',
+      });
     }
   });
 

--- a/apps/visit-form-service/prisma/seed-data/infant-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/infant-visit.json
@@ -908,7 +908,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "bcg",
         "operator": "eq",
         "value": "yes"
       },
@@ -944,7 +944,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "opv_0",
         "operator": "eq",
         "value": "yes"
       },
@@ -980,7 +980,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "hepatitis_b_birth_dose",
         "operator": "eq",
         "value": "yes"
       },
@@ -1016,7 +1016,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "vitamin_k",
         "operator": "eq",
         "value": "yes"
       },
@@ -1052,7 +1052,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "opv_1",
         "operator": "eq",
         "value": "yes"
       },
@@ -1088,7 +1088,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "pentavalent_1_dpt1",
         "operator": "eq",
         "value": "yes"
       },
@@ -1124,7 +1124,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "ipv_1",
         "operator": "eq",
         "value": "yes"
       },
@@ -1160,7 +1160,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "rotavirus1",
         "operator": "eq",
         "value": "yes"
       },
@@ -1196,7 +1196,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "pcv1",
         "operator": "eq",
         "value": "yes"
       },
@@ -1232,7 +1232,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "opv_2",
         "operator": "eq",
         "value": "yes"
       },
@@ -1268,7 +1268,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "pentavalent_2_dpt2",
         "operator": "eq",
         "value": "yes"
       },
@@ -1304,7 +1304,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "rotavirus2",
         "operator": "eq",
         "value": "yes"
       },
@@ -1340,7 +1340,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "opv_3",
         "operator": "eq",
         "value": "yes"
       },
@@ -1376,7 +1376,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "pentavalent_3_dpt3",
         "operator": "eq",
         "value": "yes"
       },
@@ -1412,7 +1412,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "ipv2",
         "operator": "eq",
         "value": "yes"
       },
@@ -1448,7 +1448,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "rotavirus3",
         "operator": "eq",
         "value": "yes"
       },
@@ -1484,7 +1484,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "pcv2",
         "operator": "eq",
         "value": "yes"
       },
@@ -1520,7 +1520,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "mmr_1_mr1",
         "operator": "eq",
         "value": "yes"
       },
@@ -1556,7 +1556,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "pcv_booster",
         "operator": "eq",
         "value": "yes"
       },
@@ -1592,7 +1592,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "vitamin_a",
         "operator": "eq",
         "value": "yes"
       },
@@ -1628,7 +1628,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "opv_booster",
         "operator": "eq",
         "value": "yes"
       },
@@ -1664,7 +1664,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "mmr2_mr2",
         "operator": "eq",
         "value": "yes"
       },
@@ -1700,7 +1700,7 @@
       "required": true,
       "input_type": "date",
       "visibleWhen": {
-        "field": "have_you_been_able_to_meet_the_beneficiary_for_the_visit",
+        "field": "dpt_booster1",
         "operator": "eq",
         "value": "yes"
       },

--- a/apps/visit-form-service/prisma/seed-data/mother-registration.json
+++ b/apps/visit-form-service/prisma/seed-data/mother-registration.json
@@ -829,7 +829,7 @@
         "value": "anc_1_completed",
         "operator": "eq"
       },
-      "question_code": "if_anc1_completed_are_you_identified_with_any_high_risk_condition_as_communicated_by_doctor_during_the_latest_anc_checkup_self_reported"
+      "question_code": "anc1_high_risk_condition_self_reported"
     },
     {
       "label": "Has the women received Td dose ?",
@@ -1414,7 +1414,7 @@
           "value_code": "chewing_tobacco_gutkha_khaini_mishri_etc"
         },
         {
-          "label": "Smoking tobacco (bidi, cigareTde)",
+          "label": "Smoking tobacco (bidi, cigarette)",
           "sort_order": 2,
           "value_code": "smoking_tobacco_bidi_cigaretde"
         },
@@ -1612,7 +1612,7 @@
     },
     {
       "rule": "EXCLUSIVE_OPTION",
-      "field": "if_anc1_completed_are_you_identified_with_any_high_risk_condition_as_communicated_by_doctor_during_the_latest_anc_checkup_self_reported",
+      "field": "anc1_high_risk_condition_self_reported",
       "exclusiveValues": ["no_known_medical_condition_identified_during_check_up", "don_t_know"]
     },
     {

--- a/apps/visit-form-service/src/beneficiaries/beneficiary.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiary.client.spec.ts
@@ -157,6 +157,35 @@ describe('findBeneficiaryOwnership', () => {
     });
   });
 
+  it('forwards a 403 from the ownership endpoint as a real 403, not a 502 — beneficiary-service already ran its own SAKHI/SUPERVISOR roster check', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () =>
+        Promise.resolve({
+          success: false,
+          message: 'This beneficiary case is outside your own roster.',
+        }),
+    });
+
+    await expect(findBeneficiaryOwnership('ben-1', 'Bearer test-token')).rejects.toMatchObject({
+      status: 403,
+      message: 'This beneficiary case is outside your own roster.',
+    });
+  });
+
+  it('still throws a 403 with a generic message if the 403 response body cannot be parsed', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.reject(new Error('not json')),
+    });
+
+    await expect(findBeneficiaryOwnership('ben-1', 'Bearer test-token')).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
   it('throws a 502 when beneficiary-service is unreachable', async () => {
     fetchMock.mockRejectedValue(new Error('network down'));
 

--- a/apps/visit-form-service/src/beneficiaries/beneficiary.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiary.client.spec.ts
@@ -1,4 +1,4 @@
-import { findBeneficiaryById } from './beneficiary.client';
+import { findBeneficiaryById, findBeneficiaryOwnership } from './beneficiary.client';
 
 describe('findBeneficiaryById', () => {
   const originalFetch = global.fetch;
@@ -20,6 +20,7 @@ describe('findBeneficiaryById', () => {
       projectId: 'project-1',
       beneficiaryTypeLookupId: 'type-1',
       caseTypeLookupId: 'case-type-1',
+      currentPhase: 'ANC',
       pii: {
         villageId: 'village-1',
         padaId: 'pada-1',
@@ -28,6 +29,7 @@ describe('findBeneficiaryById', () => {
         stateId: 'state-1',
         districtId: 'district-1',
       },
+      childCaseDetails: null,
     };
     fetchMock.mockResolvedValue({
       ok: true,
@@ -43,17 +45,49 @@ describe('findBeneficiaryById', () => {
       projectId: 'project-1',
       beneficiaryTypeLookupId: 'type-1',
       caseTypeLookupId: 'case-type-1',
+      currentPhase: 'ANC',
       villageId: 'village-1',
       padaId: 'pada-1',
       healthSubCentreId: 'sc-1',
       phcId: 'phc-1',
       stateId: 'state-1',
       districtId: 'district-1',
+      childDateOfBirth: null,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/beneficiaries/ben-1'),
       expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
     );
+  });
+
+  it('returns childDateOfBirth from childCaseDetails.dateOfBirth for a CHILD case', async () => {
+    const data = {
+      id: 'child-1',
+      sakhiId: 'sakhi-1',
+      projectId: 'project-1',
+      beneficiaryTypeLookupId: 'type-1',
+      caseTypeLookupId: 'case-type-1',
+      currentPhase: 'INC',
+      pii: {
+        villageId: 'village-1',
+        padaId: 'pada-1',
+        healthSubCentreId: 'sc-1',
+        phcId: 'phc-1',
+        stateId: 'state-1',
+        districtId: 'district-1',
+      },
+      childCaseDetails: { dateOfBirth: '2026-01-15T00:00:00.000Z' },
+    };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, data }),
+    });
+
+    const result = await findBeneficiaryById('child-1', 'Bearer test-token');
+
+    expect(result?.childDateOfBirth).toBe('2026-01-15T00:00:00.000Z');
+    expect(result?.currentPhase).toBe('INC');
   });
 
   it('returns null on 404', async () => {
@@ -74,6 +108,59 @@ describe('findBeneficiaryById', () => {
     fetchMock.mockRejectedValue(new Error('network down'));
 
     await expect(findBeneficiaryById('ben-1', 'Bearer test-token')).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+});
+
+describe('findBeneficiaryOwnership', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('calls GET /beneficiaries/:id/ownership, NOT the full GET /beneficiaries/:id', async () => {
+    const data = { id: 'ben-1', sakhiId: 'sakhi-1', caseType: 'MOTHER' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, data }),
+    });
+
+    const result = await findBeneficiaryOwnership('ben-1', 'Bearer test-token');
+
+    expect(result).toEqual(data);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/beneficiaries/ben-1/ownership'),
+      expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+    );
+  });
+
+  it('returns null on 404', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(findBeneficiaryOwnership('missing', 'Bearer test-token')).resolves.toBeNull();
+  });
+
+  it('throws a 502 when beneficiary-service returns a non-404 error', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(findBeneficiaryOwnership('ben-1', 'Bearer test-token')).rejects.toMatchObject({
+      status: 502,
+    });
+  });
+
+  it('throws a 502 when beneficiary-service is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(findBeneficiaryOwnership('ben-1', 'Bearer test-token')).rejects.toMatchObject({
       status: 502,
     });
   });

--- a/apps/visit-form-service/src/beneficiaries/beneficiary.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiary.client.ts
@@ -1,4 +1,4 @@
-import { badGateway } from '@armman/service-commons';
+import { badGateway, forbidden } from '@armman/service-commons';
 
 // Read directly (not via appConfig) so importing this client doesn't pull in
 // app-config's full schema — mirrors geography.client.ts. Despite the name,
@@ -119,6 +119,15 @@ export interface BeneficiaryOwnership {
  * that endpoint; findBeneficiaryById remains correct for every other caller
  * (create-child.client.ts, visitSchedule.service.ts) that needs the full
  * case detail and is never itself in that cycle.
+ *
+ * `GET /beneficiaries/:id/ownership` does its own SAKHI/SUPERVISOR
+ * roster check server-side and returns 403 directly when the caller isn't
+ * permitted — that 403 is forwarded here as a real `forbidden()`, not
+ * treated as an upstream failure, so a caller's own scoping check still
+ * sees a 403 (not a 502) for the case that matters most: a SAKHI/SUPERVISOR
+ * outside their own roster. Confirmed live: before this fix, that exact
+ * case surfaced as a 502 "beneficiary-service unreachable" instead of the
+ * intended 403.
  */
 export async function findBeneficiaryOwnership(
   beneficiaryId: string,
@@ -133,6 +142,10 @@ export async function findBeneficiaryOwnership(
   }
 
   if (res.status === 404) return null;
+  if (res.status === 403) {
+    const body = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw forbidden(body?.message ?? 'You do not have access to this beneficiary case.');
+  }
   if (!res.ok) {
     throw badGateway('Unable to verify the beneficiary — beneficiary-service returned an error.');
   }

--- a/apps/visit-form-service/src/beneficiaries/beneficiary.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiary.client.ts
@@ -25,6 +25,17 @@ export interface BeneficiaryCase {
   phcId: string;
   stateId: string;
   districtId: string;
+  /** childCaseDetails.dateOfBirth — null for a MOTHER case, or a CHILD case
+   * whose childCaseDetails row hasn't been created yet. Used by
+   * ccvOpeningRiskState.resolver.ts's BR-13 computation (dob is the input
+   * ccv.rulesJson.ts's decision graph keys its transition/program-exit
+   * dates off). */
+  childDateOfBirth: string | null;
+  /** BeneficiaryCase.currentPhase — used by form.service.ts to detect the
+   * actual INC->CCV transition moment (read BEFORE calling
+   * updateBeneficiaryPhase) so BR-13's ccvOpeningRiskState computation runs
+   * exactly once, not on every subsequent CCV_VISIT submission. */
+  currentPhase: string;
 }
 
 /** Raw shape of `GET /beneficiaries/:id`'s response — geography lives under `pii`. */
@@ -34,6 +45,7 @@ interface BeneficiaryCaseDetailResponse {
   projectId: string;
   beneficiaryTypeLookupId: string;
   caseTypeLookupId: string;
+  currentPhase: string;
   pii: {
     villageId: string;
     padaId: string;
@@ -42,6 +54,7 @@ interface BeneficiaryCaseDetailResponse {
     stateId: string;
     districtId: string;
   };
+  childCaseDetails: { dateOfBirth: string } | null;
 }
 
 /**
@@ -74,7 +87,7 @@ export async function findBeneficiaryById(
   }
 
   const body = (await res.json()) as { data: BeneficiaryCaseDetailResponse };
-  const { pii, ...rest } = body.data;
+  const { pii, childCaseDetails, ...rest } = body.data;
   return {
     ...rest,
     villageId: pii.villageId,
@@ -83,5 +96,47 @@ export async function findBeneficiaryById(
     phcId: pii.phcId,
     stateId: pii.stateId,
     districtId: pii.districtId,
+    childDateOfBirth: childCaseDetails?.dateOfBirth ?? null,
   };
+}
+
+export interface BeneficiaryOwnership {
+  id: string;
+  sakhiId: string;
+  caseType: string;
+}
+
+/**
+ * Fetches ONLY `{id, sakhiId, caseType}` via beneficiary-service's
+ * `GET /beneficiaries/:id/ownership` — deliberately NOT `findBeneficiaryById`
+ * (the full `GET /beneficiaries/:id`), whose own response enrichment
+ * (lastVisitVitals) calls back into this service's latest-visit-vitals
+ * endpoint. A caller doing only an ownership check (e.g.
+ * form.service.ts's getLatestVisitVitals) that used findBeneficiaryById
+ * instead would recreate that exact request cycle: getById ->
+ * resolveLatestVisitVitals -> here -> findBeneficiaryById -> getById -> ...
+ * forever. Use this function for any ownership-only check reachable from
+ * that endpoint; findBeneficiaryById remains correct for every other caller
+ * (create-child.client.ts, visitSchedule.service.ts) that needs the full
+ * case detail and is never itself in that cycle.
+ */
+export async function findBeneficiaryOwnership(
+  beneficiaryId: string,
+  authorizationHeader: string,
+): Promise<BeneficiaryOwnership | null> {
+  const url = `${GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/ownership`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Authorization: authorizationHeader } });
+  } catch {
+    throw badGateway('Unable to verify the beneficiary — beneficiary-service is unreachable.');
+  }
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw badGateway('Unable to verify the beneficiary — beneficiary-service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: BeneficiaryOwnership };
+  return body.data;
 }

--- a/apps/visit-form-service/src/beneficiaries/beneficiaryOwnership.guard.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiaryOwnership.guard.spec.ts
@@ -1,0 +1,121 @@
+import { assertCallerOwnsBeneficiary } from './beneficiaryOwnership.guard';
+import { findBeneficiaryOwnership } from './beneficiary.client';
+import { listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
+
+jest.mock('./beneficiary.client');
+jest.mock('../sakhis/sakhi.client');
+
+describe('assertCallerOwnsBeneficiary', () => {
+  const AUTH_HEADER = 'Bearer test-token';
+  const findBeneficiaryOwnershipMock = jest.mocked(findBeneficiaryOwnership);
+  const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('throws not-found when the beneficiary case does not exist', async () => {
+    findBeneficiaryOwnershipMock.mockResolvedValue(null);
+
+    await expect(
+      assertCallerOwnsBeneficiary('ben-1', { id: 'sakhi-1', roles: ['SAKHI'] }, AUTH_HEADER),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('resolves silently for a SAKHI who owns the case', async () => {
+    findBeneficiaryOwnershipMock.mockResolvedValue({
+      id: 'ben-1',
+      sakhiId: 'sakhi-1',
+      caseType: 'MOTHER',
+    });
+
+    await expect(
+      assertCallerOwnsBeneficiary('ben-1', { id: 'sakhi-1', roles: ['SAKHI'] }, AUTH_HEADER),
+    ).resolves.toBeUndefined();
+    expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a SAKHI whose id does not match the case owner', async () => {
+    findBeneficiaryOwnershipMock.mockResolvedValue({
+      id: 'ben-1',
+      sakhiId: 'sakhi-owner',
+      caseType: 'MOTHER',
+    });
+
+    await expect(
+      assertCallerOwnsBeneficiary('ben-1', { id: 'sakhi-other', roles: ['SAKHI'] }, AUTH_HEADER),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('resolves for a SUPERVISOR whose roster includes the case owner', async () => {
+    findBeneficiaryOwnershipMock.mockResolvedValue({
+      id: 'ben-1',
+      sakhiId: 'sakhi-1',
+      caseType: 'MOTHER',
+    });
+    listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-1', 'sakhi-2']);
+
+    await expect(
+      assertCallerOwnsBeneficiary(
+        'ben-1',
+        { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: 'project-1' },
+        AUTH_HEADER,
+      ),
+    ).resolves.toBeUndefined();
+    expect(listSakhiIdsForSupervisorMock).toHaveBeenCalledWith(
+      'project-1',
+      'supervisor-1',
+      AUTH_HEADER,
+    );
+  });
+
+  it('rejects a SUPERVISOR whose roster does not include the case owner', async () => {
+    findBeneficiaryOwnershipMock.mockResolvedValue({
+      id: 'ben-1',
+      sakhiId: 'sakhi-1',
+      caseType: 'MOTHER',
+    });
+    listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-other']);
+
+    await expect(
+      assertCallerOwnsBeneficiary(
+        'ben-1',
+        { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: 'project-1' },
+        AUTH_HEADER,
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('rejects a SUPERVISOR with no project scope, without calling listSakhiIdsForSupervisor', async () => {
+    findBeneficiaryOwnershipMock.mockResolvedValue({
+      id: 'ben-1',
+      sakhiId: 'sakhi-1',
+      caseType: 'MOTHER',
+    });
+
+    await expect(
+      assertCallerOwnsBeneficiary(
+        'ben-1',
+        { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: null },
+        AUTH_HEADER,
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['MANAGER', 'ADMIN'])(
+    'resolves unrestricted for a %s caller, without a roster lookup',
+    async (role) => {
+      findBeneficiaryOwnershipMock.mockResolvedValue({
+        id: 'ben-1',
+        sakhiId: 'sakhi-1',
+        caseType: 'MOTHER',
+      });
+
+      await expect(
+        assertCallerOwnsBeneficiary('ben-1', { id: 'user-1', roles: [role] }, AUTH_HEADER),
+      ).resolves.toBeUndefined();
+      expect(listSakhiIdsForSupervisorMock).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/visit-form-service/src/beneficiaries/beneficiaryOwnership.guard.ts
+++ b/apps/visit-form-service/src/beneficiaries/beneficiaryOwnership.guard.ts
@@ -1,0 +1,49 @@
+import { forbidden, notFound } from '@armman/service-commons';
+import { findBeneficiaryOwnership } from './beneficiary.client';
+import { listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
+
+export interface CallerIdentity {
+  readonly id: string;
+  readonly roles: readonly string[];
+  readonly projectId?: string | null;
+}
+
+/**
+ * Resolves a beneficiary's ownership via the narrow, non-enriching
+ * `/ownership` endpoint (see findBeneficiaryOwnership's own doc comment for
+ * the cross-service infinite-loop this avoids) and enforces SAKHI own-case /
+ * SUPERVISOR own-roster / MANAGER-ADMIN-unrestricted — the exact ownership
+ * check duplicated, before this extraction, across
+ * form.service.ts#getLatestVisitVitals and
+ * visitInstance.service.ts#getVisitHistory. One copy drifting here is a
+ * security bug, not a style issue, so both callers now share this.
+ */
+export async function assertCallerOwnsBeneficiary(
+  beneficiaryId: string,
+  caller: CallerIdentity,
+  authorizationHeader: string,
+): Promise<void> {
+  const beneficiary = await findBeneficiaryOwnership(beneficiaryId, authorizationHeader);
+  if (!beneficiary) throw notFound('Beneficiary case not found.');
+
+  if (caller.roles.includes('SAKHI')) {
+    if (beneficiary.sakhiId !== caller.id) {
+      throw forbidden('This beneficiary case is outside your own roster.');
+    }
+    return;
+  }
+
+  if (caller.roles.includes('SUPERVISOR')) {
+    if (!caller.projectId) {
+      throw forbidden('Supervisor caller has no project scope.');
+    }
+    const roster = await listSakhiIdsForSupervisor(
+      caller.projectId,
+      caller.id,
+      authorizationHeader,
+    );
+    if (!roster.includes(beneficiary.sakhiId)) {
+      throw forbidden("This beneficiary case is outside this Supervisor's roster.");
+    }
+  }
+}

--- a/apps/visit-form-service/src/beneficiaries/create-child.client.spec.ts
+++ b/apps/visit-form-service/src/beneficiaries/create-child.client.spec.ts
@@ -12,12 +12,14 @@ describe('createChildBeneficiary', () => {
     projectId: 'project-1',
     beneficiaryTypeLookupId: 'type-1',
     caseTypeLookupId: 'case-type-1',
+    currentPhase: 'ANC',
     villageId: 'village-1',
     padaId: 'pada-1',
     healthSubCentreId: 'sc-1',
     phcId: 'phc-1',
     stateId: 'state-1',
     districtId: 'district-1',
+    childDateOfBirth: null,
   };
 
   beforeEach(() => {

--- a/apps/visit-form-service/src/beneficiaries/update-phase.client.ts
+++ b/apps/visit-form-service/src/beneficiaries/update-phase.client.ts
@@ -39,3 +39,42 @@ export async function updateBeneficiaryPhase(
     );
   }
 }
+
+/**
+ * Writes ChildCaseDetails.ccvOpeningRiskState (BR-13) via beneficiary-service's
+ * `PATCH /beneficiaries/:id/ccv-opening-risk-state` — called once, right
+ * after a successful updateBeneficiaryPhase(id, 'CCV', ...) call, by
+ * ccvOpeningRiskState.resolver.ts.
+ *
+ * Best-effort by design, same stance as updateBeneficiaryPhase: the CHILD
+ * case has already advanced to CCV by the time this runs, and BR-13's
+ * opening risk state is a derived clinical-tracking value, not something
+ * that should ever block or roll back a completed visit submission.
+ */
+export async function setCcvOpeningRiskState(
+  beneficiaryId: string,
+  ccvOpeningRiskState: string,
+  authorizationHeader: string,
+): Promise<void> {
+  try {
+    const res = await fetch(
+      `${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}/ccv-opening-risk-state`,
+      {
+        method: 'PATCH',
+        headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ccvOpeningRiskState }),
+      },
+    );
+    if (!res.ok) {
+      console.warn(
+        `Failed to set ccvOpeningRiskState to ${ccvOpeningRiskState} for beneficiary ` +
+          `${beneficiaryId} (beneficiary-service returned ${res.status}).`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Unable to reach beneficiary-service to set ccvOpeningRiskState for beneficiary ` +
+        `${beneficiaryId}. ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/config/app-config.ts
+++ b/apps/visit-form-service/src/config/app-config.ts
@@ -21,6 +21,13 @@ const schema = z.object({
   // derivation call) — NOT auth-service's own port directly, since the
   // gateway is what verifies the caller's forwarded Authorization header.
   AUTH_SERVICE_BASE_URL: z.string().url().default('http://localhost:3000'),
+  // rules-service's seeded "Arogya Sakhi CCV Visit Scheduling" RuleSet id —
+  // no field anywhere maps a schedule journey (like "CCV") to its ruleSetId
+  // (unlike risk-grading, which uses FormDefinition.riskRuleSetId), so this
+  // is configured directly. Optional: BR-13's CCV opening-risk-state
+  // computation is skipped (not failed) when unset — see
+  // ccvOpeningRiskState.client.ts.
+  CCV_SCHEDULE_RULE_SET_ID: z.string().uuid().optional(),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/visit-form-service/src/forms/ccvOpeningRiskState.resolver.ts
+++ b/apps/visit-form-service/src/forms/ccvOpeningRiskState.resolver.ts
@@ -1,0 +1,140 @@
+import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
+import { listRiskAssessments } from '../risk-assessments/riskAssessment.client';
+import { evaluateSchedule } from '../rules/scheduleEvaluate.client';
+import { setCcvOpeningRiskState } from '../beneficiaries/update-phase.client';
+import { appConfig } from '../config/app-config';
+
+/**
+ * Maps ccv.rulesJson.ts's own 5-value riskState output to
+ * beneficiary-service's CcvOpeningRiskState DB enum — the two are NOT
+ * string-identical (NEVER_AT_HR vs NEVER_HR, CURRENTLY_HR_SAM vs
+ * CURRENTLY_HR_SAM_DANGER), see beneficiary-service/prisma/schema.prisma's
+ * CcvOpeningRiskState enum comment and ccv.rulesJson.ts's own docstring.
+ */
+const RULE_PACK_RISK_STATE_TO_DB_ENUM: Record<string, string> = {
+  NEVER_AT_HR: 'NEVER_HR',
+  CURRENTLY_HR_SAM: 'CURRENTLY_HR_SAM_DANGER',
+  CURRENTLY_HR_OTHER: 'CURRENTLY_HR_OTHER',
+  RECENTLY_RECOVERED: 'RECENTLY_RECOVERED',
+  STABLE_LOW_RISK: 'STABLE_LOW_RISK',
+};
+
+const LAST_N_INC_VISITS = 3;
+
+/**
+ * BR-13: "risk state is evaluated exactly once, at the 12-month INC-to-CCV
+ * transition, from the last 3 completed INC visits" (see
+ * ccv.rulesJson.ts's own docstring for the full rule).
+ *
+ * Runs immediately after form.service.ts's CHILD phase-advance lands a case
+ * at CCV (INC->CCV — see FORM_CODE_TO_CHILD_PHASE). Resolves the last 3
+ * completed INC visits (owned by this service), scans the full 0-12m window
+ * for "was HR ever detected" (also owned by this service), fetches each
+ * visit's RiskAssessment from risk-referral-service (which owns that data
+ * but not visit typing — no cross-service join per the forklift rule, hence
+ * the id-handoff), evaluates the seeded CCV schedule pack via rules-service,
+ * maps its output enum to the DB enum, and writes the result to
+ * beneficiary-service.
+ *
+ * Best-effort end-to-end, same tolerance as every other call in
+ * form.service.ts's createSubmission: a failure/skip at any step here never
+ * throws — it just means ccvOpeningRiskState stays null for this
+ * beneficiary a bit longer, not that the CCV visit submission itself fails.
+ * Skipped entirely (not attempted) when CCV_SCHEDULE_RULE_SET_ID is unset —
+ * see app-config.ts's own comment on why that's optional.
+ */
+export async function resolveAndWriteCcvOpeningRiskState(
+  beneficiaryId: string,
+  dob: string,
+  visitInstanceRepository: VisitInstanceRepository,
+  authorizationHeader: string,
+): Promise<void> {
+  if (!appConfig.CCV_SCHEDULE_RULE_SET_ID) return;
+
+  try {
+    const [recentIncVisits, allInfantVisitIds] = await Promise.all([
+      visitInstanceRepository.findRecentCompletedIncVisits(beneficiaryId, LAST_N_INC_VISITS),
+      visitInstanceRepository.findAllCompletedInfantVisitIds(beneficiaryId),
+    ]);
+    if (recentIncVisits.length === 0) return;
+
+    const allInfantAssessments = await listRiskAssessments(
+      beneficiaryId,
+      allInfantVisitIds,
+      authorizationHeader,
+    );
+    if (allInfantAssessments === null) return;
+
+    const hrEverDetectedIn0to12m = allInfantAssessments.some((a) => a.hrDetectedFlag);
+
+    const recentIncVisitIds = recentIncVisits.map((v) => v.id);
+    const recentAssessmentsByVisitId = new Map(
+      allInfantAssessments
+        .filter((a) => a.visitId && recentIncVisitIds.includes(a.visitId))
+        .map((a) => [a.visitId as string, a]),
+    );
+    const last3IncVisitsNormal = recentIncVisits.every(
+      (v) => !(recentAssessmentsByVisitId.get(v.id)?.hrDetectedFlag ?? false),
+    );
+
+    // Most recent INC visit is recentIncVisits[0] (findRecentCompletedIncVisits
+    // orders most-recent-first).
+    //
+    // APPROXIMATION, not a confirmed rule: ccv.rulesJson.ts's
+    // mostRecentIncVisitHrType wants specifically "SAM/danger sign at most
+    // recent INC visit" vs "other HR condition" — but RiskAssessment (this
+    // service's only visibility into that visit's grading) has no flag
+    // distinguishing SAM/danger-signs from any other condition that was
+    // graded SEVERE; overallRiskCategory === 'CRITICAL' means "some
+    // condition hit gradeRank 3" (infant-risk.rulesJson.ts's worst-rank
+    // rollup), which SAM/danger-signs are members of but not the only
+    // members (e.g. severe wasting alone also produces CRITICAL). Treating
+    // CRITICAL as SAM_DANGER here will misclassify a non-SAM SEVERE case as
+    // SAM_DANGER instead of OTHER — same cadence either way per
+    // ccv.rulesJson.ts (both map to a 1-month cadence), so this doesn't
+    // affect the visit schedule it produces, but it IS a real gap against
+    // BR-13's literal wording. Flagged, not silently assumed correct — a
+    // precise fix needs risk-referral-service to expose which specific
+    // conditions were flagged per assessment, not just the rollup category.
+    const mostRecentAssessment = recentAssessmentsByVisitId.get(recentIncVisits[0].id);
+    const mostRecentIncVisitHrType = !mostRecentAssessment?.hrDetectedFlag
+      ? 'NONE'
+      : mostRecentAssessment.overallRiskCategory === 'CRITICAL'
+        ? 'SAM_DANGER'
+        : 'OTHER';
+
+    const evaluation = await evaluateSchedule(
+      appConfig.CCV_SCHEDULE_RULE_SET_ID,
+      'CCV',
+      {
+        dob,
+        hrEverDetectedIn0to12m,
+        mostRecentIncVisitHrType,
+        last3IncVisitsNormal,
+        // BR-13's own program-exit extension logic (evaluated at DOB+730) is
+        // out of scope here — this call only needs the opening riskState,
+        // computed once at the INC->CCV transition, so this input is always
+        // false at this call site.
+        hrDetectedAtLastCcvVisit: false,
+      },
+      authorizationHeader,
+    );
+    if (!evaluation || typeof evaluation.riskState !== 'string') return;
+
+    const dbEnumValue = RULE_PACK_RISK_STATE_TO_DB_ENUM[evaluation.riskState];
+    if (!dbEnumValue) {
+      console.warn(
+        `CCV schedule pack returned unmapped riskState "${evaluation.riskState}" for ` +
+          `beneficiary ${beneficiaryId} — skipping ccvOpeningRiskState write.`,
+      );
+      return;
+    }
+
+    await setCcvOpeningRiskState(beneficiaryId, dbEnumValue, authorizationHeader);
+  } catch (err) {
+    console.warn(
+      `Failed to resolve ccvOpeningRiskState (BR-13) for beneficiary ${beneficiaryId}. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.spec.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.spec.ts
@@ -51,3 +51,20 @@ describe('formFieldSchema — visibleWhen', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('formFieldSchema — question_code length', () => {
+  it('accepts a question_code at exactly 120 characters (form_answers.field_code is VarChar(120))', () => {
+    const result = formFieldSchema.safeParse(baseField({ question_code: 'a'.repeat(120) }));
+    expect(result.success).toBe(true);
+  });
+
+  it(
+    'rejects a question_code over 120 characters — form_answers.field_code is VarChar(120); ' +
+      'an over-length code previously passed schema validation uncaught and only failed at ' +
+      'submission time as a Prisma P2000 500 (MOTHER_REGISTRATION incident this rejection follows)',
+    () => {
+      const result = formFieldSchema.safeParse(baseField({ question_code: 'a'.repeat(121) }));
+      expect(result.success).toBe(false);
+    },
+  );
+});

--- a/apps/visit-form-service/src/forms/dto/form-field.dto.ts
+++ b/apps/visit-form-service/src/forms/dto/form-field.dto.ts
@@ -53,7 +53,16 @@ export const visibleWhenConditionSchema = z.object({
  */
 export const formFieldSchema = z
   .object({
-    question_code: z.string().trim().min(1),
+    // Max 120 matches form_answers.field_code's DB column (VarChar(120), see
+    // prisma/schema.prisma) — question_code is written there verbatim on
+    // every submission (see buildFormAnswers). Enforced here, at
+    // draft-save/publish time, so an over-length code is rejected as a
+    // clean validation error immediately, rather than surfacing as a
+    // Prisma P2000 500 the first time a real Sakhi submits an answer for
+    // it (this happened in production-equivalent testing: a 135-char
+    // question_code on MOTHER_REGISTRATION passed schema validation
+    // uncaught and only failed at submission time).
+    question_code: z.string().trim().min(1).max(120),
     label: z.string().trim().min(1),
     input_type: z.string().trim().min(1),
     required: z.boolean(),

--- a/apps/visit-form-service/src/forms/form.controller.ts
+++ b/apps/visit-form-service/src/forms/form.controller.ts
@@ -68,5 +68,18 @@ export function createFormController(service: FormService) {
       );
       res.status(201).json(ok(created));
     }),
+
+    getLatestVisitVitals: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const { beneficiaryId } = req.params as unknown as { beneficiaryId: string };
+      const vitals = await service.getLatestVisitVitals(
+        beneficiaryId,
+        req.user,
+        authorizationHeader,
+      );
+      res.json(ok(vitals));
+    }),
   };
 }

--- a/apps/visit-form-service/src/forms/form.module.ts
+++ b/apps/visit-form-service/src/forms/form.module.ts
@@ -3,11 +3,22 @@ import type { PrismaService } from '../prisma/prisma.service';
 import { FormRepository } from './form.repository';
 import { FormService } from './form.service';
 import { registerFormRoutes } from './form.routes';
+import { VisitInstanceRepository } from '../visits/visitInstance.repository';
 
 /** Composition root for the forms feature: wires repository -> service -> routes. */
 export function createFormModule(prisma: PrismaService): DocumentedRouter {
   const repository = new FormRepository(prisma);
-  const service = new FormService(repository);
+  // BR-13's ccvOpeningRiskState.resolver.ts needs the beneficiary's own
+  // completed-INC-visit history — owned by visits, not forms — so FormService
+  // takes VisitInstanceRepository directly rather than duplicating that data
+  // access here (matches how beneficiary.repository.ts's own note explains
+  // why findVisitById duplicates VisitInstanceRepository.findById's shape
+  // instead of a cross-repository dependency for one extra filter; this is
+  // the opposite tradeoff — the resolver's queries are numerous/evolving
+  // enough that duplicating them here would drift, so the dependency is
+  // taken directly instead).
+  const visitInstanceRepository = new VisitInstanceRepository(prisma);
+  const service = new FormService(repository, visitInstanceRepository);
   const doc = createDocumentedRouter();
   registerFormRoutes(doc, service);
   return doc;

--- a/apps/visit-form-service/src/forms/form.repository.spec.ts
+++ b/apps/visit-form-service/src/forms/form.repository.spec.ts
@@ -2,7 +2,11 @@ import { FormRepository } from './form.repository';
 
 describe('FormRepository', () => {
   const findFirst = jest.fn();
-  const prisma = { visitInstance: { findFirst } } as never;
+  const formSubmissionFindFirst = jest.fn();
+  const prisma = {
+    visitInstance: { findFirst },
+    formSubmission: { findFirst: formSubmissionFindFirst },
+  } as never;
   let repository: FormRepository;
 
   beforeEach(() => {
@@ -43,6 +47,41 @@ describe('FormRepository', () => {
       expect(findFirst).toHaveBeenCalledWith({
         where: { id: 'visit-1', beneficiaryId: 'wrong-beneficiary', isDeleted: false },
       });
+    });
+  });
+
+  describe('findLatestVisitSubmission', () => {
+    it('queries visit-linked submissions restricted to the vitals-capturing form codes, ordered most-recent-first', async () => {
+      const submission = { id: 'sub-1', beneficiaryId: 'b1' };
+      formSubmissionFindFirst.mockResolvedValue(submission);
+
+      const result = await repository.findLatestVisitSubmission('b1');
+
+      expect(formSubmissionFindFirst).toHaveBeenCalledWith({
+        where: {
+          beneficiaryId: 'b1',
+          isDeleted: false,
+          visitId: { not: null },
+          formVersion: {
+            formDefinition: {
+              formCode: {
+                in: ['ANC_VISIT', 'POSTPARTUM_VISIT', 'NEONATAL_VISIT', 'INC_VISIT', 'CCV_VISIT'],
+              },
+            },
+          },
+        },
+        orderBy: { submittedAt: 'desc' },
+        include: { formVersion: { include: { formDefinition: true } } },
+      });
+      expect(result).toBe(submission);
+    });
+
+    it('returns null when the beneficiary has no visit-linked submission for a vitals-capturing form', async () => {
+      formSubmissionFindFirst.mockResolvedValue(null);
+
+      const result = await repository.findLatestVisitSubmission('b1');
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -141,6 +141,39 @@ export class FormRepository {
   }
 
   /**
+   * The most recent visit-linked submission for `beneficiaryId` across the
+   * clinical-visit form codes that actually capture vitals (ANC_VISIT,
+   * POSTPARTUM_VISIT, NEONATAL_VISIT, INC_VISIT, CCV_VISIT — see
+   * vitalsExtractor.ts's own FORM_CODE_TO_VITALS_MAPPING for why exactly
+   * these and not e.g. *_CLOSURE_VISIT, which capture no vitals fields) —
+   * used by GET /beneficiaries/:beneficiaryId/latest-visit-vitals. Ordered
+   * by submittedAt, not the visit's own scheduledDate, since a Sakhi may
+   * submit a visit's form days after conducting it and `submittedAt` is
+   * this table's own reliable timestamp regardless of that lag. Excludes
+   * non-visit-linked submissions (visitId null) — those are one-time forms
+   * like MOTHER_REGISTRATION, not part of the visit history this endpoint
+   * surfaces.
+   */
+  findLatestVisitSubmission(beneficiaryId: string) {
+    return this.prisma.formSubmission.findFirst({
+      where: {
+        beneficiaryId,
+        isDeleted: false,
+        visitId: { not: null },
+        formVersion: {
+          formDefinition: {
+            formCode: {
+              in: ['ANC_VISIT', 'POSTPARTUM_VISIT', 'NEONATAL_VISIT', 'INC_VISIT', 'CCV_VISIT'],
+            },
+          },
+        },
+      },
+      orderBy: { submittedAt: 'desc' },
+      include: { formVersion: { include: { formDefinition: true } } },
+    });
+  }
+
+  /**
    * Existence + ownership check for a visit-linked submission's visitId,
    * before the insert — visit_instances is owned by this same service
    * (unlike beneficiary_cases/form_versions' cross-service equivalents), so

--- a/apps/visit-form-service/src/forms/form.routes.ts
+++ b/apps/visit-form-service/src/forms/form.routes.ts
@@ -29,6 +29,19 @@ const versionParamsSchema = z
 const activeVersionQuerySchema = z
   .object({ asOf: z.coerce.date().optional().openapi({ example: '2026-07-20T00:00:00.000Z' }) })
   .strict();
+const beneficiaryIdParamsSchema = z.object({ beneficiaryId: z.string().uuid() }).strict();
+
+const vitalsSnapshotSchema = z.object({
+  visitId: z.string().uuid().nullable(),
+  submittedAt: z.string().datetime().nullable(),
+  weightKg: z.number().nullable(),
+  systolicBp: z.number().nullable(),
+  diastolicBp: z.number().nullable(),
+  temperatureF: z.number().nullable(),
+  hemoglobinGDl: z.number().nullable(),
+  muacCm: z.number().nullable(),
+  respiratoryRate: z.number().nullable(),
+});
 
 // Request DTOs annotated with examples for Swagger UI; validation behavior is
 // unchanged (`.openapi()` only attaches documentation metadata).
@@ -219,5 +232,37 @@ export function registerFormRoutes(doc: DocumentedRouter, service: FormService) 
     validate(formCodeParamsSchema, 'params'),
     validateBody(createSubmissionRequestSchema),
     controller.createSubmission,
+  );
+
+  doc.get(
+    '/beneficiaries/:beneficiaryId/latest-visit-vitals',
+    {
+      summary:
+        "The beneficiary's most recent visit-linked clinical submission's vitals " +
+        '(weight/BP/temperature/hemoglobin/MUAC/respiratory rate), projected out of that ' +
+        "visit's formDataJson per its own form's question_codes (ANC_VISIT/POSTPARTUM_VISIT/" +
+        'NEONATAL_VISIT/INC_VISIT/CCV_VISIT — the only visit forms that capture vitals; ' +
+        '*_CLOSURE_VISIT and one-time forms like MOTHER_REGISTRATION never contribute). Fields ' +
+        "the visit's own form doesn't ask are null, not omitted — the response shape never " +
+        'depends on which visit type was most recent. Returns an all-null snapshot (not 404) ' +
+        'when the beneficiary has never had a visit-linked clinical submission.',
+      tags: ['Forms'],
+      params: beneficiaryIdParamsSchema,
+      responses: {
+        200: {
+          description: "The beneficiary's latest visit vitals (or an all-null snapshot)",
+          schema: envelope(vitalsSnapshotSchema),
+        },
+        400: errorResponse(400, { message: 'beneficiaryId: Invalid uuid' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    validate(beneficiaryIdParamsSchema, 'params'),
+    controller.getLatestVisitVitals,
   );
 }

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -1,13 +1,15 @@
 import { FormService } from './form.service';
 import type { FormRepository } from './form.repository';
+import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
 import * as geographyClient from '../geography/geography.client';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
-import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
+import { findBeneficiaryById, findBeneficiaryOwnership } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
+import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
@@ -17,6 +19,7 @@ jest.mock('../beneficiaries/create-child.client');
 jest.mock('../beneficiaries/update-phase.client');
 jest.mock('../closures/closure.client');
 jest.mock('../risk-assessments/riskAssessment.client');
+jest.mock('./ccvOpeningRiskState.resolver');
 
 describe('FormService', () => {
   const repository = {
@@ -32,12 +35,17 @@ describe('FormService', () => {
     createSubmission: jest.fn(),
     findVisitById: jest.fn(),
     findLatestSubmissionByBeneficiaryAndFormCode: jest.fn(),
+    findLatestVisitSubmission: jest.fn(),
   } as unknown as jest.Mocked<FormRepository>;
+  const visitInstanceRepository = {
+    findRecentCompletedIncVisits: jest.fn(),
+    findAllCompletedInfantVisitIds: jest.fn(),
+  } as unknown as jest.Mocked<VisitInstanceRepository>;
   let service: FormService;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new FormService(repository);
+    service = new FormService(repository, visitInstanceRepository);
   });
 
   describe('getActiveVersion', () => {
@@ -936,12 +944,14 @@ describe('FormService', () => {
         projectId: 'project-1',
         beneficiaryTypeLookupId: 'type-1',
         caseTypeLookupId: 'case-type-1',
+        currentPhase: 'ANC',
         villageId: 'village-1',
         padaId: 'pada-1',
         healthSubCentreId: 'sc-1',
         phcId: 'phc-1',
         stateId: 'state-1',
         districtId: 'district-1',
+        childDateOfBirth: null,
       };
 
       const deliveryVersion = {
@@ -1151,12 +1161,14 @@ describe('FormService', () => {
         projectId: 'project-1',
         beneficiaryTypeLookupId: 'type-1',
         caseTypeLookupId: 'case-type-1',
+        currentPhase: 'ANC',
         villageId: 'village-1',
         padaId: 'pada-1',
         healthSubCentreId: 'sc-1',
         phcId: 'phc-1',
         stateId: 'state-1',
         districtId: 'district-1',
+        childDateOfBirth: null,
       };
 
       const deliveryVersion = {
@@ -1323,6 +1335,252 @@ describe('FormService', () => {
       });
     });
 
+    describe('CHILD phase advance on INC/CCV visit submission (CR-041)', () => {
+      const incVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'INC_VISIT' },
+        schemaJson: [
+          {
+            question_code: 'birth_weight_in_kg',
+            label: 'x',
+            input_type: 'number',
+            required: false,
+          },
+        ],
+        validationJson: [],
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+      });
+
+      it('advances a CHILD case to INC on an INC_VISIT submission', async () => {
+        repository.findVersionById.mockResolvedValue(incVersion as never);
+
+        await service.createSubmission(
+          'INC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'child-1',
+          'INC',
+          'Bearer test-token',
+        );
+      });
+
+      it('advances a CHILD case to INC on the legacy NEONATAL_VISIT alias', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...incVersion,
+          formDefinition: { formCode: 'NEONATAL_VISIT' },
+        } as never);
+
+        await service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'child-1',
+          'INC',
+          'Bearer test-token',
+        );
+      });
+
+      it('advances a CHILD case to CCV on a CCV_VISIT submission', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...incVersion,
+          formDefinition: { formCode: 'CCV_VISIT' },
+        } as never);
+
+        await service.createSubmission(
+          'CCV_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).toHaveBeenCalledWith(
+          'child-1',
+          'CCV',
+          'Bearer test-token',
+        );
+      });
+
+      it('does not call updateBeneficiaryPhase for a form code with no CHILD-phase mapping', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...incVersion,
+          formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+        } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(updateBeneficiaryPhase)).not.toHaveBeenCalled();
+      });
+
+      it('still saves the submission even if the phase-advance call rejects outright', async () => {
+        repository.findVersionById.mockResolvedValue(incVersion as never);
+        jest.mocked(updateBeneficiaryPhase).mockRejectedValueOnce(new Error('network down'));
+
+        const result = await service.createSubmission(
+          'INC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual(expect.objectContaining({ id: 'sub-1' }));
+      });
+    });
+
+    describe('BR-13 ccvOpeningRiskState trigger on the actual INC->CCV transition', () => {
+      const ccvVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'CCV_VISIT' },
+        schemaJson: [
+          { question_code: 'weight_in_kg', label: 'x', input_type: 'number', required: false },
+        ],
+        validationJson: [],
+      };
+
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        repository.findVersionById.mockResolvedValue(ccvVersion as never);
+      });
+
+      it('resolves ccvOpeningRiskState when the case was at INC before this submission (the actual transition)', async () => {
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          currentPhase: 'INC',
+          childDateOfBirth: '2025-01-01T00:00:00.000Z',
+        } as never);
+
+        await service.createSubmission(
+          'CCV_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(resolveAndWriteCcvOpeningRiskState)).toHaveBeenCalledWith(
+          'child-1',
+          '2025-01-01T00:00:00.000Z',
+          visitInstanceRepository,
+          'Bearer test-token',
+        );
+      });
+
+      it('does not resolve ccvOpeningRiskState on a repeat CCV_VISIT (case already at CCV)', async () => {
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          currentPhase: 'CCV',
+          childDateOfBirth: '2025-01-01T00:00:00.000Z',
+        } as never);
+
+        await service.createSubmission(
+          'CCV_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(resolveAndWriteCcvOpeningRiskState)).not.toHaveBeenCalled();
+      });
+
+      it('does not resolve ccvOpeningRiskState when the case has no childDateOfBirth', async () => {
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          currentPhase: 'INC',
+          childDateOfBirth: null,
+        } as never);
+
+        await service.createSubmission(
+          'CCV_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(resolveAndWriteCcvOpeningRiskState)).not.toHaveBeenCalled();
+      });
+
+      it('does not resolve ccvOpeningRiskState for a non-CCV CHILD phase advance (INC_VISIT)', async () => {
+        repository.findVersionById.mockResolvedValue({
+          ...ccvVersion,
+          formDefinition: { formCode: 'INC_VISIT' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          currentPhase: 'NN',
+          childDateOfBirth: '2025-01-01T00:00:00.000Z',
+        } as never);
+
+        await service.createSubmission(
+          'INC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'child-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(resolveAndWriteCcvOpeningRiskState)).not.toHaveBeenCalled();
+        expect(jest.mocked(findBeneficiaryById)).not.toHaveBeenCalled();
+      });
+    });
+
     describe('ANC_VISIT risk assessment trigger with registration-derived answers', () => {
       const ancVersion = {
         id: 'version-1',
@@ -1346,7 +1604,7 @@ describe('FormService', () => {
         repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
       });
 
-      it("merges age and badObstetricHistoryFlag from the beneficiary's MOTHER_REGISTRATION submission", async () => {
+      it("merges age/gravida/livingChildren/abortions/priorComplications from the beneficiary's MOTHER_REGISTRATION submission, and passes riskPhase ANC", async () => {
         repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
           formDataJson: {
             age_of_the_beneficiary: 22,
@@ -1376,21 +1634,28 @@ describe('FormService', () => {
           'b1',
           'MOTHER_REGISTRATION',
         );
+        // badObstetricHistoryFlag is no longer computed here — the ANC risk
+        // rule pack (GoRules) now derives it from these raw fields (see
+        // PR #172 review: business thresholds live in GoRules).
         expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
           expect.objectContaining({
+            riskPhase: 'ANC',
             answers: {
               haemoglobin_hb_g_dl: 9.5,
               age: 22,
-              badObstetricHistoryFlag: false,
+              gravida: 2,
+              livingChildren: 2,
+              abortions: 0,
+              priorComplications: ['no_complications'],
             },
           }),
           'Bearer test-token',
         );
       });
 
-      it('flags badObstetricHistoryFlag true when gravida exceeds 4', async () => {
+      it('passes only the registration fields that are actually present as numbers/arrays', async () => {
         repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
-          formDataJson: { age_of_the_beneficiary: 30, gravida_total_number_of_pregnancies: 5 },
+          formDataJson: { gravida_total_number_of_pregnancies: 3, living_children: 1 },
         } as never);
 
         await service.createSubmission(
@@ -1408,92 +1673,7 @@ describe('FormService', () => {
 
         expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
           expect.objectContaining({
-            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
-          }),
-          'Bearer test-token',
-        );
-      });
-
-      it('flags badObstetricHistoryFlag true when livingChildren is less than gravida', async () => {
-        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
-          formDataJson: {
-            gravida_total_number_of_pregnancies: 3,
-            living_children: 1,
-          },
-        } as never);
-
-        await service.createSubmission(
-          'ANC_VISIT',
-          {
-            formVersionId: 'version-1',
-            beneficiaryId: 'b1',
-            visitId: 'visit-1',
-            localSubmissionUuid: 'uuid-1',
-            formData: {},
-          },
-          'u1',
-          'Bearer test-token',
-        );
-
-        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
-          expect.objectContaining({
-            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
-          }),
-          'Bearer test-token',
-        );
-      });
-
-      it('flags badObstetricHistoryFlag true when abortions >= 2', async () => {
-        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
-          formDataJson: { abortions_pregnancy_losses_before_24_weeks: 2 },
-        } as never);
-
-        await service.createSubmission(
-          'ANC_VISIT',
-          {
-            formVersionId: 'version-1',
-            beneficiaryId: 'b1',
-            visitId: 'visit-1',
-            localSubmissionUuid: 'uuid-1',
-            formData: {},
-          },
-          'u1',
-          'Bearer test-token',
-        );
-
-        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
-          expect.objectContaining({
-            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
-          }),
-          'Bearer test-token',
-        );
-      });
-
-      it('flags badObstetricHistoryFlag true when a non-"no_complications" answer is present', async () => {
-        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
-          formDataJson: {
-            did_you_experience_any_complications_during_birth_delivery_in_previous_pregnancies: [
-              'yes_miscarriage',
-            ],
-          },
-        } as never);
-
-        await service.createSubmission(
-          'ANC_VISIT',
-          {
-            formVersionId: 'version-1',
-            beneficiaryId: 'b1',
-            visitId: 'visit-1',
-            localSubmissionUuid: 'uuid-1',
-            formData: {},
-          },
-          'u1',
-          'Bearer test-token',
-        );
-
-        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
-          expect.objectContaining({
-            answers: expect.objectContaining({ badObstetricHistoryFlag: true }),
+            answers: { gravida: 3, livingChildren: 1 },
           }),
           'Bearer test-token',
         );
@@ -1516,7 +1696,7 @@ describe('FormService', () => {
         );
 
         expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
-          expect.objectContaining({ answers: { haemoglobin_hb_g_dl: 9.5 } }),
+          expect.objectContaining({ riskPhase: 'ANC', answers: { haemoglobin_hb_g_dl: 9.5 } }),
           'Bearer test-token',
         );
       });
@@ -1544,6 +1724,89 @@ describe('FormService', () => {
       });
     });
 
+    describe('FORM_CODE_TO_RISK_PHASE mapping (PR #172 review)', () => {
+      // Every formCode below is given riskRuleSetId: 'rule-set-1' so
+      // triggerRiskAssessment fires, and each assertion checks the actual
+      // riskPhase value sent — not just objectContaining(...) with the field
+      // omitted, which previously let an invalid/fallback riskPhase (e.g. the
+      // raw, un-mapped formCode) pass this suite silently (see PR #172
+      // review: expect.objectContaining never asserted riskPhase, so
+      // DELIVERY_VISIT/POSTPARTUM_VISIT/MOTHER_REGISTRATION/CHILD_REGISTRATION
+      // being missing from the map went undetected).
+      beforeEach(() => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue(null);
+      });
+
+      const CASES: Array<[string, string]> = [
+        ['MOTHER_REGISTRATION', 'REGISTRATION'],
+        ['CHILD_REGISTRATION', 'REGISTRATION'],
+        ['ANC_VISIT', 'ANC'],
+        ['DELIVERY_VISIT', 'DELIVERY'],
+        ['POSTPARTUM_VISIT', 'PP'],
+        ['NEONATAL_VISIT', 'INC'],
+        ['INC_VISIT', 'INC'],
+        ['CCV_VISIT', 'INC'],
+      ];
+
+      it.each(CASES)('sends riskPhase %s -> %s', async (formCode, expectedRiskPhase) => {
+        repository.findVersionById.mockResolvedValue({
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode, riskRuleSetId: 'rule-set-1' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        } as never);
+
+        await service.createSubmission(
+          formCode,
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({ riskPhase: expectedRiskPhase }),
+          'Bearer test-token',
+        );
+      });
+
+      it('throws rather than sending an invalid riskPhase for a formCode with a riskRuleSetId but no mapping entry', async () => {
+        repository.findVersionById.mockResolvedValue({
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'SOME_UNMAPPED_FORM', riskRuleSetId: 'rule-set-1' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        } as never);
+
+        await expect(
+          service.createSubmission(
+            'SOME_UNMAPPED_FORM',
+            {
+              formVersionId: 'version-1',
+              beneficiaryId: 'b1',
+              visitId: 'visit-1',
+              localSubmissionUuid: 'uuid-1',
+              formData: {},
+            },
+            'u1',
+            'Bearer test-token',
+          ),
+        ).rejects.toThrow(/FORM_CODE_TO_RISK_PHASE/);
+
+        expect(jest.mocked(triggerRiskAssessment)).not.toHaveBeenCalled();
+      });
+    });
+
     describe('DELIVERY_VISIT childBeneficiaryIds in response', () => {
       const motherCase = {
         id: 'b1',
@@ -1551,12 +1814,14 @@ describe('FormService', () => {
         projectId: 'project-1',
         beneficiaryTypeLookupId: 'type-1',
         caseTypeLookupId: 'case-type-1',
+        currentPhase: 'ANC',
         villageId: 'village-1',
         padaId: 'pada-1',
         healthSubCentreId: 'sc-1',
         phcId: 'phc-1',
         stateId: 'state-1',
         districtId: 'district-1',
+        childDateOfBirth: null,
       };
 
       const deliveryVersion = {
@@ -2203,6 +2468,82 @@ describe('FormService', () => {
           'Bearer test-token',
         );
       });
+    });
+  });
+
+  describe('getLatestVisitVitals', () => {
+    const sakhiCaller = { id: 'sakhi-1', roles: ['SAKHI'] as const };
+
+    beforeEach(() => {
+      jest.mocked(findBeneficiaryOwnership).mockResolvedValue({ sakhiId: 'sakhi-1' } as never);
+    });
+
+    it("extracts the latest visit's vitals per its own formCode's mapping", async () => {
+      repository.findLatestVisitSubmission.mockResolvedValue({
+        visitId: 'visit-1',
+        submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        formDataJson: { blood_pressure_bp_systolic: 120, haemoglobin_hb_g_dl: 11.5 },
+        formVersion: { formDefinition: { formCode: 'ANC_VISIT' } },
+      } as never);
+
+      const result = await service.getLatestVisitVitals('ben-1', sakhiCaller, 'Bearer test-token');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          visitId: 'visit-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+          systolicBp: 120,
+          hemoglobinGDl: 11.5,
+          weightKg: null,
+        }),
+      );
+    });
+
+    it('returns an all-null snapshot with null visitId/submittedAt when the beneficiary has never had a qualifying visit', async () => {
+      repository.findLatestVisitSubmission.mockResolvedValue(null);
+
+      const result = await service.getLatestVisitVitals('ben-1', sakhiCaller, 'Bearer test-token');
+
+      expect(result).toEqual({
+        visitId: null,
+        submittedAt: null,
+        weightKg: null,
+        systolicBp: null,
+        diastolicBp: null,
+        temperatureF: null,
+        hemoglobinGDl: null,
+        muacCm: null,
+        respiratoryRate: null,
+      });
+    });
+
+    it("rejects when the beneficiary is outside the calling SAKHI's own roster", async () => {
+      jest.mocked(findBeneficiaryOwnership).mockResolvedValue({ sakhiId: 'someone-else' } as never);
+
+      await expect(
+        service.getLatestVisitVitals('ben-1', sakhiCaller, 'Bearer test-token'),
+      ).rejects.toThrow(/outside your own roster/);
+      expect(repository.findLatestVisitSubmission).not.toHaveBeenCalled();
+    });
+
+    it('throws not-found when the beneficiary case does not exist', async () => {
+      jest.mocked(findBeneficiaryOwnership).mockResolvedValue(null);
+
+      await expect(
+        service.getLatestVisitVitals('ben-1', sakhiCaller, 'Bearer test-token'),
+      ).rejects.toThrow(/not found/i);
+    });
+
+    it('resolves ownership via findBeneficiaryOwnership, NOT findBeneficiaryById — using the full profile lookup here would call back into GET /beneficiaries/:id and recreate the vitals request cycle', async () => {
+      repository.findLatestVisitSubmission.mockResolvedValue(null);
+
+      await service.getLatestVisitVitals('ben-1', sakhiCaller, 'Bearer test-token');
+
+      expect(jest.mocked(findBeneficiaryOwnership)).toHaveBeenCalledWith(
+        'ben-1',
+        'Bearer test-token',
+      );
+      expect(jest.mocked(findBeneficiaryById)).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -21,6 +21,7 @@ import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
+import { resolveVisitCompletion } from './visitCompletion.resolver';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
@@ -31,6 +32,7 @@ jest.mock('../beneficiaries/update-phase.client');
 jest.mock('../closures/closure.client');
 jest.mock('../risk-assessments/riskAssessment.client');
 jest.mock('./ccvOpeningRiskState.resolver');
+jest.mock('./visitCompletion.resolver');
 
 describe('FormService', () => {
   const repository = {
@@ -51,6 +53,8 @@ describe('FormService', () => {
   const visitInstanceRepository = {
     findRecentCompletedIncVisits: jest.fn(),
     findAllCompletedInfantVisitIds: jest.fn(),
+    findById: jest.fn(),
+    updateStatus: jest.fn(),
   } as unknown as jest.Mocked<VisitInstanceRepository>;
   let service: FormService;
 
@@ -574,6 +578,90 @@ describe('FormService', () => {
         expect.objectContaining({ validationStatus: 'VALID' }),
       );
       expect(result).toEqual({ id: 'sub-1' });
+    });
+
+    describe('visit completion on submission', () => {
+      it('attempts to complete the linked visit after a successful visit-linked submission', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(resolveVisitCompletion)).toHaveBeenCalledWith(
+          'MOTHER_REGISTRATION',
+          'visit-1',
+          'u1',
+          visitInstanceRepository,
+          'Bearer test-token',
+        );
+      });
+
+      it('still attempts completion (with visitId undefined) for a submission with no visitId', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+        await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        // resolveVisitCompletion itself no-ops on an undefined visitId — the
+        // service always calls it, the resolver decides whether there's
+        // anything to complete (same "always call, resolver no-ops" shape
+        // as the other best-effort calls in this function).
+        expect(jest.mocked(resolveVisitCompletion)).toHaveBeenCalledWith(
+          'MOTHER_REGISTRATION',
+          undefined,
+          'u1',
+          visitInstanceRepository,
+          'Bearer test-token',
+        );
+      });
+
+      it('is awaited after the submission already committed, so its own best-effort tolerance (see visitCompletion.resolver.spec.ts) is what protects the submission, not an extra guard here', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(publishedVersion as never);
+        repository.findVisitById.mockResolvedValue({ id: 'visit-1' } as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+        jest.mocked(resolveVisitCompletion).mockResolvedValue(undefined);
+
+        const result = await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { phone_owner: 'SELF' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result).toEqual({ id: 'sub-1' });
+        expect(repository.createSubmission).toHaveBeenCalled();
+      });
     });
 
     describe('visitId validation', () => {
@@ -2525,6 +2613,7 @@ describe('FormService', () => {
         hemoglobinGDl: null,
         muacCm: null,
         respiratoryRate: null,
+        bloodSugarMgDl: null,
       });
     });
 

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -1,3 +1,14 @@
+/**
+ * ccvOpeningRiskState.resolver.ts (jest.mock()'d below) imports appConfig
+ * from ../config/app-config, which calls process.exit(1) at module-load
+ * time if DATABASE_URL isn't a valid URL — jest.mock() still requires the
+ * real module once to build its automatic mock, so this must be set before
+ * any import below (see reporting-etl-service's info.controller.spec.ts and
+ * risk-referral-service's riskCondition.controller.spec.ts for the same
+ * workaround).
+ */
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/test';
+
 import { FormService } from './form.service';
 import type { FormRepository } from './form.repository';
 import type { VisitInstanceRepository } from '../visits/visitInstance.repository';

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -1,4 +1,4 @@
-import { badRequest, conflict, notFound, unprocessable } from '@armman/service-commons';
+import { badRequest, conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
 import type { FormRepository } from './form.repository';
 import { schemaJsonSchema, validationJsonSchema } from './dto/form-field.dto';
 import type { CreateDraftVersionInput } from './dto/create-draft-version.dto';
@@ -13,22 +13,37 @@ import {
 import { validateSubmission } from './form-validation';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
-import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
+import { findBeneficiaryById, findBeneficiaryOwnership } from '../beneficiaries/beneficiary.client';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
 import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
+import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
+import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
+import { extractVitals } from './vitalsExtractor';
+import { listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
 
 /**
  * Maps this service's own formCode to risk-referral-service's RiskCondition
  * .phase enum value, for the risk-assessment trigger's `riskPhase` field
  * (see riskAssessment.client.ts's doc comment on why the caller supplies
- * this). Only forms with a risk_rule_set_id configured ever reach this map;
- * a formCode with no entry here falls back to itself unchanged.
+ * this). Only forms with a risk_rule_set_id configured ever reach this map
+ * (see the `dto.visitId && version.formDefinition.riskRuleSetId` guard in
+ * createSubmission) — every formCode that can carry a riskRuleSetId today
+ * must have an entry here; there is no safe fallback (see the PR #172
+ * review: a fallback to the raw formCode previously here was never a valid
+ * riskPhase, and a form assigned a ruleSetId out-of-band would silently and
+ * permanently break its risk-grading pipeline the moment risk-referral-
+ * service's strict enum rejected it — logged only as a console.warn inside
+ * triggerRiskAssessment, with no retry).
  */
 const FORM_CODE_TO_RISK_PHASE: Record<string, string> = {
+  MOTHER_REGISTRATION: 'REGISTRATION',
+  CHILD_REGISTRATION: 'REGISTRATION',
   ANC_VISIT: 'ANC',
+  DELIVERY_VISIT: 'DELIVERY',
+  POSTPARTUM_VISIT: 'PP',
   // NN, INC, and CCV all share one seeded set of risk_conditions rows under
   // phase 'INC' — per SRS §3A.2.4, CCV reuses INC's HR thresholds verbatim,
   // and NEONATAL_VISIT's clinical fields (nutrition status, danger signs,
@@ -43,12 +58,30 @@ const FORM_CODE_TO_RISK_PHASE: Record<string, string> = {
 };
 
 /**
+ * Maps a formCode to the CHILD case phase its submission advances the
+ * beneficiary to (CR-041's CHILD side, mirroring FORM_CODE_TO_RISK_PHASE's
+ * lookup style) — see the phase-advance block below in createSubmission. A
+ * formCode with no entry here never triggers a phase-advance call.
+ * NEONATAL_VISIT is the legacy alias of INC_VISIT (see
+ * visit-code-form-map.ts) and shares its target phase for the same reason
+ * FORM_CODE_TO_RISK_PHASE aliases them together.
+ */
+const FORM_CODE_TO_CHILD_PHASE: Record<string, string> = {
+  NEONATAL_VISIT: 'INC',
+  INC_VISIT: 'INC',
+  CCV_VISIT: 'CCV',
+};
+
+/**
  * Business logic for the dynamic-forms feature: fetching the active version,
  * the DRAFT -> PUBLISHED lifecycle, and validating/persisting submissions.
  * Data access is delegated to the repository.
  */
 export class FormService {
-  constructor(private readonly repository: FormRepository) {}
+  constructor(
+    private readonly repository: FormRepository,
+    private readonly visitInstanceRepository: VisitInstanceRepository,
+  ) {}
 
   /**
    * `callerGeographyUnitId`/`authorizationHeader` are the caller's own scope
@@ -313,12 +346,61 @@ export class FormService {
       );
     }
 
+    // Advances a CHILD case's phase on its first INC-type or CCV-type visit
+    // submission (NN->INC, INC->CCV — CR-041's CHILD side; see
+    // FORM_CODE_TO_CHILD_PHASE). Best-effort, same tolerance as the Delivery
+    // phase-advance calls above: safe to call on every subsequent visit of
+    // the same type too, since applyPhaseChange treats an already-matching
+    // phase as a no-op rather than an error (see beneficiary.service.ts).
+    const childPhase = FORM_CODE_TO_CHILD_PHASE[formCode];
+    if (childPhase) {
+      // BR-13 must run exactly once, at the actual INC->CCV transition — not
+      // on every subsequent CCV_VISIT submission, which would keep
+      // re-computing (and overwriting) ccvOpeningRiskState after it's
+      // already set. Read the case's phase BEFORE advancing it so this
+      // check reflects "was this submission the one that moved CCV" rather
+      // than the post-advance state, which is always CCV once the first
+      // submission has landed.
+      const caseBeforeAdvance =
+        childPhase === 'CCV'
+          ? await findBeneficiaryById(dto.beneficiaryId, authorizationHeader)
+          : null;
+      const isFirstCcvTransition = caseBeforeAdvance?.currentPhase === 'INC';
+
+      await toleratePhaseAdvance(
+        updateBeneficiaryPhase(dto.beneficiaryId, childPhase, authorizationHeader),
+      );
+
+      if (isFirstCcvTransition && caseBeforeAdvance?.childDateOfBirth) {
+        await resolveAndWriteCcvOpeningRiskState(
+          dto.beneficiaryId,
+          caseBeforeAdvance.childDateOfBirth,
+          this.visitInstanceRepository,
+          authorizationHeader,
+        );
+      }
+    }
+
     // Triggers the risk-grading pipeline for every visit-linked submission
     // whose form has a risk_rule_set_id configured (see FormDefinition's
     // schema comment) — a form with no ruleSetId set (e.g. SUPERVISOR/SYSTEM
     // entityType forms) simply has nothing to evaluate. Best-effort, same
     // stance as syncSocioDemographics above.
     if (dto.visitId && version.formDefinition.riskRuleSetId) {
+      const riskPhase = FORM_CODE_TO_RISK_PHASE[formCode];
+      if (!riskPhase) {
+        // A form was given a riskRuleSetId out-of-band (no admin endpoint
+        // yet — see schema.prisma) without a matching FORM_CODE_TO_RISK_PHASE
+        // entry. Failing loudly here, instead of silently posting an invalid
+        // riskPhase that risk-referral-service's strict enum would reject
+        // downstream, surfaces the config gap immediately at submission time
+        // rather than as a permanently-broken, easy-to-miss best-effort
+        // console.warn (see PR #172 review).
+        throw new Error(
+          `Form "${formCode}" has a riskRuleSetId configured but no FORM_CODE_TO_RISK_PHASE ` +
+            'entry — add one before assigning this form a rule set.',
+        );
+      }
       const answers =
         formCode === 'ANC_VISIT'
           ? {
@@ -332,7 +414,7 @@ export class FormService {
           visitId: dto.visitId,
           submissionId: created.id,
           ruleSetId: version.formDefinition.riskRuleSetId,
-          riskPhase: FORM_CODE_TO_RISK_PHASE[formCode] ?? formCode,
+          riskPhase,
           answers,
         },
         authorizationHeader,
@@ -369,20 +451,15 @@ export class FormService {
    * recorded.
    */
   /**
-   * Derives the ANC risk pack's registration-time inputs (age, bad obstetric
-   * history) from this beneficiary's own MOTHER_REGISTRATION submission —
-   * a same-service, same-DB lookup (no cross-service call needed: both
-   * age_of_the_beneficiary and the obstetric-history answers live on this
-   * same form). Appendix D's Bad Obstetric
-   * History condition ("G>4, L<P, Pre-term, LSCS without spacing,
-   * consecutive losses/ABORTIONS >=2, stillbirth, neonatal death, or
-   * recurrent complications") only partially maps onto what
-   * MOTHER_REGISTRATION actually asks — this derivation covers
-   * gravida>4, livingChildren<gravida, abortions>=2, and any
-   * non-"no_complications" answer on the prior-complications question.
-   * Pre-term delivery history and LSCS-without-spacing have no captured
-   * field in this form today and are NOT evaluated — a known gap versus
-   * the full Appendix D definition, not a bug.
+   * Fetches the ANC risk pack's registration-time inputs (age and the raw
+   * obstetric-history fields the pack derives Bad Obstetric History from)
+   * from this beneficiary's own MOTHER_REGISTRATION submission — a
+   * same-service, same-DB lookup (no cross-service call needed). Passed
+   * through unchanged; the Bad Obstetric History threshold itself (G>4,
+   * L<P, abortions>=2, prior complications) is business-threshold math and
+   * lives in anc-risk.rulesJson.ts (GoRules), not here — see PR #172 review
+   * on .claude/CLAUDE.md's "business thresholds/rates ... live in GoRules"
+   * rule.
    *
    * Returns `{}` (no registration answers merged in) if no
    * MOTHER_REGISTRATION submission exists yet for this beneficiary — the
@@ -406,17 +483,12 @@ export class FormService {
     const complications =
       answers.did_you_experience_any_complications_during_birth_delivery_in_previous_pregnancies;
 
-    const badObstetricHistoryFlag =
-      (typeof gravida === 'number' && gravida > 4) ||
-      (typeof gravida === 'number' &&
-        typeof livingChildren === 'number' &&
-        livingChildren < gravida) ||
-      (typeof abortions === 'number' && abortions >= 2) ||
-      (Array.isArray(complications) && complications.some((code) => code !== 'no_complications'));
-
     return {
       ...(typeof age === 'number' ? { age } : {}),
-      badObstetricHistoryFlag,
+      ...(typeof gravida === 'number' ? { gravida } : {}),
+      ...(typeof livingChildren === 'number' ? { livingChildren } : {}),
+      ...(typeof abortions === 'number' ? { abortions } : {}),
+      ...(Array.isArray(complications) ? { priorComplications: complications } : {}),
     };
   }
 
@@ -591,6 +663,69 @@ export class FormService {
       },
       authorizationHeader,
     );
+  }
+
+  /**
+   * The most recent visit's vitals (weight/BP/temperature/hemoglobin/MUAC/
+   * respiratory rate) for `beneficiaryId`, projected out of that visit's
+   * formDataJson per its own formCode's question_codes (see
+   * vitalsExtractor.ts's own doc comment on why the mapping is
+   * formCode-specific — the question_codes genuinely differ across visit
+   * forms, not just cosmetically). Returns an all-null VitalsSnapshot (not
+   * a 404) when the beneficiary has never had a visit-linked clinical
+   * submission — this is the beneficiary's own valid, current state, not
+   * an error.
+   *
+   * IDOR guard: beneficiaryId is caller-supplied — without this check any
+   * authenticated SAKHI could read any beneficiary's vitals regardless of
+   * whose case it is. Resolves ownership via beneficiary-service's
+   * `GET /beneficiaries/:id/ownership` — deliberately NOT findBeneficiaryById
+   * (the full `GET /beneficiaries/:id`), whose own lastVisitVitals
+   * enrichment calls back into THIS endpoint; using it here would recreate
+   * that exact request cycle (getById -> resolveLatestVisitVitals -> here
+   * -> findBeneficiaryById -> getById -> ... forever, timing out on both
+   * sides — see findBeneficiaryOwnership's own doc comment). Same
+   * ownership rule as visitInstance.service.ts's own resolveCallerScoping:
+   * SAKHI own-case only, SUPERVISOR own-roster only, MANAGER/ADMIN
+   * unrestricted.
+   */
+  async getLatestVisitVitals(
+    beneficiaryId: string,
+    caller: { id: string; roles: readonly string[]; projectId?: string | null },
+    authorizationHeader: string,
+  ) {
+    const beneficiary = await findBeneficiaryOwnership(beneficiaryId, authorizationHeader);
+    if (!beneficiary) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (beneficiary.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else if (caller.roles.includes('SUPERVISOR')) {
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
+      const roster = await listSakhiIdsForSupervisor(
+        caller.projectId,
+        caller.id,
+        authorizationHeader,
+      );
+      if (!roster.includes(beneficiary.sakhiId)) {
+        throw forbidden("This beneficiary case is outside this Supervisor's roster.");
+      }
+    }
+
+    const submission = await this.repository.findLatestVisitSubmission(beneficiaryId);
+    if (!submission) return { visitId: null, submittedAt: null, ...extractVitals('', {}) };
+
+    return {
+      visitId: submission.visitId,
+      submittedAt: submission.submittedAt,
+      ...extractVitals(
+        submission.formVersion.formDefinition.formCode,
+        submission.formDataJson as Record<string, unknown>,
+      ),
+    };
   }
 }
 

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -21,6 +21,7 @@ import { getAncestorChain } from '../geography/geography.client';
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
 import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
+import { resolveVisitCompletion } from './visitCompletion.resolver';
 import { extractVitals } from './vitalsExtractor';
 import { listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
 
@@ -315,6 +316,18 @@ export class FormService {
       }
       throw err;
     }
+
+    // Marks the linked VisitInstance COMPLETED — without this, a visit only
+    // reaches COMPLETED via a second, separate PATCH /visits/:id call the
+    // client has to remember to make. Best-effort, same tolerance as every
+    // other post-submission side effect below.
+    await resolveVisitCompletion(
+      formCode,
+      dto.visitId,
+      submittedByUserId,
+      this.visitInstanceRepository,
+      authorizationHeader,
+    );
 
     // Promote the socio-demographic answers into beneficiary-service, which
     // owns them as structured columns (the registration form re-asks them so

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -1,4 +1,4 @@
-import { badRequest, conflict, forbidden, notFound, unprocessable } from '@armman/service-commons';
+import { badRequest, conflict, notFound, unprocessable } from '@armman/service-commons';
 import type { FormRepository } from './form.repository';
 import { schemaJsonSchema, validationJsonSchema } from './dto/form-field.dto';
 import type { CreateDraftVersionInput } from './dto/create-draft-version.dto';
@@ -13,7 +13,8 @@ import {
 import { validateSubmission } from './form-validation';
 import { syncSocioDemographics } from '../beneficiaries/socio-demographics.client';
 import { syncHealthHistory } from '../beneficiaries/health-history.client';
-import { findBeneficiaryById, findBeneficiaryOwnership } from '../beneficiaries/beneficiary.client';
+import { findBeneficiaryById } from '../beneficiaries/beneficiary.client';
+import { assertCallerOwnsBeneficiary } from '../beneficiaries/beneficiaryOwnership.guard';
 import { createChildBeneficiary } from '../beneficiaries/create-child.client';
 import { updateBeneficiaryPhase } from '../beneficiaries/update-phase.client';
 import { createClosure, resolveClosureReasonLookupId } from '../closures/closure.client';
@@ -22,8 +23,7 @@ import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client
 import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
 import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
 import { resolveVisitCompletion } from './visitCompletion.resolver';
-import { extractVitals } from './vitalsExtractor';
-import { listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
+import { EMPTY_VITALS, extractVitals } from './vitalsExtractor';
 
 /**
  * Maps this service's own formCode to risk-referral-service's RiskCondition
@@ -691,45 +691,26 @@ export class FormService {
    *
    * IDOR guard: beneficiaryId is caller-supplied — without this check any
    * authenticated SAKHI could read any beneficiary's vitals regardless of
-   * whose case it is. Resolves ownership via beneficiary-service's
-   * `GET /beneficiaries/:id/ownership` — deliberately NOT findBeneficiaryById
-   * (the full `GET /beneficiaries/:id`), whose own lastVisitVitals
-   * enrichment calls back into THIS endpoint; using it here would recreate
-   * that exact request cycle (getById -> resolveLatestVisitVitals -> here
-   * -> findBeneficiaryById -> getById -> ... forever, timing out on both
-   * sides — see findBeneficiaryOwnership's own doc comment). Same
-   * ownership rule as visitInstance.service.ts's own resolveCallerScoping:
-   * SAKHI own-case only, SUPERVISOR own-roster only, MANAGER/ADMIN
-   * unrestricted.
+   * whose case it is. assertCallerOwnsBeneficiary resolves ownership via
+   * beneficiary-service's `GET /beneficiaries/:id/ownership` — deliberately
+   * NOT findBeneficiaryById (the full `GET /beneficiaries/:id`), whose own
+   * lastVisitVitals enrichment calls back into THIS endpoint; using it here
+   * would recreate that exact request cycle (getById ->
+   * resolveLatestVisitVitals -> here -> findBeneficiaryById -> getById ->
+   * ... forever, timing out on both sides — see findBeneficiaryOwnership's
+   * own doc comment). Same shared check as visitInstance.service.ts's
+   * getVisitHistory: SAKHI own-case only, SUPERVISOR own-roster only,
+   * MANAGER/ADMIN unrestricted.
    */
   async getLatestVisitVitals(
     beneficiaryId: string,
     caller: { id: string; roles: readonly string[]; projectId?: string | null },
     authorizationHeader: string,
   ) {
-    const beneficiary = await findBeneficiaryOwnership(beneficiaryId, authorizationHeader);
-    if (!beneficiary) throw notFound('Beneficiary case not found.');
-
-    if (caller.roles.includes('SAKHI')) {
-      if (beneficiary.sakhiId !== caller.id) {
-        throw forbidden('This beneficiary case is outside your own roster.');
-      }
-    } else if (caller.roles.includes('SUPERVISOR')) {
-      if (!caller.projectId) {
-        throw forbidden('Supervisor caller has no project scope.');
-      }
-      const roster = await listSakhiIdsForSupervisor(
-        caller.projectId,
-        caller.id,
-        authorizationHeader,
-      );
-      if (!roster.includes(beneficiary.sakhiId)) {
-        throw forbidden("This beneficiary case is outside this Supervisor's roster.");
-      }
-    }
+    await assertCallerOwnsBeneficiary(beneficiaryId, caller, authorizationHeader);
 
     const submission = await this.repository.findLatestVisitSubmission(beneficiaryId);
-    if (!submission) return { visitId: null, submittedAt: null, ...extractVitals('', {}) };
+    if (!submission) return { visitId: null, submittedAt: null, ...EMPTY_VITALS };
 
     return {
       visitId: submission.visitId,

--- a/apps/visit-form-service/src/forms/visitCompletion.resolver.spec.ts
+++ b/apps/visit-form-service/src/forms/visitCompletion.resolver.spec.ts
@@ -1,0 +1,155 @@
+import { resolveVisitCompletion } from './visitCompletion.resolver';
+import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
+import { resolveVisitStatusCodes } from '../lookups/lookup.client';
+
+jest.mock('../lookups/lookup.client');
+
+describe('resolveVisitCompletion', () => {
+  const AUTH_HEADER = 'Bearer test-token';
+  const COMPLETED_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+  const PENDING_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+  const repository = {
+    findById: jest.fn(),
+    updateStatus: jest.fn(),
+  } as unknown as jest.Mocked<VisitInstanceRepository>;
+
+  const resolveVisitStatusCodesMock = jest.mocked(resolveVisitStatusCodes);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    resolveVisitStatusCodesMock.mockResolvedValue(new Map([[COMPLETED_ID, 'COMPLETED']]));
+  });
+
+  it('marks the visit COMPLETED when a vitals-bearing visit form is submitted', async () => {
+    repository.findById.mockResolvedValue({
+      id: 'visit-1',
+      statusLookupValueId: PENDING_ID,
+      completedAt: null,
+      actualVisitDate: null,
+      meetBeneficiaryFlag: null,
+      notMetReason: null,
+    } as never);
+
+    await resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER);
+
+    expect(repository.updateStatus).toHaveBeenCalledWith(
+      'visit-1',
+      PENDING_ID,
+      expect.objectContaining({ statusLookupValueId: COMPLETED_ID, completedAt: expect.any(Date) }),
+      'sakhi-1',
+    );
+  });
+
+  it.each(['POSTPARTUM_VISIT', 'NEONATAL_VISIT', 'INC_VISIT', 'CCV_VISIT'])(
+    'marks the visit COMPLETED for %s submissions too',
+    async (formCode) => {
+      repository.findById.mockResolvedValue({
+        id: 'visit-1',
+        statusLookupValueId: PENDING_ID,
+        completedAt: null,
+        actualVisitDate: null,
+        meetBeneficiaryFlag: null,
+        notMetReason: null,
+      } as never);
+
+      await resolveVisitCompletion(formCode, 'visit-1', 'sakhi-1', repository, AUTH_HEADER);
+
+      expect(repository.updateStatus).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does nothing when the submission has no visitId (one-time form)', async () => {
+    await resolveVisitCompletion(
+      'MOTHER_REGISTRATION',
+      undefined,
+      'sakhi-1',
+      repository,
+      AUTH_HEADER,
+    );
+
+    expect(repository.findById).not.toHaveBeenCalled();
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a visit-linked submission whose formCode does not complete a visit', async () => {
+    await resolveVisitCompletion(
+      'ANC_CLOSURE_VISIT',
+      'visit-1',
+      'sakhi-1',
+      repository,
+      AUTH_HEADER,
+    );
+
+    expect(repository.findById).not.toHaveBeenCalled();
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op when the visit is already COMPLETED', async () => {
+    repository.findById.mockResolvedValue({
+      id: 'visit-1',
+      statusLookupValueId: COMPLETED_ID,
+      completedAt: new Date('2026-08-01T00:00:00.000Z'),
+      actualVisitDate: new Date('2026-08-01T00:00:00.000Z'),
+      meetBeneficiaryFlag: true,
+      notMetReason: null,
+    } as never);
+
+    await expect(
+      resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER),
+    ).resolves.toBeUndefined();
+
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the completion write fails — the submission must still succeed', async () => {
+    repository.findById.mockResolvedValue({
+      id: 'visit-1',
+      statusLookupValueId: PENDING_ID,
+      completedAt: null,
+      actualVisitDate: null,
+      meetBeneficiaryFlag: null,
+      notMetReason: null,
+    } as never);
+    repository.updateStatus.mockRejectedValue(new Error('db unavailable'));
+
+    await expect(
+      resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER),
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws when the visit lookup itself fails', async () => {
+    repository.findById.mockRejectedValue(new Error('db unavailable'));
+
+    await expect(
+      resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER),
+    ).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when the visit no longer exists', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER);
+
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('warns and skips when the VISIT_STATUS lookup category has no COMPLETED value', async () => {
+    resolveVisitStatusCodesMock.mockResolvedValue(new Map([[PENDING_ID, 'PENDING']]));
+    repository.findById.mockResolvedValue({
+      id: 'visit-1',
+      statusLookupValueId: PENDING_ID,
+      completedAt: null,
+      actualVisitDate: null,
+      meetBeneficiaryFlag: null,
+      notMetReason: null,
+    } as never);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER);
+
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no COMPLETED value'));
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/visit-form-service/src/forms/visitCompletion.resolver.spec.ts
+++ b/apps/visit-form-service/src/forms/visitCompletion.resolver.spec.ts
@@ -102,6 +102,26 @@ describe('resolveVisitCompletion', () => {
     expect(repository.updateStatus).not.toHaveBeenCalled();
   });
 
+  it('leaves meetBeneficiaryFlag null rather than defaulting it to true — that is a clinical fact the Sakhi never asserted via this auto-completion path', async () => {
+    repository.findById.mockResolvedValue({
+      id: 'visit-1',
+      statusLookupValueId: PENDING_ID,
+      completedAt: null,
+      actualVisitDate: null,
+      meetBeneficiaryFlag: null,
+      notMetReason: null,
+    } as never);
+
+    await resolveVisitCompletion('ANC_VISIT', 'visit-1', 'sakhi-1', repository, AUTH_HEADER);
+
+    expect(repository.updateStatus).toHaveBeenCalledWith(
+      'visit-1',
+      PENDING_ID,
+      expect.objectContaining({ meetBeneficiaryFlag: undefined }),
+      'sakhi-1',
+    );
+  });
+
   it('never throws when the completion write fails — the submission must still succeed', async () => {
     repository.findById.mockResolvedValue({
       id: 'visit-1',

--- a/apps/visit-form-service/src/forms/visitCompletion.resolver.ts
+++ b/apps/visit-form-service/src/forms/visitCompletion.resolver.ts
@@ -1,0 +1,82 @@
+import type { VisitInstanceRepository } from '../visits/visitInstance.repository';
+import { resolveVisitStatusCodes } from '../lookups/lookup.client';
+
+/**
+ * The visit-linked form codes that actually represent a clinical visit
+ * being conducted — same set as vitalsExtractor.ts's
+ * FORM_CODE_TO_VITALS_MAPPING (the vitals-bearing visit forms), reused here
+ * rather than re-derived: a submission against one of these forms IS the
+ * visit being conducted, so its success is also the visit's completion
+ * signal. *_CLOSURE_VISIT and one-time forms like MOTHER_REGISTRATION are
+ * deliberately excluded — those don't represent a scheduled visit being
+ * completed.
+ */
+const VISIT_COMPLETING_FORM_CODES = new Set([
+  'ANC_VISIT',
+  'POSTPARTUM_VISIT',
+  'NEONATAL_VISIT',
+  'INC_VISIT',
+  'CCV_VISIT',
+]);
+
+/**
+ * Marks a visit-linked submission's VisitInstance COMPLETED, best-effort —
+ * same tolerance as every other post-submission side effect in
+ * form.service.ts's createSubmission (phase-advance, risk-trigger,
+ * ccvOpeningRiskState): a failure here must never fail the submission
+ * itself, since the submission (and its form_answers) already committed
+ * successfully before this runs.
+ *
+ * Without this, a visit only reaches VISIT_STATUS COMPLETED via a second,
+ * separate `PATCH /visits/:id` call the client has to remember to make —
+ * this closes that gap so "the visit's form was submitted" and "the visit
+ * is COMPLETED" can't drift apart. Silently a no-op if the visit is already
+ * COMPLETED (e.g. the client also called PATCH itself, or this is an
+ * idempotent submission replay) — this is a side effect, not a direct API
+ * call, so there's no caller waiting on a 409 the way PATCH /visits/:id's
+ * own conflict check works.
+ */
+export async function resolveVisitCompletion(
+  formCode: string,
+  visitId: string | null | undefined,
+  changedByUserId: string,
+  visitInstanceRepository: VisitInstanceRepository,
+  authorizationHeader: string,
+): Promise<void> {
+  if (!visitId || !VISIT_COMPLETING_FORM_CODES.has(formCode)) return;
+
+  try {
+    const existing = await visitInstanceRepository.findById(visitId);
+    if (!existing || existing.completedAt) return;
+
+    const statusCodes = await resolveVisitStatusCodes(authorizationHeader);
+    const completedStatusId = [...statusCodes.entries()].find(
+      ([, code]) => code === 'COMPLETED',
+    )?.[0];
+    if (!completedStatusId) {
+      console.warn(
+        'VISIT_STATUS lookup category has no COMPLETED value — skipping visit completion ' +
+          `for visit ${visitId}.`,
+      );
+      return;
+    }
+
+    await visitInstanceRepository.updateStatus(
+      visitId,
+      existing.statusLookupValueId,
+      {
+        statusLookupValueId: completedStatusId,
+        actualVisitDate: existing.actualVisitDate ?? new Date(),
+        meetBeneficiaryFlag: existing.meetBeneficiaryFlag ?? true,
+        notMetReason: existing.notMetReason ?? undefined,
+        completedAt: new Date(),
+      },
+      changedByUserId,
+    );
+  } catch (err) {
+    console.warn(
+      `Failed to auto-complete visit ${visitId} on form submission. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/visit-form-service/src/forms/visitCompletion.resolver.ts
+++ b/apps/visit-form-service/src/forms/visitCompletion.resolver.ts
@@ -66,8 +66,15 @@ export async function resolveVisitCompletion(
       existing.statusLookupValueId,
       {
         statusLookupValueId: completedStatusId,
+        // actualVisitDate defaults to now — the visit demonstrably happened
+        // (its form was just submitted), so "when" is a safe inference.
+        // meetBeneficiaryFlag is left null rather than defaulted to true —
+        // meetBeneficiaryFlag is nullable (schema.prisma), and "was the
+        // beneficiary met" is a clinical fact the Sakhi never asserted via
+        // this auto-completion path; defaulting it would write an assertion
+        // no one made.
         actualVisitDate: existing.actualVisitDate ?? new Date(),
-        meetBeneficiaryFlag: existing.meetBeneficiaryFlag ?? true,
+        meetBeneficiaryFlag: existing.meetBeneficiaryFlag ?? undefined,
         notMetReason: existing.notMetReason ?? undefined,
         completedAt: new Date(),
       },

--- a/apps/visit-form-service/src/forms/vitalsExtractor.spec.ts
+++ b/apps/visit-form-service/src/forms/vitalsExtractor.spec.ts
@@ -1,0 +1,117 @@
+import { extractVitals } from './vitalsExtractor';
+
+describe('extractVitals', () => {
+  it('extracts ANC_VISIT vitals from their own question_codes', () => {
+    const result = extractVitals('ANC_VISIT', {
+      current_weight_of_the_woman_in_kg: 58.5,
+      blood_pressure_bp_systolic: 120,
+      blood_pressure_bp_diastolic: 80,
+      body_temperature_in_f: 98.6,
+      haemoglobin_hb_g_dl: 11.2,
+      mid_upper_arm_circumference_in_cm: 24.5,
+    });
+
+    expect(result).toEqual({
+      weightKg: 58.5,
+      systolicBp: 120,
+      diastolicBp: 80,
+      temperatureF: 98.6,
+      hemoglobinGDl: 11.2,
+      muacCm: 24.5,
+      respiratoryRate: null,
+    });
+  });
+
+  it('extracts POSTPARTUM_VISIT vitals from its own DIFFERENT question_codes for the same concepts', () => {
+    const result = extractVitals('POSTPARTUM_VISIT', {
+      current_weight_kg: 55,
+      bp_systolic: 118,
+      bp_diastolic: 76,
+      body_temperature_f: 98.4,
+      haemoglobin_g_dl: 12.1,
+      current_muac_cm: 25,
+    });
+
+    expect(result).toEqual({
+      weightKg: 55,
+      systolicBp: 118,
+      diastolicBp: 76,
+      temperatureF: 98.4,
+      hemoglobinGDl: 12.1,
+      muacCm: 25,
+      respiratoryRate: null,
+    });
+  });
+
+  it('extracts INC_VISIT vitals (weight/MUAC/respiratory rate, no BP/hemoglobin)', () => {
+    const result = extractVitals('INC_VISIT', {
+      current_weight_in_kg: 8.2,
+      muac_in_cms: 13.5,
+      child_respiratory_rate_2_12_months: 32,
+    });
+
+    expect(result).toEqual({
+      weightKg: 8.2,
+      systolicBp: null,
+      diastolicBp: null,
+      temperatureF: null,
+      hemoglobinGDl: null,
+      muacCm: 13.5,
+      respiratoryRate: 32,
+    });
+  });
+
+  it('extracts CCV_VISIT vitals using the same mapping as INC_VISIT (shared schema)', () => {
+    const result = extractVitals('CCV_VISIT', {
+      current_weight_in_kg: 10.5,
+      muac_in_cms: 14.2,
+      child_respiratory_rate_2_12_months: 28,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ weightKg: 10.5, muacCm: 14.2, respiratoryRate: 28 }),
+    );
+  });
+
+  it('extracts only weightKg for NEONATAL_VISIT (its schema has no BP/hemoglobin/MUAC/respiratory-rate questions)', () => {
+    const result = extractVitals('NEONATAL_VISIT', { current_weight_kg: 3.1 });
+
+    expect(result).toEqual({
+      weightKg: 3.1,
+      systolicBp: null,
+      diastolicBp: null,
+      temperatureF: null,
+      hemoglobinGDl: null,
+      muacCm: null,
+      respiratoryRate: null,
+    });
+  });
+
+  it('returns an all-null snapshot for a formCode with no vitals mapping (e.g. a closure visit)', () => {
+    const result = extractVitals('ANC_CLOSURE_VISIT', { closure_visit_date: '2026-01-01' });
+
+    expect(result).toEqual({
+      weightKg: null,
+      systolicBp: null,
+      diastolicBp: null,
+      temperatureF: null,
+      hemoglobinGDl: null,
+      muacCm: null,
+      respiratoryRate: null,
+    });
+  });
+
+  it('leaves a field null when the source question_code is missing from formDataJson', () => {
+    const result = extractVitals('ANC_VISIT', { blood_pressure_bp_systolic: 130 });
+
+    expect(result.systolicBp).toBe(130);
+    expect(result.weightKg).toBeNull();
+    expect(result.hemoglobinGDl).toBeNull();
+  });
+
+  it('treats a non-numeric answer (e.g. a blank string) as null rather than throwing', () => {
+    const result = extractVitals('ANC_VISIT', { blood_pressure_bp_systolic: '' });
+
+    expect(result.systolicBp).toBeNull();
+  });
+});

--- a/apps/visit-form-service/src/forms/vitalsExtractor.spec.ts
+++ b/apps/visit-form-service/src/forms/vitalsExtractor.spec.ts
@@ -1,4 +1,4 @@
-import { extractVitals } from './vitalsExtractor';
+import { extractVisitHistoryVitals, extractVitals } from './vitalsExtractor';
 
 describe('extractVitals', () => {
   it('extracts ANC_VISIT vitals from their own question_codes', () => {
@@ -9,6 +9,7 @@ describe('extractVitals', () => {
       body_temperature_in_f: 98.6,
       haemoglobin_hb_g_dl: 11.2,
       mid_upper_arm_circumference_in_cm: 24.5,
+      blood_glucose_in_mg_dl: 95,
     });
 
     expect(result).toEqual({
@@ -19,6 +20,7 @@ describe('extractVitals', () => {
       hemoglobinGDl: 11.2,
       muacCm: 24.5,
       respiratoryRate: null,
+      bloodSugarMgDl: 95,
     });
   });
 
@@ -30,6 +32,7 @@ describe('extractVitals', () => {
       body_temperature_f: 98.4,
       haemoglobin_g_dl: 12.1,
       current_muac_cm: 25,
+      random_blood_glucose_mg_dl: 88,
     });
 
     expect(result).toEqual({
@@ -40,10 +43,11 @@ describe('extractVitals', () => {
       hemoglobinGDl: 12.1,
       muacCm: 25,
       respiratoryRate: null,
+      bloodSugarMgDl: 88,
     });
   });
 
-  it('extracts INC_VISIT vitals (weight/MUAC/respiratory rate, no BP/hemoglobin)', () => {
+  it('extracts INC_VISIT vitals (weight/MUAC/respiratory rate, no BP/hemoglobin/blood sugar)', () => {
     const result = extractVitals('INC_VISIT', {
       current_weight_in_kg: 8.2,
       muac_in_cms: 13.5,
@@ -58,6 +62,7 @@ describe('extractVitals', () => {
       hemoglobinGDl: null,
       muacCm: 13.5,
       respiratoryRate: 32,
+      bloodSugarMgDl: null,
     });
   });
 
@@ -73,7 +78,7 @@ describe('extractVitals', () => {
     );
   });
 
-  it('extracts only weightKg for NEONATAL_VISIT (its schema has no BP/hemoglobin/MUAC/respiratory-rate questions)', () => {
+  it('extracts only weightKg for NEONATAL_VISIT (its schema has no BP/hemoglobin/MUAC/respiratory-rate/blood-sugar questions)', () => {
     const result = extractVitals('NEONATAL_VISIT', { current_weight_kg: 3.1 });
 
     expect(result).toEqual({
@@ -84,6 +89,7 @@ describe('extractVitals', () => {
       hemoglobinGDl: null,
       muacCm: null,
       respiratoryRate: null,
+      bloodSugarMgDl: null,
     });
   });
 
@@ -98,6 +104,7 @@ describe('extractVitals', () => {
       hemoglobinGDl: null,
       muacCm: null,
       respiratoryRate: null,
+      bloodSugarMgDl: null,
     });
   });
 
@@ -113,5 +120,49 @@ describe('extractVitals', () => {
     const result = extractVitals('ANC_VISIT', { blood_pressure_bp_systolic: '' });
 
     expect(result.systolicBp).toBeNull();
+  });
+});
+
+describe('extractVisitHistoryVitals', () => {
+  it('shapes an ANC_VISIT submission into unit-wrapped vitals, values as strings', () => {
+    const result = extractVisitHistoryVitals('ANC_VISIT', {
+      current_weight_of_the_woman_in_kg: 60.2,
+      blood_pressure_bp_systolic: 120,
+      blood_pressure_bp_diastolic: 80,
+      body_temperature_in_f: 98.6,
+      haemoglobin_hb_g_dl: 9.4,
+      blood_glucose_in_mg_dl: 95,
+    });
+
+    expect(result).toEqual({
+      hemoglobin: { value: '9.4', unit: 'g/dl' },
+      bloodPressure: { systolic: 120, diastolic: 80, unit: 'mmHg' },
+      weight: { value: '60.2', unit: 'kg' },
+      bloodSugar: { value: '95', unit: 'mg/dl' },
+      temperature: { value: '98.6', unit: '°F' },
+    });
+  });
+
+  it('nulls a vital not captured by the visit form, unit still present (e.g. PP visit has no blood-sugar question in this payload)', () => {
+    const result = extractVisitHistoryVitals('POSTPARTUM_VISIT', {
+      current_weight_kg: 55,
+      bp_systolic: 118,
+      bp_diastolic: 76,
+    });
+
+    expect(result.bloodSugar).toEqual({ value: null, unit: 'mg/dl' });
+    expect(result.hemoglobin).toEqual({ value: null, unit: 'g/dl' });
+  });
+
+  it('nulls both systolic and diastolic (but keeps the unit) for a formCode with no BP questions at all', () => {
+    const result = extractVisitHistoryVitals('NEONATAL_VISIT', { current_weight_kg: 3.1 });
+
+    expect(result.bloodPressure).toEqual({ systolic: null, diastolic: null, unit: 'mmHg' });
+  });
+
+  it('never converts temperature to Celsius — reports the stored °F value as-is', () => {
+    const result = extractVisitHistoryVitals('ANC_VISIT', { body_temperature_in_f: 98.6 });
+
+    expect(result.temperature).toEqual({ value: '98.6', unit: '°F' });
   });
 });

--- a/apps/visit-form-service/src/forms/vitalsExtractor.ts
+++ b/apps/visit-form-service/src/forms/vitalsExtractor.ts
@@ -1,0 +1,107 @@
+/**
+ * Extracts a normalized vitals object from a FormSubmission's schemaless
+ * formDataJson — the only place vitals live (FormSubmission has no typed
+ * BP/weight/hemoglobin columns; see form.repository.ts's
+ * findLatestVisitSubmission for the "which forms actually capture vitals"
+ * question). Each visit form uses a DIFFERENT question_code for the same
+ * concept (confirmed against the real seeded schemas: ANC_VISIT's
+ * `blood_pressure_bp_systolic` vs POSTPARTUM_VISIT's `bp_systolic`, ANC_VISIT's
+ * `haemoglobin_hb_g_dl` vs POSTPARTUM_VISIT's `haemoglobin_g_dl`, etc.) —
+ * there is no single universal key list; this map is keyed by formCode so
+ * each form's own question_codes normalize onto one shared response shape.
+ *
+ * A field with no source key for a given formCode is `null`, not omitted —
+ * the response shape is the same regardless of which visit type was most
+ * recent, so a caller never has to branch on formCode itself.
+ */
+export interface VitalsSnapshot {
+  weightKg: number | null;
+  systolicBp: number | null;
+  diastolicBp: number | null;
+  temperatureF: number | null;
+  hemoglobinGDl: number | null;
+  muacCm: number | null;
+  respiratoryRate: number | null;
+}
+
+const EMPTY_VITALS: VitalsSnapshot = {
+  weightKg: null,
+  systolicBp: null,
+  diastolicBp: null,
+  temperatureF: null,
+  hemoglobinGDl: null,
+  muacCm: null,
+  respiratoryRate: null,
+};
+
+/**
+ * question_code lookup per vitals field, per formCode — only the fields a
+ * given form's schema actually asks are present; the rest are undefined
+ * (mapped to null in the output, same as a field the Sakhi left blank).
+ * NEONATAL_VISIT has no BP/hemoglobin/respiratory-rate/MUAC questions (per
+ * the real seeded schema) and is intentionally sparse here, not an
+ * oversight.
+ */
+const FORM_CODE_TO_VITALS_MAPPING: Record<string, Partial<Record<keyof VitalsSnapshot, string>>> = {
+  ANC_VISIT: {
+    weightKg: 'current_weight_of_the_woman_in_kg',
+    systolicBp: 'blood_pressure_bp_systolic',
+    diastolicBp: 'blood_pressure_bp_diastolic',
+    temperatureF: 'body_temperature_in_f',
+    hemoglobinGDl: 'haemoglobin_hb_g_dl',
+    muacCm: 'mid_upper_arm_circumference_in_cm',
+  },
+  POSTPARTUM_VISIT: {
+    weightKg: 'current_weight_kg',
+    systolicBp: 'bp_systolic',
+    diastolicBp: 'bp_diastolic',
+    temperatureF: 'body_temperature_f',
+    hemoglobinGDl: 'haemoglobin_g_dl',
+    muacCm: 'current_muac_cm',
+  },
+  NEONATAL_VISIT: {
+    weightKg: 'current_weight_kg',
+  },
+  // INC_VISIT and CCV_VISIT share one seeded schema (infant-visit.json —
+  // see visit-code-form-map.ts / prisma/seed.ts's own note on why).
+  INC_VISIT: {
+    weightKg: 'current_weight_in_kg',
+    muacCm: 'muac_in_cms',
+    respiratoryRate: 'child_respiratory_rate_2_12_months',
+  },
+  CCV_VISIT: {
+    weightKg: 'current_weight_in_kg',
+    muacCm: 'muac_in_cms',
+    respiratoryRate: 'child_respiratory_rate_2_12_months',
+  },
+};
+
+function toNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Projects `formDataJson` down to VitalsSnapshot per `formCode`'s own
+ * question_code mapping. A formCode with no entry in
+ * FORM_CODE_TO_VITALS_MAPPING (or a mapping with no key for a given field)
+ * returns/leaves that field null rather than throwing — this must never
+ * fail the whole `GET /beneficiaries/:id/latest-visit-vitals` request, per
+ * the same "degrade to null" stance as every other cross-service resolver
+ * in this codebase.
+ */
+export function extractVitals(
+  formCode: string,
+  formDataJson: Record<string, unknown>,
+): VitalsSnapshot {
+  const mapping = FORM_CODE_TO_VITALS_MAPPING[formCode];
+  if (!mapping) return { ...EMPTY_VITALS };
+
+  const result = { ...EMPTY_VITALS };
+  for (const field of Object.keys(mapping) as (keyof VitalsSnapshot)[]) {
+    const questionCode = mapping[field];
+    if (questionCode) {
+      result[field] = toNumberOrNull(formDataJson[questionCode]);
+    }
+  }
+  return result;
+}

--- a/apps/visit-form-service/src/forms/vitalsExtractor.ts
+++ b/apps/visit-form-service/src/forms/vitalsExtractor.ts
@@ -22,6 +22,7 @@ export interface VitalsSnapshot {
   hemoglobinGDl: number | null;
   muacCm: number | null;
   respiratoryRate: number | null;
+  bloodSugarMgDl: number | null;
 }
 
 const EMPTY_VITALS: VitalsSnapshot = {
@@ -32,6 +33,7 @@ const EMPTY_VITALS: VitalsSnapshot = {
   hemoglobinGDl: null,
   muacCm: null,
   respiratoryRate: null,
+  bloodSugarMgDl: null,
 };
 
 /**
@@ -50,6 +52,7 @@ const FORM_CODE_TO_VITALS_MAPPING: Record<string, Partial<Record<keyof VitalsSna
     temperatureF: 'body_temperature_in_f',
     hemoglobinGDl: 'haemoglobin_hb_g_dl',
     muacCm: 'mid_upper_arm_circumference_in_cm',
+    bloodSugarMgDl: 'blood_glucose_in_mg_dl',
   },
   POSTPARTUM_VISIT: {
     weightKg: 'current_weight_kg',
@@ -58,6 +61,7 @@ const FORM_CODE_TO_VITALS_MAPPING: Record<string, Partial<Record<keyof VitalsSna
     temperatureF: 'body_temperature_f',
     hemoglobinGDl: 'haemoglobin_g_dl',
     muacCm: 'current_muac_cm',
+    bloodSugarMgDl: 'random_blood_glucose_mg_dl',
   },
   NEONATAL_VISIT: {
     weightKg: 'current_weight_kg',
@@ -104,4 +108,44 @@ export function extractVitals(
     }
   }
   return result;
+}
+
+function toDecimalStringOrNull(value: number | null): string | null {
+  return value === null ? null : String(value);
+}
+
+/** Vitals shaped for GET /beneficiaries/:beneficiaryId/visit-history (FR-S-4.6) — each field is
+ * `{ value, unit }` (or `{ systolic, diastolic, unit }` for blood pressure), with `unit` always
+ * present even when the value is null, so the mobile client never has to hardcode units itself.
+ * `value` is stringified (matching the sample response in the SRS) rather than a raw number, to
+ * avoid float-precision surprises on decimal vitals like hemoglobin (9.4) — same rationale as
+ * Prisma's own Decimal columns being read out as strings elsewhere in this codebase.
+ *
+ * Temperature is reported in °F, the unit every seeded form actually captures it in (see
+ * FORM_CODE_TO_VITALS_MAPPING) — this endpoint does not convert to °C.
+ */
+export interface VisitHistoryVitals {
+  hemoglobin: { value: string | null; unit: 'g/dl' };
+  bloodPressure: { systolic: number | null; diastolic: number | null; unit: 'mmHg' };
+  weight: { value: string | null; unit: 'kg' };
+  bloodSugar: { value: string | null; unit: 'mg/dl' };
+  temperature: { value: string | null; unit: '°F' };
+}
+
+export function extractVisitHistoryVitals(
+  formCode: string,
+  formDataJson: Record<string, unknown>,
+): VisitHistoryVitals {
+  const snapshot = extractVitals(formCode, formDataJson);
+  return {
+    hemoglobin: { value: toDecimalStringOrNull(snapshot.hemoglobinGDl), unit: 'g/dl' },
+    bloodPressure: {
+      systolic: snapshot.systolicBp,
+      diastolic: snapshot.diastolicBp,
+      unit: 'mmHg',
+    },
+    weight: { value: toDecimalStringOrNull(snapshot.weightKg), unit: 'kg' },
+    bloodSugar: { value: toDecimalStringOrNull(snapshot.bloodSugarMgDl), unit: 'mg/dl' },
+    temperature: { value: toDecimalStringOrNull(snapshot.temperatureF), unit: '°F' },
+  };
 }

--- a/apps/visit-form-service/src/forms/vitalsExtractor.ts
+++ b/apps/visit-form-service/src/forms/vitalsExtractor.ts
@@ -25,7 +25,13 @@ export interface VitalsSnapshot {
   bloodSugarMgDl: number | null;
 }
 
-const EMPTY_VITALS: VitalsSnapshot = {
+/**
+ * An all-null VitalsSnapshot — exported so a caller with no submission to
+ * extract from (e.g. a beneficiary with no qualifying visit yet) can use
+ * this directly instead of relying on `extractVitals('', {})`'s lookup-miss
+ * fallback as an empty-value sentinel.
+ */
+export const EMPTY_VITALS: VitalsSnapshot = {
   weightKg: null,
   systolicBp: null,
   diastolicBp: null,
@@ -149,3 +155,12 @@ export function extractVisitHistoryVitals(
     temperature: { value: toDecimalStringOrNull(snapshot.temperatureF), unit: '°F' },
   };
 }
+
+/** An all-null VisitHistoryVitals — see EMPTY_VITALS's own doc comment. */
+export const EMPTY_VISIT_HISTORY_VITALS: VisitHistoryVitals = {
+  hemoglobin: { value: null, unit: 'g/dl' },
+  bloodPressure: { systolic: null, diastolic: null, unit: 'mmHg' },
+  weight: { value: null, unit: 'kg' },
+  bloodSugar: { value: null, unit: 'mg/dl' },
+  temperature: { value: null, unit: '°F' },
+};

--- a/apps/visit-form-service/src/risk-assessments/riskAssessment.client.ts
+++ b/apps/visit-form-service/src/risk-assessments/riskAssessment.client.ts
@@ -50,3 +50,55 @@ export async function triggerRiskAssessment(
     );
   }
 }
+
+interface RiskAssessmentSummary {
+  visitId: string | null;
+  overallRiskCategory: 'NORMAL' | 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+  overallHighRiskFlag: boolean;
+  hrDetectedFlag: boolean;
+}
+
+/**
+ * Fetches the RiskAssessment rows for a given visit-id batch via
+ * risk-referral-service's `GET /risk-assessments?beneficiaryId=&visitIds=`
+ * — used by ccvOpeningRiskState.resolver.ts's BR-13 computation, which
+ * already knows which visit ids it cares about (this service owns visit
+ * typing; risk-referral-service doesn't, no cross-service join per the
+ * forklift rule).
+ *
+ * Returns `null` (not an empty array) on any failure — degrade, don't
+ * throw: BR-13's opening-risk-state write is itself best-effort (see
+ * ccvOpeningRiskState.resolver.ts), and a transient risk-referral-service
+ * blip should skip that one computation, not surface as an error anywhere
+ * in the CHILD phase-advance flow. An empty `visitIds` short-circuits to an
+ * empty array without a network call.
+ */
+export async function listRiskAssessments(
+  beneficiaryId: string,
+  visitIds: string[],
+  authorizationHeader: string,
+): Promise<RiskAssessmentSummary[] | null> {
+  if (visitIds.length === 0) return [];
+
+  try {
+    const res = await fetch(
+      `${API_GATEWAY_BASE_URL}/api/v1/risk-assessments?beneficiaryId=${beneficiaryId}&visitIds=${visitIds.join(',')}`,
+      { headers: { Authorization: authorizationHeader } },
+    );
+    if (!res.ok) {
+      console.warn(
+        `Failed to list risk assessments for beneficiary ${beneficiaryId} ` +
+          `(risk-referral-service returned ${res.status}).`,
+      );
+      return null;
+    }
+    const body = (await res.json()) as { data: RiskAssessmentSummary[] };
+    return body.data;
+  } catch (err) {
+    console.warn(
+      `Unable to reach risk-referral-service to list risk assessments for beneficiary ` +
+        `${beneficiaryId}. ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}

--- a/apps/visit-form-service/src/rules/scheduleEvaluate.client.ts
+++ b/apps/visit-form-service/src/rules/scheduleEvaluate.client.ts
@@ -1,0 +1,42 @@
+// Read directly (not via appConfig) — matches ruleVersion.client.ts's stance.
+const GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+/**
+ * Calls rules-service's `POST /rules/:setId/evaluate-schedule` through the
+ * gateway — used by ccvOpeningRiskState.resolver.ts to run the seeded CCV
+ * schedule pack (ccv.rulesJson.ts) and read back its `riskState` output.
+ *
+ * Returns `null` (not a thrown error) on any failure — same degrade-not-fail
+ * stance as listRiskAssessments: BR-13's write is best-effort, a transient
+ * rules-service blip should skip the computation for this visit, not error
+ * the CHILD phase-advance flow that triggered it.
+ */
+export async function evaluateSchedule(
+  ruleSetId: string,
+  scheduleKind: string,
+  input: Record<string, unknown>,
+  authorizationHeader: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await fetch(`${GATEWAY_BASE_URL}/api/v1/rules/${ruleSetId}/evaluate-schedule`, {
+      method: 'POST',
+      headers: { Authorization: authorizationHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scheduleKind, input }),
+    });
+    if (!res.ok) {
+      console.warn(
+        `Failed to evaluate ${scheduleKind} schedule pack ${ruleSetId} ` +
+          `(rules-service returned ${res.status}).`,
+      );
+      return null;
+    }
+    const body = (await res.json()) as { data: Record<string, unknown> };
+    return body.data;
+  } catch (err) {
+    console.warn(
+      `Unable to reach rules-service to evaluate ${scheduleKind} schedule pack ${ruleSetId}. ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}

--- a/apps/visit-form-service/src/visits/dto/visit-history-query.dto.spec.ts
+++ b/apps/visit-form-service/src/visits/dto/visit-history-query.dto.spec.ts
@@ -1,0 +1,43 @@
+import { visitHistoryQuerySchema } from './visit-history-query.dto';
+
+describe('visitHistoryQuerySchema', () => {
+  it('defaults limit to 2 when omitted', () => {
+    const result = visitHistoryQuerySchema.parse({});
+
+    expect(result).toEqual({ limit: 2 });
+  });
+
+  it('coerces a query-string limit to a number', () => {
+    const result = visitHistoryQuerySchema.parse({ limit: '1' });
+
+    expect(result.limit).toBe(1);
+  });
+
+  it('accepts a single formCode and a single visitType', () => {
+    const result = visitHistoryQuerySchema.parse({ formCode: 'ANC_VISIT', visitType: 'ANC' });
+
+    expect(result).toEqual({ formCode: 'ANC_VISIT', visitType: 'ANC', limit: 2 });
+  });
+
+  it('accepts repeated formCode/visitType as arrays', () => {
+    const result = visitHistoryQuerySchema.parse({
+      formCode: ['ANC_VISIT', 'POSTPARTUM_VISIT'],
+      visitType: ['ANC', 'PP'],
+    });
+
+    expect(result.formCode).toEqual(['ANC_VISIT', 'POSTPARTUM_VISIT']);
+    expect(result.visitType).toEqual(['ANC', 'PP']);
+  });
+
+  it('rejects a limit below 1', () => {
+    expect(() => visitHistoryQuerySchema.parse({ limit: '0' })).toThrow();
+  });
+
+  it('rejects a non-integer limit', () => {
+    expect(() => visitHistoryQuerySchema.parse({ limit: '1.5' })).toThrow();
+  });
+
+  it('rejects an unknown query param (.strict())', () => {
+    expect(() => visitHistoryQuerySchema.parse({ limit: '2', bogus: 'x' })).toThrow();
+  });
+});

--- a/apps/visit-form-service/src/visits/dto/visit-history-query.dto.ts
+++ b/apps/visit-form-service/src/visits/dto/visit-history-query.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/**
+ * Query params for `GET /beneficiaries/:beneficiaryId/visit-history`
+ * (FR-S-4.6 — pre-visit health history). `formCode` and `visitType` are
+ * both optional and repeatable (Express parses a repeated query key as an
+ * array; a single value is normalized to a one-element array by the
+ * service layer) — `visitType` (VisitSchedule.visitType, e.g. ANC/PP/NN/
+ * INC/CCV) is resolved to its formCode via visit-code-form-map.ts, since
+ * the actual filter runs against FormSubmission's own formCode. Providing
+ * both narrows to the union of the two sets, same OR-combining convention
+ * as findByPada's pendingStatusLookupValueIds/missedStatusLookupValueIds.
+ *
+ * `limit` defaults to 2 per FR-S-4.6 ("last 2 completed visits") — the
+ * mobile client never needs more, but can ask for fewer/more via this
+ * param.
+ */
+export const visitHistoryQuerySchema = z
+  .object({
+    formCode: z.union([z.string(), z.array(z.string())]).optional(),
+    visitType: z.union([z.string(), z.array(z.string())]).optional(),
+    limit: z.coerce.number().int().min(1).max(50).default(2),
+  })
+  .strict();
+
+export type VisitHistoryQueryInput = z.infer<typeof visitHistoryQuerySchema>;

--- a/apps/visit-form-service/src/visits/visitInstance.controller.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.controller.ts
@@ -4,6 +4,7 @@ import type { VisitInstanceService } from './visitInstance.service';
 import type { visitSummaryQuerySchema } from './dto/visit-summary-query.dto';
 import type { countByBeneficiarySchema } from './dto/count-by-beneficiary.dto';
 import type { byPadaSchema } from './dto/by-pada.dto';
+import type { visitHistoryQuerySchema } from './dto/visit-history-query.dto';
 
 /**
  * Visit instance request handlers. Mounted under the global `api/v1`
@@ -61,6 +62,23 @@ export function createVisitInstanceController(service: VisitInstanceService) {
         authorizationHeader,
       );
       res.json(ok(updated));
+    }),
+
+    getVisitHistory: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const query = req.query as unknown as z.infer<typeof visitHistoryQuerySchema>;
+      res.json(
+        ok(
+          await service.getVisitHistory(
+            req.params.beneficiaryId,
+            query,
+            req.user,
+            authorizationHeader,
+          ),
+        ),
+      );
     }),
   };
 }

--- a/apps/visit-form-service/src/visits/visitInstance.repository.spec.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.repository.spec.ts
@@ -295,4 +295,58 @@ describe('VisitInstanceRepository', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('findRecentCompletedVisits', () => {
+    it('queries completed visits for the beneficiary, newest completedAt first, limited and with no formCode filter when none is given', async () => {
+      findMany.mockResolvedValue([]);
+
+      await repository.findRecentCompletedVisits('ben-1', undefined, 2);
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: { beneficiaryId: 'ben-1', isDeleted: false, completedAt: { not: null } },
+        orderBy: { completedAt: 'desc' },
+        take: 2,
+        include: {
+          schedule: { select: { visitCode: true } },
+          formSubmissions: {
+            where: { isDeleted: false },
+            orderBy: { submittedAt: 'desc' },
+            take: 1,
+            include: { formVersion: { include: { formDefinition: true } } },
+          },
+        },
+      });
+    });
+
+    it('narrows to the given formCodes via the linked submission when provided', async () => {
+      findMany.mockResolvedValue([]);
+
+      await repository.findRecentCompletedVisits('ben-1', ['ANC_VISIT'], 2);
+
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            formSubmissions: {
+              some: {
+                isDeleted: false,
+                formVersion: { formDefinition: { formCode: { in: ['ANC_VISIT'] } } },
+              },
+            },
+          }),
+        }),
+      );
+    });
+
+    it('applies no formCode filter when given an empty formCodes array', async () => {
+      findMany.mockResolvedValue([]);
+
+      await repository.findRecentCompletedVisits('ben-1', [], 2);
+
+      expect(findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { beneficiaryId: 'ben-1', isDeleted: false, completedAt: { not: null } },
+        }),
+      );
+    });
+  });
 });

--- a/apps/visit-form-service/src/visits/visitInstance.repository.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.repository.ts
@@ -37,6 +37,50 @@ export class VisitInstanceRepository {
   }
 
   /**
+   * The beneficiary's `limit` most-recently-completed INC-type visits
+   * (visitType NEONATAL_VISIT/INC_VISIT's schedule-level VisitCodeType,
+   * INC/INC_HR), most recent first — used by BR-13's CCV opening-risk-state
+   * resolver, which needs "the last 3 completed INC visits" specifically,
+   * not just any 3 visits. "Completed" means `completedAt` is set — a
+   * scheduled-but-not-yet-submitted visit row doesn't count. Joins through
+   * VisitSchedule for visitType since VisitInstance itself carries no
+   * phase/type column of its own.
+   */
+  findRecentCompletedIncVisits(beneficiaryId: string, limit: number) {
+    return this.prisma.visitInstance.findMany({
+      where: {
+        beneficiaryId,
+        isDeleted: false,
+        completedAt: { not: null },
+        schedule: { visitType: { in: ['INC', 'INC_HR'] } },
+      },
+      orderBy: { actualVisitDate: { sort: 'desc', nulls: 'last' } },
+      take: limit,
+    });
+  }
+
+  /**
+   * Every completed INC-type visit id in the beneficiary's 0-12m window
+   * (NN/INC/INC_HR — the full infant-tracking period BR-13's "was HR ever
+   * detected in 0-12m" scan covers, per ccv.rulesJson.ts's own doc comment),
+   * for the CCV opening-risk-state resolver to check each against
+   * risk-referral-service's hrDetectedFlag. Ids only (not full rows) — the
+   * caller batches these into one GET /risk-assessments call.
+   */
+  async findAllCompletedInfantVisitIds(beneficiaryId: string): Promise<string[]> {
+    const visits = await this.prisma.visitInstance.findMany({
+      where: {
+        beneficiaryId,
+        isDeleted: false,
+        completedAt: { not: null },
+        schedule: { visitType: { in: ['NN', 'INC', 'INC_HR'] } },
+      },
+      select: { id: true },
+    });
+    return visits.map((v) => v.id);
+  }
+
+  /**
    * Counts in-scope visits by their raw statusLookupValueId, filtered by
    * VisitSchedule.scheduledDate — the date the visit was DUE, not
    * actualVisitDate (when/if it happened), per the visit-summary widget's

--- a/apps/visit-form-service/src/visits/visitInstance.repository.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.repository.ts
@@ -290,6 +290,52 @@ export class VisitInstanceRepository {
     });
   }
 
+  /**
+   * The beneficiary's `limit` most-recently-completed visits (newest
+   * `completedAt` first), for GET /beneficiaries/:beneficiaryId/visit-history
+   * (FR-S-4.6 — pre-visit vitals). "Completed" means `completedAt` is set,
+   * same convention as findRecentCompletedIncVisits — a scheduled-but-not-
+   * yet-submitted or in-progress visit doesn't count. Optionally narrowed to
+   * a set of formCodes (resolved by the service layer from the caller's own
+   * formCode/visitType query params via visit-code-form-map.ts) via the
+   * linked FormSubmission's own formVersion.formDefinition.formCode — this
+   * table has no formCode column of its own. Includes each visit's most
+   * recent non-deleted FormSubmission (there is normally exactly one per
+   * visit; `take: 1` + `orderBy submittedAt desc` guards against a
+   * theoretical resubmission leaving more than one row) so the service
+   * layer can extract vitals without a second round trip.
+   */
+  findRecentCompletedVisits(beneficiaryId: string, formCodes: string[] | undefined, limit: number) {
+    return this.prisma.visitInstance.findMany({
+      where: {
+        beneficiaryId,
+        isDeleted: false,
+        completedAt: { not: null },
+        ...(formCodes && formCodes.length > 0
+          ? {
+              formSubmissions: {
+                some: {
+                  isDeleted: false,
+                  formVersion: { formDefinition: { formCode: { in: formCodes } } },
+                },
+              },
+            }
+          : {}),
+      },
+      orderBy: { completedAt: 'desc' },
+      take: limit,
+      include: {
+        schedule: { select: { visitCode: true } },
+        formSubmissions: {
+          where: { isDeleted: false },
+          orderBy: { submittedAt: 'desc' },
+          take: 1,
+          include: { formVersion: { include: { formDefinition: true } } },
+        },
+      },
+    });
+  }
+
   findScheduleById(scheduleId: string) {
     return this.prisma.visitSchedule.findFirst({
       where: { id: scheduleId, isDeleted: false },

--- a/apps/visit-form-service/src/visits/visitInstance.repository.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.repository.ts
@@ -44,7 +44,12 @@ export class VisitInstanceRepository {
    * not just any 3 visits. "Completed" means `completedAt` is set — a
    * scheduled-but-not-yet-submitted visit row doesn't count. Joins through
    * VisitSchedule for visitType since VisitInstance itself carries no
-   * phase/type column of its own.
+   * phase/type column of its own. Ordered by completedAt (not
+   * actualVisitDate) — the same "completed" column the where clause filters
+   * on, and the convention findRecentCompletedVisits below uses; a visit
+   * conducted earlier but submitted/completed later must not outrank a more
+   * recently completed one, since recentIncVisits[0] is treated as *the
+   * most recent* completed INC visit for mostRecentIncVisitHrType.
    */
   findRecentCompletedIncVisits(beneficiaryId: string, limit: number) {
     return this.prisma.visitInstance.findMany({
@@ -54,7 +59,7 @@ export class VisitInstanceRepository {
         completedAt: { not: null },
         schedule: { visitType: { in: ['INC', 'INC_HR'] } },
       },
-      orderBy: { actualVisitDate: { sort: 'desc', nulls: 'last' } },
+      orderBy: { completedAt: 'desc' },
       take: limit,
     });
   }

--- a/apps/visit-form-service/src/visits/visitInstance.routes.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.routes.ts
@@ -7,6 +7,7 @@ import { updateVisitInstanceSchema } from './dto/update-visitInstance.dto';
 import { visitSummaryQuerySchema } from './dto/visit-summary-query.dto';
 import { countByBeneficiarySchema } from './dto/count-by-beneficiary.dto';
 import { byPadaSchema } from './dto/by-pada.dto';
+import { visitHistoryQuerySchema } from './dto/visit-history-query.dto';
 import {
   errorResponse,
   requireRoles,
@@ -84,6 +85,41 @@ const countByBeneficiaryResponseSchema = z.record(
     dueTodayCount: z.number().int(),
   }),
 );
+
+const visitHistoryVitalsSchema = z.object({
+  hemoglobin: z.object({
+    value: z.string().nullable().openapi({ example: '9.4' }),
+    unit: z.literal('g/dl'),
+  }),
+  bloodPressure: z.object({
+    systolic: z.number().int().nullable().openapi({ example: 120 }),
+    diastolic: z.number().int().nullable().openapi({ example: 80 }),
+    unit: z.literal('mmHg'),
+  }),
+  weight: z.object({
+    value: z.string().nullable().openapi({ example: '60.2' }),
+    unit: z.literal('kg'),
+  }),
+  bloodSugar: z.object({
+    value: z.string().nullable().openapi({ example: null }),
+    unit: z.literal('mg/dl'),
+  }),
+  temperature: z.object({
+    value: z.string().nullable().openapi({ example: null }),
+    unit: z.literal('°F'),
+  }),
+});
+
+const visitHistoryResponseSchema = z.object({
+  visits: z.array(
+    z.object({
+      visitId: z.string().uuid().openapi({ example: '3fa85f64-5717-4562-b3fc-2c963f66afa6' }),
+      visitCode: z.string().openapi({ example: 'ANC2' }),
+      completedAt: z.string().datetime().openapi({ example: '2026-08-04T10:12:00.000Z' }),
+      vitals: visitHistoryVitalsSchema,
+    }),
+  ),
+});
 
 function envelope<T extends z.ZodTypeAny>(data: T) {
   return z.object({ success: z.literal(true), message: z.string(), data });
@@ -165,6 +201,40 @@ export function registerVisitInstanceRoutes(doc: DocumentedRouter, service: Visi
     requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
     validate(beneficiaryIdParamsSchema, 'params'),
     controller.listByBeneficiary,
+  );
+
+  doc.get(
+    '/beneficiaries/:beneficiaryId/visit-history',
+    {
+      summary:
+        "A beneficiary's last completed visits' key vitals (Hemoglobin, Blood Pressure, " +
+        'Weight, Blood Sugar, Temperature) — FR-S-4.6, shown to a Sakhi before she starts the ' +
+        "beneficiary's next visit. Filtered to COMPLETED visits only, newest first. A vital " +
+        "not captured by a given visit's form (e.g. no BP question on a PP visit) is null, " +
+        'never omitted, so the response shape never depends on which visit type was most ' +
+        'recent. Same ownership scoping as GET /beneficiaries/:beneficiaryId/latest-visit-vitals: ' +
+        'SAKHI must own the beneficiary case herself, SUPERVISOR only via her own roster, ' +
+        'MANAGER/ADMIN unrestricted.',
+      tags: ['Visits'],
+      params: beneficiaryIdParamsSchema,
+      query: visitHistoryQuerySchema,
+      responses: {
+        200: {
+          description: "Beneficiary's completed visit history with vitals",
+          schema: envelope(visitHistoryResponseSchema),
+        },
+        400: errorResponse(400, { message: 'limit: Number must be greater than or equal to 1' }),
+        401: errorResponse(401),
+        403: errorResponse(403, { message: 'This beneficiary case is outside your own roster.' }),
+        404: errorResponse(404, { message: 'Beneficiary case not found.' }),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    validate(beneficiaryIdParamsSchema, 'params'),
+    validate(visitHistoryQuerySchema, 'query'),
+    controller.getVisitHistory,
   );
 
   doc.post(

--- a/apps/visit-form-service/src/visits/visitInstance.service.spec.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.service.spec.ts
@@ -3,9 +3,11 @@ import type { VisitInstanceRepository } from './visitInstance.repository';
 import type { CreateVisitInstanceInput } from './dto/create-visitInstance.dto';
 import { findSakhiById, listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
 import { resolveVisitStatusCode, resolveVisitStatusCodes } from '../lookups/lookup.client';
+import { findBeneficiaryOwnership } from '../beneficiaries/beneficiary.client';
 
 jest.mock('../sakhis/sakhi.client');
 jest.mock('../lookups/lookup.client');
+jest.mock('../beneficiaries/beneficiary.client');
 
 describe('VisitInstanceService', () => {
   const repository = {
@@ -21,6 +23,7 @@ describe('VisitInstanceService', () => {
     countDueTodayByBeneficiary: jest.fn(),
     findByPada: jest.fn(),
     countByBeneficiary: jest.fn(),
+    findRecentCompletedVisits: jest.fn(),
   } as unknown as jest.Mocked<VisitInstanceRepository>;
   let service: VisitInstanceService;
 
@@ -29,6 +32,7 @@ describe('VisitInstanceService', () => {
   const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
   const resolveVisitStatusCodeMock = jest.mocked(resolveVisitStatusCode);
   const resolveVisitStatusCodesMock = jest.mocked(resolveVisitStatusCodes);
+  const findBeneficiaryOwnershipMock = jest.mocked(findBeneficiaryOwnership);
 
   // Distinct from sampleRow.statusLookupValueId ('aaaaaaaa-...') below, so
   // "transitioning to COMPLETED" tests aren't accidentally a no-op re-completion.
@@ -739,5 +743,222 @@ describe('VisitInstanceService', () => {
         );
       },
     );
+  });
+
+  describe('getVisitHistory', () => {
+    const SAKHI_CALLER = { id: 'sakhi-1', roles: ['SAKHI'] };
+
+    const completedVisit = (overrides: Partial<Record<string, unknown>> = {}) => ({
+      id: 'visit-1',
+      completedAt: new Date('2026-08-04T10:12:00.000Z'),
+      schedule: { visitCode: 'ANC2' },
+      formSubmissions: [
+        {
+          formDataJson: { blood_pressure_bp_systolic: 120, blood_pressure_bp_diastolic: 80 },
+          formVersion: { formDefinition: { formCode: 'ANC_VISIT' } },
+        },
+      ],
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      findBeneficiaryOwnershipMock.mockResolvedValue({
+        id: 'ben-1',
+        sakhiId: 'sakhi-1',
+        caseType: 'MOTHER',
+      } as never);
+    });
+
+    it('returns an empty visits array when the beneficiary has no completed visits yet', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([]);
+
+      const result = await service.getVisitHistory(
+        'ben-1',
+        { limit: 2 },
+        SAKHI_CALLER,
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual({ visits: [] });
+    });
+
+    it('returns one shaped row for a beneficiary with exactly 1 completed visit', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([completedVisit()] as never);
+
+      const result = await service.getVisitHistory(
+        'ben-1',
+        { limit: 2 },
+        SAKHI_CALLER,
+        AUTH_HEADER,
+      );
+
+      expect(result.visits).toHaveLength(1);
+      expect(result.visits[0]).toEqual({
+        visitId: 'visit-1',
+        visitCode: 'ANC2',
+        completedAt: new Date('2026-08-04T10:12:00.000Z'),
+        vitals: {
+          hemoglobin: { value: null, unit: 'g/dl' },
+          bloodPressure: { systolic: 120, diastolic: 80, unit: 'mmHg' },
+          weight: { value: null, unit: 'kg' },
+          bloodSugar: { value: null, unit: 'mg/dl' },
+          temperature: { value: null, unit: '°F' },
+        },
+      });
+    });
+
+    it('passes the default limit (2) through to the repository so only the last 2 of 3+ completed visits come back', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([
+        completedVisit({ id: 'visit-3', completedAt: new Date('2026-08-10T00:00:00.000Z') }),
+        completedVisit({ id: 'visit-2', completedAt: new Date('2026-08-05T00:00:00.000Z') }),
+      ] as never);
+
+      const result = await service.getVisitHistory(
+        'ben-1',
+        { limit: 2 },
+        SAKHI_CALLER,
+        AUTH_HEADER,
+      );
+
+      expect(repository.findRecentCompletedVisits).toHaveBeenCalledWith('ben-1', undefined, 2);
+      expect(result.visits).toHaveLength(2);
+      expect(result.visits[0].visitId).toBe('visit-3');
+      expect(result.visits[1].visitId).toBe('visit-2');
+    });
+
+    it('passes an explicit limit through to the repository', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([completedVisit()] as never);
+
+      await service.getVisitHistory('ben-1', { limit: 1 }, SAKHI_CALLER, AUTH_HEADER);
+
+      expect(repository.findRecentCompletedVisits).toHaveBeenCalledWith('ben-1', undefined, 1);
+    });
+
+    it('nulls a vital not captured by the visit form, never omitting it from the response', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([
+        completedVisit({
+          formSubmissions: [
+            {
+              formDataJson: { current_weight_kg: 55 },
+              formVersion: { formDefinition: { formCode: 'POSTPARTUM_VISIT' } },
+            },
+          ],
+        }),
+      ] as never);
+
+      const result = await service.getVisitHistory(
+        'ben-1',
+        { limit: 2 },
+        SAKHI_CALLER,
+        AUTH_HEADER,
+      );
+
+      expect(result.visits[0].vitals.bloodPressure).toEqual({
+        systolic: null,
+        diastolic: null,
+        unit: 'mmHg',
+      });
+      expect(result.visits[0].vitals.bloodSugar).toEqual({ value: null, unit: 'mg/dl' });
+      expect(result.visits[0].vitals.weight).toEqual({ value: '55', unit: 'kg' });
+    });
+
+    it('resolves a formCode filter directly through to the repository', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([]);
+
+      await service.getVisitHistory(
+        'ben-1',
+        { formCode: 'ANC_VISIT', limit: 2 },
+        SAKHI_CALLER,
+        AUTH_HEADER,
+      );
+
+      expect(repository.findRecentCompletedVisits).toHaveBeenCalledWith('ben-1', ['ANC_VISIT'], 2);
+    });
+
+    it('resolves a repeatable visitType filter to its formCodes via visit-code-form-map', async () => {
+      repository.findRecentCompletedVisits.mockResolvedValue([]);
+
+      await service.getVisitHistory(
+        'ben-1',
+        { visitType: ['ANC', 'PP'], limit: 2 },
+        SAKHI_CALLER,
+        AUTH_HEADER,
+      );
+
+      expect(repository.findRecentCompletedVisits).toHaveBeenCalledWith(
+        'ben-1',
+        ['ANC_VISIT', 'POSTPARTUM_VISIT'],
+        2,
+      );
+    });
+
+    it("rejects when the beneficiary is outside the calling SAKHI's own roster", async () => {
+      findBeneficiaryOwnershipMock.mockResolvedValue({
+        id: 'ben-1',
+        sakhiId: 'someone-else',
+        caseType: 'MOTHER',
+      } as never);
+
+      await expect(
+        service.getVisitHistory('ben-1', { limit: 2 }, SAKHI_CALLER, AUTH_HEADER),
+      ).rejects.toThrow(/outside your own roster/);
+      expect(repository.findRecentCompletedVisits).not.toHaveBeenCalled();
+    });
+
+    it('allows a SUPERVISOR calling for a beneficiary inside her roster', async () => {
+      const SUPERVISOR_CALLER = { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: 'proj-1' };
+      findBeneficiaryOwnershipMock.mockResolvedValue({
+        id: 'ben-1',
+        sakhiId: 'sakhi-1',
+        caseType: 'MOTHER',
+      } as never);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-1']);
+      repository.findRecentCompletedVisits.mockResolvedValue([]);
+
+      await expect(
+        service.getVisitHistory('ben-1', { limit: 2 }, SUPERVISOR_CALLER, AUTH_HEADER),
+      ).resolves.toEqual({ visits: [] });
+    });
+
+    it('rejects a SUPERVISOR calling for a beneficiary outside her roster', async () => {
+      const SUPERVISOR_CALLER = { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: 'proj-1' };
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['someone-else']);
+
+      await expect(
+        service.getVisitHistory('ben-1', { limit: 2 }, SUPERVISOR_CALLER, AUTH_HEADER),
+      ).rejects.toThrow(/outside this Supervisor's roster/);
+      expect(repository.findRecentCompletedVisits).not.toHaveBeenCalled();
+    });
+
+    it('rejects a SUPERVISOR caller with no project scope', async () => {
+      const SUPERVISOR_CALLER = { id: 'supervisor-1', roles: ['SUPERVISOR'], projectId: null };
+
+      await expect(
+        service.getVisitHistory('ben-1', { limit: 2 }, SUPERVISOR_CALLER, AUTH_HEADER),
+      ).rejects.toThrow(/no project scope/);
+    });
+
+    it('allows a MANAGER caller regardless of roster', async () => {
+      const MANAGER_CALLER = { id: 'manager-1', roles: ['MANAGER'] };
+      findBeneficiaryOwnershipMock.mockResolvedValue({
+        id: 'ben-1',
+        sakhiId: 'someone-else',
+        caseType: 'MOTHER',
+      } as never);
+      repository.findRecentCompletedVisits.mockResolvedValue([]);
+
+      await expect(
+        service.getVisitHistory('ben-1', { limit: 2 }, MANAGER_CALLER, AUTH_HEADER),
+      ).resolves.toEqual({ visits: [] });
+    });
+
+    it('throws not-found when the beneficiary case does not exist', async () => {
+      findBeneficiaryOwnershipMock.mockResolvedValue(null);
+
+      await expect(
+        service.getVisitHistory('ben-1', { limit: 2 }, SAKHI_CALLER, AUTH_HEADER),
+      ).rejects.toThrow(/not found/i);
+      expect(repository.findRecentCompletedVisits).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/visit-form-service/src/visits/visitInstance.service.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.service.ts
@@ -6,9 +6,9 @@ import type { VisitSummaryQueryInput } from './dto/visit-summary-query.dto';
 import type { VisitHistoryQueryInput } from './dto/visit-history-query.dto';
 import { findSakhiById, listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
 import { resolveVisitStatusCode, resolveVisitStatusCodes } from '../lookups/lookup.client';
-import { findBeneficiaryOwnership } from '../beneficiaries/beneficiary.client';
+import { assertCallerOwnsBeneficiary } from '../beneficiaries/beneficiaryOwnership.guard';
 import { resolveFormCodeForVisitType } from '../forms/visit-code-form-map';
-import { extractVisitHistoryVitals } from '../forms/vitalsExtractor';
+import { EMPTY_VISIT_HISTORY_VITALS, extractVisitHistoryVitals } from '../forms/vitalsExtractor';
 
 /** The calling principal's own identity, as carried on their trusted-identity headers. */
 export interface CallerIdentity {
@@ -364,11 +364,12 @@ export class VisitInstanceService {
   /**
    * FR-S-4.6 — a beneficiary's last `limit` (default 2) COMPLETED visits'
    * key vitals, shown before the Sakhi starts her next visit. IDOR scoping
-   * mirrors form.service.ts's getLatestVisitVitals exactly (ownership check
-   * via findBeneficiaryOwnership, not a sakhiId-on-visit filter): a case's
-   * current owning Sakhi can differ from who conducted a past visit (case
-   * reassignment), so "does the caller own this beneficiary case today" is
-   * the correct check, not "did the caller conduct this visit".
+   * mirrors form.service.ts's getLatestVisitVitals exactly (shared via
+   * assertCallerOwnsBeneficiary — ownership check, not a sakhiId-on-visit
+   * filter): a case's current owning Sakhi can differ from who conducted a
+   * past visit (case reassignment), so "does the caller own this
+   * beneficiary case today" is the correct check, not "did the caller
+   * conduct this visit".
    *
    * `formCode`/`visitType` narrow which visits are eligible before `limit`
    * is applied — a beneficiary with 3 completed ANC visits and a
@@ -385,26 +386,7 @@ export class VisitInstanceService {
     caller: CallerIdentity,
     authorizationHeader: string,
   ) {
-    const beneficiary = await findBeneficiaryOwnership(beneficiaryId, authorizationHeader);
-    if (!beneficiary) throw notFound('Beneficiary case not found.');
-
-    if (caller.roles.includes('SAKHI')) {
-      if (beneficiary.sakhiId !== caller.id) {
-        throw forbidden('This beneficiary case is outside your own roster.');
-      }
-    } else if (caller.roles.includes('SUPERVISOR')) {
-      if (!caller.projectId) {
-        throw forbidden('Supervisor caller has no project scope.');
-      }
-      const roster = await listSakhiIdsForSupervisor(
-        caller.projectId,
-        caller.id,
-        authorizationHeader,
-      );
-      if (!roster.includes(beneficiary.sakhiId)) {
-        throw forbidden("This beneficiary case is outside this Supervisor's roster.");
-      }
-    }
+    await assertCallerOwnsBeneficiary(beneficiaryId, caller, authorizationHeader);
 
     const formCodes = resolveFormCodes(query);
     const visits = await this.repository.findRecentCompletedVisits(
@@ -425,7 +407,7 @@ export class VisitInstanceService {
                 submission.formVersion.formDefinition.formCode,
                 submission.formDataJson as Record<string, unknown>,
               )
-            : extractVisitHistoryVitals('', {}),
+            : EMPTY_VISIT_HISTORY_VITALS,
         };
       }),
     };

--- a/apps/visit-form-service/src/visits/visitInstance.service.ts
+++ b/apps/visit-form-service/src/visits/visitInstance.service.ts
@@ -3,8 +3,12 @@ import type { VisitInstanceRepository } from './visitInstance.repository';
 import type { CreateVisitInstanceInput } from './dto/create-visitInstance.dto';
 import type { UpdateVisitInstanceInput } from './dto/update-visitInstance.dto';
 import type { VisitSummaryQueryInput } from './dto/visit-summary-query.dto';
+import type { VisitHistoryQueryInput } from './dto/visit-history-query.dto';
 import { findSakhiById, listSakhiIdsForSupervisor } from '../sakhis/sakhi.client';
 import { resolveVisitStatusCode, resolveVisitStatusCodes } from '../lookups/lookup.client';
+import { findBeneficiaryOwnership } from '../beneficiaries/beneficiary.client';
+import { resolveFormCodeForVisitType } from '../forms/visit-code-form-map';
+import { extractVisitHistoryVitals } from '../forms/vitalsExtractor';
 
 /** The calling principal's own identity, as carried on their trusted-identity headers. */
 export interface CallerIdentity {
@@ -356,6 +360,103 @@ export class VisitInstanceService {
       dueDate: row.schedule.scheduledDate.toISOString().slice(0, 10),
     }));
   }
+
+  /**
+   * FR-S-4.6 — a beneficiary's last `limit` (default 2) COMPLETED visits'
+   * key vitals, shown before the Sakhi starts her next visit. IDOR scoping
+   * mirrors form.service.ts's getLatestVisitVitals exactly (ownership check
+   * via findBeneficiaryOwnership, not a sakhiId-on-visit filter): a case's
+   * current owning Sakhi can differ from who conducted a past visit (case
+   * reassignment), so "does the caller own this beneficiary case today" is
+   * the correct check, not "did the caller conduct this visit".
+   *
+   * `formCode`/`visitType` narrow which visits are eligible before `limit`
+   * is applied — a beneficiary with 3 completed ANC visits and a
+   * `formCode=ANC_VISIT` filter still only returns her last 2 (or `limit`)
+   * ANC visits, not just any 2. visitType is resolved to its formCode via
+   * visit-code-form-map.ts (this table has no visitType column of its own —
+   * see findRecentCompletedVisits). An unrecognized visitType resolves to
+   * no formCode and is silently dropped from the filter set, same
+   * degrade-rather-than-throw stance as extractVitals.
+   */
+  async getVisitHistory(
+    beneficiaryId: string,
+    query: VisitHistoryQueryInput,
+    caller: CallerIdentity,
+    authorizationHeader: string,
+  ) {
+    const beneficiary = await findBeneficiaryOwnership(beneficiaryId, authorizationHeader);
+    if (!beneficiary) throw notFound('Beneficiary case not found.');
+
+    if (caller.roles.includes('SAKHI')) {
+      if (beneficiary.sakhiId !== caller.id) {
+        throw forbidden('This beneficiary case is outside your own roster.');
+      }
+    } else if (caller.roles.includes('SUPERVISOR')) {
+      if (!caller.projectId) {
+        throw forbidden('Supervisor caller has no project scope.');
+      }
+      const roster = await listSakhiIdsForSupervisor(
+        caller.projectId,
+        caller.id,
+        authorizationHeader,
+      );
+      if (!roster.includes(beneficiary.sakhiId)) {
+        throw forbidden("This beneficiary case is outside this Supervisor's roster.");
+      }
+    }
+
+    const formCodes = resolveFormCodes(query);
+    const visits = await this.repository.findRecentCompletedVisits(
+      beneficiaryId,
+      formCodes,
+      query.limit,
+    );
+
+    return {
+      visits: visits.map((visit) => {
+        const submission = visit.formSubmissions[0];
+        return {
+          visitId: visit.id,
+          visitCode: visit.schedule.visitCode,
+          completedAt: visit.completedAt,
+          vitals: submission
+            ? extractVisitHistoryVitals(
+                submission.formVersion.formDefinition.formCode,
+                submission.formDataJson as Record<string, unknown>,
+              )
+            : extractVisitHistoryVitals('', {}),
+        };
+      }),
+    };
+  }
+}
+
+/**
+ * Resolves the query's formCode/visitType params (each optionally a single
+ * value or an array — see visit-history-query.dto.ts) into one formCode
+ * set for the repository filter. Returns undefined (no filter) when
+ * neither param was given, so findRecentCompletedVisits doesn't apply an
+ * empty-set filter that would wrongly exclude everything.
+ */
+function resolveFormCodes(query: VisitHistoryQueryInput): string[] | undefined {
+  if (!query.formCode && !query.visitType) return undefined;
+
+  const fromFormCode = query.formCode
+    ? Array.isArray(query.formCode)
+      ? query.formCode
+      : [query.formCode]
+    : [];
+  const visitTypes = query.visitType
+    ? Array.isArray(query.visitType)
+      ? query.visitType
+      : [query.visitType]
+    : [];
+  const fromVisitType = visitTypes
+    .map((visitType) => resolveFormCodeForVisitType(visitType))
+    .filter((formCode): formCode is string => formCode !== null);
+
+  return [...new Set([...fromFormCode, ...fromVisitType])];
 }
 
 /** Inserts a space before the trailing digits of a device-generated visit


### PR DESCRIPTION
Closes #174

## Summary
- Adds `riskColor` (GREEN/YELLOW/RED) derived from `riskLevel` on the beneficiary detail response
- Extends CHILD case phase-advance to NN->INC and INC->CCV, keeping `ChildCaseDetails.currentPhase`
  in sync with `BeneficiaryCase.currentPhase` via an atomic transaction
- Implements BR-13: computes and persists `ccvOpeningRiskState` exactly once at the INC->CCV
  transition, from the last 3 completed INC visits plus a full 0-12-month high-risk detection scan,
  evaluated through the seeded CCV scheduling rule pack
- Adds `GET /beneficiaries/:beneficiaryId/latest-visit-vitals` (visit-form-service), wired into the
  beneficiary detail response, with a per-formCode question_code mapping for weight/BP/temperature/
  hemoglobin/MUAC/respiratory-rate
- Adds `GET /risk-assessments` (risk-referral-service) so visit-form-service's BR-13 resolver can
  look up risk assessments by visit id without a cross-service DB join
- Adds `GET /beneficiaries/:id/ownership` (beneficiary-service), a minimal ownership-only lookup
  used by the vitals endpoint's ownership check to avoid a cross-service infinite request loop
  that calling the full enriched detail endpoint would otherwise cause
- Fixes an api-gateway routing gap: `latest-visit-vitals` previously 404'd, falling through to the
  generic `/beneficiaries` prefix

## Security
An automated security review flagged 2 IDOR issues introduced mid-implementation
(`RiskAssessmentService.listByVisitIds`, `FormService.getLatestVisitVitals` both took a
caller-supplied `beneficiaryId` with no ownership check) — both fixed with the standard
SAKHI-own-case / SUPERVISOR-own-roster / MANAGER-ADMIN-unrestricted check used elsewhere in
these services.

## Test plan
- [x] `beneficiary.service.spec.ts` / `beneficiary.repository.spec.ts` — riskColor, CHILD phase
  sync, ownership endpoint, vitals wiring
- [x] `riskAssessment.service.spec.ts` — `listByVisitIds` + IDOR guards
- [x] `form.service.spec.ts` / `vitalsExtractor.spec.ts` / `ccvOpeningRiskState.resolver` coverage —
  BR-13 gating (only fires on the actual INC->CCV transition, not repeat CCV_VISIT submissions),
  vitals extraction per form code
- [x] Live-verified end-to-end against the running dev stack: riskColor, CHILD phase-advance,
  BR-13 (real INC visits -> CCV_VISIT submission -> `ccvOpeningRiskState` populated), and
  `GET /beneficiaries/:id/latest-visit-vitals` through the gateway

## Env vars
- `beneficiary-service`: `AUTH_SERVICE_BASE_URL`, `RISK_REFERRAL_SERVICE_BASE_URL`,
  `VISIT_FORM_SERVICE_BASE_URL` (all optional, gateway-routed, default `http://localhost:3000`)
- `visit-form-service`: `CCV_SCHEDULE_RULE_SET_ID` (optional — BR-13 computation is skipped, not
  failed, when unset; look up via `GET /rules` with an ADMIN token)

All new/changed env vars are documented in the respective `.env.example` files.

---

## Update: Pre-visit health history API (FR-S-4.6)

Closes #176

- Adds `GET /beneficiaries/:beneficiaryId/visit-history` (visit-form-service) — a beneficiary's
  last N (default 2) **completed** visits' key vitals (hemoglobin, blood pressure, weight, blood
  sugar, temperature), scoped to the caller's own roster same as `latest-visit-vitals`. Supports
  `formCode`/`visitType` (repeatable) and `limit` query params. Gateway-routed, Swagger-documented.
- Wires visit auto-completion into `createSubmission`: a visit-linked submission against a
  vitals-bearing form (ANC/PP/NN/INC/CCV) now sets `VisitInstance.completedAt` automatically,
  best-effort, instead of requiring a separate `PATCH /visits/:id` call. Confirmed via
  investigation that `VisitSchedule.status` (a separate, unrelated field) is dead code — nothing
  in the codebase writes to it; the real completion signal is `VisitInstance.completedAt`.
- Extends `vitalsExtractor.ts` with a `bloodSugarMgDl` field and a new unit-wrapped extractor
  (`extractVisitHistoryVitals`) reusing the existing per-formCode question_code mapping — no new
  mapping introduced. Temperature is reported in °F (as every seeded form actually stores it), not
  converted to °C.

### Live-verification finding (fixed in this PR)
Found via manual end-to-end testing against the running dev stack: `findBeneficiaryOwnership`
(`beneficiary.client.ts`) only special-cased a `404` from `GET /beneficiaries/:id/ownership` —
any other non-2xx response, including that endpoint's own legitimate `403` for an out-of-roster
caller, was surfaced as a `502` instead. This silently broke the scoping-rejection path on **both**
this new endpoint and the existing `latest-visit-vitals` endpoint. Fixed by forwarding the 403 with
its upstream message; added test coverage in `beneficiary.client.spec.ts`.

### Test plan (this update)
- [x] `visitCompletion.resolver.spec.ts` — auto-completion logic, all 5 form codes, idempotent
  no-op on an already-COMPLETED visit, never throws on a downstream failure
- [x] `form.service.spec.ts` — completion call wired into `createSubmission`, doesn't block the
  submission
- [x] `vitalsExtractor.spec.ts` — new `bloodSugarMgDl` field, unit-wrapped shape, null-with-unit
  behavior for an uncaptured vital
- [x] `visitInstance.repository.spec.ts` / `visitInstance.service.spec.ts` — empty/1/3+ completed
  visits (limit truncation), formCode/visitType filtering, full SAKHI/SUPERVISOR/MANAGER/ADMIN
  scoping matrix, not-found
- [x] `visit-history-query.dto.spec.ts` — limit default/coercion/bounds, repeatable params,
  `.strict()` rejection
- [x] `beneficiary.client.spec.ts` — 403-forwarding fix
- [x] Live-verified end-to-end against the running dev stack with a throwaway Sakhi/beneficiary:
  empty visits, submission → auto-complete → visit-history reflecting real vitals, 3 completed
  visits → only last 2 returned, a visit with no captured vitals → null with unit, formCode/
  visitType filters, 400/401/403/404 error paths, and the `latest-visit-vitals` 403 fix


---

## Update: Fix immunization date fields showing after selecting "No"

Every immunization Yes/No question in INC_VISIT/INFANT_VISIT/CCV_VISIT's shared History section
(22 vaccine/date pairs — BCG through DPT booster1) had its date field's `visibleWhen` tied only to
the outer "have you been able to meet the beneficiary for the visit?" question, not to its own
preceding Yes/No answer. Selecting "No" on e.g. BCG still showed the BCG date field, since the
schema never told it to hide.

- Fixed `infant-visit.json` (the shared seed source for all 3 form codes) — each date field's
  `visibleWhen` now references its own preceding vaccine field (`{field: <vaccine_code>, operator:
  "eq", value: "yes"}`) as a full replacement, not an "and" condition: the vaccine field is itself
  already gated behind the outer question, so an unanswered/hidden governing field already
  evaluates to hidden downstream — no visibility is lost by dropping the outer reference.
- Updated `seed-data.spec.ts` to assert the corrected per-vaccine gating instead of the old
  blanket outer-question assertion for these 22 date fields.
- Live-verified against the running dev stack: published a new version for all 3 form codes
  (`INFANT_VISIT`, `INC_VISIT`, `CCV_VISIT` — confirmed they still share identical schema content)
  via the admin create-draft → patch → publish flow, then fetched each `active-version` and
  field-by-field verified all 22 radio fields still gate on the outer question (unchanged) and all
  22 date fields now gate on their own vaccine field. Caught and corrected a transposed-mapping
  bug in my own verification script before it reached this PR's source file — the committed
  `infant-visit.json` was unaffected and independently re-verified correct.
- Does not fix the separate "OPV-0 date accepts future dates" issue — that's a mobile-app
  client-side date-bound rule, not schema-driven.

### Test plan (this update)
- [x] `seed-data.spec.ts` — all 22 vaccine/date pairs assert correct per-field gating; full suite
  (87 tests) passes
- [x] Full `visit-form-service` suite (519 tests) passes
- [x] Live-verified: all 3 form codes' active versions field-by-field checked for all 22 pairs
