### PR TITLE
feat(seed): add supervisor-app seed fixture across 6 services

### DIFF
--- a/apps/approval-service/package.json
+++ b/apps/approval-service/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "description": "Generic supervisor approval surface.",
   "private": true,
-  "scripts": { "prisma:generate": "prisma generate", "prisma:migrate": "prisma migrate deploy" },
+  "scripts": {
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "seed": "ts-node --compiler-options {\"module\":\"commonjs\"} prisma/seed.ts"
+  },
   "dependencies": {
     "@armman/core": "*",
     "@armman/service-commons": "*",
@@ -14,5 +18,8 @@
     "pino-http": "^10.2.0",
     "zod": "^3.23.8"
   },
-  "devDependencies": { "@types/express": "^4.17.21", "prisma": "^5.18.0" }
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "prisma": "^5.18.0"
+  }
 }

--- a/apps/approval-service/prisma/seed.ts
+++ b/apps/approval-service/prisma/seed.ts
@@ -1,0 +1,120 @@
+import { PrismaClient } from '../../../node_modules/.prisma/client-approval-service';
+
+const prisma = new PrismaClient();
+
+interface SeedResult {
+  step: string;
+  created: boolean;
+  message: string;
+}
+
+// lookup_values.lookup_value_id (category APPROVAL_STATUS, code PENDING),
+// owned by auth-service — cross-service scalar ref, not FK-enforced.
+const APPROVAL_STATUS_PENDING_LOOKUP_ID = 'e08a9cac-cafd-4e6b-bf68-c41ee9037cdf';
+
+const CARD_TYPES: (
+  | 'LMP_CHANGE'
+  | 'CLOSURE_REVIEW'
+  | 'REOPEN'
+  | 'ACCOMPANIED_REFERRAL'
+  | 'REFERRAL_INCOMPLETE'
+  | 'DATA_RESTORE'
+)[] = [
+  'LMP_CHANGE',
+  'CLOSURE_REVIEW',
+  'REOPEN',
+  'ACCOMPANIED_REFERRAL',
+  'REFERRAL_INCOMPLETE',
+  'DATA_RESTORE',
+];
+
+// One beneficiary case per sakhi (the first mother seeded by
+// beneficiary-service's own prisma/seed.ts) — used as sourceEntityId/
+// beneficiaryId for the 5 card types that reference a beneficiary.
+// DATA_RESTORE has no beneficiary of its own; it targets the sakhi's User row.
+const SAKHIS: { username: string; sakhiUserId: string; firstBeneficiaryId: string }[] = [
+  {
+    username: 'lakshmi.sakhi',
+    sakhiUserId: '3df86ec1-8115-4db9-b558-a091f15b5a99',
+    firstBeneficiaryId: 'a29616a5-cc9d-4de2-9bfc-399fa82700ca',
+  },
+  {
+    username: 'nithya.sakhi',
+    sakhiUserId: '9252ff42-6904-4005-9184-14cbbb75e84b',
+    firstBeneficiaryId: 'cb2c9ae5-06fe-4a41-a89e-5b93bd9cb8ad',
+  },
+  {
+    username: 'sandhya.sakhi',
+    sakhiUserId: 'f84745fd-f105-40d9-bbf0-9127b3948112',
+    firstBeneficiaryId: '2451a47d-da90-41a3-9d79-2fdad3846043',
+  },
+  {
+    username: 'revathi.sakhi',
+    sakhiUserId: '079bd637-01a7-45f1-9216-fa819b736e54',
+    firstBeneficiaryId: '1b529119-87d4-408b-904e-94700c5e2c37',
+  },
+  {
+    username: 'shobana.sakhi',
+    sakhiUserId: '63407922-ecb4-4812-be4e-4567938bfb20',
+    firstBeneficiaryId: '34460e35-1f86-499e-9efb-973f2de02dff',
+  },
+];
+
+/**
+ * Supervisor-app "Quick Response" QA fixture: one PENDING approval_requests
+ * row per card type (6) per sakhi (5) = 30 rows, so `GET /quick-response`
+ * returns real cards for every approval-service-backed card type.
+ */
+async function seedSupervisorAppApprovals(): Promise<SeedResult> {
+  let created = 0;
+  let skipped = 0;
+
+  for (const sakhi of SAKHIS) {
+    for (const requestType of CARD_TYPES) {
+      const isDataRestore = requestType === 'DATA_RESTORE';
+      const sourceEntityId = isDataRestore ? sakhi.sakhiUserId : sakhi.firstBeneficiaryId;
+
+      const existing = await prisma.approvalRequest.findFirst({
+        where: { requestedByUserId: sakhi.sakhiUserId, requestType },
+      });
+      if (existing) {
+        skipped += 1;
+        continue;
+      }
+
+      await prisma.approvalRequest.create({
+        data: {
+          requestType,
+          sourceEntityType: isDataRestore ? 'User' : 'BeneficiaryCase',
+          sourceEntityId,
+          beneficiaryId: isDataRestore ? undefined : sakhi.firstBeneficiaryId,
+          requestedByUserId: sakhi.sakhiUserId,
+          decisionStatusLookupId: APPROVAL_STATUS_PENDING_LOOKUP_ID,
+        },
+      });
+      created += 1;
+    }
+  }
+
+  return {
+    step: 'supervisor-app-approvals',
+    created: created > 0,
+    message: `Created ${created} approval request(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
+async function main(): Promise<void> {
+  const results = [await seedSupervisorAppApprovals()];
+
+  console.log('\nSeed summary:');
+  for (const r of results) {
+    console.log(`  [${r.created ? 'created' : 'skipped'}] ${r.step}: ${r.message}`);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/auth-service/prisma/seed.ts
+++ b/apps/auth-service/prisma/seed.ts
@@ -312,6 +312,243 @@ async function seedTestProject(): Promise<SeedResult & { projectId: string }> {
   };
 }
 
+/**
+ * Links the test project to its full geography chain (leaf unit + every
+ * ancestor up to the state) via `project_geographies`. Without this, a
+ * client that scopes its offline geography-unit download to the project
+ * (see `GET /project-geography`) silently excludes every record tied to
+ * this geography — the exact gap that made freshly-seeded beneficiaries
+ * invisible on the mobile app despite the API returning them correctly.
+ */
+async function seedProjectGeography(
+  projectId: string,
+  leafGeographyUnitId: string,
+): Promise<SeedResult> {
+  const chain: string[] = [];
+  let currentId: string | null = leafGeographyUnitId;
+  while (currentId) {
+    chain.push(currentId);
+    const unit: { parentId: string | null } | null = await prisma.geographyUnit.findUnique({
+      where: { geographyUnitId: currentId },
+      select: { parentId: true },
+    });
+    currentId = unit?.parentId ?? null;
+  }
+
+  let created = 0;
+  let skipped = 0;
+  for (const geographyUnitId of chain) {
+    const existing = await prisma.projectGeography.findFirst({
+      where: { projectId, geographyUnitId, isDeleted: false },
+    });
+    if (existing) {
+      skipped += 1;
+      continue;
+    }
+    await prisma.projectGeography.create({
+      data: { projectId, geographyUnitId, activeFrom: new Date('2026-01-01') },
+    });
+    created += 1;
+  }
+
+  return {
+    step: 'projectGeography',
+    created: created > 0,
+    message: `Linked ${created} geography unit(s) to the test project, skipped ${skipped} already-linked.`,
+  };
+}
+
+interface SupervisorAppAccountSeed {
+  id: string;
+  username: string;
+  password: string;
+  displayName: string;
+  mobileNumber: string;
+  roleCode: 'SUPERVISOR' | 'SAKHI';
+  supervisorId?: string;
+}
+
+// Supervisor-app QA fixture: 6 supervisors + 5 sakhis, fixed ids matching what
+// beneficiary-service/visit-form-service/supervisor-operations-service/
+// approval-service/notification-escalation-service's own seed.ts files
+// already hardcode as cross-service references — unlike the generic
+// SUPERVISOR/SAKHI env-var mechanism above (which mints new random ids on
+// every fresh database), these fixed ids make the whole seed suite portable:
+// running `npm run seed` on any environment reproduces this exact dataset,
+// wired together correctly.
+const SUPERVISOR_APP_ACCOUNTS: SupervisorAppAccountSeed[] = [
+  {
+    id: '742e8dfe-984c-4c9f-af24-c3dacffecac4',
+    username: 'arun.supervisor',
+    password: 'Arun@1234',
+    displayName: 'Arun Supervisor',
+    mobileNumber: '+919100000001',
+    roleCode: 'SUPERVISOR',
+  },
+  {
+    id: '40f6e942-2101-426b-9251-947e7db9f869',
+    username: 'suresh.supervisor',
+    password: 'Suresh@1234',
+    displayName: 'Suresh Supervisor',
+    mobileNumber: '+919100000002',
+    roleCode: 'SUPERVISOR',
+  },
+  {
+    id: '55cdb187-12e5-475f-902c-c4bf50d4e220',
+    username: 'deepak.supervisor',
+    password: 'Deepak@1234',
+    displayName: 'Deepak Supervisor',
+    mobileNumber: '+919100000003',
+    roleCode: 'SUPERVISOR',
+  },
+  {
+    id: '6242e4ae-19c8-4a4b-b7ca-63768fff1615',
+    username: 'vijay.supervisor',
+    password: 'Vijay@1234',
+    displayName: 'Vijay Supervisor',
+    mobileNumber: '+919100000004',
+    roleCode: 'SUPERVISOR',
+  },
+  {
+    id: '23002b65-40c3-45e2-9c6d-76d1c42b0053',
+    username: 'manoj.supervisor',
+    password: 'Manoj@1234',
+    displayName: 'Manoj Supervisor',
+    mobileNumber: '+919100000005',
+    roleCode: 'SUPERVISOR',
+  },
+  {
+    id: '11925f16-4399-47a2-977b-ef06e89acd94',
+    username: 'raj.supervisor',
+    password: 'Str0ngPass!23',
+    displayName: 'Raj Supervisor',
+    mobileNumber: '+919800000106',
+    roleCode: 'SUPERVISOR',
+  },
+  {
+    id: '3df86ec1-8115-4db9-b558-a091f15b5a99',
+    username: 'lakshmi.sakhi',
+    password: 'lakshmi@123',
+    displayName: 'Lakshmi Sakhi',
+    mobileNumber: '+919100000011',
+    roleCode: 'SAKHI',
+    supervisorId: '742e8dfe-984c-4c9f-af24-c3dacffecac4',
+  },
+  {
+    id: '9252ff42-6904-4005-9184-14cbbb75e84b',
+    username: 'nithya.sakhi',
+    password: 'nithya@123',
+    displayName: 'Nithya Sakhi',
+    mobileNumber: '+919100000012',
+    roleCode: 'SAKHI',
+    supervisorId: '40f6e942-2101-426b-9251-947e7db9f869',
+  },
+  {
+    id: 'f84745fd-f105-40d9-bbf0-9127b3948112',
+    username: 'sandhya.sakhi',
+    password: 'sandhya@123',
+    displayName: 'Sandhya Sakhi',
+    mobileNumber: '+919100000013',
+    roleCode: 'SAKHI',
+    supervisorId: '55cdb187-12e5-475f-902c-c4bf50d4e220',
+  },
+  {
+    id: '079bd637-01a7-45f1-9216-fa819b736e54',
+    username: 'revathi.sakhi',
+    password: 'revathi@123',
+    displayName: 'Revathi Sakhi',
+    mobileNumber: '+919100000014',
+    roleCode: 'SAKHI',
+    supervisorId: '6242e4ae-19c8-4a4b-b7ca-63768fff1615',
+  },
+  {
+    id: '63407922-ecb4-4812-be4e-4567938bfb20',
+    username: 'shobana.sakhi',
+    password: 'shobana@123',
+    displayName: 'Shobana Sakhi',
+    mobileNumber: '+919100000015',
+    roleCode: 'SAKHI',
+    supervisorId: '23002b65-40c3-45e2-9c6d-76d1c42b0053',
+  },
+];
+
+async function seedSupervisorAppAccounts(scope: {
+  projectId: string;
+  geographyUnitId: string;
+}): Promise<SeedResult[]> {
+  if (process.env.NODE_ENV === 'production') {
+    return [
+      { step: 'supervisorAppAccounts', created: false, message: 'NODE_ENV=production — skipped.' },
+    ];
+  }
+
+  const roles = await prisma.role.findMany({
+    where: { roleCode: { in: ['SUPERVISOR', 'SAKHI'] } },
+  });
+  const roleIdByCode = new Map(roles.map((r) => [r.roleCode, r.id]));
+  const results: SeedResult[] = [];
+
+  for (const account of SUPERVISOR_APP_ACCOUNTS) {
+    const existing = await prisma.user.findUnique({ where: { id: account.id } });
+    if (existing) {
+      results.push({
+        step: `supervisorAppAccount:${account.username}`,
+        created: false,
+        message: `User ${account.username} already exists — skipped.`,
+      });
+      continue;
+    }
+
+    const roleId = roleIdByCode.get(account.roleCode);
+    if (!roleId) {
+      throw new Error(`Role ${account.roleCode} not found — run seedRoles first.`);
+    }
+    const passwordHash = await argon2.hash(account.password);
+
+    await prisma.$transaction(async (tx) => {
+      await tx.user.create({
+        data: {
+          id: account.id,
+          username: account.username,
+          mobileNumber: account.mobileNumber,
+          passwordHash,
+          displayName: account.displayName,
+          status: 'ACTIVE',
+        },
+      });
+      await tx.userRole.create({
+        data: {
+          userId: account.id,
+          roleId,
+          projectId: scope.projectId,
+          geographyUnitId: scope.geographyUnitId,
+          effectiveFrom: new Date(),
+          status: 'ACTIVE',
+        },
+      });
+      if (account.roleCode === 'SAKHI') {
+        await tx.sakhiProfile.create({
+          data: {
+            userId: account.id,
+            primaryProjectId: scope.projectId,
+            phoneNumber: account.mobileNumber,
+            supervisorId: account.supervisorId,
+            activeFrom: new Date(),
+          },
+        });
+      }
+    });
+
+    results.push({
+      step: `supervisorAppAccount:${account.username}`,
+      created: true,
+      message: `Seeded ${account.roleCode} user ${account.username} (id ${account.id}).`,
+    });
+  }
+
+  return results;
+}
+
 async function main(): Promise<void> {
   const results = [await seedRoles(prisma), ...(await seedAdminUsers(prisma))];
 
@@ -321,6 +558,15 @@ async function main(): Promise<void> {
   const geographyResult = await seedGeographyUnits();
   const projectResult = await seedTestProject();
   results.push(geographyResult, projectResult);
+  results.push(
+    await seedProjectGeography(projectResult.projectId, geographyResult.leafGeographyUnitId),
+  );
+  results.push(
+    ...(await seedSupervisorAppAccounts({
+      projectId: projectResult.projectId,
+      geographyUnitId: geographyResult.leafGeographyUnitId,
+    })),
+  );
 
   for (const spec of MANUAL_SEED_USER_ENV_VARS) {
     results.push(

--- a/apps/beneficiary-service/package.json
+++ b/apps/beneficiary-service/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "description": "Beneficiary lifecycle service — PII vault, cases, consent, duplicate detection.",
   "private": true,
-  "scripts": { "prisma:generate": "prisma generate", "prisma:migrate": "prisma migrate deploy" },
+  "scripts": {
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "seed": "ts-node --compiler-options {\"module\":\"commonjs\"} prisma/seed.ts"
+  },
   "dependencies": {
     "@armman/core": "*",
     "@armman/service-commons": "*",
@@ -14,5 +18,8 @@
     "pino-http": "^10.2.0",
     "zod": "^3.23.8"
   },
-  "devDependencies": { "@types/express": "^4.17.21", "prisma": "^5.18.0" }
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "prisma": "^5.18.0"
+  }
 }

--- a/apps/beneficiary-service/prisma/seed.ts
+++ b/apps/beneficiary-service/prisma/seed.ts
@@ -1,0 +1,570 @@
+import { createCipheriv, createHmac, randomBytes } from 'node:crypto';
+import { PrismaClient } from '../../../node_modules/.prisma/client-beneficiary-service';
+
+const prisma = new PrismaClient();
+
+interface SeedResult {
+  step: string;
+  created: boolean;
+  message: string;
+}
+
+// PII columns are AES-256-GCM encrypted / HMAC-SHA256 search-hashed at the
+// application layer (libs/service-commons/src/crypto/pii-crypto.ts). Standalone
+// seed scripts here can't import `@armman/*` (see risk-referral-service's
+// prisma/seed.ts note — no path-alias registration under plain ts-node), so the
+// two functions are duplicated verbatim rather than imported.
+function encryptPii(plaintext: string): Buffer {
+  const key = Buffer.from(process.env.PII_ENCRYPTION_KEY ?? '', 'base64');
+  if (key.length !== 32) {
+    throw new Error('PII_ENCRYPTION_KEY must be set and decode to 32 bytes — cannot seed PII.');
+  }
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return Buffer.concat([iv, ciphertext, cipher.getAuthTag()]);
+}
+
+function hashForSearch(normalizedValue: string): Buffer {
+  const key = Buffer.from(process.env.PII_SEARCH_HASH_KEY ?? '', 'base64');
+  if (key.length !== 32) {
+    throw new Error('PII_SEARCH_HASH_KEY must be set and decode to 32 bytes — cannot seed PII.');
+  }
+  return createHmac('sha256', key).update(normalizedValue, 'utf8').digest();
+}
+
+function normalizeForSearch(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    .replace(/\s+/g, ' ');
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+// Fixed geography/project/master-data ids — already seeded on the shared dev
+// database by auth-service's own seed data (project + full State→Pada
+// geography chain) and risk-referral-service (risk conditions). Override via
+// env if a target environment generates these differently.
+const PROJECT_ID =
+  process.env.SEED_BENEFICIARY_PROJECT_ID ?? '4b4084cf-d572-4020-9438-c82640275201';
+const VILLAGE_ID =
+  process.env.SEED_BENEFICIARY_VILLAGE_ID ?? '0307a68f-d480-4866-94fa-2094a21f2bb3';
+const PADA_ID = process.env.SEED_BENEFICIARY_PADA_ID ?? '7337fe8d-c5b4-418d-81f2-8047e3ab885d';
+const SUB_CENTRE_ID =
+  process.env.SEED_BENEFICIARY_SUBCENTRE_ID ?? '4e34fa81-bb38-4fee-b254-64111113ff28';
+const PHC_ID = process.env.SEED_BENEFICIARY_PHC_ID ?? '8a781eb5-f2a5-432b-8aa2-247d73e84e82';
+const BLOCK_ID = process.env.SEED_BENEFICIARY_BLOCK_ID ?? '858b7d8b-b825-4b2e-962f-5c987f1477f4';
+const STATE_ID = process.env.SEED_BENEFICIARY_STATE_ID ?? '650e14c8-62a9-4d98-89d6-6b82108bd375';
+const DISTRICT_ID =
+  process.env.SEED_BENEFICIARY_DISTRICT_ID ?? 'ae59f40c-961f-4f66-a142-73659058518e';
+
+const BENEFICIARY_TYPE_PREGNANT_WOMAN_LOOKUP_ID = '717ada96-2e6c-4fdd-b5c7-7ced61c14b41';
+const BENEFICIARY_TYPE_CHILD_LOOKUP_ID = 'ce48bea6-ab28-4603-bcfc-64625db49491';
+const CASE_TYPE_MOTHER_LOOKUP_ID = 'b7926eb3-a446-45b4-a42e-0693178dd66b';
+const CASE_TYPE_CHILD_LOOKUP_ID = '03fde668-d75d-4c7b-aed1-10e2494bb6be';
+// risk_conditions.risk_condition_id (Hypertension / High BP), owned by risk-referral-service.
+const HYPERTENSION_RISK_CONDITION_ID = 'cf20ee77-948f-40d6-b046-7c1d9873f763';
+
+interface MotherSeed {
+  beneficiaryId: string;
+  localCaseUuid: string;
+  fullName: string;
+  phone: string;
+  dateOfBirth: string;
+  registrationDate: string;
+  lmpDate: string;
+  riskGrade?: 'HIGH' | 'MODERATE';
+}
+
+interface ChildSeed {
+  beneficiaryId: string;
+  localCaseUuid: string;
+  fullName: string;
+  phone: string;
+  dateOfBirth: string;
+  registrationDate: string;
+}
+
+interface SakhiSeed {
+  sakhiUsername: string;
+  sakhiUserId: string;
+  mothers: MotherSeed[];
+  children: ChildSeed[];
+}
+
+// Fixed ids reuse exactly what was already created via the live API this
+// session — re-running this script against that same database is a no-op;
+// against a fresh one (e.g. develop's), it recreates the identical dataset.
+const SAKHIS: SakhiSeed[] = [
+  {
+    sakhiUsername: 'lakshmi.sakhi',
+    sakhiUserId: '3df86ec1-8115-4db9-b558-a091f15b5a99',
+    mothers: [
+      {
+        beneficiaryId: 'a29616a5-cc9d-4de2-9bfc-399fa82700ca',
+        localCaseUuid: 'seed-lakshmi-mother-1',
+        fullName: 'lakshmi.sakhi Mother 1',
+        phone: '9876500001',
+        dateOfBirth: '1997-02-10',
+        registrationDate: '2026-07-01',
+        lmpDate: '2026-01-01',
+        riskGrade: 'HIGH',
+      },
+      {
+        beneficiaryId: '8fc12c0d-7887-4fe6-b7bc-92ef7d953ff4',
+        localCaseUuid: 'seed-lakshmi-mother-2',
+        fullName: 'lakshmi.sakhi Mother 2',
+        phone: '9876500002',
+        dateOfBirth: '1997-03-10',
+        registrationDate: '2026-07-02',
+        lmpDate: '2026-01-02',
+        riskGrade: 'MODERATE',
+      },
+      {
+        beneficiaryId: '22f8e16c-d678-4f08-930e-c85e0dced2dd',
+        localCaseUuid: 'seed-lakshmi-mother-3',
+        fullName: 'lakshmi.sakhi Mother 3',
+        phone: '9876500003',
+        dateOfBirth: '1997-04-10',
+        registrationDate: '2026-07-03',
+        lmpDate: '2026-01-03',
+      },
+      {
+        beneficiaryId: 'a3eeb96a-aa94-4535-b647-5b9f1204a126',
+        localCaseUuid: 'seed-lakshmi-mother-4',
+        fullName: 'lakshmi.sakhi Mother 4',
+        phone: '9876500004',
+        dateOfBirth: '1997-05-10',
+        registrationDate: '2026-07-04',
+        lmpDate: '2026-01-04',
+      },
+    ],
+    children: [
+      {
+        beneficiaryId: 'e20f17ba-006c-4f5c-8607-7162a9674d2d',
+        localCaseUuid: 'seed-lakshmi-child-1',
+        fullName: 'lakshmi.sakhi Child 1',
+        phone: '9876510001',
+        dateOfBirth: '2026-06-11',
+        registrationDate: '2026-07-11',
+      },
+      {
+        beneficiaryId: '54a09c3a-1ae7-4b58-bf14-a81798eec698',
+        localCaseUuid: 'seed-lakshmi-child-2',
+        fullName: 'lakshmi.sakhi Child 2',
+        phone: '9876510002',
+        dateOfBirth: '2026-06-12',
+        registrationDate: '2026-07-12',
+      },
+    ],
+  },
+  {
+    sakhiUsername: 'nithya.sakhi',
+    sakhiUserId: '9252ff42-6904-4005-9184-14cbbb75e84b',
+    mothers: [
+      {
+        beneficiaryId: 'cb2c9ae5-06fe-4a41-a89e-5b93bd9cb8ad',
+        localCaseUuid: 'seed-nithya-mother-1',
+        fullName: 'nithya.sakhi Mother 1',
+        phone: '9876500011',
+        dateOfBirth: '1997-02-10',
+        registrationDate: '2026-07-01',
+        lmpDate: '2026-01-01',
+        riskGrade: 'HIGH',
+      },
+      {
+        beneficiaryId: '88baaa7f-b54a-419b-9a25-f59c08b23815',
+        localCaseUuid: 'seed-nithya-mother-2',
+        fullName: 'nithya.sakhi Mother 2',
+        phone: '9876500012',
+        dateOfBirth: '1997-03-10',
+        registrationDate: '2026-07-02',
+        lmpDate: '2026-01-02',
+        riskGrade: 'MODERATE',
+      },
+      {
+        beneficiaryId: 'aeec7340-5838-482f-862e-7f778822a4c2',
+        localCaseUuid: 'seed-nithya-mother-3',
+        fullName: 'nithya.sakhi Mother 3',
+        phone: '9876500013',
+        dateOfBirth: '1997-04-10',
+        registrationDate: '2026-07-03',
+        lmpDate: '2026-01-03',
+      },
+      {
+        beneficiaryId: '0bfc9aac-2ef1-496c-b78e-1c8d50cded41',
+        localCaseUuid: 'seed-nithya-mother-4',
+        fullName: 'nithya.sakhi Mother 4',
+        phone: '9876500014',
+        dateOfBirth: '1997-05-10',
+        registrationDate: '2026-07-04',
+        lmpDate: '2026-01-04',
+      },
+    ],
+    children: [
+      {
+        beneficiaryId: '91143832-c91e-4ca7-a293-7299ed29283c',
+        localCaseUuid: 'seed-nithya-child-1',
+        fullName: 'nithya.sakhi Child 1',
+        phone: '9876510011',
+        dateOfBirth: '2026-06-11',
+        registrationDate: '2026-07-11',
+      },
+      {
+        beneficiaryId: 'e6002e06-d054-496e-a6ca-2a770a673435',
+        localCaseUuid: 'seed-nithya-child-2',
+        fullName: 'nithya.sakhi Child 2',
+        phone: '9876510012',
+        dateOfBirth: '2026-06-12',
+        registrationDate: '2026-07-12',
+      },
+    ],
+  },
+  {
+    sakhiUsername: 'sandhya.sakhi',
+    sakhiUserId: 'f84745fd-f105-40d9-bbf0-9127b3948112',
+    mothers: [
+      {
+        beneficiaryId: '2451a47d-da90-41a3-9d79-2fdad3846043',
+        localCaseUuid: 'seed-sandhya-mother-1',
+        fullName: 'sandhya.sakhi Mother 1',
+        phone: '9876500021',
+        dateOfBirth: '1997-02-10',
+        registrationDate: '2026-07-01',
+        lmpDate: '2026-01-01',
+        riskGrade: 'HIGH',
+      },
+      {
+        beneficiaryId: '771b04f6-54b9-4446-9381-02deadc53c47',
+        localCaseUuid: 'seed-sandhya-mother-2',
+        fullName: 'sandhya.sakhi Mother 2',
+        phone: '9876500022',
+        dateOfBirth: '1997-03-10',
+        registrationDate: '2026-07-02',
+        lmpDate: '2026-01-02',
+        riskGrade: 'MODERATE',
+      },
+      {
+        beneficiaryId: '90a98f9c-9ec2-47b9-87a2-35cdb720e51e',
+        localCaseUuid: 'seed-sandhya-mother-3',
+        fullName: 'sandhya.sakhi Mother 3',
+        phone: '9876500023',
+        dateOfBirth: '1997-04-10',
+        registrationDate: '2026-07-03',
+        lmpDate: '2026-01-03',
+      },
+      {
+        beneficiaryId: '7446bfaa-0d32-4997-ae0a-0cfb77b6726c',
+        localCaseUuid: 'seed-sandhya-mother-4',
+        fullName: 'sandhya.sakhi Mother 4',
+        phone: '9876500024',
+        dateOfBirth: '1997-05-10',
+        registrationDate: '2026-07-04',
+        lmpDate: '2026-01-04',
+      },
+    ],
+    children: [
+      {
+        beneficiaryId: '5a84e3bf-a396-4182-9ea4-6b0e5a215b69',
+        localCaseUuid: 'seed-sandhya-child-1',
+        fullName: 'sandhya.sakhi Child 1',
+        phone: '9876510021',
+        dateOfBirth: '2026-06-11',
+        registrationDate: '2026-07-11',
+      },
+      {
+        beneficiaryId: '8d7cdb63-16e8-4dd6-bb65-85a134e24cdf',
+        localCaseUuid: 'seed-sandhya-child-2',
+        fullName: 'sandhya.sakhi Child 2',
+        phone: '9876510022',
+        dateOfBirth: '2026-06-12',
+        registrationDate: '2026-07-12',
+      },
+    ],
+  },
+  {
+    sakhiUsername: 'revathi.sakhi',
+    sakhiUserId: '079bd637-01a7-45f1-9216-fa819b736e54',
+    mothers: [
+      {
+        beneficiaryId: '1b529119-87d4-408b-904e-94700c5e2c37',
+        localCaseUuid: 'seed-revathi-mother-1',
+        fullName: 'revathi.sakhi Mother 1',
+        phone: '9876500031',
+        dateOfBirth: '1997-02-10',
+        registrationDate: '2026-07-01',
+        lmpDate: '2026-01-01',
+        riskGrade: 'HIGH',
+      },
+      {
+        beneficiaryId: '989f33f2-236e-4b2b-a943-04258d9bb8c0',
+        localCaseUuid: 'seed-revathi-mother-2',
+        fullName: 'revathi.sakhi Mother 2',
+        phone: '9876500032',
+        dateOfBirth: '1997-03-10',
+        registrationDate: '2026-07-02',
+        lmpDate: '2026-01-02',
+        riskGrade: 'MODERATE',
+      },
+      {
+        beneficiaryId: '7938f2fc-337c-4a9c-86ed-63f10fb19438',
+        localCaseUuid: 'seed-revathi-mother-3',
+        fullName: 'revathi.sakhi Mother 3',
+        phone: '9876500033',
+        dateOfBirth: '1997-04-10',
+        registrationDate: '2026-07-03',
+        lmpDate: '2026-01-03',
+      },
+      {
+        beneficiaryId: '9cd6a2f6-2000-4e84-99ac-7933da0e34e1',
+        localCaseUuid: 'seed-revathi-mother-4',
+        fullName: 'revathi.sakhi Mother 4',
+        phone: '9876500034',
+        dateOfBirth: '1997-05-10',
+        registrationDate: '2026-07-04',
+        lmpDate: '2026-01-04',
+      },
+    ],
+    children: [
+      {
+        beneficiaryId: '56eb51a0-4c8b-44b4-8e5d-02dc89225508',
+        localCaseUuid: 'seed-revathi-child-1',
+        fullName: 'revathi.sakhi Child 1',
+        phone: '9876510031',
+        dateOfBirth: '2026-06-11',
+        registrationDate: '2026-07-11',
+      },
+      {
+        beneficiaryId: 'bd8d91fa-8053-4cb9-b31f-6b7176acb96f',
+        localCaseUuid: 'seed-revathi-child-2',
+        fullName: 'revathi.sakhi Child 2',
+        phone: '9876510032',
+        dateOfBirth: '2026-06-12',
+        registrationDate: '2026-07-12',
+      },
+    ],
+  },
+  {
+    sakhiUsername: 'shobana.sakhi',
+    sakhiUserId: '63407922-ecb4-4812-be4e-4567938bfb20',
+    mothers: [
+      {
+        beneficiaryId: '34460e35-1f86-499e-9efb-973f2de02dff',
+        localCaseUuid: 'seed-shobana-mother-1',
+        fullName: 'shobana.sakhi Mother 1',
+        phone: '9876500041',
+        dateOfBirth: '1997-02-10',
+        registrationDate: '2026-07-01',
+        lmpDate: '2026-01-01',
+        riskGrade: 'HIGH',
+      },
+      {
+        beneficiaryId: '342e8e0e-00ad-494d-be41-adecb9b70bd8',
+        localCaseUuid: 'seed-shobana-mother-2',
+        fullName: 'shobana.sakhi Mother 2',
+        phone: '9876500042',
+        dateOfBirth: '1997-03-10',
+        registrationDate: '2026-07-02',
+        lmpDate: '2026-01-02',
+        riskGrade: 'MODERATE',
+      },
+      {
+        beneficiaryId: 'fb03e8e7-5a19-40fd-8400-af42ad1aaff6',
+        localCaseUuid: 'seed-shobana-mother-3',
+        fullName: 'shobana.sakhi Mother 3',
+        phone: '9876500043',
+        dateOfBirth: '1997-04-10',
+        registrationDate: '2026-07-03',
+        lmpDate: '2026-01-03',
+      },
+      {
+        beneficiaryId: '94594dbe-48cc-4905-90bc-336b123e824e',
+        localCaseUuid: 'seed-shobana-mother-4',
+        fullName: 'shobana.sakhi Mother 4',
+        phone: '9876500044',
+        dateOfBirth: '1997-05-10',
+        registrationDate: '2026-07-04',
+        lmpDate: '2026-01-04',
+      },
+    ],
+    children: [
+      {
+        beneficiaryId: 'dbc7e805-af1e-4b14-80ce-8076ae080de7',
+        localCaseUuid: 'seed-shobana-child-1',
+        fullName: 'shobana.sakhi Child 1',
+        phone: '9876510041',
+        dateOfBirth: '2026-06-11',
+        registrationDate: '2026-07-11',
+      },
+      {
+        beneficiaryId: 'a6f18f05-dba8-47b8-9159-0938b23e06d5',
+        localCaseUuid: 'seed-shobana-child-2',
+        fullName: 'shobana.sakhi Child 2',
+        phone: '9876510042',
+        dateOfBirth: '2026-06-12',
+        registrationDate: '2026-07-12',
+      },
+    ],
+  },
+];
+
+async function createPii(fullName: string, phone: string, dateOfBirth: string): Promise<string> {
+  const pii = await prisma.beneficiaryPii.create({
+    data: {
+      fullNameEnc: encryptPii(fullName),
+      fullNameSearchHash: hashForSearch(normalizeForSearch(fullName)),
+      phoneEnc: encryptPii(phone),
+      phoneSearchHash: hashForSearch(normalizeForSearch(phone)),
+      villageId: VILLAGE_ID,
+      padaId: PADA_ID,
+      healthSubCentreId: SUB_CENTRE_ID,
+      phcId: PHC_ID,
+      healthBlockId: BLOCK_ID,
+      stateId: STATE_ID,
+      districtId: DISTRICT_ID,
+      dateOfBirth: new Date(dateOfBirth),
+    },
+  });
+  return pii.id;
+}
+
+async function seedMother(sakhi: SakhiSeed, mother: MotherSeed): Promise<boolean> {
+  const existing = await prisma.beneficiaryCase.findUnique({ where: { id: mother.beneficiaryId } });
+  if (existing) return false;
+
+  const piiId = await createPii(mother.fullName, mother.phone, mother.dateOfBirth);
+  const registrationDate = new Date(mother.registrationDate);
+  const lmpDate = new Date(mother.lmpDate);
+
+  await prisma.beneficiaryCase.create({
+    data: {
+      id: mother.beneficiaryId,
+      localCaseUuid: mother.localCaseUuid,
+      piiId,
+      projectId: PROJECT_ID,
+      caseType: 'MOTHER',
+      sakhiId: sakhi.sakhiUserId,
+      registrationDate,
+      currentPhase: 'ANC',
+      beneficiaryTypeLookupId: BENEFICIARY_TYPE_PREGNANT_WOMAN_LOOKUP_ID,
+      caseTypeLookupId: CASE_TYPE_MOTHER_LOOKUP_ID,
+      journeyStartDate: registrationDate,
+      motherCaseDetails: {
+        create: { lmpDate, eddDate: addDays(lmpDate, 280) },
+      },
+      consentRecords: {
+        create: {
+          consentType: 'PROGRAM_ENROLLMENT',
+          consentStatus: 'GIVEN',
+          consentDate: registrationDate,
+          capturedByUserId: sakhi.sakhiUserId,
+        },
+      },
+      ...(mother.riskGrade && {
+        riskConditionSummaries: {
+          create: {
+            riskConditionId: HYPERTENSION_RISK_CONDITION_ID,
+            phase: 'ANC',
+            latestGrade: mother.riskGrade,
+            latestGradeRank: mother.riskGrade === 'HIGH' ? 4 : 2,
+            latestAssessedAt: new Date('2026-08-15T00:00:00.000Z'),
+            everHighestGrade: mother.riskGrade,
+            everHighestGradeRank: mother.riskGrade === 'HIGH' ? 4 : 2,
+            everHighestAssessedAt: new Date('2026-08-15T00:00:00.000Z'),
+            everAtRiskFlag: true,
+            currentReferralTriggerFlag: mother.riskGrade === 'HIGH',
+            currentHrVisitTriggerFlag: true,
+          },
+        },
+      }),
+    },
+  });
+  return true;
+}
+
+async function seedChild(sakhi: SakhiSeed, child: ChildSeed): Promise<boolean> {
+  const existing = await prisma.beneficiaryCase.findUnique({ where: { id: child.beneficiaryId } });
+  if (existing) return false;
+
+  const piiId = await createPii(child.fullName, child.phone, child.dateOfBirth);
+  const registrationDate = new Date(child.registrationDate);
+  const dateOfBirth = new Date(child.dateOfBirth);
+
+  await prisma.beneficiaryCase.create({
+    data: {
+      id: child.beneficiaryId,
+      localCaseUuid: child.localCaseUuid,
+      piiId,
+      projectId: PROJECT_ID,
+      caseType: 'CHILD',
+      sakhiId: sakhi.sakhiUserId,
+      registrationDate,
+      currentPhase: 'NN',
+      beneficiaryTypeLookupId: BENEFICIARY_TYPE_CHILD_LOOKUP_ID,
+      caseTypeLookupId: CASE_TYPE_CHILD_LOOKUP_ID,
+      journeyStartDate: registrationDate,
+      childCaseDetails: {
+        create: { dateOfBirth },
+      },
+      consentRecords: {
+        create: {
+          consentType: 'PROGRAM_ENROLLMENT',
+          consentStatus: 'GIVEN',
+          consentDate: registrationDate,
+          capturedByUserId: sakhi.sakhiUserId,
+        },
+      },
+    },
+  });
+  return true;
+}
+
+/**
+ * Supervisor-app QA fixture: 4 mother + 2 child beneficiary cases per sakhi
+ * (5 sakhis — lakshmi/nithya/sandhya/revathi/shobana), with the first two
+ * mothers per sakhi flagged HIGH/MODERATE risk so `atRiskOnly=true` and the
+ * risk-summary dashboard return non-empty results.
+ */
+async function seedSupervisorAppBeneficiaries(): Promise<SeedResult> {
+  let created = 0;
+  let skipped = 0;
+
+  for (const sakhi of SAKHIS) {
+    for (const mother of sakhi.mothers) {
+      if (await seedMother(sakhi, mother)) created++;
+      else skipped++;
+    }
+    for (const child of sakhi.children) {
+      if (await seedChild(sakhi, child)) created++;
+      else skipped++;
+    }
+  }
+
+  return {
+    step: 'supervisor-app-beneficiaries',
+    created: created > 0,
+    message: `Created ${created} beneficiary case(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
+async function main(): Promise<void> {
+  const results = [await seedSupervisorAppBeneficiaries()];
+
+  console.log('\nSeed summary:');
+  for (const r of results) {
+    console.log(`  [${r.created ? 'created' : 'skipped'}] ${r.step}: ${r.message}`);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/notification-escalation-service/package.json
+++ b/apps/notification-escalation-service/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "description": "Event-driven notifications and escalations.",
   "private": true,
-  "scripts": { "prisma:generate": "prisma generate", "prisma:migrate": "prisma migrate deploy" },
+  "scripts": {
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "seed": "ts-node --compiler-options {\"module\":\"commonjs\"} prisma/seed.ts"
+  },
   "dependencies": {
     "@armman/core": "*",
     "@armman/service-commons": "*",
@@ -14,5 +18,8 @@
     "pino-http": "^10.3.0",
     "zod": "^3.23.8"
   },
-  "devDependencies": { "@types/express": "^4.17.21", "prisma": "^5.18.0" }
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "prisma": "^5.18.0"
+  }
 }

--- a/apps/notification-escalation-service/prisma/seed.ts
+++ b/apps/notification-escalation-service/prisma/seed.ts
@@ -1,0 +1,76 @@
+import { PrismaClient } from '../../../node_modules/.prisma/client-notification-escalation-service';
+
+const prisma = new PrismaClient();
+
+interface SeedResult {
+  step: string;
+  created: boolean;
+  message: string;
+}
+
+// One beneficiary case per sakhi (the first mother seeded by
+// beneficiary-service's own prisma/seed.ts) — used as beneficiaryId for both
+// escalation types below.
+const SAKHIS: { username: string; firstBeneficiaryId: string }[] = [
+  { username: 'lakshmi.sakhi', firstBeneficiaryId: 'a29616a5-cc9d-4de2-9bfc-399fa82700ca' },
+  { username: 'nithya.sakhi', firstBeneficiaryId: 'cb2c9ae5-06fe-4a41-a89e-5b93bd9cb8ad' },
+  { username: 'sandhya.sakhi', firstBeneficiaryId: '2451a47d-da90-41a3-9d79-2fdad3846043' },
+  { username: 'revathi.sakhi', firstBeneficiaryId: '1b529119-87d4-408b-904e-94700c5e2c37' },
+  { username: 'shobana.sakhi', firstBeneficiaryId: '34460e35-1f86-499e-9efb-973f2de02dff' },
+];
+
+const ESCALATION_TYPES: ('ANC_2_MISSED' | 'EDD_NEARING')[] = ['ANC_2_MISSED', 'EDD_NEARING'];
+
+/**
+ * Supervisor-app "Quick Response" QA fixture: one OPEN escalation_events row
+ * per type (ANC_2_MISSED → the MISSED_VISIT card, and EDD_NEARING) per sakhi
+ * (5) = 10 rows, so `GET /quick-response` returns real cards for both
+ * notification-escalation-service-backed card types.
+ */
+async function seedSupervisorAppEscalations(): Promise<SeedResult> {
+  let created = 0;
+  let skipped = 0;
+
+  for (const sakhi of SAKHIS) {
+    for (const escalationType of ESCALATION_TYPES) {
+      const existing = await prisma.escalationEvent.findFirst({
+        where: { beneficiaryId: sakhi.firstBeneficiaryId, escalationType },
+      });
+      if (existing) {
+        skipped += 1;
+        continue;
+      }
+
+      await prisma.escalationEvent.create({
+        data: {
+          beneficiaryId: sakhi.firstBeneficiaryId,
+          escalationType,
+          status: 'OPEN',
+        },
+      });
+      created += 1;
+    }
+  }
+
+  return {
+    step: 'supervisor-app-escalations',
+    created: created > 0,
+    message: `Created ${created} escalation event(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
+async function main(): Promise<void> {
+  const results = [await seedSupervisorAppEscalations()];
+
+  console.log('\nSeed summary:');
+  for (const r of results) {
+    console.log(`  [${r.created ? 'created' : 'skipped'}] ${r.step}: ${r.message}`);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/apps/supervisor-operations-service/prisma/seed.ts
+++ b/apps/supervisor-operations-service/prisma/seed.ts
@@ -9,103 +9,6 @@ interface SeedResult {
 }
 
 /**
- * Item Master List demo data (SRS/ERD §4.7 inventory_items) — the global
- * consumables/instruments catalog behind GET /inventory-items and the
- * mobile app's "Add Item Transaction" screen. No project/sakhi scoping (this
- * table has none), so seeding once makes every item visible app-wide.
- * itemCategory/status are real Prisma enums (InventoryItemCategory/
- * InventoryItemStatus) — the DB itself rejects any value outside
- * CONSUMABLE/INSTRUMENT or ACTIVE/INACTIVE, so there is no risk of the app's
- * strict-enum parsing seeing something else.
- *
- * Deduplicated by itemCode (@unique on the table) — re-running this script
- * never creates duplicates or errors on the ones already seeded.
- */
-const DEFAULT_INVENTORY_ITEMS: {
-  itemCode: string;
-  itemName: string;
-  itemCategory: 'CONSUMABLE' | 'INSTRUMENT';
-  unit: string;
-  status: 'ACTIVE' | 'INACTIVE';
-}[] = [
-  {
-    itemCode: 'CONS-PENCIL-01',
-    itemName: 'Pencil',
-    itemCategory: 'CONSUMABLE',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-  {
-    itemCode: 'CONS-CELLS-01',
-    itemName: 'Cells',
-    itemCategory: 'CONSUMABLE',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-  {
-    itemCode: 'CONS-SUGARSTRIP-01',
-    itemName: 'Sugar Strips',
-    itemCategory: 'CONSUMABLE',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-  {
-    itemCode: 'CONS-HBSTRIP-01',
-    itemName: 'HB Strips',
-    itemCategory: 'CONSUMABLE',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-  {
-    itemCode: 'INST-DOPPLER-01',
-    itemName: 'Doppler Test Kit',
-    itemCategory: 'INSTRUMENT',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-  {
-    itemCode: 'INST-BPMONITOR-01',
-    itemName: 'BP Monitor',
-    itemCategory: 'INSTRUMENT',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-  {
-    itemCode: 'INST-WEIGHSCALE-01',
-    itemName: 'Weighing Scale',
-    itemCategory: 'INSTRUMENT',
-    unit: 'pcs',
-    status: 'ACTIVE',
-  },
-];
-
-async function seedInventoryItems(): Promise<SeedResult> {
-  const step = 'inventory-items-master-list';
-  const items = process.env.SEED_INVENTORY_ITEMS
-    ? (JSON.parse(process.env.SEED_INVENTORY_ITEMS) as typeof DEFAULT_INVENTORY_ITEMS)
-    : DEFAULT_INVENTORY_ITEMS;
-
-  let created = 0;
-  let skipped = 0;
-  for (const item of items) {
-    const existing = await prisma.inventoryItem.findUnique({ where: { itemCode: item.itemCode } });
-    if (existing) {
-      skipped += 1;
-      continue;
-    }
-
-    await prisma.inventoryItem.create({ data: item });
-    created += 1;
-  }
-
-  return {
-    step,
-    created: created > 0,
-    message: `Created ${created} inventory item(s), skipped ${skipped} already-seeded row(s).`,
-  };
-}
-
-/**
  * Demo Call Sheet data (SRS FR-SV-3.1/3.2, ERD §4.7 call_logs) — all under
  * one Supervisor/Sakhi pair (Pemma Deshmukh / Meera Sakhi) already present
  * in this environment's auth-service data (see sakhi_profiles), so this
@@ -253,8 +156,376 @@ async function seedCallLogs(): Promise<SeedResult> {
   };
 }
 
+// --- Supervisor-app QA fixture: 5 supervisor↔sakhi pairs (arun/lakshmi,
+// suresh/nithya, deepak/sandhya, vijay/revathi, manoj/shobana), separate from
+// the Pemma/Meera demo pair above. Reuses the exact ids already created via
+// the live API this session, so re-running against that database is a no-op.
+
+const SUPERVISOR_APP_PROJECT_ID = '4b4084cf-d572-4020-9438-c82640275201';
+
+const SUPERVISOR_APP_PAIRS: { supervisorId: string; sakhiId: string; label: string }[] = [
+  {
+    supervisorId: '742e8dfe-984c-4c9f-af24-c3dacffecac4',
+    sakhiId: '3df86ec1-8115-4db9-b558-a091f15b5a99',
+    label: 'lakshmi',
+  },
+  {
+    supervisorId: '40f6e942-2101-426b-9251-947e7db9f869',
+    sakhiId: '9252ff42-6904-4005-9184-14cbbb75e84b',
+    label: 'nithya',
+  },
+  {
+    supervisorId: '55cdb187-12e5-475f-902c-c4bf50d4e220',
+    sakhiId: 'f84745fd-f105-40d9-bbf0-9127b3948112',
+    label: 'sandhya',
+  },
+  {
+    supervisorId: '6242e4ae-19c8-4a4b-b7ca-63768fff1615',
+    sakhiId: '079bd637-01a7-45f1-9216-fa819b736e54',
+    label: 'revathi',
+  },
+  {
+    supervisorId: '23002b65-40c3-45e2-9c6d-76d1c42b0053',
+    sakhiId: '63407922-ecb4-4812-be4e-4567938bfb20',
+    label: 'shobana',
+  },
+];
+
+/** 6 call logs per pair, cycling the full callStatus enum; one CALL_BACK per
+ * sakhi with no followupAction, driving the Followup Pending drill-down. */
+async function seedSupervisorAppCallLogs(): Promise<SeedResult> {
+  const statuses: (typeof DEFAULT_CALLS)[number]['callStatus'][] = [
+    'PICKED_UP_TALKED',
+    'PICKED_UP_NO_ONE_TALKING',
+    'NOT_PICKED_UP',
+    'CALL_BACK',
+    'RINGING',
+    'PHONE_OFF',
+  ];
+
+  let created = 0;
+  let skipped = 0;
+  for (const pair of SUPERVISOR_APP_PAIRS) {
+    for (let i = 0; i < statuses.length; i++) {
+      const callDatetime = new Date(`2026-08-${10 + i}T10:00:00.000Z`);
+      const existing = await prisma.callLog.findFirst({
+        where: { sakhiId: pair.sakhiId, callDatetime },
+      });
+      if (existing) {
+        skipped += 1;
+        continue;
+      }
+      await prisma.callLog.create({
+        data: {
+          projectId: SUPERVISOR_APP_PROJECT_ID,
+          supervisorId: pair.supervisorId,
+          sakhiId: pair.sakhiId,
+          callDatetime,
+          callStatus: statuses[i],
+          callStartAt: callDatetime,
+          callEndAt:
+            statuses[i] === 'CALL_BACK' ? undefined : new Date(callDatetime.getTime() + 5 * 60_000),
+          responder: 'SAKHI',
+        },
+      });
+      created += 1;
+    }
+  }
+
+  return {
+    step: 'supervisor-app-call-logs',
+    created: created > 0,
+    message: `Created ${created} call log(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
+const INVENTORY_CATALOG: {
+  itemCode: string;
+  itemName: string;
+  itemCategory: 'CONSUMABLE' | 'INSTRUMENT';
+  unit: string;
+}[] = [
+  { itemCode: 'CONS-PENCIL-01', itemName: 'Pencil', itemCategory: 'CONSUMABLE', unit: 'pcs' },
+  { itemCode: 'CONS-CELLS-01', itemName: 'Cells', itemCategory: 'CONSUMABLE', unit: 'pcs' },
+  {
+    itemCode: 'CONS-SUGARSTRIP-01',
+    itemName: 'Sugar Strips',
+    itemCategory: 'CONSUMABLE',
+    unit: 'pcs',
+  },
+  { itemCode: 'CONS-HBSTRIP-01', itemName: 'HB Strips', itemCategory: 'CONSUMABLE', unit: 'pcs' },
+  {
+    itemCode: 'INST-DOPPLER-01',
+    itemName: 'Doppler Test Kit',
+    itemCategory: 'INSTRUMENT',
+    unit: 'pcs',
+  },
+  {
+    itemCode: 'INST-BPMONITOR-01',
+    itemName: 'BP Monitor',
+    itemCategory: 'INSTRUMENT',
+    unit: 'pcs',
+  },
+  {
+    itemCode: 'INST-WEIGHSCALE-01',
+    itemName: 'Weighing Scale',
+    itemCategory: 'INSTRUMENT',
+    unit: 'pcs',
+  },
+];
+
+async function seedInventoryCatalog(): Promise<SeedResult> {
+  let created = 0;
+  for (const item of INVENTORY_CATALOG) {
+    const existing = await prisma.inventoryItem.findUnique({ where: { itemCode: item.itemCode } });
+    if (existing) continue;
+    await prisma.inventoryItem.create({ data: { ...item, status: 'ACTIVE' } });
+    created += 1;
+  }
+  return {
+    step: 'inventory-catalog',
+    created: created > 0,
+    message: `Created ${created} inventory item(s), skipped ${INVENTORY_CATALOG.length - created} already-seeded row(s).`,
+  };
+}
+
+/** 6 inventory transactions per sakhi (one per transactionType), each moving
+ * a different catalog item, logged by that sakhi's supervisor. */
+async function seedSupervisorAppInventoryTransactions(): Promise<SeedResult> {
+  const transactionTypes: (
+    'HANDOVER' | 'RETURNED' | 'PERMANENT_DAMAGED' | 'MISPLACED' | 'CONSUMED'
+  )[] = ['HANDOVER', 'HANDOVER', 'CONSUMED', 'RETURNED', 'MISPLACED', 'PERMANENT_DAMAGED'];
+
+  const items = await prisma.inventoryItem.findMany({
+    where: { itemCode: { in: INVENTORY_CATALOG.map((i) => i.itemCode) } },
+  });
+  const itemByCode = new Map(items.map((i) => [i.itemCode, i.id]));
+  const itemCodesInOrder = INVENTORY_CATALOG.slice(0, 6).map((i) => i.itemCode);
+
+  let created = 0;
+  let skipped = 0;
+  for (const pair of SUPERVISOR_APP_PAIRS) {
+    for (let i = 0; i < transactionTypes.length; i++) {
+      const itemId = itemByCode.get(itemCodesInOrder[i]);
+      if (!itemId) continue;
+      const transactionDate = new Date(`2026-08-${10 + i}`);
+      const existing = await prisma.inventoryTransaction.findFirst({
+        where: {
+          sakhiId: pair.sakhiId,
+          itemId,
+          transactionType: transactionTypes[i],
+          transactionDate,
+        },
+      });
+      if (existing) {
+        skipped += 1;
+        continue;
+      }
+      await prisma.inventoryTransaction.create({
+        data: {
+          projectId: SUPERVISOR_APP_PROJECT_ID,
+          supervisorId: pair.supervisorId,
+          sakhiId: pair.sakhiId,
+          itemId,
+          transactionType: transactionTypes[i],
+          quantity: 1,
+          transactionDate,
+        },
+      });
+      created += 1;
+    }
+  }
+
+  return {
+    step: 'supervisor-app-inventory-transactions',
+    created: created > 0,
+    message: `Created ${created} inventory transaction(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
+const TRAINING_TOPICS: { topicCode: string; topicName: string }[] = [
+  { topicCode: 'ANC-BASICS', topicName: 'ANC Basics' },
+  { topicCode: 'NUTRITION-101', topicName: 'Maternal Nutrition' },
+];
+
+async function seedTrainingTopics(): Promise<SeedResult> {
+  let created = 0;
+  for (const topic of TRAINING_TOPICS) {
+    const existing = await prisma.trainingTopic.findUnique({
+      where: { topicCode: topic.topicCode },
+    });
+    if (existing) continue;
+    await prisma.trainingTopic.create({ data: { ...topic, status: 'ACTIVE' } });
+    created += 1;
+  }
+  return {
+    step: 'training-topics',
+    created: created > 0,
+    message: `Created ${created} training topic(s), skipped ${TRAINING_TOPICS.length - created} already-seeded row(s).`,
+  };
+}
+
+/** Per supervisor: 1 MEETING event (+ attendance) and 1 TRAINING event (+
+ * attendance, a gathering with both topics, gathering attendance, and PRE/POST
+ * TopicMark scores on the first topic) for that supervisor's sakhi. */
+async function seedSupervisorAppMeetings(): Promise<SeedResult> {
+  const topics = await prisma.trainingTopic.findMany({
+    where: { topicCode: { in: TRAINING_TOPICS.map((t) => t.topicCode) } },
+  });
+  const topicIds = topics.map((t) => t.id);
+  const firstTopicId = topicIds[0];
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const pair of SUPERVISOR_APP_PAIRS) {
+    const meetingRemarks = `Seeded MEETING event for ${pair.label}.sakhi`;
+    let meeting = await prisma.supervisorEvent.findFirst({
+      where: { supervisorId: pair.supervisorId, eventType: 'MEETING', remarks: meetingRemarks },
+    });
+    if (!meeting) {
+      meeting = await prisma.supervisorEvent.create({
+        data: {
+          projectId: SUPERVISOR_APP_PROJECT_ID,
+          supervisorId: pair.supervisorId,
+          eventType: 'MEETING',
+          eventDate: new Date('2026-08-25'),
+          topicsJson: [],
+          status: 'SCHEDULED',
+          remarks: meetingRemarks,
+        },
+      });
+      created += 1;
+    } else {
+      skipped += 1;
+    }
+    const meetingAttendance = await prisma.eventAttendance.findFirst({
+      where: { eventId: meeting.id, sakhiId: pair.sakhiId },
+    });
+    if (!meetingAttendance) {
+      await prisma.eventAttendance.create({
+        data: { eventId: meeting.id, sakhiId: pair.sakhiId, attendanceStatus: 'PRESENT' },
+      });
+      created += 1;
+    } else {
+      skipped += 1;
+    }
+
+    const trainingRemarks = `Seeded TRAINING event for ${pair.label}.sakhi`;
+    let training = await prisma.supervisorEvent.findFirst({
+      where: { supervisorId: pair.supervisorId, eventType: 'TRAINING', remarks: trainingRemarks },
+    });
+    if (!training) {
+      training = await prisma.supervisorEvent.create({
+        data: {
+          projectId: SUPERVISOR_APP_PROJECT_ID,
+          supervisorId: pair.supervisorId,
+          eventType: 'TRAINING',
+          eventDate: new Date('2026-08-26'),
+          topicsJson: [],
+          status: 'SCHEDULED',
+          remarks: trainingRemarks,
+        },
+      });
+      created += 1;
+    } else {
+      skipped += 1;
+    }
+    const trainingAttendance = await prisma.eventAttendance.findFirst({
+      where: { eventId: training.id, sakhiId: pair.sakhiId },
+    });
+    if (!trainingAttendance) {
+      await prisma.eventAttendance.create({
+        data: { eventId: training.id, sakhiId: pair.sakhiId, attendanceStatus: 'PRESENT' },
+      });
+      created += 1;
+    } else {
+      skipped += 1;
+    }
+
+    let gathering = await prisma.eventGathering.findFirst({ where: { eventId: training.id } });
+    if (!gathering) {
+      gathering = await prisma.eventGathering.create({
+        data: { eventId: training.id, gatheringDate: new Date('2026-08-26') },
+      });
+      created += 1;
+    } else {
+      skipped += 1;
+    }
+
+    for (const topicId of topicIds) {
+      const existingGatheringTopic = await prisma.gatheringTopic.findUnique({
+        where: { gatheringId_topicId: { gatheringId: gathering.id, topicId } },
+      });
+      if (!existingGatheringTopic) {
+        await prisma.gatheringTopic.create({ data: { gatheringId: gathering.id, topicId } });
+        created += 1;
+      } else {
+        skipped += 1;
+      }
+    }
+
+    const existingGatheringAttendance = await prisma.gatheringAttendance.findUnique({
+      where: { gatheringId_sakhiId: { gatheringId: gathering.id, sakhiId: pair.sakhiId } },
+    });
+    if (!existingGatheringAttendance) {
+      await prisma.gatheringAttendance.create({
+        data: { gatheringId: gathering.id, sakhiId: pair.sakhiId, attendanceStatus: 'PRESENT' },
+      });
+      created += 1;
+    } else {
+      skipped += 1;
+    }
+
+    if (firstTopicId) {
+      for (const [markType, score] of [
+        ['PRE', 40],
+        ['POST', 85],
+      ] as const) {
+        const existingMark = await prisma.topicMark.findUnique({
+          where: {
+            gatheringId_topicId_sakhiId_markType: {
+              gatheringId: gathering.id,
+              topicId: firstTopicId,
+              sakhiId: pair.sakhiId,
+              markType,
+            },
+          },
+        });
+        if (!existingMark) {
+          await prisma.topicMark.create({
+            data: {
+              gatheringId: gathering.id,
+              topicId: firstTopicId,
+              sakhiId: pair.sakhiId,
+              markType,
+              score,
+            },
+          });
+          created += 1;
+        } else {
+          skipped += 1;
+        }
+      }
+    }
+  }
+
+  return {
+    step: 'supervisor-app-meetings',
+    created: created > 0,
+    message: `Created ${created} meeting/training record(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
 async function main(): Promise<void> {
-  const results = [await seedCallLogs(), await seedInventoryItems()];
+  const results = [
+    await seedCallLogs(),
+    await seedSupervisorAppCallLogs(),
+    await seedInventoryCatalog(),
+    await seedSupervisorAppInventoryTransactions(),
+    await seedTrainingTopics(),
+    await seedSupervisorAppMeetings(),
+  ];
 
   console.log('\nSeed summary:');
   for (const r of results) {

--- a/apps/visit-form-service/prisma/seed.ts
+++ b/apps/visit-form-service/prisma/seed.ts
@@ -427,8 +427,165 @@ async function seedVisitMasters(): Promise<SeedResult> {
   };
 }
 
+// rule_versions.rule_version_id (generic SCHEDULE pack, PUBLISHED), owned by
+// rules-service — cross-service scalar ref, not FK-enforced (forklift rule).
+const GENERIC_RULE_VERSION_ID = '22222222-2222-4222-8222-222222222222';
+// lookup_values.lookup_value_id (category VISIT_STATUS), owned by auth-service.
+const VISIT_STATUS_PENDING_LOOKUP_ID = 'b2260191-2da0-4f18-92b1-0f271912effc';
+const VISIT_STATUS_MISSED_LOOKUP_ID = '618732a3-20f6-46bd-99b1-83845920d662';
+const VISIT_STATUS_COMPLETED_LOOKUP_ID = 'e40ece64-58b6-4fb7-9daf-5a0ca529606f';
+
+interface SupervisorAppVisitSeed {
+  sakhiId: string;
+  beneficiaryId: string;
+  localUuidSuffix: string;
+  statusLookupValueId: string;
+}
+
+// One visit per beneficiary case seeded by beneficiary-service's own
+// prisma/seed.ts (same fixed beneficiary ids), cycling PENDING/MISSED/COMPLETED
+// across each sakhi's 6 beneficiaries — reuses exactly what was created via the
+// live API this session, so re-running against that database is a no-op.
+const SUPERVISOR_APP_VISITS: SupervisorAppVisitSeed[] = [
+  ...[
+    {
+      sakhi: 'lakshmi',
+      sakhiId: '3df86ec1-8115-4db9-b558-a091f15b5a99',
+      beneficiaryIds: [
+        'a29616a5-cc9d-4de2-9bfc-399fa82700ca',
+        '8fc12c0d-7887-4fe6-b7bc-92ef7d953ff4',
+        '22f8e16c-d678-4f08-930e-c85e0dced2dd',
+        'a3eeb96a-aa94-4535-b647-5b9f1204a126',
+        'e20f17ba-006c-4f5c-8607-7162a9674d2d',
+        '54a09c3a-1ae7-4b58-bf14-a81798eec698',
+      ],
+    },
+    {
+      sakhi: 'nithya',
+      sakhiId: '9252ff42-6904-4005-9184-14cbbb75e84b',
+      beneficiaryIds: [
+        'cb2c9ae5-06fe-4a41-a89e-5b93bd9cb8ad',
+        '88baaa7f-b54a-419b-9a25-f59c08b23815',
+        'aeec7340-5838-482f-862e-7f778822a4c2',
+        '0bfc9aac-2ef1-496c-b78e-1c8d50cded41',
+        '91143832-c91e-4ca7-a293-7299ed29283c',
+        'e6002e06-d054-496e-a6ca-2a770a673435',
+      ],
+    },
+    {
+      sakhi: 'sandhya',
+      sakhiId: 'f84745fd-f105-40d9-bbf0-9127b3948112',
+      beneficiaryIds: [
+        '2451a47d-da90-41a3-9d79-2fdad3846043',
+        '771b04f6-54b9-4446-9381-02deadc53c47',
+        '90a98f9c-9ec2-47b9-87a2-35cdb720e51e',
+        '7446bfaa-0d32-4997-ae0a-0cfb77b6726c',
+        '5a84e3bf-a396-4182-9ea4-6b0e5a215b69',
+        '8d7cdb63-16e8-4dd6-bb65-85a134e24cdf',
+      ],
+    },
+    {
+      sakhi: 'revathi',
+      sakhiId: '079bd637-01a7-45f1-9216-fa819b736e54',
+      beneficiaryIds: [
+        '1b529119-87d4-408b-904e-94700c5e2c37',
+        '989f33f2-236e-4b2b-a943-04258d9bb8c0',
+        '7938f2fc-337c-4a9c-86ed-63f10fb19438',
+        '9cd6a2f6-2000-4e84-99ac-7933da0e34e1',
+        '56eb51a0-4c8b-44b4-8e5d-02dc89225508',
+        'bd8d91fa-8053-4cb9-b31f-6b7176acb96f',
+      ],
+    },
+    {
+      sakhi: 'shobana',
+      sakhiId: '63407922-ecb4-4812-be4e-4567938bfb20',
+      beneficiaryIds: [
+        '34460e35-1f86-499e-9efb-973f2de02dff',
+        '342e8e0e-00ad-494d-be41-adecb9b70bd8',
+        'fb03e8e7-5a19-40fd-8400-af42ad1aaff6',
+        '94594dbe-48cc-4905-90bc-336b123e824e',
+        'dbc7e805-af1e-4b14-80ce-8076ae080de7',
+        'a6f18f05-dba8-47b8-9159-0938b23e06d5',
+      ],
+    },
+  ].flatMap(({ sakhi, sakhiId, beneficiaryIds }) => {
+    const statuses = [
+      VISIT_STATUS_PENDING_LOOKUP_ID,
+      VISIT_STATUS_MISSED_LOOKUP_ID,
+      VISIT_STATUS_COMPLETED_LOOKUP_ID,
+      VISIT_STATUS_PENDING_LOOKUP_ID,
+      VISIT_STATUS_MISSED_LOOKUP_ID,
+      VISIT_STATUS_COMPLETED_LOOKUP_ID,
+    ];
+    return beneficiaryIds.map((beneficiaryId, i) => ({
+      sakhiId,
+      beneficiaryId,
+      localUuidSuffix: `${sakhi}-${i + 1}`,
+      statusLookupValueId: statuses[i],
+    }));
+  }),
+];
+
+/**
+ * Supervisor-app QA fixture: one VisitSchedule + VisitInstance per beneficiary
+ * case seeded by beneficiary-service (30 total across 5 sakhis), cycling
+ * PENDING/MISSED/COMPLETED so the Visit Summary screen has non-zero counts in
+ * every status bucket.
+ */
+async function seedSupervisorAppVisits(): Promise<SeedResult> {
+  let created = 0;
+  let skipped = 0;
+
+  for (const visit of SUPERVISOR_APP_VISITS) {
+    const localScheduleUuid = `seed-visit-schedule-${visit.localUuidSuffix}`;
+    const localVisitUuid = `seed-visit-instance-${visit.localUuidSuffix}`;
+
+    const existingSchedule = await prisma.visitSchedule.findUnique({
+      where: { localScheduleUuid },
+    });
+    const schedule =
+      existingSchedule ??
+      (await prisma.visitSchedule.create({
+        data: {
+          localScheduleUuid,
+          beneficiaryId: visit.beneficiaryId,
+          visitCode: `SEED-${visit.localUuidSuffix.toUpperCase()}`,
+          visitType: 'ANC',
+          scheduledDate: new Date('2026-08-25'),
+          windowStartDate: new Date('2026-08-15'),
+          windowEndDate: new Date('2026-09-05'),
+          anchorType: 'REGISTRATION',
+          generatedByRuleVersionId: GENERIC_RULE_VERSION_ID,
+        },
+      }));
+
+    const existingInstance = await prisma.visitInstance.findUnique({ where: { localVisitUuid } });
+    if (existingInstance) {
+      skipped += 1;
+      continue;
+    }
+
+    await prisma.visitInstance.create({
+      data: {
+        scheduleId: schedule.id,
+        beneficiaryId: visit.beneficiaryId,
+        sakhiId: visit.sakhiId,
+        localVisitUuid,
+        statusLookupValueId: visit.statusLookupValueId,
+      },
+    });
+    created += 1;
+  }
+
+  return {
+    step: 'supervisor-app-visits',
+    created: created > 0,
+    message: `Created ${created} visit instance(s), skipped ${skipped} already-seeded row(s).`,
+  };
+}
+
 async function main(): Promise<void> {
-  const results = [await seedForms(), await seedVisitMasters()];
+  const results = [await seedForms(), await seedVisitMasters(), await seedSupervisorAppVisits()];
 
   console.log('\nSeed summary:');
   for (const r of results) {


### PR DESCRIPTION
## Summary
- Adds a reproducible seed dataset for end-to-end testing of the Supervisor app: 6 supervisors, 5 sakhis, supervisor-sakhi assignments, 30 beneficiary cases with risk flags, 30 visits, call logs, 30 quick-response approval requests, 10 escalation events, inventory transactions, and meetings/trainings.
- Adds a `project_geographies` seed step in auth-service that was previously missing — without it, freshly-seeded records were invisible to the mobile app's offline geography scoping despite the API returning them correctly.
- All ids are fixed (not randomly generated) across the 6 services' seed scripts so they reference each other correctly on a fresh database.

## Files
- `apps/auth-service/prisma/seed.ts` — extended: `seedSupervisorAppAccounts` (11 fixed accounts + assignments), `seedProjectGeography`
- `apps/beneficiary-service/prisma/seed.ts` — **new**
- `apps/visit-form-service/prisma/seed.ts` — extended: `seedSupervisorAppVisits`
- `apps/supervisor-operations-service/prisma/seed.ts` — extended: call logs (5 pairs), inventory, meetings/trainings
- `apps/approval-service/prisma/seed.ts` — **new**
- `apps/notification-escalation-service/prisma/seed.ts` — **new**

## Test plan
- [x] All 6 seed.ts files type-check clean (`tsc --noEmit --strict`)
- [x] `npm run seed` run end-to-end against the dev database — every step reports correctly (created on first run, skipped/idempotent on re-run)
- [x] Spot-checked via live API (login, `GET /beneficiaries`, `GET /quick-response`, `GET /visits/visit-summary`) that seeded data is queryable and correctly scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)