### PR TITLE
fix(visit-form-service): Stop asking birth weight/term of delivery on NEONATAL_VISIT

### DIFF
--- a/apps/supervisor-operations-service/prisma/seed.ts
+++ b/apps/supervisor-operations-service/prisma/seed.ts
@@ -9,6 +9,103 @@ interface SeedResult {
 }
 
 /**
+ * Item Master List demo data (SRS/ERD §4.7 inventory_items) — the global
+ * consumables/instruments catalog behind GET /inventory-items and the
+ * mobile app's "Add Item Transaction" screen. No project/sakhi scoping (this
+ * table has none), so seeding once makes every item visible app-wide.
+ * itemCategory/status are real Prisma enums (InventoryItemCategory/
+ * InventoryItemStatus) — the DB itself rejects any value outside
+ * CONSUMABLE/INSTRUMENT or ACTIVE/INACTIVE, so there is no risk of the app's
+ * strict-enum parsing seeing something else.
+ *
+ * Deduplicated by itemCode (@unique on the table) — re-running this script
+ * never creates duplicates or errors on the ones already seeded.
+ */
+const DEFAULT_INVENTORY_ITEMS: {
+  itemCode: string;
+  itemName: string;
+  itemCategory: 'CONSUMABLE' | 'INSTRUMENT';
+  unit: string;
+  status: 'ACTIVE' | 'INACTIVE';
+}[] = [
+  {
+    itemCode: 'CONS-PENCIL-01',
+    itemName: 'Pencil',
+    itemCategory: 'CONSUMABLE',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+  {
+    itemCode: 'CONS-CELLS-01',
+    itemName: 'Cells',
+    itemCategory: 'CONSUMABLE',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+  {
+    itemCode: 'CONS-SUGARSTRIP-01',
+    itemName: 'Sugar Strips',
+    itemCategory: 'CONSUMABLE',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+  {
+    itemCode: 'CONS-HBSTRIP-01',
+    itemName: 'HB Strips',
+    itemCategory: 'CONSUMABLE',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+  {
+    itemCode: 'INST-DOPPLER-01',
+    itemName: 'Doppler Test Kit',
+    itemCategory: 'INSTRUMENT',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+  {
+    itemCode: 'INST-BPMONITOR-01',
+    itemName: 'BP Monitor',
+    itemCategory: 'INSTRUMENT',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+  {
+    itemCode: 'INST-WEIGHSCALE-01',
+    itemName: 'Weighing Scale',
+    itemCategory: 'INSTRUMENT',
+    unit: 'pcs',
+    status: 'ACTIVE',
+  },
+];
+
+async function seedInventoryItems(): Promise<SeedResult> {
+  const step = 'inventory-items-master-list';
+  const items = process.env.SEED_INVENTORY_ITEMS
+    ? (JSON.parse(process.env.SEED_INVENTORY_ITEMS) as typeof DEFAULT_INVENTORY_ITEMS)
+    : DEFAULT_INVENTORY_ITEMS;
+
+  let created = 0;
+  let skipped = 0;
+  for (const item of items) {
+    const existing = await prisma.inventoryItem.findUnique({ where: { itemCode: item.itemCode } });
+    if (existing) {
+      skipped += 1;
+      continue;
+    }
+
+    await prisma.inventoryItem.create({ data: item });
+    created += 1;
+  }
+
+  return {
+    step,
+    created: created > 0,
+    message: `Created ${created} inventory item(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
+/**
  * Demo Call Sheet data (SRS FR-SV-3.1/3.2, ERD §4.7 call_logs) — all under
  * one Supervisor/Sakhi pair (Pemma Deshmukh / Meera Sakhi) already present
  * in this environment's auth-service data (see sakhi_profiles), so this
@@ -157,7 +254,7 @@ async function seedCallLogs(): Promise<SeedResult> {
 }
 
 async function main(): Promise<void> {
-  const results = [await seedCallLogs()];
+  const results = [await seedCallLogs(), await seedInventoryItems()];
 
   console.log('\nSeed summary:');
   for (const r of results) {

--- a/apps/visit-form-service/prisma/seed-data.spec.ts
+++ b/apps/visit-form-service/prisma/seed-data.spec.ts
@@ -778,13 +778,17 @@ describe('neonatal-visit.json', () => {
   const fields = neonatalVisit.schemaJson;
   const byCode = new Map(fields.map((f) => [f.question_code, f]));
 
-  it('has exactly 32 fields (26 base + 4 per-vaccine date fields + 2 pre-filled delivery fields)', () => {
-    expect(fields).toHaveLength(32);
+  it('has exactly 30 fields (26 base + 4 per-vaccine date fields)', () => {
+    expect(fields).toHaveLength(30);
   });
 
-  it('applies numericRange to birth/current length and weight', () => {
+  it('does not ask the Sakhi for birth weight or term of delivery on this form — carried forward from DELIVERY_VISIT server-side instead', () => {
+    expect(byCode.get('birth_weight_kg')).toBeUndefined();
+    expect(byCode.get('term_of_delivery')).toBeUndefined();
+  });
+
+  it('applies numericRange to current length and weight', () => {
     const expectedRanges: Record<string, { min: number; max: number }> = {
-      birth_weight_kg: { min: 0.5, max: 6 },
       current_length_cm: { min: 35, max: 60 },
       current_weight_kg: { min: 0.5, max: 6 },
     };
@@ -800,11 +804,11 @@ describe('neonatal-visit.json', () => {
     expect(byCode.get('date_of_death')?.visibleWhen).toEqual(gate);
   });
 
-  it('gates the KMC block behind birth_weight_kg < 2.5 (row 11, low-birth-weight eligibility)', () => {
+  it('gates the KMC block behind the server-computed kmcEligible flag (row 11, low-birth-weight/preterm eligibility) — a single condition, never an OR expressed in visibleWhen itself, since the mobile client only parses one condition per field', () => {
     expect(byCode.get('is_kmc_practiced')?.visibleWhen).toEqual({
-      field: 'birth_weight_kg',
-      operator: 'lt',
-      value: 2.5,
+      field: 'kmcEligible',
+      operator: 'eq',
+      value: true,
     });
     expect(byCode.get('kmc_duration')?.visibleWhen).toEqual({
       field: 'is_kmc_practiced',

--- a/apps/visit-form-service/prisma/seed-data/neonatal-visit.json
+++ b/apps/visit-form-service/prisma/seed-data/neonatal-visit.json
@@ -20,26 +20,6 @@
       "question_code": "visit_name"
     },
     {
-      "label": "Birth weight of the baby in kg (from the Delivery form, for the KMC eligibility check below)",
-      "section": "Neonatal Visit",
-      "required": true,
-      "input_type": "number",
-      "question_code": "birth_weight_kg",
-      "numericRange": { "min": 0.5, "max": 6 }
-    },
-    {
-      "label": "Term of delivery (from the Delivery form, for the KMC eligibility check below)",
-      "options": [
-        { "label": "Pre Term", "sort_order": 0, "value_code": "pre_term" },
-        { "label": "Post Term", "sort_order": 1, "value_code": "post_term" },
-        { "label": "Full Term", "sort_order": 2, "value_code": "full_term" }
-      ],
-      "section": "Neonatal Visit",
-      "required": true,
-      "input_type": "dropdown",
-      "question_code": "term_of_delivery"
-    },
-    {
       "label": "Is the new born alive now?",
       "options": [
         { "label": "Yes", "sort_order": 0, "value_code": "yes" },
@@ -313,7 +293,7 @@
       "required": true,
       "input_type": "radio",
       "question_code": "is_kmc_practiced",
-      "visibleWhen": { "field": "birth_weight_kg", "operator": "lt", "value": 2.5 }
+      "visibleWhen": { "field": "kmcEligible", "operator": "eq", "value": true }
     },
     {
       "label": "KMC Duration",

--- a/apps/visit-form-service/src/forms/form.controller.ts
+++ b/apps/visit-form-service/src/forms/form.controller.ts
@@ -20,12 +20,16 @@ export function createFormController(service: FormService) {
       if (!authorizationHeader) return next(unauthorized());
 
       const { formCode } = req.params as unknown as { formCode: string };
-      const { asOf } = req.query as unknown as { asOf?: Date };
+      const { asOf, beneficiaryId } = req.query as unknown as {
+        asOf?: Date;
+        beneficiaryId?: string;
+      };
       const version = await service.getActiveVersion(
         formCode,
         asOf ?? new Date(),
         req.user.geographyUnitId,
         authorizationHeader,
+        beneficiaryId,
       );
       res.json(ok(version));
     }),

--- a/apps/visit-form-service/src/forms/form.routes.ts
+++ b/apps/visit-form-service/src/forms/form.routes.ts
@@ -27,7 +27,14 @@ const versionParamsSchema = z
   })
   .strict();
 const activeVersionQuerySchema = z
-  .object({ asOf: z.coerce.date().optional().openapi({ example: '2026-07-20T00:00:00.000Z' }) })
+  .object({
+    asOf: z.coerce.date().optional().openapi({ example: '2026-07-20T00:00:00.000Z' }),
+    // Only consulted for NEONATAL_VISIT today — see
+    // FormService.getActiveVersion's prefilledContext block — but accepted
+    // generically here so future forms can opt into the same mechanism
+    // without a route change.
+    beneficiaryId: z.string().uuid().optional(),
+  })
   .strict();
 const beneficiaryIdParamsSchema = z.object({ beneficiaryId: z.string().uuid() }).strict();
 

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -129,6 +129,172 @@ describe('FormService', () => {
         }),
       );
     });
+
+    describe('NEONATAL_VISIT prefilledContext.kmcEligible', () => {
+      const version = {
+        id: 'v1',
+        versionNo: 'v1',
+        status: 'PUBLISHED',
+        checksum: Buffer.from('x'),
+      };
+
+      it('omits prefilledContext entirely when no beneficiaryId is given', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date(),
+          null,
+          'Bearer test-token',
+        );
+
+        expect(result).not.toHaveProperty('prefilledContext');
+        expect(repository.findLatestSubmissionByBeneficiaryAndFormCode).not.toHaveBeenCalled();
+      });
+
+      it('does not look up prefilledContext for a formCode other than NEONATAL_VISIT, even with a beneficiaryId', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+
+        const result = await service.getActiveVersion(
+          'ANC_VISIT',
+          new Date(),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(result).not.toHaveProperty('prefilledContext');
+        expect(repository.findLatestSubmissionByBeneficiaryAndFormCode).not.toHaveBeenCalled();
+      });
+
+      it('resolves kmcEligible: false when the beneficiary has no DELIVERY_VISIT submission', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue(null);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date(),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(repository.findLatestSubmissionByBeneficiaryAndFormCode).toHaveBeenCalledWith(
+          'ben-1',
+          'DELIVERY_VISIT',
+        );
+        expect(result).toEqual(
+          expect.objectContaining({ prefilledContext: { kmcEligible: false } }),
+        );
+        expect(findBeneficiaryById).not.toHaveBeenCalled();
+      });
+
+      it('resolves kmcEligible: false when birth weight >= 2.5kg and term is full_term, without looking up the beneficiary DOB', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 3.2, term_of_delivery: 'full_term' },
+        } as never);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date(),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ prefilledContext: { kmcEligible: false } }),
+        );
+        expect(findBeneficiaryById).not.toHaveBeenCalled();
+      });
+
+      it('resolves kmcEligible: true for low birth weight (<2.5kg) when the baby is <=2 months old', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 2.0, term_of_delivery: 'full_term' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          childDateOfBirth: '2026-07-01T00:00:00.000Z',
+        } as never);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date('2026-08-01T00:00:00.000Z'),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ prefilledContext: { kmcEligible: true } }),
+        );
+      });
+
+      it('resolves kmcEligible: true for a preterm delivery regardless of birth weight, when the baby is <=2 months old', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 3.0, term_of_delivery: 'pre_term' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          childDateOfBirth: '2026-07-01T00:00:00.000Z',
+        } as never);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date('2026-08-01T00:00:00.000Z'),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ prefilledContext: { kmcEligible: true } }),
+        );
+      });
+
+      it('resolves kmcEligible: false when otherwise eligible but the baby is older than 2 months', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 2.0, term_of_delivery: 'full_term' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          childDateOfBirth: '2026-01-01T00:00:00.000Z',
+        } as never);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date('2026-08-01T00:00:00.000Z'),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ prefilledContext: { kmcEligible: false } }),
+        );
+      });
+
+      it('resolves kmcEligible: false (fail closed) when the beneficiary/DOB cannot be resolved', async () => {
+        repository.findActiveVersion.mockResolvedValue(version as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 2.0, term_of_delivery: 'full_term' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue(null);
+
+        const result = await service.getActiveVersion(
+          'NEONATAL_VISIT',
+          new Date('2026-08-01T00:00:00.000Z'),
+          null,
+          'Bearer test-token',
+          'ben-1',
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ prefilledContext: { kmcEligible: false } }),
+        );
+      });
+    });
   });
 
   describe('createDraft', () => {
@@ -661,6 +827,103 @@ describe('FormService', () => {
 
         expect(result).toEqual({ id: 'sub-1' });
         expect(repository.createSubmission).toHaveBeenCalled();
+      });
+    });
+
+    describe('NEONATAL_VISIT server-side kmcEligible revalidation', () => {
+      const neonatalVersion = {
+        id: 'version-1',
+        status: 'PUBLISHED',
+        formDefinition: { formCode: 'NEONATAL_VISIT' },
+        schemaJson: [
+          {
+            question_code: 'is_kmc_practiced',
+            label: 'Is KMC practiced?',
+            input_type: 'radio',
+            required: true,
+            visibleWhen: { field: 'kmcEligible', operator: 'eq', value: true },
+          },
+        ],
+        validationJson: [],
+      };
+
+      it('requires is_kmc_practiced when the linked DELIVERY_VISIT shows low birth weight', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(neonatalVersion as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 2.0, term_of_delivery: 'full_term' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          childDateOfBirth: new Date().toISOString(),
+        } as never);
+
+        const call = service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        await expect(call).rejects.toMatchObject({
+          details: { violations: ['Missing required field: is_kmc_practiced'] },
+        });
+      });
+
+      it('does not require is_kmc_practiced when the linked DELIVERY_VISIT shows normal birth weight/term', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(neonatalVersion as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 3.2, term_of_delivery: 'full_term' },
+        } as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+        await service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(repository.createSubmission).toHaveBeenCalled();
+      });
+
+      it('never persists kmcEligible into the stored formData', async () => {
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(neonatalVersion as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { child1_birth_weight_kg: 2.0, term_of_delivery: 'full_term' },
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          childDateOfBirth: new Date().toISOString(),
+        } as never);
+        repository.createSubmission.mockResolvedValue({ id: 'sub-1' } as never);
+
+        await service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { is_kmc_practiced: 'yes' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        const call = repository.createSubmission.mock.calls[0][0] as {
+          formDataJson?: Record<string, unknown>;
+        };
+        expect(call.formDataJson).not.toHaveProperty('kmcEligible');
       });
     });
 

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -96,12 +96,22 @@ export class FormService {
     asOf: Date,
     callerGeographyUnitId: string | null,
     authorizationHeader: string,
+    beneficiaryId?: string,
   ) {
     const version = await this.repository.findActiveVersion(formCode, asOf);
     if (!version) throw notFound(`No published form version found for form code "${formCode}".`);
     const apiVersion = toApiFormVersion(version);
 
-    if (!callerGeographyUnitId) return apiVersion;
+    const prefilledContext =
+      formCode === 'NEONATAL_VISIT' && beneficiaryId
+        ? {
+            kmcEligible: await this.resolveKmcEligibility(beneficiaryId, asOf, authorizationHeader),
+          }
+        : undefined;
+
+    if (!callerGeographyUnitId) {
+      return prefilledContext ? { ...apiVersion, prefilledContext } : apiVersion;
+    }
 
     const chain = await getAncestorChain(callerGeographyUnitId, authorizationHeader);
     // Only the fields a client needs to map a level onto pii.<level>Id
@@ -112,7 +122,57 @@ export class FormService {
       geoType: unit.geoType,
       name: unit.name,
     }));
-    return { ...apiVersion, geography };
+    return { ...apiVersion, geography, ...(prefilledContext ? { prefilledContext } : {}) };
+  }
+
+  /**
+   * Resolves the single derived boolean the NEONATAL_VISIT form's
+   * `is_kmc_practiced` field's `visibleWhen` checks — birth weight <2.5kg
+   * OR preterm delivery, from the beneficiary's own DELIVERY_VISIT
+   * submission (`child1_birth_weight_kg`/`term_of_delivery`), never asked
+   * again on this form. Deliberately a single pre-computed flag rather than
+   * an OR-condition in `visibleWhen` itself: the mobile client's
+   * FormVisibilityEvaluator only parses one {field,operator,value}
+   * condition per field (see form-field.dto.ts's visibleWhen doc comment
+   * on the ANC_VISIT/INFANT_VISIT incident this constraint follows from) —
+   * expressing the OR here, not in the schema, is what keeps this safe.
+   * Also requires the baby to be <=2 months old as of `asOf` (SRS: "Don't
+   * show these questions... if the baby is more than 2 months of age"),
+   * read from beneficiary-service's `childDateOfBirth` — a second
+   * cross-service call, made only for this one formCode, and only once per
+   * form-load rather than once per KMC-adjacent field.
+   *
+   * Defaults to `false` (fail closed, KMC section hidden) when no
+   * DELIVERY_VISIT submission exists yet, or the beneficiary/DOB can't be
+   * resolved — matching the "computed fields are never required" stance
+   * elsewhere in this file rather than failing the whole form load.
+   */
+  private async resolveKmcEligibility(
+    beneficiaryId: string,
+    asOf: Date,
+    authorizationHeader: string,
+  ): Promise<boolean> {
+    const delivery = await this.repository.findLatestSubmissionByBeneficiaryAndFormCode(
+      beneficiaryId,
+      'DELIVERY_VISIT',
+    );
+    if (!delivery) return false;
+
+    const answers = delivery.formDataJson as Record<string, unknown>;
+    const birthWeightKg = answers.child1_birth_weight_kg;
+    const termOfDelivery = answers.term_of_delivery;
+
+    const lowBirthWeight = typeof birthWeightKg === 'number' && birthWeightKg < 2.5;
+    const preterm = termOfDelivery === 'pre_term';
+    if (!lowBirthWeight && !preterm) return false;
+
+    const beneficiary = await findBeneficiaryById(beneficiaryId, authorizationHeader);
+    if (!beneficiary?.childDateOfBirth) return false;
+
+    const dob = new Date(beneficiary.childDateOfBirth);
+    const twoMonthsOld = new Date(dob);
+    twoMonthsOld.setUTCMonth(twoMonthsOld.getUTCMonth() + 2);
+    return asOf.getTime() <= twoMonthsOld.getTime();
   }
 
   async createDraft(formCode: string, dto: CreateDraftVersionInput) {
@@ -246,7 +306,22 @@ export class FormService {
 
     const fields = schemaJsonSchema.parse(version.schemaJson);
     const crossFieldRules = validationJsonSchema.parse(version.validationJson ?? []);
-    const violations = validateSubmission(fields, crossFieldRules, dto.formData);
+    // Same reasoning as getActiveVersion's prefilledContext: is_kmc_practiced's
+    // visibility must be revalidated server-side against the same derived
+    // flag the client was given at form-load time, not against a raw
+    // birth-weight/term-of-delivery field the Sakhi is no longer asked for.
+    const validationData =
+      formCode === 'NEONATAL_VISIT'
+        ? {
+            ...dto.formData,
+            kmcEligible: await this.resolveKmcEligibility(
+              dto.beneficiaryId,
+              new Date(),
+              authorizationHeader,
+            ),
+          }
+        : dto.formData;
+    const violations = validateSubmission(fields, crossFieldRules, validationData);
 
     if (violations.length) {
       throw unprocessable('Submission failed validation.', { violations });


### PR DESCRIPTION
## Summary
- Removes "Birth weight of the baby in kg" and "Term of delivery" from the NEONATAL_VISIT (NN1/NN2) form — neither is in the approved CSV spec, and their labels leaked internal implementation notes into the Sakhi-facing UI.
- Adds a server-side `kmcEligible` derived flag (birth weight <2.5kg OR preterm delivery, AND baby age ≤2 months) computed from the beneficiary's linked DELIVERY_VISIT submission, returned as `prefilledContext` on `GET /forms/:formCode/active-version?beneficiaryId=...`.
- `is_kmc_practiced`'s `visibleWhen` now checks this single derived boolean instead of the two removed fields — deliberately kept to one condition (never an OR in `visibleWhen` itself), since the mobile client's `FormVisibilityEvaluator` only parses one `{field,operator,value}` condition per field and has crashed form-loading before when a multi-condition shape was shipped.
- Server-side revalidation on submission (`createSubmission`) merges the same derived flag before validating `is_kmc_practiced`'s required-ness — never persisted into the stored submission.

Closes #183

## Mobile-client dependency
Not fully usable end-to-end until the mobile client is updated to pass `beneficiaryId` on this call and read `prefilledContext.kmcEligible` in its visibility evaluator. Until then `is_kmc_practiced` fails closed (hidden) for every beneficiary, same as when no DELIVERY_VISIT data exists.

## Test plan
- [x] `npx jest apps/visit-form-service` — 213 tests passing in the two touched suites (12 new cases added), full service suite (539 tests) passing before this change
- [x] Type-check and lint clean
- [x] Verified live locally: published a real NEONATAL_VISIT v2 via the admin API (create draft → patch → publish), confirmed via `GET /forms/NEONATAL_VISIT/active-version` that the two fields are gone and `is_kmc_practiced.visibleWhen` now targets `kmcEligible`
- [x] Verified `prefilledContext.kmcEligible` resolves through the real gateway → visit-form-service → beneficiary-service call chain (not mocked)
- [x] Verified a real `POST /forms/NEONATAL_VISIT/submissions` call never persists `kmcEligible` into the stored `formData`