### PR TITLE
fix(auth-service): Match supervisor-app seed accounts by username too

### DIFF
--- a/apps/auth-service/prisma/seed.ts
+++ b/apps/auth-service/prisma/seed.ts
@@ -489,7 +489,9 @@ async function seedSupervisorAppAccounts(scope: {
   const results: SeedResult[] = [];
 
   for (const account of SUPERVISOR_APP_ACCOUNTS) {
-    const existing = await prisma.user.findUnique({ where: { id: account.id } });
+    const existing = await prisma.user.findFirst({
+      where: { OR: [{ id: account.id }, { username: account.username }] },
+    });
     if (existing) {
       results.push({
         step: `supervisorAppAccount:${account.username}`,

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -771,7 +771,7 @@ describe('AuthService', () => {
     });
 
     describe('role/project/geography scope', () => {
-      it('updates projectId and geographyUnitId on the matching active role row', async () => {
+      it('updates projectId and geographyUnitId on the matching active role row for a non-SAKHI role', async () => {
         repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
         repository.findProjectById.mockResolvedValue({ projectId: 'project-2' } as never);
         repository.updateUserTransaction.mockResolvedValue(
@@ -780,7 +780,7 @@ describe('AuthService', () => {
               {
                 projectId: 'project-2',
                 geographyUnitId: 'geo-2',
-                role: { roleCode: 'SAKHI' },
+                role: { roleCode: 'MANAGER' },
                 project: { projectName: 'GEP-2425' },
               },
             ],
@@ -788,12 +788,12 @@ describe('AuthService', () => {
         );
 
         await service.updateUser('user-1', {
-          roleCode: 'SAKHI',
+          roleCode: 'MANAGER',
           projectId: 'project-2',
           geographyUnitId: 'geo-2',
         });
 
-        expect(repository.findActiveUserRole).toHaveBeenCalledWith('user-1', 'SAKHI');
+        expect(repository.findActiveUserRole).toHaveBeenCalledWith('user-1', 'MANAGER');
         expect(repository.findProjectById).toHaveBeenCalledWith('project-2');
         expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
           user: {},
@@ -820,21 +820,105 @@ describe('AuthService', () => {
         repository.findProjectById.mockResolvedValue(null);
 
         await expect(
-          service.updateUser('user-1', { roleCode: 'SAKHI', projectId: 'missing-project' }),
+          service.updateUser('user-1', { roleCode: 'MANAGER', projectId: 'missing-project' }),
         ).rejects.toMatchObject({ status: 404 });
         expect(repository.updateUserTransaction).not.toHaveBeenCalled();
       });
 
-      it('allows clearing projectId to null on the matching role row', async () => {
+      it('allows clearing projectId to null on the matching role row for a non-SAKHI role', async () => {
         repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
         repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
 
-        await service.updateUser('user-1', { roleCode: 'SAKHI', projectId: null });
+        await service.updateUser('user-1', { roleCode: 'MANAGER', projectId: null });
 
         expect(repository.findProjectById).not.toHaveBeenCalled();
         expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
           user: {},
           userRole: { id: 'user-role-1', data: { projectId: null } },
+          sakhiProfile: undefined,
+          revokeSessions: false,
+        });
+      });
+    });
+
+    describe('SAKHI role project reassignment (primaryProjectId)', () => {
+      it('also updates sakhi_profiles.primaryProjectId when roleCode is SAKHI and projectId is set', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+        repository.findProjectById.mockResolvedValue({ projectId: 'project-2' } as never);
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(
+          updatedUserRow({
+            userRoles: [
+              {
+                projectId: 'project-2',
+                geographyUnitId: 'geo-2',
+                role: { roleCode: 'SAKHI' },
+                project: { projectName: 'GEP-2425' },
+              },
+            ],
+            sakhiProfile: { employeeCode: null, bankAccountToken: null, supervisorId: null },
+          }) as never,
+        );
+
+        await service.updateUser('user-1', {
+          roleCode: 'SAKHI',
+          projectId: 'project-2',
+          geographyUnitId: 'geo-2',
+        });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: {
+            id: 'user-role-1',
+            data: { projectId: 'project-2', geographyUnitId: 'geo-2' },
+          },
+          sakhiProfile: { id: 'sakhi-profile-1', data: { primaryProjectId: 'project-2' } },
+          revokeSessions: false,
+        });
+      });
+
+      it('combines primaryProjectId with other Sakhi profile fields (e.g. supervisorId) in one write', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+        repository.findProjectById.mockResolvedValue({ projectId: 'project-2' } as never);
+        repository.findSakhiProfileByUserId.mockResolvedValue({ id: 'sakhi-profile-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', {
+          roleCode: 'SAKHI',
+          projectId: 'project-2',
+          supervisorId: 'supervisor-9',
+        });
+
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: { id: 'user-role-1', data: { projectId: 'project-2' } },
+          sakhiProfile: {
+            id: 'sakhi-profile-1',
+            data: { supervisorId: 'supervisor-9', primaryProjectId: 'project-2' },
+          },
+          revokeSessions: false,
+        });
+      });
+
+      it('throws 400 when roleCode is SAKHI and projectId is explicitly null', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+
+        await expect(
+          service.updateUser('user-1', { roleCode: 'SAKHI', projectId: null }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(repository.updateUserTransaction).not.toHaveBeenCalled();
+      });
+
+      it('does not touch primaryProjectId when roleCode is SAKHI but projectId is not provided', async () => {
+        repository.findActiveUserRole.mockResolvedValue({ id: 'user-role-1' } as never);
+        repository.updateUserTransaction.mockResolvedValue(updatedUserRow() as never);
+
+        await service.updateUser('user-1', { roleCode: 'SAKHI', geographyUnitId: 'geo-9' });
+
+        expect(repository.findSakhiProfileByUserId).not.toHaveBeenCalled();
+        expect(repository.updateUserTransaction).toHaveBeenCalledWith('user-1', {
+          user: {},
+          userRole: { id: 'user-role-1', data: { geographyUnitId: 'geo-9' } },
           sakhiProfile: undefined,
           revokeSessions: false,
         });
@@ -996,7 +1080,11 @@ describe('AuthService', () => {
                   phoneNumber: '+919876544139',
                   activeFrom: expect.any(Date),
                 },
-                data: { supervisorId: 'supervisor-1', phoneNumber: '+919876544139' },
+                data: {
+                  supervisorId: 'supervisor-1',
+                  phoneNumber: '+919876544139',
+                  primaryProjectId: 'project-new',
+                },
               },
             }),
           );

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -209,6 +209,17 @@ export class AuthService {
     if (input.bankAccountNumber !== undefined) {
       sakhiProfileFields.bankAccountToken = encryptPii(input.bankAccountNumber);
     }
+    if (input.roleCode === 'SAKHI' && input.projectId !== undefined) {
+      // primaryProjectId drives every roster/ACL check (sakhi.repository.ts's
+      // findByProject, sakhi.service.ts's getById) — without this, moving a
+      // Sakhi's SAKHI role to a new project left her invisible to her new
+      // supervisor despite the user_roles scope and supervisorId both being
+      // updated correctly.
+      if (input.projectId === null) {
+        throw badRequest('projectId: Cannot be null for a Sakhi — primaryProjectId is required.');
+      }
+      sakhiProfileFields.primaryProjectId = input.projectId;
+    }
     if (Object.keys(sakhiProfileFields).length > 0) {
       const profile = await this.repository.findSakhiProfileByUserId(id);
       if (profile) {


### PR DESCRIPTION
## Summary
- Fixes #186 — `seedSupervisorAppAccounts` only checked for an existing row by
  the seed's fixed hardcoded `id`, so a row with the same `username` under a
  different `id` (e.g. from an earlier partial seed run) wasn't detected, and
  the insert failed on the DB's `username @unique` constraint instead of
  skipping gracefully like every other step in this seed file.
- Extended the existence check to `findFirst` matching on `id` OR `username`,
  matching the idempotent "skip if already-seeded" pattern used elsewhere in
  the file.
- **Second fix bundled in**: `PATCH /users/:id` accepted a SAKHI's
  `roleCode`+`projectId` and updated the `user_roles` scope row, but never
  synced `sakhi_profiles.primaryProjectId` — the field every roster/ACL check
  (`SakhiRepository.findByProject`, `SakhiService.getById`) actually reads.
  Reassigning a Sakhi to a new supervisor's project therefore left her
  invisible to that supervisor even though the API call reported success.
  Fixed by also updating `primaryProjectId` when `roleCode === 'SAKHI'` and
  `projectId` is provided (rejecting `projectId: null` for a SAKHI, since
  `primaryProjectId` is non-nullable).

## Test plan
- [x] `npx tsc --noEmit -p apps/auth-service/tsconfig.json` — clean
- [x] `npx nx test auth-service` — 321/321 passing (pre-existing unrelated
      failure in `ses-email.client.spec.ts` due to a missing `@aws-sdk/client-ses`
      dependency, not touched by this change)
- [x] `auth.service.spec.ts`'s `updateUser` suite: 77/77 passing, including 4
      new tests for the `primaryProjectId` sync behavior
- [ ] Re-run the seed script on the affected environment to confirm it now
      skips existing usernames instead of throwing P2002
- [x] Verified live on dev (api.armman.org): PATCH with roleCode SAKHI +
      projectId now updates primaryProjectId, confirmed via the target
      supervisor's own roster call returning the reassigned Sakhi

🤖 Generated with [Claude Code](https://claude.com/claude-code)