### PR TITLE
feat(notification-escalation-service,rules-service): system-raised escalations

### DIFF
--- a/apps/notification-escalation-service/prisma/migrations/20260827090000_add_quick_response_notification_types/migration.sql
+++ b/apps/notification-escalation-service/prisma/migrations/20260827090000_add_quick_response_notification_types/migration.sql
@@ -1,0 +1,14 @@
+-- AlterEnum
+-- REFERRAL_INCOMPLETE_UPDATE / ACCOMPANIED_REFERRAL_UPDATE / DATA_RESTORE_UPDATE /
+-- CLOSURE_REVIEW_UPDATE — approval-service's and closure-reopen-service's Quick
+-- Response decision-outcome notify() calls have always sent these notificationType
+-- values, but they were missing from this enum, so POST /notifications 400'd and
+-- the notification was silently never created (best-effort try/catch at every
+-- call site swallowed the failure). ALTER TYPE ... ADD VALUE cannot run inside
+-- the same transaction as other statements that use the new value, but this
+-- migration only adds the values (no data backfill references them), so separate
+-- single statements are safe here.
+ALTER TYPE "NotificationType" ADD VALUE 'REFERRAL_INCOMPLETE_UPDATE';
+ALTER TYPE "NotificationType" ADD VALUE 'ACCOMPANIED_REFERRAL_UPDATE';
+ALTER TYPE "NotificationType" ADD VALUE 'DATA_RESTORE_UPDATE';
+ALTER TYPE "NotificationType" ADD VALUE 'CLOSURE_REVIEW_UPDATE';

--- a/apps/notification-escalation-service/prisma/migrations/20260831080000_escalation_events_sakhi_user_id/migration.sql
+++ b/apps/notification-escalation-service/prisma/migrations/20260831080000_escalation_events_sakhi_user_id/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "escalation_events" ALTER COLUMN "beneficiary_id" DROP NOT NULL;
+ALTER TABLE "escalation_events" ADD COLUMN "sakhi_user_id" TEXT;

--- a/apps/notification-escalation-service/prisma/migrations/20260831130000_add_hr_missed_visit_escalation_notification_type/migration.sql
+++ b/apps/notification-escalation-service/prisma/migrations/20260831130000_add_hr_missed_visit_escalation_notification_type/migration.sql
@@ -1,0 +1,7 @@
+-- AlterEnum
+-- HR_MISSED_VISIT_ESCALATION — visit-form-service's HR-missed-visit escalation
+-- trigger (missedVisit.job.ts) sends this notificationType to the assigned
+-- supervisor whenever an HR visit family (ANC_HR/PP_HR/NN_HR/INC_HR/CCV_HR)
+-- crosses its escalation threshold, distinct from the generic
+-- MISSED_VISIT_ESCALATION every other missed-visit family still uses.
+ALTER TYPE "NotificationType" ADD VALUE 'HR_MISSED_VISIT_ESCALATION';

--- a/apps/notification-escalation-service/prisma/schema.prisma
+++ b/apps/notification-escalation-service/prisma/schema.prisma
@@ -53,6 +53,11 @@ enum EscalationStatus {
 
 enum NotificationType {
   MISSED_VISIT_ESCALATION
+  // Sent to the assigned supervisor by visit-form-service's HR-missed-visit
+  // escalation trigger (missedVisit.job.ts) for ANC_HR/PP_HR/NN_HR/INC_HR/
+  // CCV_HR families — distinct from MISSED_VISIT_ESCALATION above, which
+  // every non-HR missed-visit family still uses.
+  HR_MISSED_VISIT_ESCALATION
   // Missed Visit Escalation TRANSFER (FR-SV-4.3) — the Sakhi's in-app
   // notification that her beneficiary has been removed from her active
   // list pending a Manager's review.
@@ -63,6 +68,15 @@ enum NotificationType {
   REOPEN_UPDATE
   CLOSURE_UPDATE
   LMP_CHANGE_UPDATE
+  // Quick Response decision-outcome types (approval-service/closure-reopen-service
+  // notify() calls) — added alongside REOPEN_UPDATE/LMP_CHANGE_UPDATE/CLOSURE_UPDATE
+  // above, which this enum already had; these three were missing entirely, so
+  // POST /notifications 400'd on them and the notification was silently never
+  // created (best-effort try/catch at every call site swallowed the failure).
+  REFERRAL_INCOMPLETE_UPDATE
+  ACCOMPANIED_REFERRAL_UPDATE
+  DATA_RESTORE_UPDATE
+  CLOSURE_REVIEW_UPDATE
   FORM_UPDATE
   DATA_SYNC_STATUS
   VISIT_NEAR_MISS
@@ -87,7 +101,15 @@ enum NotificationStatus {
 model EscalationEvent {
   id                   String           @id @default(uuid()) @map("escalation_id")
   // beneficiary_cases.beneficiary_id — owned by another service, no cross-service relation.
-  beneficiaryId        String           @map("beneficiary_id")
+  // Nullable: a SYNC_DELAY escalation is about a Sakhi/device, not a specific
+  // beneficiary — it carries sakhiUserId instead (see that column below).
+  // Every other escalationType still requires beneficiaryId; enforced in
+  // createEscalationEventSchema ("exactly one of beneficiaryId/sakhiUserId"),
+  // not at the DB level.
+  beneficiaryId        String?          @map("beneficiary_id")
+  // users.user_id — owned by another service, no cross-service relation.
+  // SYNC_DELAY only — see beneficiaryId's comment above.
+  sakhiUserId          String?          @map("sakhi_user_id")
   // visit_instances.visit_id — owned by another service, no cross-service relation.
   visitId              String?          @map("visit_id")
   // referrals.referral_id — owned by another service, no cross-service relation.

--- a/apps/notification-escalation-service/src/escalations/beneficiary.client.ts
+++ b/apps/notification-escalation-service/src/escalations/beneficiary.client.ts
@@ -10,7 +10,8 @@ export interface BeneficiaryRecord {
   id: string;
   sakhiId: string;
   motherCaseDetails: { eddDate: string } | null;
-  pii: { fullName: string };
+  pii: { fullName: string; mobileNumber: string };
+  riskLevel: 'none' | 'mild' | 'moderate' | 'high';
 }
 
 /**

--- a/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.spec.ts
@@ -60,4 +60,27 @@ describe('createEscalationEventSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts a SYNC_DELAY payload with sakhiUserId instead of beneficiaryId', () => {
+    const result = createEscalationEventSchema.safeParse({
+      sakhiUserId: '66666666-6666-6666-6666-666666666666',
+      escalationType: 'SYNC_DELAY' as const,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects both beneficiaryId and sakhiUserId set at once', () => {
+    const result = createEscalationEventSchema.safeParse({
+      ...baseInput,
+      sakhiUserId: '66666666-6666-6666-6666-666666666666',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects neither beneficiaryId nor sakhiUserId set', () => {
+    const result = createEscalationEventSchema.safeParse({
+      escalationType: baseInput.escalationType,
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.spec.ts
@@ -4,6 +4,7 @@ describe('createEscalationEventSchema', () => {
   const baseInput = {
     beneficiaryId: '22222222-2222-2222-2222-222222222222',
     escalationType: 'ANC_2_MISSED' as const,
+    assignedSupervisorId: '55555555-5555-5555-5555-555555555555',
   };
 
   it('accepts a minimal Missed-Visit-type payload', () => {
@@ -32,6 +33,15 @@ describe('createEscalationEventSchema', () => {
 
   it('rejects a missing beneficiaryId', () => {
     const result = createEscalationEventSchema.safeParse({
+      escalationType: baseInput.escalationType,
+      assignedSupervisorId: baseInput.assignedSupervisorId,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing assignedSupervisorId', () => {
+    const result = createEscalationEventSchema.safeParse({
+      beneficiaryId: baseInput.beneficiaryId,
       escalationType: baseInput.escalationType,
     });
     expect(result.success).toBe(false);
@@ -65,6 +75,7 @@ describe('createEscalationEventSchema', () => {
     const result = createEscalationEventSchema.safeParse({
       sakhiUserId: '66666666-6666-6666-6666-666666666666',
       escalationType: 'SYNC_DELAY' as const,
+      assignedSupervisorId: baseInput.assignedSupervisorId,
     });
     expect(result.success).toBe(true);
   });
@@ -80,6 +91,25 @@ describe('createEscalationEventSchema', () => {
   it('rejects neither beneficiaryId nor sakhiUserId set', () => {
     const result = createEscalationEventSchema.safeParse({
       escalationType: baseInput.escalationType,
+      assignedSupervisorId: baseInput.assignedSupervisorId,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a SYNC_DELAY payload carrying beneficiaryId instead of sakhiUserId', () => {
+    const result = createEscalationEventSchema.safeParse({
+      beneficiaryId: baseInput.beneficiaryId,
+      escalationType: 'SYNC_DELAY' as const,
+      assignedSupervisorId: baseInput.assignedSupervisorId,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-SYNC_DELAY type carrying sakhiUserId instead of beneficiaryId', () => {
+    const result = createEscalationEventSchema.safeParse({
+      sakhiUserId: '66666666-6666-6666-6666-666666666666',
+      escalationType: 'ANC_2_MISSED' as const,
+      assignedSupervisorId: baseInput.assignedSupervisorId,
     });
     expect(result.success).toBe(false);
   });

--- a/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.ts
+++ b/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.ts
@@ -14,7 +14,13 @@ import { z } from 'zod';
  */
 export const createEscalationEventSchema = z
   .object({
-    beneficiaryId: z.string().uuid(),
+    // Exactly one of beneficiaryId/sakhiUserId must be set — enforced by the
+    // .refine below, not per-field .optional() semantics alone. SYNC_DELAY
+    // is the one escalationType that uses sakhiUserId instead of
+    // beneficiaryId (a sync delay is about a Sakhi/device, not a specific
+    // beneficiary); every other type still requires beneficiaryId.
+    beneficiaryId: z.string().uuid().optional(),
+    sakhiUserId: z.string().uuid().optional(),
     escalationType: z.enum([
       'ANC_2_MISSED',
       'ANC_HR_MISSED',
@@ -42,6 +48,9 @@ export const createEscalationEventSchema = z
     visitsMissedCount: z.number().int().optional(),
     assignedSupervisorId: z.string().uuid().optional(),
   })
-  .strict();
+  .strict()
+  .refine((v) => Boolean(v.beneficiaryId) !== Boolean(v.sakhiUserId), {
+    message: 'Exactly one of beneficiaryId or sakhiUserId must be provided.',
+  });
 
 export type CreateEscalationEventInput = z.infer<typeof createEscalationEventSchema>;

--- a/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.ts
+++ b/apps/notification-escalation-service/src/escalations/dto/create-escalation-event.dto.ts
@@ -46,11 +46,22 @@ export const createEscalationEventSchema = z
     visitId: z.string().uuid().optional(),
     referralId: z.string().uuid().optional(),
     visitsMissedCount: z.number().int().optional(),
-    assignedSupervisorId: z.string().uuid().optional(),
+    // Required, not derived server-side: this service has no roster lookup of
+    // its own, so the raiser (cron/rules process) must resolve and supply the
+    // owning Supervisor. Every row list() serves is scoped by this field, so
+    // an omitted value silently orphans the row from every Supervisor's feed.
+    assignedSupervisorId: z.string().uuid(),
   })
   .strict()
   .refine((v) => Boolean(v.beneficiaryId) !== Boolean(v.sakhiUserId), {
     message: 'Exactly one of beneficiaryId or sakhiUserId must be provided.',
-  });
+  })
+  .refine(
+    (v) => (v.escalationType === 'SYNC_DELAY' ? Boolean(v.sakhiUserId) : Boolean(v.beneficiaryId)),
+    {
+      message:
+        'SYNC_DELAY escalations must provide sakhiUserId; every other escalationType must provide beneficiaryId.',
+    },
+  );
 
 export type CreateEscalationEventInput = z.infer<typeof createEscalationEventSchema>;

--- a/apps/notification-escalation-service/src/escalations/escalation.controller.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.controller.ts
@@ -28,9 +28,10 @@ export function createEscalationController(service: EscalationService) {
     }),
 
     findById: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
       const authorizationHeader = req.header('authorization');
       if (!authorizationHeader) return next(unauthorized());
-      const card = await service.findById(req.params.id, authorizationHeader);
+      const card = await service.findById(req.params.id, req.user, authorizationHeader);
       if (!card) throw notFound('Escalation event not found.');
       res.json(ok(card));
     }),

--- a/apps/notification-escalation-service/src/escalations/escalation.controller.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.controller.ts
@@ -12,9 +12,12 @@ import type { SubmitClosurePendingReasonInput } from './dto/submit-closure-pendi
  */
 export function createEscalationController(service: EscalationService) {
   return {
-    list: asyncHandler(async (req, res) => {
+    list: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
       const query = req.query as unknown as ListEscalationEventsInput;
-      res.json(ok(await service.list(query)));
+      res.json(ok(await service.list(query, req.user, authorizationHeader)));
     }),
 
     create: asyncHandler(async (req, res, next) => {
@@ -24,8 +27,10 @@ export function createEscalationController(service: EscalationService) {
       res.status(201).json(ok(row));
     }),
 
-    findById: asyncHandler(async (req, res) => {
-      const card = await service.findById(req.params.id);
+    findById: asyncHandler(async (req, res, next) => {
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const card = await service.findById(req.params.id, authorizationHeader);
       if (!card) throw notFound('Escalation event not found.');
       res.json(ok(card));
     }),

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.spec.ts
@@ -1,0 +1,74 @@
+import { EscalationRepository } from './escalation.repository';
+import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
+
+describe('EscalationRepository', () => {
+  const findMany = jest.fn();
+  const findFirst = jest.fn();
+  const create = jest.fn();
+  const updateMany = jest.fn();
+  const prisma = {
+    escalationEvent: { findMany, findFirst, create, updateMany },
+  } as never;
+  let repository: EscalationRepository;
+
+  const baseQuery: ListEscalationEventsInput = { status: 'OPEN', limit: 50 };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new EscalationRepository(prisma);
+  });
+
+  describe('findMany', () => {
+    it('includes assignedSupervisorId in the where clause when provided', async () => {
+      findMany.mockResolvedValue([]);
+
+      await repository.findMany(baseQuery, null, 'supervisor-1');
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'OPEN',
+          isDeleted: false,
+          assignedSupervisorId: 'supervisor-1',
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 51,
+      });
+    });
+
+    it('omits assignedSupervisorId from the where clause when not provided', async () => {
+      findMany.mockResolvedValue([]);
+
+      await repository.findMany(baseQuery, null);
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'OPEN',
+          isDeleted: false,
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 51,
+      });
+    });
+
+    it('still applies the cursor OR clause alongside the assignedSupervisorId filter', async () => {
+      findMany.mockResolvedValue([]);
+      const cursor = { createdAt: new Date('2026-08-05T10:00:00.000Z'), id: 'event-1' };
+
+      await repository.findMany(baseQuery, cursor, 'supervisor-1');
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: {
+          status: 'OPEN',
+          isDeleted: false,
+          assignedSupervisorId: 'supervisor-1',
+          OR: [
+            { createdAt: { lt: cursor.createdAt } },
+            { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+          ],
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: 51,
+      });
+    });
+  });
+});

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.spec.ts
@@ -1,13 +1,21 @@
 import { EscalationRepository } from './escalation.repository';
 import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
+import type { CreateEscalationEventInput } from './dto/create-escalation-event.dto';
 
 describe('EscalationRepository', () => {
   const findMany = jest.fn();
   const findFirst = jest.fn();
   const create = jest.fn();
+  const update = jest.fn();
   const updateMany = jest.fn();
+  const executeRaw = jest.fn();
+  const txClient = {
+    escalationEvent: { findFirst, create, update },
+    $executeRaw: executeRaw,
+  };
   const prisma = {
     escalationEvent: { findMany, findFirst, create, updateMany },
+    $transaction: jest.fn((fn: (tx: typeof txClient) => unknown) => fn(txClient)),
   } as never;
   let repository: EscalationRepository;
 
@@ -68,6 +76,96 @@ describe('EscalationRepository', () => {
         },
         orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
         take: 51,
+      });
+    });
+  });
+
+  describe('createOrReuseOpen', () => {
+    const baseInput: CreateEscalationEventInput = {
+      beneficiaryId: 'beneficiary-1',
+      escalationType: 'ANC_2_MISSED',
+      assignedSupervisorId: 'supervisor-1',
+    };
+
+    it('takes an advisory lock keyed on the natural key before checking for a duplicate', async () => {
+      findFirst.mockResolvedValue(null);
+      create.mockResolvedValue({ id: 'new-row' });
+
+      await repository.createOrReuseOpen(baseInput, 'admin-user-id');
+
+      expect(executeRaw).toHaveBeenCalled();
+    });
+
+    it('inserts a new row when no OPEN duplicate exists', async () => {
+      findFirst.mockResolvedValue(null);
+      const created = { id: 'new-row' };
+      create.mockResolvedValue(created);
+
+      const result = await repository.createOrReuseOpen(baseInput, 'admin-user-id');
+
+      expect(result).toBe(created);
+      expect(create).toHaveBeenCalledWith({
+        data: {
+          beneficiaryId: 'beneficiary-1',
+          sakhiUserId: null,
+          escalationType: 'ANC_2_MISSED',
+          visitId: null,
+          referralId: null,
+          visitsMissedCount: null,
+          assignedSupervisorId: 'supervisor-1',
+          status: 'OPEN',
+          createdByUserId: 'admin-user-id',
+        },
+      });
+    });
+
+    it('returns the existing OPEN row unchanged when its assignedSupervisorId already matches', async () => {
+      const existing = { id: 'existing-row', assignedSupervisorId: 'supervisor-1' };
+      findFirst.mockResolvedValue(existing);
+
+      const result = await repository.createOrReuseOpen(baseInput, 'admin-user-id');
+
+      expect(result).toBe(existing);
+      expect(create).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it('self-heals assignedSupervisorId on the existing row when it has changed', async () => {
+      const existing = { id: 'existing-row', assignedSupervisorId: 'old-supervisor' };
+      findFirst.mockResolvedValue(existing);
+      const updated = { ...existing, assignedSupervisorId: 'supervisor-1' };
+      update.mockResolvedValue(updated);
+
+      const result = await repository.createOrReuseOpen(baseInput, 'admin-user-id');
+
+      expect(result).toBe(updated);
+      expect(update).toHaveBeenCalledWith({
+        where: { id: 'existing-row' },
+        data: { assignedSupervisorId: 'supervisor-1' },
+      });
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('only narrows the duplicate match by fields actually present on the input', async () => {
+      findFirst.mockResolvedValue(null);
+      create.mockResolvedValue({ id: 'new-row' });
+
+      await repository.createOrReuseOpen(
+        {
+          sakhiUserId: 'sakhi-1',
+          escalationType: 'SYNC_DELAY',
+          assignedSupervisorId: 'supervisor-1',
+        },
+        'system-account-id',
+      );
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: {
+          status: 'OPEN',
+          isDeleted: false,
+          escalationType: 'SYNC_DELAY',
+          sakhiUserId: 'sakhi-1',
+        },
       });
     });
   });

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.ts
@@ -49,47 +49,72 @@ export class EscalationRepository {
   }
 
   /**
-   * Raises a new escalation event, always OPEN — status is never a create
-   * input (see createEscalationEventSchema's doc comment).
+   * Raises a new escalation event, always OPEN (status is never a create
+   * input — see createEscalationEventSchema's doc comment) — or, if an OPEN
+   * escalation already exists for the same natural key, returns that row
+   * instead (self-healing its assignedSupervisorId to the incoming value if
+   * it's changed, e.g. after a beneficiary/Sakhi reassignment) so an
+   * automated job re-raising the same missed visit/follow-up/sync-delay on
+   * its next tick no-ops instead of piling up duplicate OPEN rows.
+   *
+   * The natural key varies by how the event was raised (visitId for a
+   * missed visit, referralId for a follow-up, sakhiUserId for a sync
+   * delay) — only the fields actually present on `input` narrow the match,
+   * so e.g. a visit-driven escalation is never matched against one raised
+   * for a different visitId on the same beneficiary.
+   *
+   * The find-then-write is wrapped in a transaction holding a Postgres
+   * advisory lock keyed on the natural key, so two concurrent calls for the
+   * same key serialize instead of both passing the "no existing row" check
+   * and inserting duplicates — there's no DB-level unique constraint
+   * backing this natural key (it's conditional on which fields are
+   * present), so the lock is what actually closes the race.
    */
-  create(input: CreateEscalationEventInput, createdByUserId: string) {
-    return this.prisma.escalationEvent.create({
-      data: {
-        beneficiaryId: input.beneficiaryId ?? null,
-        sakhiUserId: input.sakhiUserId ?? null,
-        escalationType: input.escalationType,
-        visitId: input.visitId ?? null,
-        referralId: input.referralId ?? null,
-        visitsMissedCount: input.visitsMissedCount ?? null,
-        assignedSupervisorId: input.assignedSupervisorId ?? null,
-        status: 'OPEN',
-        createdByUserId,
-      },
-    });
-  }
+  createOrReuseOpen(input: CreateEscalationEventInput, createdByUserId: string) {
+    return this.prisma.$transaction(async (tx) => {
+      const lockKey = [
+        input.escalationType,
+        input.beneficiaryId ?? '',
+        input.sakhiUserId ?? '',
+        input.visitId ?? '',
+        input.referralId ?? '',
+      ].join('|');
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
 
-  /**
-   * Finds an existing OPEN escalation sharing the same natural key as
-   * `input` — the idempotency guard EscalationService.create checks before
-   * inserting, so an automated job re-raising the same missed
-   * visit/follow-up/sync-delay on its next tick no-ops instead of piling up
-   * duplicate OPEN rows. The natural key varies by how the event was raised
-   * (visitId for a missed visit, referralId for a follow-up, sakhiUserId
-   * for a sync delay) — only the fields actually present on `input` narrow
-   * the match, so e.g. a visit-driven escalation is never matched against
-   * one raised for a different visitId on the same beneficiary.
-   */
-  findOpenDuplicate(input: CreateEscalationEventInput) {
-    return this.prisma.escalationEvent.findFirst({
-      where: {
-        status: 'OPEN',
-        isDeleted: false,
-        escalationType: input.escalationType,
-        ...(input.beneficiaryId ? { beneficiaryId: input.beneficiaryId } : {}),
-        ...(input.sakhiUserId ? { sakhiUserId: input.sakhiUserId } : {}),
-        ...(input.visitId ? { visitId: input.visitId } : {}),
-        ...(input.referralId ? { referralId: input.referralId } : {}),
-      },
+      const existing = await tx.escalationEvent.findFirst({
+        where: {
+          status: 'OPEN',
+          isDeleted: false,
+          escalationType: input.escalationType,
+          ...(input.beneficiaryId ? { beneficiaryId: input.beneficiaryId } : {}),
+          ...(input.sakhiUserId ? { sakhiUserId: input.sakhiUserId } : {}),
+          ...(input.visitId ? { visitId: input.visitId } : {}),
+          ...(input.referralId ? { referralId: input.referralId } : {}),
+        },
+      });
+      if (existing) {
+        if (existing.assignedSupervisorId !== input.assignedSupervisorId) {
+          return tx.escalationEvent.update({
+            where: { id: existing.id },
+            data: { assignedSupervisorId: input.assignedSupervisorId },
+          });
+        }
+        return existing;
+      }
+
+      return tx.escalationEvent.create({
+        data: {
+          beneficiaryId: input.beneficiaryId ?? null,
+          sakhiUserId: input.sakhiUserId ?? null,
+          escalationType: input.escalationType,
+          visitId: input.visitId ?? null,
+          referralId: input.referralId ?? null,
+          visitsMissedCount: input.visitsMissedCount ?? null,
+          assignedSupervisorId: input.assignedSupervisorId,
+          status: 'OPEN',
+          createdByUserId,
+        },
+      });
     });
   }
 

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.ts
@@ -11,11 +11,24 @@ export class EscalationRepository {
    * same millisecond so the cursor stays gapless. Fetches `limit + 1` rows to
    * know whether a next page exists without a separate count query.
    */
-  async findMany(query: ListEscalationEventsInput, cursor: { createdAt: Date; id: string } | null) {
+  /**
+   * `assignedSupervisorId` scopes results to only escalations raised for
+   * this supervisor — undefined for a privileged (MANAGER/ADMIN) caller,
+   * the caller's own id for a SUPERVISOR caller. Unlike approval-service's
+   * approval_requests, this table already carries the column (snapshotted
+   * at creation time — see missedVisit.job.ts), so no cross-service lookup
+   * is needed to scope it.
+   */
+  async findMany(
+    query: ListEscalationEventsInput,
+    cursor: { createdAt: Date; id: string } | null,
+    assignedSupervisorId?: string,
+  ) {
     const rows = await this.prisma.escalationEvent.findMany({
       where: {
         status: query.status,
         isDeleted: false,
+        ...(assignedSupervisorId ? { assignedSupervisorId } : {}),
         ...(cursor
           ? {
               OR: [
@@ -42,7 +55,8 @@ export class EscalationRepository {
   create(input: CreateEscalationEventInput, createdByUserId: string) {
     return this.prisma.escalationEvent.create({
       data: {
-        beneficiaryId: input.beneficiaryId,
+        beneficiaryId: input.beneficiaryId ?? null,
+        sakhiUserId: input.sakhiUserId ?? null,
         escalationType: input.escalationType,
         visitId: input.visitId ?? null,
         referralId: input.referralId ?? null,
@@ -50,6 +64,31 @@ export class EscalationRepository {
         assignedSupervisorId: input.assignedSupervisorId ?? null,
         status: 'OPEN',
         createdByUserId,
+      },
+    });
+  }
+
+  /**
+   * Finds an existing OPEN escalation sharing the same natural key as
+   * `input` — the idempotency guard EscalationService.create checks before
+   * inserting, so an automated job re-raising the same missed
+   * visit/follow-up/sync-delay on its next tick no-ops instead of piling up
+   * duplicate OPEN rows. The natural key varies by how the event was raised
+   * (visitId for a missed visit, referralId for a follow-up, sakhiUserId
+   * for a sync delay) — only the fields actually present on `input` narrow
+   * the match, so e.g. a visit-driven escalation is never matched against
+   * one raised for a different visitId on the same beneficiary.
+   */
+  findOpenDuplicate(input: CreateEscalationEventInput) {
+    return this.prisma.escalationEvent.findFirst({
+      where: {
+        status: 'OPEN',
+        isDeleted: false,
+        escalationType: input.escalationType,
+        ...(input.beneficiaryId ? { beneficiaryId: input.beneficiaryId } : {}),
+        ...(input.sakhiUserId ? { sakhiUserId: input.sakhiUserId } : {}),
+        ...(input.visitId ? { visitId: input.visitId } : {}),
+        ...(input.referralId ? { referralId: input.referralId } : {}),
       },
     });
   }

--- a/apps/notification-escalation-service/src/escalations/escalation.routes.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.routes.ts
@@ -33,10 +33,19 @@ const escalationCardSchema = z.object({
   cardType: z.enum(['MISSED_VISIT', 'EDD_NEARING']),
   cardSource: z.literal('escalation_events'),
   beneficiaryId: z.string().uuid(),
+  beneficiaryName: z.string().nullable().openapi({ example: 'Nithya Sakhi Mother 4' }),
+  beneficiaryPhone: z.string().nullable().openapi({ example: '9810015405' }),
+  riskLevel: z.enum(['none', 'mild', 'moderate', 'high']).nullable(),
+  assignedSupervisorId: z.string().uuid().nullable(),
+  sakhiId: z.string().nullable(),
+  sakhiName: z.string().nullable().openapi({ example: 'Priya Sakhi' }),
+  sakhiContact: z.string().nullable().openapi({ example: '9812345678' }),
   visitId: z.string().uuid().nullable(),
   referralId: z.string().uuid().nullable(),
   escalationType: z.string().openapi({ example: 'ANC_2_MISSED' }),
   status: z.string().openapi({ example: 'OPEN' }),
+  resolvedAt: z.string().datetime().nullable(),
+  actionTaken: z.string().nullable(),
   raisedAt: z.string().datetime(),
 });
 
@@ -52,7 +61,8 @@ const listEscalationEventsResponseSchema = z.object({
 // state (status/resolvedAt/actionTaken), not the card-list projection.
 const escalationEventSchema = z.object({
   id: z.string().uuid(),
-  beneficiaryId: z.string().uuid(),
+  beneficiaryId: z.string().uuid().nullable(),
+  sakhiUserId: z.string().uuid().nullable(),
   visitId: z.string().uuid().nullable(),
   referralId: z.string().uuid().nullable(),
   escalationType: z.string().openapi({ example: 'EDD_NEARING' }),
@@ -147,7 +157,7 @@ export function registerEscalationRoutes(doc: DocumentedRouter, service: Escalat
       },
     },
     trustGatewayIdentity,
-    requireRoles('ADMIN'),
+    requireRoles('ADMIN', 'SYSTEM'),
     validateBody(createEscalationEventSchema),
     controller.create,
   );
@@ -166,6 +176,10 @@ export function registerEscalationRoutes(doc: DocumentedRouter, service: Escalat
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
         403: { description: 'Caller role not permitted', schema: apiErrorSchema },
         404: { description: 'Escalation event not found', schema: apiErrorSchema },
+        502: {
+          description: 'beneficiary-service or auth-service unreachable while enriching the card',
+          schema: apiErrorSchema,
+        },
       },
     },
     trustGatewayIdentity,

--- a/apps/notification-escalation-service/src/escalations/escalation.routes.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.routes.ts
@@ -86,7 +86,7 @@ const missedVisitDetailSchema = z.object({
   id: z.string().uuid(),
   beneficiaryId: z.string().uuid(),
   visitsMissedCount: z.number().int().nullable(),
-  visitType: z.enum(['ANC', 'PP', 'NN', 'INC', 'INC-HR', 'CCV', 'CCV-HR']),
+  visitType: z.enum(['ANC', 'PP', 'NN', 'INC', 'INC-HR', 'CCV', 'CCV-HR', 'ANC_POST_EDD']),
   requestedAt: z.string().datetime(),
   status: z.enum(['PENDING', 'TRANSFERRED', 'CLOSED']),
 });

--- a/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
@@ -29,7 +29,14 @@ function sakhiRecord(overrides: Partial<SakhiRecord> = {}): SakhiRecord {
   };
 }
 
-function row(overrides: { id?: string; escalationType?: EscalationType; createdAt?: Date } = {}) {
+function row(
+  overrides: {
+    id?: string;
+    escalationType?: EscalationType;
+    createdAt?: Date;
+    assignedSupervisorId?: string | null;
+  } = {},
+) {
   return {
     id: overrides.id ?? '11111111-1111-1111-1111-111111111111',
     beneficiaryId: '22222222-2222-2222-2222-222222222222',
@@ -39,7 +46,7 @@ function row(overrides: { id?: string; escalationType?: EscalationType; createdA
     escalationType: overrides.escalationType ?? ('ANC_2_MISSED' as const),
     triggerRuleVersionId: null,
     status: 'OPEN' as const,
-    assignedSupervisorId: null,
+    assignedSupervisorId: overrides.assignedSupervisorId ?? null,
     visitsMissedCount: null,
     resolvedAt: null,
     reviewDeadlineAt: null,
@@ -60,8 +67,7 @@ describe('EscalationService', () => {
   const repository = {
     findMany: jest.fn(),
     findById: jest.fn(),
-    create: jest.fn(),
-    findOpenDuplicate: jest.fn(),
+    createOrReuseOpen: jest.fn(),
     updateStatus: jest.fn(),
     updatePendingReason: jest.fn(),
   } as unknown as jest.Mocked<EscalationRepository>;
@@ -96,7 +102,6 @@ describe('EscalationService', () => {
     );
     beneficiaryClient.getById.mockResolvedValue(beneficiaryRecord());
     sakhiClient.findById.mockResolvedValue(sakhiRecord());
-    repository.findOpenDuplicate.mockResolvedValue(null);
   });
 
   it('groups every *_MISSED escalation type under MISSED_VISIT', async () => {
@@ -249,84 +254,49 @@ describe('EscalationService', () => {
   });
 
   describe('create', () => {
-    it('creates a Missed-Visit-type escalation row', async () => {
+    const SUPERVISOR_ID = '55555555-5555-5555-5555-555555555555';
+
+    it('delegates to the repository, returning whatever it resolves', async () => {
       const created = row({ escalationType: 'ANC_2_MISSED' });
-      repository.create.mockResolvedValue(created);
+      repository.createOrReuseOpen.mockResolvedValue(created);
+      const input = {
+        beneficiaryId: created.beneficiaryId,
+        escalationType: 'ANC_2_MISSED' as const,
+        assignedSupervisorId: SUPERVISOR_ID,
+      };
 
-      const result = await service.create(
-        { beneficiaryId: created.beneficiaryId, escalationType: 'ANC_2_MISSED' },
-        'admin-user-id',
-      );
-
-      expect(result).toBe(created);
-      expect(repository.create).toHaveBeenCalledWith(
-        { beneficiaryId: created.beneficiaryId, escalationType: 'ANC_2_MISSED' },
-        'admin-user-id',
-      );
-    });
-
-    it('creates an EDD_NEARING escalation row', async () => {
-      const created = row({ escalationType: 'EDD_NEARING' });
-      repository.create.mockResolvedValue(created);
-
-      const result = await service.create(
-        { beneficiaryId: created.beneficiaryId, escalationType: 'EDD_NEARING' },
-        'admin-user-id',
-      );
+      const result = await service.create(input, 'admin-user-id');
 
       expect(result).toBe(created);
-      expect(result.status).toBe('OPEN');
+      expect(repository.createOrReuseOpen).toHaveBeenCalledWith(input, 'admin-user-id');
     });
 
     it('passes optional fields through to the repository unchanged', async () => {
       const created = row({ escalationType: 'ANC_2_MISSED' });
-      repository.create.mockResolvedValue(created);
+      repository.createOrReuseOpen.mockResolvedValue(created);
       const input = {
         beneficiaryId: created.beneficiaryId,
         escalationType: 'ANC_2_MISSED' as const,
         visitId: '33333333-3333-3333-3333-333333333333',
         referralId: '44444444-4444-4444-4444-444444444444',
         visitsMissedCount: 2,
-        assignedSupervisorId: '55555555-5555-5555-5555-555555555555',
+        assignedSupervisorId: SUPERVISOR_ID,
       };
 
       await service.create(input, 'admin-user-id');
 
-      expect(repository.create).toHaveBeenCalledWith(input, 'admin-user-id');
-    });
-
-    it('returns the existing OPEN escalation instead of inserting a duplicate', async () => {
-      const existing = row({ escalationType: 'ANC_2_MISSED' });
-      repository.findOpenDuplicate.mockResolvedValue(existing);
-
-      const result = await service.create(
-        { beneficiaryId: existing.beneficiaryId, escalationType: 'ANC_2_MISSED' },
-        'system-account-id',
-      );
-
-      expect(result).toBe(existing);
-      expect(repository.create).not.toHaveBeenCalled();
-    });
-
-    it('inserts when no OPEN duplicate exists', async () => {
-      repository.findOpenDuplicate.mockResolvedValue(null);
-      const created = row({ escalationType: 'SYNC_DELAY' });
-      repository.create.mockResolvedValue(created);
-
-      const result = await service.create(
-        { sakhiUserId: 'sakhi-user-1', escalationType: 'SYNC_DELAY' },
-        'system-account-id',
-      );
-
-      expect(result).toBe(created);
-      expect(repository.create).toHaveBeenCalled();
+      expect(repository.createOrReuseOpen).toHaveBeenCalledWith(input, 'admin-user-id');
     });
   });
 
   describe('findById', () => {
     it('returns the enriched card shape for a supported card type', async () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
-      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      const result = await service.findById(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        AUTH_HEADER,
+      );
       expect(result).toMatchObject({
         cardType: 'EDD_NEARING',
         cardSource: 'escalation_events',
@@ -341,20 +311,28 @@ describe('EscalationService', () => {
 
     it('returns null when the row does not exist', async () => {
       repository.findById.mockResolvedValue(null);
-      const result = await service.findById('unknown-id', AUTH_HEADER);
+      const result = await service.findById('unknown-id', managerCaller, AUTH_HEADER);
       expect(result).toBeNull();
       expect(beneficiaryClient.getById).not.toHaveBeenCalled();
     });
 
     it('resolves POST_EDD_MISSED to a MISSED_VISIT card (was previously omitted)', async () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'POST_EDD_MISSED' }));
-      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      const result = await service.findById(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        AUTH_HEADER,
+      );
       expect(result).toMatchObject({ cardType: 'MISSED_VISIT', escalationType: 'POST_EDD_MISSED' });
     });
 
     it('returns null for an escalation type outside the 8 supported card types', async () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'SYNC_DELAY' }));
-      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      const result = await service.findById(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        AUTH_HEADER,
+      );
       expect(result).toBeNull();
       expect(beneficiaryClient.getById).not.toHaveBeenCalled();
     });
@@ -362,7 +340,11 @@ describe('EscalationService', () => {
     it('does not call the Sakhi client when the beneficiary has no sakhiId', async () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
       beneficiaryClient.getById.mockResolvedValue(beneficiaryRecord({ sakhiId: '' }));
-      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      const result = await service.findById(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        AUTH_HEADER,
+      );
       expect(sakhiClient.findById).not.toHaveBeenCalled();
       expect(result).toMatchObject({ sakhiName: null, sakhiContact: null });
     });
@@ -371,7 +353,7 @@ describe('EscalationService', () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
       beneficiaryClient.getById.mockRejectedValue(new Error('beneficiary-service down'));
       await expect(
-        service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER),
+        service.findById('11111111-1111-1111-1111-111111111111', managerCaller, AUTH_HEADER),
       ).rejects.toThrow('beneficiary-service down');
     });
 
@@ -379,8 +361,47 @@ describe('EscalationService', () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
       sakhiClient.findById.mockRejectedValue(new Error('auth-service down'));
       await expect(
-        service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER),
+        service.findById('11111111-1111-1111-1111-111111111111', managerCaller, AUTH_HEADER),
       ).rejects.toThrow('auth-service down');
+    });
+
+    describe('roster scoping', () => {
+      it('returns null for a SUPERVISOR requesting a card assigned to a different supervisor (IDOR)', async () => {
+        repository.findById.mockResolvedValue(
+          row({ escalationType: 'EDD_NEARING', assignedSupervisorId: 'other-supervisor' }),
+        );
+        const result = await service.findById(
+          '11111111-1111-1111-1111-111111111111',
+          supervisorCaller('supervisor-1'),
+          AUTH_HEADER,
+        );
+        expect(result).toBeNull();
+        expect(beneficiaryClient.getById).not.toHaveBeenCalled();
+      });
+
+      it('returns the card for a SUPERVISOR requesting their own assigned card', async () => {
+        repository.findById.mockResolvedValue(
+          row({ escalationType: 'EDD_NEARING', assignedSupervisorId: 'supervisor-1' }),
+        );
+        const result = await service.findById(
+          '11111111-1111-1111-1111-111111111111',
+          supervisorCaller('supervisor-1'),
+          AUTH_HEADER,
+        );
+        expect(result).toMatchObject({ cardType: 'EDD_NEARING' });
+      });
+
+      it('returns the card for a MANAGER/ADMIN caller regardless of assignedSupervisorId', async () => {
+        repository.findById.mockResolvedValue(
+          row({ escalationType: 'EDD_NEARING', assignedSupervisorId: 'some-other-supervisor' }),
+        );
+        const result = await service.findById(
+          '11111111-1111-1111-1111-111111111111',
+          managerCaller,
+          AUTH_HEADER,
+        );
+        expect(result).toMatchObject({ cardType: 'EDD_NEARING' });
+      });
     });
   });
 

--- a/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
@@ -2,15 +2,38 @@ import { EscalationService } from './escalation.service';
 import type { EscalationRepository } from './escalation.repository';
 import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
 import type { NotificationRepository } from '../notifications/notification.repository';
-import type { BeneficiaryClient } from './beneficiary.client';
+import type { BeneficiaryClient, BeneficiaryRecord } from './beneficiary.client';
 import type { ManagerNoticeClient } from './manager-notice.client';
 import type { LookupClient } from './lookup.client';
+import type { SakhiClient, SakhiRecord } from './sakhi.client';
 import type { EscalationType } from '../../../../node_modules/.prisma/client-notification-escalation-service';
+
+function beneficiaryRecord(overrides: Partial<BeneficiaryRecord> = {}): BeneficiaryRecord {
+  return {
+    id: '22222222-2222-2222-2222-222222222222',
+    sakhiId: 'sakhi-a',
+    motherCaseDetails: null,
+    pii: { fullName: 'Nithya Sakhi Mother 4', mobileNumber: '9810015405' },
+    riskLevel: 'none',
+    ...overrides,
+  };
+}
+
+function sakhiRecord(overrides: Partial<SakhiRecord> = {}): SakhiRecord {
+  return {
+    sakhiId: 'sakhi-a',
+    displayName: 'Priya Sakhi',
+    mobileNumber: '9812345678',
+    supervisorId: null,
+    ...overrides,
+  };
+}
 
 function row(overrides: { id?: string; escalationType?: EscalationType; createdAt?: Date } = {}) {
   return {
     id: overrides.id ?? '11111111-1111-1111-1111-111111111111',
     beneficiaryId: '22222222-2222-2222-2222-222222222222',
+    sakhiUserId: null,
     visitId: null,
     referralId: null,
     escalationType: overrides.escalationType ?? ('ANC_2_MISSED' as const),
@@ -38,6 +61,7 @@ describe('EscalationService', () => {
     findMany: jest.fn(),
     findById: jest.fn(),
     create: jest.fn(),
+    findOpenDuplicate: jest.fn(),
     updateStatus: jest.fn(),
     updatePendingReason: jest.fn(),
   } as unknown as jest.Mocked<EscalationRepository>;
@@ -45,18 +69,39 @@ describe('EscalationService', () => {
     findMany: jest.fn(),
     create: jest.fn(),
   } as unknown as jest.Mocked<NotificationRepository>;
+  const beneficiaryClient = {
+    getById: jest.fn(),
+    markPendingTransfer: jest.fn(),
+  } as unknown as jest.Mocked<BeneficiaryClient>;
+  const sakhiClient = { findById: jest.fn() } as unknown as jest.Mocked<SakhiClient>;
   let service: EscalationService;
   const baseQuery: ListEscalationEventsInput = { status: 'OPEN', limit: 50 };
   const AUTH_HEADER = 'Bearer test-token';
+  const managerCaller = { id: 'manager-1', roles: ['MANAGER'], projectId: null };
+  const supervisorCaller = (id = 'supervisor-1') => ({
+    id,
+    roles: ['SUPERVISOR'],
+    projectId: 'project-1',
+  });
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new EscalationService(repository, notificationRepository);
+    service = new EscalationService(
+      repository,
+      notificationRepository,
+      beneficiaryClient,
+      undefined,
+      undefined,
+      sakhiClient,
+    );
+    beneficiaryClient.getById.mockResolvedValue(beneficiaryRecord());
+    sakhiClient.findById.mockResolvedValue(sakhiRecord());
+    repository.findOpenDuplicate.mockResolvedValue(null);
   });
 
   it('groups every *_MISSED escalation type under MISSED_VISIT', async () => {
     repository.findMany.mockResolvedValue([row({ escalationType: 'PP_HR_MISSED' })]);
-    const result = await service.list(baseQuery);
+    const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
     expect(result.cards).toHaveLength(1);
     expect(result.cards[0].cardType).toBe('MISSED_VISIT');
     expect(result.cards[0].cardSource).toBe('escalation_events');
@@ -64,19 +109,19 @@ describe('EscalationService', () => {
 
   it('surfaces EDD_NEARING as its own card type', async () => {
     repository.findMany.mockResolvedValue([row({ escalationType: 'EDD_NEARING' })]);
-    const result = await service.list(baseQuery);
+    const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
     expect(result.cards[0].cardType).toBe('EDD_NEARING');
   });
 
   it('omits escalation types outside the 8 supported Quick Response card types', async () => {
     repository.findMany.mockResolvedValue([row({ escalationType: 'SYNC_DELAY' })]);
-    const result = await service.list(baseQuery);
+    const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
     expect(result.cards).toHaveLength(0);
   });
 
   it('returns no nextCursor when the repository returns exactly `limit` rows', async () => {
     repository.findMany.mockResolvedValue([row()]);
-    const result = await service.list({ ...baseQuery, limit: 1 });
+    const result = await service.list({ ...baseQuery, limit: 1 }, managerCaller, AUTH_HEADER);
     expect(result.nextCursor).toBeNull();
   });
 
@@ -86,7 +131,7 @@ describe('EscalationService', () => {
       row({ id: 'b', createdAt: new Date('2026-08-05T10:00:01.000Z') }),
     ];
     repository.findMany.mockResolvedValue(rows);
-    const result = await service.list({ ...baseQuery, limit: 1 });
+    const result = await service.list({ ...baseQuery, limit: 1 }, managerCaller, AUTH_HEADER);
     expect(result.cards).toHaveLength(1);
     expect(result.cards[0].cardId).toBe('a');
     expect(result.nextCursor).not.toBeNull();
@@ -97,23 +142,110 @@ describe('EscalationService', () => {
     const cursor = Buffer.from(
       '2026-08-05T10:00:00.000Z|11111111-1111-1111-1111-111111111111',
     ).toString('base64url');
-    await service.list({ ...baseQuery, cursor });
+    await service.list({ ...baseQuery, cursor }, managerCaller, AUTH_HEADER);
     expect(repository.findMany).toHaveBeenCalledWith(
       { ...baseQuery, cursor },
       {
         createdAt: new Date('2026-08-05T10:00:00.000Z'),
         id: '11111111-1111-1111-1111-111111111111',
       },
+      undefined,
     );
   });
 
   it('rejects a malformed cursor with a 400', async () => {
     await expect(
-      service.list({ ...baseQuery, cursor: 'not-valid-base64!!' }),
+      service.list({ ...baseQuery, cursor: 'not-valid-base64!!' }, managerCaller, AUTH_HEADER),
     ).rejects.toMatchObject({
       status: 400,
     });
     expect(repository.findMany).not.toHaveBeenCalled();
+  });
+
+  describe('list enrichment', () => {
+    it('enriches each card with beneficiary + Sakhi details', async () => {
+      repository.findMany.mockResolvedValue([row({ escalationType: 'ANC_2_MISSED' })]);
+      const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
+      expect(result.cards[0]).toMatchObject({
+        beneficiaryName: 'Nithya Sakhi Mother 4',
+        beneficiaryPhone: '9810015405',
+        riskLevel: 'none',
+        sakhiId: 'sakhi-a',
+        sakhiName: 'Priya Sakhi',
+        sakhiContact: '9812345678',
+      });
+    });
+
+    it('keeps every existing card field unchanged alongside the new ones', async () => {
+      repository.findMany.mockResolvedValue([
+        row({ id: 'card-1', escalationType: 'ANC_2_MISSED' }),
+      ]);
+      const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
+      expect(result.cards[0]).toMatchObject({
+        cardId: 'card-1',
+        cardType: 'MISSED_VISIT',
+        cardSource: 'escalation_events',
+        beneficiaryId: '22222222-2222-2222-2222-222222222222',
+        visitId: null,
+        referralId: null,
+        escalationType: 'ANC_2_MISSED',
+        status: 'OPEN',
+      });
+    });
+
+    it('dedupes beneficiary and Sakhi lookups across rows sharing the same ids', async () => {
+      repository.findMany.mockResolvedValue([
+        row({ id: 'card-1', escalationType: 'ANC_2_MISSED' }),
+        row({ id: 'card-2', escalationType: 'EDD_NEARING' }),
+      ]);
+      await service.list(baseQuery, managerCaller, AUTH_HEADER);
+      expect(beneficiaryClient.getById).toHaveBeenCalledTimes(1);
+      expect(sakhiClient.findById).toHaveBeenCalledTimes(1);
+    });
+
+    it("nulls a row's enrichment fields (without failing the list) when the beneficiary lookup fails", async () => {
+      repository.findMany.mockResolvedValue([row({ escalationType: 'ANC_2_MISSED' })]);
+      beneficiaryClient.getById.mockRejectedValue(new Error('beneficiary-service down'));
+      const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
+      expect(result.cards[0]).toMatchObject({
+        beneficiaryName: null,
+        beneficiaryPhone: null,
+        riskLevel: null,
+        sakhiId: null,
+        sakhiName: null,
+        sakhiContact: null,
+      });
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+
+    it('nulls only the Sakhi fields when the Sakhi lookup fails', async () => {
+      repository.findMany.mockResolvedValue([row({ escalationType: 'ANC_2_MISSED' })]);
+      sakhiClient.findById.mockRejectedValue(new Error('auth-service down'));
+      const result = await service.list(baseQuery, managerCaller, AUTH_HEADER);
+      expect(result.cards[0]).toMatchObject({
+        beneficiaryName: 'Nithya Sakhi Mother 4',
+        sakhiName: null,
+        sakhiContact: null,
+      });
+    });
+  });
+
+  describe('list scoping', () => {
+    it("passes the SUPERVISOR caller's own id as assignedSupervisorId to the repository", async () => {
+      repository.findMany.mockResolvedValue([]);
+
+      await service.list(baseQuery, supervisorCaller('supervisor-1'), AUTH_HEADER);
+
+      expect(repository.findMany).toHaveBeenCalledWith(baseQuery, null, 'supervisor-1');
+    });
+
+    it('passes no supervisor filter for a MANAGER/ADMIN caller (unrestricted)', async () => {
+      repository.findMany.mockResolvedValue([]);
+
+      await service.list(baseQuery, managerCaller, AUTH_HEADER);
+
+      expect(repository.findMany).toHaveBeenCalledWith(baseQuery, null, undefined);
+    });
   });
 
   describe('create', () => {
@@ -162,25 +294,93 @@ describe('EscalationService', () => {
 
       expect(repository.create).toHaveBeenCalledWith(input, 'admin-user-id');
     });
+
+    it('returns the existing OPEN escalation instead of inserting a duplicate', async () => {
+      const existing = row({ escalationType: 'ANC_2_MISSED' });
+      repository.findOpenDuplicate.mockResolvedValue(existing);
+
+      const result = await service.create(
+        { beneficiaryId: existing.beneficiaryId, escalationType: 'ANC_2_MISSED' },
+        'system-account-id',
+      );
+
+      expect(result).toBe(existing);
+      expect(repository.create).not.toHaveBeenCalled();
+    });
+
+    it('inserts when no OPEN duplicate exists', async () => {
+      repository.findOpenDuplicate.mockResolvedValue(null);
+      const created = row({ escalationType: 'SYNC_DELAY' });
+      repository.create.mockResolvedValue(created);
+
+      const result = await service.create(
+        { sakhiUserId: 'sakhi-user-1', escalationType: 'SYNC_DELAY' },
+        'system-account-id',
+      );
+
+      expect(result).toBe(created);
+      expect(repository.create).toHaveBeenCalled();
+    });
   });
 
   describe('findById', () => {
-    it('returns the card shape for a supported card type', async () => {
+    it('returns the enriched card shape for a supported card type', async () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
-      const result = await service.findById('11111111-1111-1111-1111-111111111111');
-      expect(result).toMatchObject({ cardType: 'EDD_NEARING', cardSource: 'escalation_events' });
+      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      expect(result).toMatchObject({
+        cardType: 'EDD_NEARING',
+        cardSource: 'escalation_events',
+        beneficiaryName: 'Nithya Sakhi Mother 4',
+        beneficiaryPhone: '9810015405',
+        riskLevel: 'none',
+        sakhiId: 'sakhi-a',
+        sakhiName: 'Priya Sakhi',
+        sakhiContact: '9812345678',
+      });
     });
 
     it('returns null when the row does not exist', async () => {
       repository.findById.mockResolvedValue(null);
-      const result = await service.findById('unknown-id');
+      const result = await service.findById('unknown-id', AUTH_HEADER);
       expect(result).toBeNull();
+      expect(beneficiaryClient.getById).not.toHaveBeenCalled();
+    });
+
+    it('resolves POST_EDD_MISSED to a MISSED_VISIT card (was previously omitted)', async () => {
+      repository.findById.mockResolvedValue(row({ escalationType: 'POST_EDD_MISSED' }));
+      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      expect(result).toMatchObject({ cardType: 'MISSED_VISIT', escalationType: 'POST_EDD_MISSED' });
     });
 
     it('returns null for an escalation type outside the 8 supported card types', async () => {
       repository.findById.mockResolvedValue(row({ escalationType: 'SYNC_DELAY' }));
-      const result = await service.findById('11111111-1111-1111-1111-111111111111');
+      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
       expect(result).toBeNull();
+      expect(beneficiaryClient.getById).not.toHaveBeenCalled();
+    });
+
+    it('does not call the Sakhi client when the beneficiary has no sakhiId', async () => {
+      repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
+      beneficiaryClient.getById.mockResolvedValue(beneficiaryRecord({ sakhiId: '' }));
+      const result = await service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ sakhiName: null, sakhiContact: null });
+    });
+
+    it('propagates a beneficiary-service failure instead of nulling the enrichment', async () => {
+      repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
+      beneficiaryClient.getById.mockRejectedValue(new Error('beneficiary-service down'));
+      await expect(
+        service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER),
+      ).rejects.toThrow('beneficiary-service down');
+    });
+
+    it('propagates an auth-service (Sakhi) failure instead of nulling the enrichment', async () => {
+      repository.findById.mockResolvedValue(row({ escalationType: 'EDD_NEARING' }));
+      sakhiClient.findById.mockRejectedValue(new Error('auth-service down'));
+      await expect(
+        service.findById('11111111-1111-1111-1111-111111111111', AUTH_HEADER),
+      ).rejects.toThrow('auth-service down');
     });
   });
 
@@ -249,6 +449,7 @@ describe('EscalationService', () => {
       ['INC_HR_MISSED', 'INC-HR'],
       ['CCV_MISSED', 'CCV'],
       ['CCV_HR_MISSED', 'CCV-HR'],
+      ['POST_EDD_MISSED', 'ANC_POST_EDD'],
     ])('maps %s to visitType %s', async (escalationType, visitType) => {
       repository.findById.mockResolvedValue({
         ...row({ escalationType: escalationType as EscalationType }),
@@ -297,7 +498,8 @@ describe('EscalationService', () => {
         id: '22222222-2222-2222-2222-222222222222',
         sakhiId: 'sakhi-a',
         motherCaseDetails: { eddDate: '2027-03-01T00:00:00.000Z' },
-        pii: { fullName: 'Jane Doe' },
+        pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+        riskLevel: 'none' as const,
       });
     });
 
@@ -347,7 +549,8 @@ describe('EscalationService', () => {
         id: '22222222-2222-2222-2222-222222222222',
         sakhiId: 'sakhi-a',
         motherCaseDetails: null,
-        pii: { fullName: 'Jane Doe' },
+        pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+        riskLevel: 'none' as const,
       });
       const result = await eddService.getEddNearingDetail(
         '11111111-1111-1111-1111-111111111111',
@@ -442,12 +645,20 @@ describe('EscalationService', () => {
     let consoleErrorSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      closeService = new EscalationService(repository, notificationRepository, beneficiaryClient);
+      closeService = new EscalationService(
+        repository,
+        notificationRepository,
+        beneficiaryClient,
+        undefined,
+        undefined,
+        sakhiClient,
+      );
       beneficiaryClient.getById.mockResolvedValue({
         id: '22222222-2222-2222-2222-222222222222',
         sakhiId: 'sakhi-a',
         motherCaseDetails: null,
-        pii: { fullName: 'Jane Doe' },
+        pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+        riskLevel: 'none' as const,
       });
       consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     });
@@ -475,6 +686,37 @@ describe('EscalationService', () => {
       );
     });
 
+    it('CLOSE: accepts a POST_EDD_MISSED escalation (was previously rejected as unsupported)', async () => {
+      const pending = row({ escalationType: 'POST_EDD_MISSED' });
+      const resolved = { ...pending, status: 'RESOLVED' as const, actionTaken: 'CLOSE' };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(resolved);
+      repository.updateStatus.mockResolvedValue(true);
+
+      const result = await closeService.decideMissedVisit(pending.id, 'CLOSE', AUTH_HEADER);
+
+      expect(result).toBe(resolved);
+      expect(repository.updateStatus).toHaveBeenCalledWith(pending.id, 'OPEN', 'RESOLVED', 'CLOSE');
+    });
+
+    it("CLOSE: also notifies the Sakhi's assigned Supervisor", async () => {
+      const pending = row({ escalationType: 'ANC_2_MISSED' });
+      const resolved = { ...pending, status: 'RESOLVED' as const, actionTaken: 'CLOSE' };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(resolved);
+      repository.updateStatus.mockResolvedValue(true);
+      sakhiClient.findById.mockResolvedValue(sakhiRecord({ supervisorId: 'supervisor-9' }));
+
+      await closeService.decideMissedVisit(pending.id, 'CLOSE', AUTH_HEADER);
+
+      expect(sakhiClient.findById).toHaveBeenCalledWith('sakhi-a', AUTH_HEADER);
+      expect(notificationRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientUserId: 'supervisor-9',
+          notificationType: 'MISSED_VISIT_ESCALATION',
+          linkedEntityId: pending.id,
+        }),
+      );
+    });
+
     it('does not fail the request when notifying the Sakhi fails', async () => {
       const pending = row({ escalationType: 'ANC_2_MISSED' });
       const resolved = { ...pending, status: 'RESOLVED' as const, actionTaken: 'CLOSE' };
@@ -487,7 +729,8 @@ describe('EscalationService', () => {
           id: '22222222-2222-2222-2222-222222222222',
           sakhiId: 'sakhi-a',
           motherCaseDetails: null,
-          pii: { fullName: 'Jane Doe' },
+          pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+          riskLevel: 'none' as const,
         })
         .mockRejectedValueOnce(new Error('beneficiary-service down'));
 
@@ -549,12 +792,15 @@ describe('EscalationService', () => {
         notificationRepository,
         beneficiaryClient,
         managerNoticeClient,
+        undefined,
+        sakhiClient,
       );
       beneficiaryClient.getById.mockResolvedValue({
         id: '22222222-2222-2222-2222-222222222222',
         sakhiId: 'sakhi-a',
         motherCaseDetails: null,
-        pii: { fullName: 'Jane Doe' },
+        pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+        riskLevel: 'none' as const,
       });
       beneficiaryClient.markPendingTransfer.mockResolvedValue(undefined);
       managerNoticeClient.send.mockResolvedValue({
@@ -618,6 +864,24 @@ describe('EscalationService', () => {
       expect(notificationRepository.create).toHaveBeenCalledWith(
         expect.objectContaining({
           recipientUserId: 'sakhi-a',
+          notificationType: 'BENEFICIARY_TRANSFER_NOTICE',
+          linkedEntityId: pending.id,
+        }),
+      );
+    });
+
+    it("TRANSFER: also notifies the Sakhi's assigned Supervisor", async () => {
+      const pending = { ...row({ escalationType: 'ANC_2_MISSED' }), visitsMissedCount: 2 };
+      repository.findById.mockResolvedValue(pending);
+      repository.updateStatus.mockResolvedValue(true);
+      sakhiClient.findById.mockResolvedValue(sakhiRecord({ supervisorId: 'supervisor-9' }));
+
+      await transferService.decideMissedVisit(pending.id, 'TRANSFER', AUTH_HEADER);
+
+      expect(sakhiClient.findById).toHaveBeenCalledWith('sakhi-a', AUTH_HEADER);
+      expect(notificationRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientUserId: 'supervisor-9',
           notificationType: 'BENEFICIARY_TRANSFER_NOTICE',
           linkedEntityId: pending.id,
         }),
@@ -719,7 +983,8 @@ describe('EscalationService', () => {
           id: '22222222-2222-2222-2222-222222222222',
           sakhiId: 'sakhi-a',
           motherCaseDetails: null,
-          pii: { fullName: 'Jane Doe' },
+          pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+          riskLevel: 'none' as const,
         })
         .mockRejectedValueOnce(new Error('beneficiary-service down'));
 
@@ -767,7 +1032,8 @@ describe('EscalationService', () => {
         id: '22222222-2222-2222-2222-222222222222',
         sakhiId: 'sakhi-a',
         motherCaseDetails: null,
-        pii: { fullName: 'Jane Doe' },
+        pii: { fullName: 'Jane Doe', mobileNumber: '9810000000' },
+        riskLevel: 'none' as const,
       });
       lookupClient.resolveClosurePendingReasonCode.mockResolvedValue('INFORMATION_NOT_RECEIVED');
       repository.updatePendingReason.mockResolvedValue(true);

--- a/apps/notification-escalation-service/src/escalations/escalation.service.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.ts
@@ -129,7 +129,8 @@ export class EscalationService {
         beneficiaryIds.map(async (id) => {
           try {
             return [id, await this.beneficiaryClient.getById(id, authorizationHeader)] as const;
-          } catch {
+          } catch (err) {
+            console.error(`Failed to enrich escalation card with beneficiary ${id}:`, err);
             return [id, null] as const;
           }
         }),
@@ -148,7 +149,8 @@ export class EscalationService {
         sakhiIds.map(async (id) => {
           try {
             return [id, await this.sakhiClient.findById(id, authorizationHeader)] as const;
-          } catch {
+          } catch (err) {
+            console.error(`Failed to enrich escalation card with sakhi ${id}:`, err);
             return [id, null] as const;
           }
         }),
@@ -186,7 +188,7 @@ export class EscalationService {
       beneficiaryPhone: enrichment?.beneficiary?.pii.mobileNumber ?? null,
       riskLevel: enrichment?.beneficiary?.riskLevel ?? null,
       assignedSupervisorId: row.assignedSupervisorId,
-      sakhiId: enrichment?.beneficiary?.sakhiId ?? null,
+      sakhiId: enrichment?.beneficiary?.sakhiId || null,
       sakhiName: enrichment?.sakhi?.displayName ?? null,
       sakhiContact: enrichment?.sakhi?.mobileNumber ?? null,
       visitId: row.visitId,
@@ -234,27 +236,32 @@ export class EscalationService {
    * here, unlike closures/reopen-requests/referrals.
    *
    * Idempotent: if an OPEN escalation already exists for the same natural
-   * key (see findOpenDuplicate), that existing row is returned instead of
-   * inserting a duplicate — a cron job re-raising the same missed
-   * visit/follow-up/sync-delay on its next tick (before a Supervisor has
-   * resolved the first one) must not pile up repeat OPEN escalations.
+   * key, that existing row is returned (with its assignedSupervisorId
+   * self-healed to the incoming value if it's changed) instead of inserting
+   * a duplicate — a cron job re-raising the same missed visit/follow-up/
+   * sync-delay on its next tick (before a Supervisor has resolved the first
+   * one) must not pile up repeat OPEN escalations. See
+   * EscalationRepository.createOrReuseOpen for how the check-then-write is
+   * made race-safe.
    */
-  async create(input: CreateEscalationEventInput, createdByUserId: string) {
-    const existing = await this.repository.findOpenDuplicate(input);
-    if (existing) return existing;
-    return this.repository.create(input, createdByUserId);
+  create(input: CreateEscalationEventInput, createdByUserId: string) {
+    return this.repository.createOrReuseOpen(input, createdByUserId);
   }
 
   /**
    * Fetches a single escalation event shaped as an enriched Quick Response
    * card, or null if it doesn't exist (or isn't one of the 8 supported card
-   * types). Unlike list()'s best-effort enrichment, a beneficiary/Sakhi
-   * lookup failure here propagates — for a single card the enrichment IS
-   * the payload, same philosophy as getEddNearingDetail.
+   * types), or if a non-privileged caller doesn't own it — same
+   * assignedSupervisorId roster scoping list() applies, so a Supervisor
+   * can't fetch another Supervisor's card by guessing/enumerating its id.
+   * Unlike list()'s best-effort enrichment, a beneficiary/Sakhi lookup
+   * failure here propagates — for a single card the enrichment IS the
+   * payload, same philosophy as getEddNearingDetail.
    */
-  async findById(id: string, authorizationHeader: string) {
+  async findById(id: string, caller: CallerScope, authorizationHeader: string) {
     const row = await this.repository.findById(id);
     if (!row) return null;
+    if (!isPrivileged(caller) && row.assignedSupervisorId !== caller.id) return null;
 
     const cardType = toCardType(row.escalationType);
     if (!cardType) return null;

--- a/apps/notification-escalation-service/src/escalations/escalation.service.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.ts
@@ -2,12 +2,14 @@ import { badRequest, conflict, notFound, unprocessable } from '@armman/service-c
 import type { EscalationRepository } from './escalation.repository';
 import type { ListEscalationEventsInput } from './dto/list-escalation-events.dto';
 import type { CreateEscalationEventInput } from './dto/create-escalation-event.dto';
-import { BeneficiaryClient } from './beneficiary.client';
+import { BeneficiaryClient, type BeneficiaryRecord } from './beneficiary.client';
 import { ManagerNoticeClient } from './manager-notice.client';
 import { LookupClient } from './lookup.client';
+import { SakhiClient, type SakhiRecord } from './sakhi.client';
 import { decideTransfer } from './missed-visit-transfer';
 import { MISSED_VISIT_TYPES, MISSED_VISIT_TYPE_MAP } from './missed-visit-types';
 import type { NotificationRepository } from '../notifications/notification.repository';
+import { fanOutToSupervisor } from '../notifications/supervisor-fanout';
 import type { SubmitClosurePendingReasonInput } from './dto/submit-closure-pending-reason.dto';
 
 /** Quick Response's fixed card type for an escalation row — everything else in
@@ -17,6 +19,28 @@ function toCardType(escalationType: string): 'MISSED_VISIT' | 'EDD_NEARING' | nu
   if (MISSED_VISIT_TYPES.has(escalationType)) return 'MISSED_VISIT';
   if (escalationType === 'EDD_NEARING') return 'EDD_NEARING';
   return null;
+}
+
+/**
+ * `EscalationEvent.beneficiaryId` is nullable at the schema/DTO level only
+ * because SYNC_DELAY escalations carry `sakhiUserId` instead (see
+ * createEscalationEventSchema's doc comment) — every other escalationType
+ * still always has one. Every call site below only ever handles a row whose
+ * type is known not to be SYNC_DELAY (MISSED_VISIT/EDD_NEARING cards,
+ * CLOSURE_PENDING, missed-visit TRANSFER), so a null here is a genuine data
+ * invariant violation, not a normal case to silently degrade — this throws
+ * rather than letting a cross-service call proceed with `null` as an id.
+ */
+function requireBeneficiaryId(row: {
+  beneficiaryId: string | null;
+  escalationType: string;
+}): string {
+  if (!row.beneficiaryId) {
+    throw new Error(
+      `Escalation ${row.escalationType} row has no beneficiaryId — expected one for this type.`,
+    );
+  }
+  return row.beneficiaryId;
 }
 
 /** Missed Visit Escalation detail's own status vocabulary — distinct from the
@@ -53,6 +77,30 @@ function encodeCursor(row: { createdAt: Date; id: string }): string {
   return Buffer.from(`${row.createdAt.toISOString()}|${row.id}`, 'utf8').toString('base64url');
 }
 
+type EscalationEventRow = NonNullable<Awaited<ReturnType<EscalationRepository['findById']>>>;
+
+/** The calling principal's own scope, as carried on their JWT/trusted-identity headers. */
+export interface CallerScope {
+  readonly id: string;
+  readonly roles: string[];
+  readonly projectId: string | null;
+}
+
+/**
+ * MANAGER/ADMIN are unrestricted across this service's supervisor-scoping
+ * checks — checked as the absence of an elevated role, not the presence of
+ * a restrictive one (SUPERVISOR), since a caller can hold multiple role
+ * assignments at once. Matches auth-service's own isPrivileged() pattern.
+ */
+function isPrivileged(caller: CallerScope): boolean {
+  return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
+}
+
+interface RowEnrichment {
+  beneficiary: BeneficiaryRecord | null;
+  sakhi: SakhiRecord | null;
+}
+
 /** Escalation event domain logic. Data access is delegated to the repository. */
 export class EscalationService {
   constructor(
@@ -61,67 +109,165 @@ export class EscalationService {
     private readonly beneficiaryClient: BeneficiaryClient = new BeneficiaryClient(),
     private readonly managerNoticeClient: ManagerNoticeClient = new ManagerNoticeClient(),
     private readonly lookupClient: LookupClient = new LookupClient(),
+    private readonly sakhiClient: SakhiClient = new SakhiClient(),
   ) {}
 
-  async list(query: ListEscalationEventsInput) {
+  /**
+   * Resolves beneficiary + Sakhi details for the Supervisor app's card view
+   * (SRS FR-SV-4.3 / PRD lines 143-150 — a card must show a name, not a bare
+   * id). Best-effort per unique beneficiary/Sakhi: a page of up to 100 cards
+   * shouldn't 502 in full because one referenced beneficiary record is gone —
+   * that row's enrichment fields just come back null instead.
+   */
+  private async enrichRows(
+    rows: EscalationEventRow[],
+    authorizationHeader: string,
+  ): Promise<Map<string, RowEnrichment>> {
+    const beneficiaryIds = [...new Set(rows.map((row) => requireBeneficiaryId(row)))];
+    const beneficiaries = new Map(
+      await Promise.all(
+        beneficiaryIds.map(async (id) => {
+          try {
+            return [id, await this.beneficiaryClient.getById(id, authorizationHeader)] as const;
+          } catch {
+            return [id, null] as const;
+          }
+        }),
+      ),
+    );
+
+    const sakhiIds = [
+      ...new Set(
+        [...beneficiaries.values()]
+          .map((beneficiary) => beneficiary?.sakhiId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    const sakhis = new Map(
+      await Promise.all(
+        sakhiIds.map(async (id) => {
+          try {
+            return [id, await this.sakhiClient.findById(id, authorizationHeader)] as const;
+          } catch {
+            return [id, null] as const;
+          }
+        }),
+      ),
+    );
+
+    const result = new Map<string, RowEnrichment>();
+    for (const row of rows) {
+      const beneficiaryId = requireBeneficiaryId(row);
+      const beneficiary = beneficiaries.get(beneficiaryId) ?? null;
+      const sakhi = beneficiary?.sakhiId ? (sakhis.get(beneficiary.sakhiId) ?? null) : null;
+      result.set(beneficiaryId, { beneficiary, sakhi });
+    }
+    return result;
+  }
+
+  /**
+   * Quick Response's existing card fields (cardId/cardType/cardSource/
+   * raisedAt/...) are kept as-is — approval-service's merged card list
+   * depends on them for sort/pagination/dispatch. Beneficiary/Sakhi/risk
+   * fields are additive, sourced from beneficiary-service and auth-service
+   * (this table carries none of them itself — see the forklift rule).
+   */
+  private toEnrichedCard(
+    row: EscalationEventRow,
+    cardType: 'MISSED_VISIT' | 'EDD_NEARING',
+    enrichment: RowEnrichment | null,
+  ) {
+    return {
+      cardId: row.id,
+      cardType,
+      cardSource: 'escalation_events' as const,
+      beneficiaryId: row.beneficiaryId,
+      beneficiaryName: enrichment?.beneficiary?.pii.fullName ?? null,
+      beneficiaryPhone: enrichment?.beneficiary?.pii.mobileNumber ?? null,
+      riskLevel: enrichment?.beneficiary?.riskLevel ?? null,
+      assignedSupervisorId: row.assignedSupervisorId,
+      sakhiId: enrichment?.beneficiary?.sakhiId ?? null,
+      sakhiName: enrichment?.sakhi?.displayName ?? null,
+      sakhiContact: enrichment?.sakhi?.mobileNumber ?? null,
+      visitId: row.visitId,
+      referralId: row.referralId,
+      escalationType: row.escalationType,
+      status: row.status,
+      resolvedAt: row.resolvedAt ? row.resolvedAt.toISOString() : null,
+      actionTaken: row.actionTaken,
+      raisedAt: row.createdAt.toISOString(),
+    };
+  }
+
+  async list(query: ListEscalationEventsInput, caller: CallerScope, authorizationHeader: string) {
     const cursor = query.cursor ? decodeCursor(query.cursor) : null;
-    const rows = await this.repository.findMany(query, cursor);
+    const assignedSupervisorId = isPrivileged(caller) ? undefined : caller.id;
+    const rows = await this.repository.findMany(query, cursor, assignedSupervisorId);
 
     const hasMore = rows.length > query.limit;
     const page = hasMore ? rows.slice(0, query.limit) : rows;
     const nextCursor = hasMore ? encodeCursor(page[page.length - 1]) : null;
 
-    const cards = page
+    const supported = page
       .map((row) => ({ row, cardType: toCardType(row.escalationType) }))
       .filter(
         (r): r is { row: (typeof page)[number]; cardType: 'MISSED_VISIT' | 'EDD_NEARING' } =>
           r.cardType !== null,
-      )
-      .map(({ row, cardType }) => ({
-        cardId: row.id,
-        cardType,
-        cardSource: 'escalation_events' as const,
-        beneficiaryId: row.beneficiaryId,
-        visitId: row.visitId,
-        referralId: row.referralId,
-        escalationType: row.escalationType,
-        status: row.status,
-        raisedAt: row.createdAt.toISOString(),
-      }));
+      );
+
+    const enrichment = await this.enrichRows(
+      supported.map(({ row }) => row),
+      authorizationHeader,
+    );
+
+    const cards = supported.map(({ row, cardType }) =>
+      this.toEnrichedCard(row, cardType, enrichment.get(requireBeneficiaryId(row)) ?? null),
+    );
 
     return { cards, nextCursor };
   }
 
   /**
-   * Raises a new escalation event. ADMIN-only (see escalation.routes.ts) —
-   * in production these rows come from an automated rules/cron process, so
-   * there is no Sakhi-ownership check to delegate here, unlike closures/
-   * reopen-requests/referrals.
+   * Raises a new escalation event. ADMIN/SYSTEM-only (see
+   * escalation.routes.ts) — in production these rows come from an automated
+   * rules/cron process, so there is no Sakhi-ownership check to delegate
+   * here, unlike closures/reopen-requests/referrals.
+   *
+   * Idempotent: if an OPEN escalation already exists for the same natural
+   * key (see findOpenDuplicate), that existing row is returned instead of
+   * inserting a duplicate — a cron job re-raising the same missed
+   * visit/follow-up/sync-delay on its next tick (before a Supervisor has
+   * resolved the first one) must not pile up repeat OPEN escalations.
    */
-  create(input: CreateEscalationEventInput, createdByUserId: string) {
+  async create(input: CreateEscalationEventInput, createdByUserId: string) {
+    const existing = await this.repository.findOpenDuplicate(input);
+    if (existing) return existing;
     return this.repository.create(input, createdByUserId);
   }
 
-  /** Fetches a single escalation event shaped as a Quick Response card, or
-   * null if it doesn't exist (or isn't one of the 8 supported card types). */
-  async findById(id: string) {
+  /**
+   * Fetches a single escalation event shaped as an enriched Quick Response
+   * card, or null if it doesn't exist (or isn't one of the 8 supported card
+   * types). Unlike list()'s best-effort enrichment, a beneficiary/Sakhi
+   * lookup failure here propagates — for a single card the enrichment IS
+   * the payload, same philosophy as getEddNearingDetail.
+   */
+  async findById(id: string, authorizationHeader: string) {
     const row = await this.repository.findById(id);
     if (!row) return null;
 
     const cardType = toCardType(row.escalationType);
     if (!cardType) return null;
 
-    return {
-      cardId: row.id,
-      cardType,
-      cardSource: 'escalation_events' as const,
-      beneficiaryId: row.beneficiaryId,
-      visitId: row.visitId,
-      referralId: row.referralId,
-      escalationType: row.escalationType,
-      status: row.status,
-      raisedAt: row.createdAt.toISOString(),
-    };
+    const beneficiary = await this.beneficiaryClient.getById(
+      requireBeneficiaryId(row),
+      authorizationHeader,
+    );
+    const sakhi = beneficiary.sakhiId
+      ? await this.sakhiClient.findById(beneficiary.sakhiId, authorizationHeader)
+      : null;
+
+    return this.toEnrichedCard(row, cardType, { beneficiary, sakhi });
   }
 
   /**
@@ -165,7 +311,7 @@ export class EscalationService {
     }
 
     const beneficiary = await this.beneficiaryClient.getById(
-      row.beneficiaryId,
+      requireBeneficiaryId(row),
       authorizationHeader,
     );
     const eddDate = beneficiary.motherCaseDetails?.eddDate?.slice(0, 10) ?? null;
@@ -231,7 +377,7 @@ export class EscalationService {
     // (SAKHI-own-case / SUPERVISOR-roster / MANAGER-unrestricted) — same pattern
     // submitClosurePendingReason already uses. Without this, a Supervisor could
     // decide (TRANSFER or CLOSE) an escalation outside their own roster (IDOR).
-    await this.beneficiaryClient.getById(existing.beneficiaryId, authorizationHeader);
+    await this.beneficiaryClient.getById(requireBeneficiaryId(existing), authorizationHeader);
 
     if (action === 'TRANSFER') {
       return decideTransfer(
@@ -241,6 +387,7 @@ export class EscalationService {
           notificationRepository: this.notificationRepository,
           beneficiaryClient: this.beneficiaryClient,
           managerNoticeClient: this.managerNoticeClient,
+          sakhiClient: this.sakhiClient,
         },
         authorizationHeader,
       );
@@ -253,19 +400,26 @@ export class EscalationService {
 
     try {
       const beneficiary = await this.beneficiaryClient.getById(
-        existing.beneficiaryId,
+        requireBeneficiaryId(existing),
         authorizationHeader,
       );
-      await this.notificationRepository.create({
+      const notificationDto = {
         recipientUserId: beneficiary.sakhiId,
-        notificationType: 'MISSED_VISIT_ESCALATION',
+        notificationType: 'MISSED_VISIT_ESCALATION' as const,
         title: 'Closure form needed',
         body: 'A beneficiary with a missed-visit escalation needs a closure form filled in.',
         priority: 5,
         linkedEntityType: 'EscalationEvent',
         linkedEntityId: id,
-        status: 'UNREAD',
-      });
+        status: 'UNREAD' as const,
+      };
+      await this.notificationRepository.create(notificationDto);
+      await fanOutToSupervisor(
+        this.notificationRepository,
+        this.sakhiClient,
+        notificationDto,
+        authorizationHeader,
+      );
     } catch (err) {
       console.error(
         `Missed Visit Escalation ${id} was closed but notifying the Sakhi failed:`,
@@ -310,7 +464,7 @@ export class EscalationService {
       throw unprocessable('This endpoint only accepts CLOSURE_PENDING escalations.');
     }
 
-    await this.beneficiaryClient.getById(existing.beneficiaryId, authorizationHeader);
+    await this.beneficiaryClient.getById(requireBeneficiaryId(existing), authorizationHeader);
 
     const reasonCode = await this.lookupClient.resolveClosurePendingReasonCode(
       input.pendingReasonLookupValueId,

--- a/apps/notification-escalation-service/src/escalations/missed-visit-transfer.ts
+++ b/apps/notification-escalation-service/src/escalations/missed-visit-transfer.ts
@@ -1,8 +1,10 @@
 import { conflict } from '@armman/service-commons';
 import type { EscalationRepository } from './escalation.repository';
 import type { NotificationRepository } from '../notifications/notification.repository';
+import { fanOutToSupervisor } from '../notifications/supervisor-fanout';
 import type { BeneficiaryClient } from './beneficiary.client';
 import type { ManagerNoticeClient } from './manager-notice.client';
+import type { SakhiClient } from './sakhi.client';
 import { MISSED_VISIT_TYPE_MAP } from './missed-visit-types';
 
 /** FR-SV-4.3 — how long a Manager has to review a TRANSFER before the
@@ -16,6 +18,7 @@ interface Deps {
   notificationRepository: NotificationRepository;
   beneficiaryClient: BeneficiaryClient;
   managerNoticeClient: ManagerNoticeClient;
+  sakhiClient: SakhiClient;
 }
 
 /**
@@ -40,9 +43,21 @@ export async function decideTransfer(
   deps: Deps,
   authorizationHeader: string,
 ) {
-  const { repository, notificationRepository, beneficiaryClient, managerNoticeClient } = deps;
+  const {
+    repository,
+    notificationRepository,
+    beneficiaryClient,
+    managerNoticeClient,
+    sakhiClient,
+  } = deps;
   const id = existing.id;
   const reviewDeadlineAt = new Date(Date.now() + MANAGER_REVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  // TRANSFER only ever applies to a MISSED_VISIT-type escalation, which
+  // always carries beneficiaryId (only SYNC_DELAY uses sakhiUserId instead —
+  // see EscalationEvent.beneficiaryId's schema doc comment).
+  if (!existing.beneficiaryId) {
+    throw new Error(`Escalation ${existing.escalationType} row has no beneficiaryId.`);
+  }
 
   await beneficiaryClient.markPendingTransfer(existing.beneficiaryId, authorizationHeader);
 
@@ -82,9 +97,9 @@ export async function decideTransfer(
     }
 
     try {
-      await notificationRepository.create({
+      const notificationDto = {
         recipientUserId: beneficiary.sakhiId,
-        notificationType: 'BENEFICIARY_TRANSFER_NOTICE',
+        notificationType: 'BENEFICIARY_TRANSFER_NOTICE' as const,
         title: 'Beneficiary removed for Manager review',
         body:
           'A beneficiary has been removed from your list pending a Manager review of a ' +
@@ -92,8 +107,15 @@ export async function decideTransfer(
         priority: 5,
         linkedEntityType: 'EscalationEvent',
         linkedEntityId: id,
-        status: 'UNREAD',
-      });
+        status: 'UNREAD' as const,
+      };
+      await notificationRepository.create(notificationDto);
+      await fanOutToSupervisor(
+        notificationRepository,
+        sakhiClient,
+        notificationDto,
+        authorizationHeader,
+      );
     } catch (err) {
       console.error(
         `Missed Visit Escalation ${id} was transferred but notifying the Sakhi failed:`,

--- a/apps/notification-escalation-service/src/escalations/missed-visit-types.ts
+++ b/apps/notification-escalation-service/src/escalations/missed-visit-types.ts
@@ -6,7 +6,15 @@
  * escalation.service.ts so neither file has to import the other.
  */
 
-/** The 10 EscalationType values that Quick Response groups under one MISSED_VISIT card. */
+/**
+ * The 11 EscalationType values that Quick Response groups under one
+ * MISSED_VISIT card. POST_EDD_MISSED (build plan: "EDD+7 delivery-form
+ * check") rides this exact same card/detail/CLOSE/TRANSFER machinery as
+ * every other visit family — it just wasn't added here yet, so it used to
+ * fall through toCardType()'s null case and never surface on the Quick
+ * Response list at all despite escalation.rulesJson.ts already escalating
+ * it (immediate, 1-miss, same as the HR types).
+ */
 export const MISSED_VISIT_TYPES = new Set([
   'ANC_2_MISSED',
   'ANC_HR_MISSED',
@@ -18,13 +26,16 @@ export const MISSED_VISIT_TYPES = new Set([
   'INC_HR_MISSED',
   'CCV_MISSED',
   'CCV_HR_MISSED',
+  'POST_EDD_MISSED',
 ]);
 
 /**
- * Maps each of the 10 missed-visit EscalationType values onto the 7-value
- * visitType the Missed Visit Escalation detail endpoint returns. The 3
- * "_HR_MISSED" ANC/PP/NN variants collapse onto their base type — that enum
- * has no ANC-HR/PP-HR/NN-HR value, unlike INC and CCV which do.
+ * Maps each of the 11 missed-visit EscalationType values onto the visitType
+ * the Missed Visit Escalation detail endpoint / TRANSFER Manager-email
+ * payload returns. The 3 "_HR_MISSED" ANC/PP/NN variants collapse onto
+ * their base type — that enum has no ANC-HR/PP-HR/NN-HR value, unlike INC
+ * and CCV which do. POST_EDD_MISSED maps to its own VisitCodeType,
+ * 'ANC_POST_EDD' — it has no HR variant to collapse.
  */
 export const MISSED_VISIT_TYPE_MAP: Record<string, string> = {
   ANC_2_MISSED: 'ANC',
@@ -37,4 +48,5 @@ export const MISSED_VISIT_TYPE_MAP: Record<string, string> = {
   INC_HR_MISSED: 'INC-HR',
   CCV_MISSED: 'CCV',
   CCV_HR_MISSED: 'CCV-HR',
+  POST_EDD_MISSED: 'ANC_POST_EDD',
 };

--- a/apps/notification-escalation-service/src/escalations/sakhi.client.ts
+++ b/apps/notification-escalation-service/src/escalations/sakhi.client.ts
@@ -1,0 +1,45 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+
+// Read directly (not via appConfig) so importing this client doesn't pull in
+// app-config's full schema at module-load time — matches this module's own
+// beneficiary.client.ts / manager-notice.client.ts / lookup.client.ts convention.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+export interface SakhiRecord {
+  sakhiId: string;
+  displayName: string;
+  mobileNumber: string;
+  supervisorId: string | null;
+}
+
+/**
+ * Resolves a Sakhi's own record from auth-service (through the gateway) —
+ * used to enrich an escalation event card with the Sakhi's name/contact for
+ * the Supervisor app's decision view (SRS FR-SV-4.3). A trimmed, single-
+ * purpose duplicate of notifications/sakhi.client.ts per this codebase's
+ * per-module client convention (see beneficiary.client.ts's own doc comment).
+ */
+export class SakhiClient {
+  async findById(sakhiId: string, authorizationHeader: string): Promise<SakhiRecord | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/sakhis/${sakhiId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the Sakhi — the auth service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the Sakhi.');
+      }
+      throw badGateway('Unable to resolve the Sakhi — the auth service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: SakhiRecord };
+    return body.data;
+  }
+}

--- a/apps/notification-escalation-service/src/main.ts
+++ b/apps/notification-escalation-service/src/main.ts
@@ -19,4 +19,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/notification-escalation-service/src/notifications/dto/create-notification.dto.spec.ts
+++ b/apps/notification-escalation-service/src/notifications/dto/create-notification.dto.spec.ts
@@ -1,0 +1,51 @@
+import { createNotificationSchema } from './create-notification.dto';
+
+describe('createNotificationSchema', () => {
+  const baseInput = {
+    recipientUserId: '22222222-2222-2222-2222-222222222222',
+    notificationType: 'MISSED_VISIT_ESCALATION' as const,
+    title: 'Missed visit',
+    status: 'UNREAD' as const,
+  };
+
+  it('accepts a minimal payload', () => {
+    const result = createNotificationSchema.safeParse(baseInput);
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    'MISSED_VISIT_ESCALATION',
+    'BENEFICIARY_TRANSFER_NOTICE',
+    'LMP_CHANGE_UPDATE',
+    'REOPEN_UPDATE',
+    'REFERRAL_INCOMPLETE_UPDATE',
+    'ACCOMPANIED_REFERRAL_UPDATE',
+    'DATA_RESTORE_UPDATE',
+    'CLOSURE_REVIEW_UPDATE',
+  ])('accepts notificationType %s', (notificationType) => {
+    const result = createNotificationSchema.safeParse({ ...baseInput, notificationType });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a notificationType outside the enum', () => {
+    const result = createNotificationSchema.safeParse({
+      ...baseInput,
+      notificationType: 'NOT_A_REAL_TYPE',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts linkedEntityType/linkedEntityId when supplied', () => {
+    const result = createNotificationSchema.safeParse({
+      ...baseInput,
+      linkedEntityType: 'ApprovalRequest',
+      linkedEntityId: '33333333-3333-3333-3333-333333333333',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown field (.strict())', () => {
+    const result = createNotificationSchema.safeParse({ ...baseInput, foo: 'bar' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/notification-escalation-service/src/notifications/dto/create-notification.dto.ts
+++ b/apps/notification-escalation-service/src/notifications/dto/create-notification.dto.ts
@@ -14,6 +14,7 @@ export const createNotificationSchema = z
     recipientUserId: z.string().trim().min(1),
     notificationType: z.enum([
       'MISSED_VISIT_ESCALATION',
+      'HR_MISSED_VISIT_ESCALATION',
       'BENEFICIARY_TRANSFER_NOTICE',
       'REFERRAL_UPDATE',
       'REFERRAL_FOLLOWUP_DUE',
@@ -21,6 +22,10 @@ export const createNotificationSchema = z
       'REOPEN_UPDATE',
       'CLOSURE_UPDATE',
       'LMP_CHANGE_UPDATE',
+      'REFERRAL_INCOMPLETE_UPDATE',
+      'ACCOMPANIED_REFERRAL_UPDATE',
+      'DATA_RESTORE_UPDATE',
+      'CLOSURE_REVIEW_UPDATE',
       'FORM_UPDATE',
       'DATA_SYNC_STATUS',
       'VISIT_NEAR_MISS',

--- a/apps/notification-escalation-service/src/notifications/dto/update-notification-status.dto.ts
+++ b/apps/notification-escalation-service/src/notifications/dto/update-notification-status.dto.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * Validation schema for PATCH /notifications/:id. Only READ/DISMISSED are
+ * client-settable transitions — UNREAD is the creation default and EXPIRED
+ * is system-managed, neither is a valid target of a caller-initiated update.
+ */
+export const updateNotificationStatusSchema = z
+  .object({
+    status: z.enum(['READ', 'DISMISSED']),
+  })
+  .strict();
+
+export type UpdateNotificationStatusInput = z.infer<typeof updateNotificationStatusSchema>;

--- a/apps/notification-escalation-service/src/notifications/notification.controller.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.controller.ts
@@ -1,5 +1,6 @@
 import { asyncHandler, ok, unauthorized } from '../app.module';
 import type { NotificationService } from './notification.service';
+import type { UpdateNotificationStatusInput } from './dto/update-notification-status.dto';
 
 /**
  * Notification request handlers. Mounted under the global `api/v1` prefix
@@ -7,8 +8,9 @@ import type { NotificationService } from './notification.service';
  */
 export function createNotificationController(service: NotificationService) {
   return {
-    list: asyncHandler(async (_req, res) => {
-      res.json(ok(await service.list()));
+    list: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      res.json(ok(await service.list(req.user)));
     }),
 
     create: asyncHandler(async (req, res, next) => {
@@ -17,6 +19,13 @@ export function createNotificationController(service: NotificationService) {
       if (!authorizationHeader) return next(unauthorized());
       const created = await service.create(req.body, req.user, authorizationHeader);
       res.status(201).json(ok(created));
+    }),
+
+    updateStatus: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const { status } = req.body as UpdateNotificationStatusInput;
+      const updated = await service.updateStatus(req.params.id, status, req.user);
+      res.json(ok(updated));
     }),
   };
 }

--- a/apps/notification-escalation-service/src/notifications/notification.repository.spec.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.repository.spec.ts
@@ -1,0 +1,29 @@
+import { NotificationRepository } from './notification.repository';
+
+/**
+ * `findMany` is the one method covered here for now — added specifically to
+ * regression-test the recipient-scoping fix: a service-level mock can't
+ * verify the actual Prisma `where` clause sent to the database.
+ */
+describe('NotificationRepository — findMany', () => {
+  const findMany = jest.fn();
+  const prisma = { notification: { findMany } } as never;
+  let repository: NotificationRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository = new NotificationRepository(prisma);
+  });
+
+  it('scopes the query to the given recipientUserId and excludes soft-deleted rows', async () => {
+    findMany.mockResolvedValue([]);
+
+    await repository.findMany('sakhi-1');
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { recipientUserId: 'sakhi-1', isDeleted: false },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+  });
+});

--- a/apps/notification-escalation-service/src/notifications/notification.repository.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.repository.ts
@@ -5,11 +5,41 @@ import type { CreateNotificationInput } from './dto/create-notification.dto';
 export class NotificationRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  findMany() {
-    return this.prisma.notification.findMany({ orderBy: { createdAt: 'desc' }, take: 50 });
+  findMany(recipientUserId: string) {
+    return this.prisma.notification.findMany({
+      where: { recipientUserId, isDeleted: false },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    });
+  }
+
+  findById(id: string) {
+    return this.prisma.notification.findFirst({ where: { id, isDeleted: false } });
   }
 
   create(data: CreateNotificationInput) {
     return this.prisma.notification.create({ data });
+  }
+
+  /**
+   * Marks a notification READ or DISMISSED. `recipientUserId` is part of the
+   * `where` (not just the service-layer check) so the ownership guard is
+   * concurrency-safe — `updateMany`'s affected count, not a separate
+   * read-then-write, decides whether the update actually applied. Same
+   * conditional-update pattern as EscalationRepository.updateStatus.
+   */
+  async updateStatus(
+    id: string,
+    recipientUserId: string,
+    status: 'READ' | 'DISMISSED',
+  ): Promise<boolean> {
+    const result = await this.prisma.notification.updateMany({
+      where: { id, recipientUserId, isDeleted: false },
+      data: {
+        status,
+        ...(status === 'READ' ? { readAt: new Date() } : { dismissedAt: new Date() }),
+      },
+    });
+    return result.count > 0;
   }
 }

--- a/apps/notification-escalation-service/src/notifications/notification.routes.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.routes.ts
@@ -3,14 +3,20 @@ import { z } from 'zod';
 import type { NotificationService } from './notification.service';
 import { createNotificationController } from './notification.controller';
 import { createNotificationSchema } from './dto/create-notification.dto';
+import { updateNotificationStatusSchema } from './dto/update-notification-status.dto';
 import {
   requireRoles,
   trustGatewayIdentity,
+  validate,
   validateBody,
   type DocumentedRouter,
 } from '../app.module';
 
 extendZodWithOpenApi(z);
+
+const notificationIdParamsSchema = z
+  .object({ id: z.string().uuid().openapi({ example: 'b3f1c2a0-1234-4a56-9abc-1234567890ab' }) })
+  .strict();
 
 const notificationSchema = z.object({
   id: z.string().uuid(),
@@ -80,13 +86,40 @@ export function registerNotificationRoutes(doc: DocumentedRouter, service: Notif
       },
     },
     trustGatewayIdentity,
-    // ADMIN direct use, plus SUPERVISOR so approval-service can notify a
-    // Sakhi on the caller's behalf after a Quick Response decision (it
-    // forwards the deciding Supervisor's own Authorization header, same
-    // pattern supervisor-operations-service's SakhiClient uses — no
-    // separate service-to-service credential scheme in this codebase yet).
-    requireRoles('ADMIN', 'SUPERVISOR'),
+    // ADMIN direct use; SUPERVISOR so approval-service can notify a Sakhi on
+    // the caller's behalf after a Quick Response decision (forwards the
+    // deciding Supervisor's own Authorization header); SYSTEM so the
+    // missed-visit/referral-followup/sync-delay cron jobs can notify a
+    // Supervisor via a service-account token (POST /auth/service-token).
+    requireRoles('ADMIN', 'SUPERVISOR', 'SYSTEM'),
     validateBody(createNotificationSchema),
     controller.create,
+  );
+
+  doc.patch(
+    '/notifications/:id',
+    {
+      summary: 'Mark a notification READ or DISMISSED',
+      tags: ['Notifications'],
+      params: notificationIdParamsSchema,
+      responses: {
+        200: { description: 'Notification updated', schema: envelope(notificationSchema) },
+        400: { description: 'Validation error', schema: apiErrorSchema },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: {
+          description: "Caller role not permitted, or not this notification's own recipient",
+          schema: apiErrorSchema,
+        },
+        404: { description: 'Notification not found', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    // Same roles as GET /notifications — ownership (caller must be
+    // recipientUserId) is enforced in NotificationService.updateStatus, not
+    // by role alone, since recipientUserId can belong to any of these roles.
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    validate(notificationIdParamsSchema, 'params'),
+    validateBody(updateNotificationStatusSchema),
+    controller.updateStatus,
   );
 }

--- a/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
@@ -6,13 +6,17 @@ import type { CreateNotificationInput } from './dto/create-notification.dto';
 describe('NotificationService', () => {
   const repository = {
     findMany: jest.fn(),
+    findById: jest.fn(),
     create: jest.fn(),
+    updateStatus: jest.fn(),
   } as unknown as jest.Mocked<NotificationRepository>;
   const sakhiClient = { findById: jest.fn() } as unknown as jest.Mocked<SakhiClient>;
   let service: NotificationService;
   const authHeader = 'Bearer token';
   const supervisor = { id: 'supervisor-1', roles: ['SUPERVISOR'] };
   const admin = { id: 'admin-1', roles: ['ADMIN'] };
+  const system = { id: 'system-1', roles: ['SYSTEM'] };
+  const sakhi = { id: 'jane.sakhi', roles: ['SAKHI'] };
 
   const dto: CreateNotificationInput = {
     recipientUserId: 'sakhi-1',
@@ -27,15 +31,25 @@ describe('NotificationService', () => {
     service = new NotificationService(repository, sakhiClient);
   });
 
-  it('lists via repository', async () => {
+  it("lists only the caller's own notifications via repository", async () => {
     repository.findMany.mockResolvedValue([]);
-    await expect(service.list()).resolves.toEqual([]);
-    expect(repository.findMany).toHaveBeenCalledTimes(1);
+    await expect(service.list(sakhi)).resolves.toEqual([]);
+    expect(repository.findMany).toHaveBeenCalledWith('jane.sakhi');
   });
 
   it('ADMIN may notify any recipient without an ownership check', async () => {
     repository.create.mockResolvedValue({ id: '1' } as never);
     await service.create(dto, admin, authHeader);
+    expect(sakhiClient.findById).not.toHaveBeenCalled();
+    expect(repository.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('SYSTEM may notify any recipient without an ownership check', async () => {
+    // The missed-visit/referral-followup/sync-delay cron jobs' service-
+    // account token sends recipientUserId values that are Supervisors, not
+    // Sakhis — the Sakhi-roster ownership check below doesn't apply to it.
+    repository.create.mockResolvedValue({ id: '1' } as never);
+    await service.create(dto, system, authHeader);
     expect(sakhiClient.findById).not.toHaveBeenCalled();
     expect(repository.create).toHaveBeenCalledWith(dto);
   });
@@ -66,5 +80,202 @@ describe('NotificationService', () => {
   it('propagates repository errors on create', async () => {
     repository.create.mockRejectedValue(new Error('db down'));
     await expect(service.create(dto, admin, authHeader)).rejects.toThrow('db down');
+  });
+
+  describe('supervisor fan-out', () => {
+    const escalationDto: CreateNotificationInput = {
+      ...dto,
+      notificationType: 'MISSED_VISIT_ESCALATION',
+    };
+    const transferDto: CreateNotificationInput = {
+      ...dto,
+      notificationType: 'BENEFICIARY_TRANSFER_NOTICE',
+    };
+    const dataRestoreDto: CreateNotificationInput = {
+      ...dto,
+      notificationType: 'DATA_RESTORE_UPDATE',
+    };
+    const closureReviewDto: CreateNotificationInput = {
+      ...dto,
+      notificationType: 'CLOSURE_REVIEW_UPDATE',
+    };
+
+    it('also notifies the assigned Supervisor for MISSED_VISIT_ESCALATION', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({
+        sakhiId: 'sakhi-1',
+        supervisorId: 'supervisor-9',
+      });
+
+      await service.create(escalationDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenNthCalledWith(1, escalationDto);
+      expect(repository.create).toHaveBeenNthCalledWith(2, {
+        ...escalationDto,
+        recipientUserId: 'supervisor-9',
+      });
+    });
+
+    it('also notifies the assigned Supervisor for BENEFICIARY_TRANSFER_NOTICE', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({
+        sakhiId: 'sakhi-1',
+        supervisorId: 'supervisor-9',
+      });
+
+      await service.create(transferDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(2);
+      expect(repository.create).toHaveBeenNthCalledWith(2, {
+        ...transferDto,
+        recipientUserId: 'supervisor-9',
+      });
+    });
+
+    it('does NOT notify the assigned Supervisor for DATA_RESTORE_UPDATE', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({
+        sakhiId: 'sakhi-1',
+        supervisorId: 'supervisor-9',
+      });
+
+      await service.create(dataRestoreDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(1);
+      expect(repository.create).toHaveBeenCalledWith(dataRestoreDto);
+    });
+
+    it('does NOT notify the assigned Supervisor for CLOSURE_REVIEW_UPDATE', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({
+        sakhiId: 'sakhi-1',
+        supervisorId: 'supervisor-9',
+      });
+
+      await service.create(closureReviewDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(1);
+      expect(repository.create).toHaveBeenCalledWith(closureReviewDto);
+    });
+
+    it('does NOT notify the assigned Supervisor when the Sakhi has no assigned Supervisor for DATA_RESTORE_UPDATE', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({ sakhiId: 'sakhi-1', supervisorId: null });
+
+      await service.create(dataRestoreDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fan out for non-escalation notification types', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+
+      await service.create(dto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(1);
+      expect(sakhiClient.findById).not.toHaveBeenCalled();
+    });
+
+    it('does not fan out when the Sakhi has no assigned Supervisor', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({ sakhiId: 'sakhi-1', supervisorId: null });
+
+      await service.create(escalationDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fan out to the same user twice if supervisorId equals the recipient', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({
+        sakhiId: 'sakhi-1',
+        supervisorId: escalationDto.recipientUserId,
+      });
+
+      await service.create(escalationDto, admin, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('the Sakhi notification still succeeds even if the Supervisor lookup fails', async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockRejectedValue(new Error('auth-service down'));
+
+      await expect(service.create(escalationDto, admin, authHeader)).resolves.toEqual({
+        id: '1',
+      });
+      expect(repository.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("a SUPERVISOR caller who is also the Sakhi's own assigned Supervisor gets fanned out to as normal", async () => {
+      repository.create.mockResolvedValue({ id: '1' } as never);
+      sakhiClient.findById.mockResolvedValue({
+        sakhiId: 'sakhi-1',
+        supervisorId: 'supervisor-1',
+      });
+
+      await service.create(escalationDto, supervisor, authHeader);
+
+      expect(repository.create).toHaveBeenCalledTimes(2);
+      expect(repository.create).toHaveBeenNthCalledWith(2, {
+        ...escalationDto,
+        recipientUserId: 'supervisor-1',
+      });
+    });
+  });
+
+  describe('updateStatus', () => {
+    const notification = {
+      id: 'notif-1',
+      recipientUserId: 'jane.sakhi',
+      status: 'UNREAD',
+    };
+
+    it('the recipient marking their own notification READ succeeds', async () => {
+      repository.findById.mockResolvedValue(notification as never);
+      repository.updateStatus.mockResolvedValue(true);
+      repository.findById.mockResolvedValueOnce(notification as never).mockResolvedValueOnce({
+        ...notification,
+        status: 'READ',
+      } as never);
+
+      const result = await service.updateStatus('notif-1', 'READ', sakhi);
+
+      expect(repository.updateStatus).toHaveBeenCalledWith('notif-1', 'jane.sakhi', 'READ');
+      expect(result).toMatchObject({ status: 'READ' });
+    });
+
+    it('the recipient marking their own notification DISMISSED succeeds', async () => {
+      repository.findById.mockResolvedValue(notification as never);
+      repository.updateStatus.mockResolvedValue(true);
+
+      await service.updateStatus('notif-1', 'DISMISSED', sakhi);
+
+      expect(repository.updateStatus).toHaveBeenCalledWith('notif-1', 'jane.sakhi', 'DISMISSED');
+    });
+
+    it('404s on an unknown notification id', async () => {
+      repository.findById.mockResolvedValue(null);
+      await expect(service.updateStatus('unknown-id', 'READ', sakhi)).rejects.toMatchObject({
+        status: 404,
+      });
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it("403s when the caller is not the notification's recipient", async () => {
+      repository.findById.mockResolvedValue(notification as never);
+      await expect(service.updateStatus('notif-1', 'READ', supervisor)).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(repository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('404s when the conditional update races with a concurrent delete', async () => {
+      repository.findById.mockResolvedValue(notification as never);
+      repository.updateStatus.mockResolvedValue(false);
+      await expect(service.updateStatus('notif-1', 'READ', sakhi)).rejects.toMatchObject({
+        status: 404,
+      });
+    });
   });
 });

--- a/apps/notification-escalation-service/src/notifications/notification.service.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.ts
@@ -1,7 +1,8 @@
-import { forbidden } from '@armman/service-commons';
+import { forbidden, notFound } from '@armman/service-commons';
 import type { NotificationRepository } from './notification.repository';
 import type { SakhiClient } from './sakhi.client';
 import type { CreateNotificationInput } from './dto/create-notification.dto';
+import { fanOutToSupervisor } from './supervisor-fanout';
 
 export interface CallerIdentity {
   id: string;
@@ -15,25 +16,60 @@ export class NotificationService {
     private readonly sakhiClient: SakhiClient,
   ) {}
 
-  list() {
-    return this.repository.findMany();
+  list(caller: CallerIdentity) {
+    return this.repository.findMany(caller.id);
   }
 
   /**
-   * ADMIN may notify anyone. A SUPERVISOR (the role widened for approval-
-   * service's Quick Response decisions to forward through) may only notify
-   * a Sakhi actually assigned to them — verified via auth-service, same
-   * ownership check supervisor-operations-service already applies to its
-   * own Sakhi-scoped endpoints. Without this, the widened role would let
-   * any Supervisor notify any recipientUserId.
+   * ADMIN and SYSTEM may notify anyone — SYSTEM is a machine identity (the
+   * missed-visit/referral-followup/sync-delay cron jobs' service-account
+   * token, per requireRoles('ADMIN', 'SUPERVISOR', 'SYSTEM') on this route)
+   * sending recipientUserId values that are Supervisors, not Sakhis, so the
+   * Sakhi-roster ownership check below doesn't apply to it (and would always
+   * 403 it, since sakhiClient.findById on a Supervisor id resolves to
+   * nothing). A SUPERVISOR (the role widened for approval-service's Quick
+   * Response decisions to forward through) may only notify a Sakhi actually
+   * assigned to them — verified via auth-service, same ownership check
+   * supervisor-operations-service already applies to its own Sakhi-scoped
+   * endpoints. Without this, the widened role would let any Supervisor
+   * notify any recipientUserId.
+   *
+   * For escalation/operational notification types, also best-effort fans
+   * out a copy to the Sakhi's assigned Supervisor (see supervisor-fanout.ts).
    */
   async create(dto: CreateNotificationInput, caller: CallerIdentity, authorizationHeader: string) {
-    if (!caller.roles.includes('ADMIN')) {
+    if (!caller.roles.includes('ADMIN') && !caller.roles.includes('SYSTEM')) {
       const sakhi = await this.sakhiClient.findById(dto.recipientUserId, authorizationHeader);
       if (!sakhi || sakhi.supervisorId !== caller.id) {
         throw forbidden('You do not have access to notify this Sakhi.');
       }
     }
-    return this.repository.create(dto);
+    const created = await this.repository.create(dto);
+    await fanOutToSupervisor(this.repository, this.sakhiClient, dto, authorizationHeader);
+    return created;
+  }
+
+  /**
+   * Marks a notification READ or DISMISSED. Ownership-only — the caller
+   * must be the notification's own recipientUserId (Sakhi dashboard banner
+   * dismiss, Supervisor notifications list tap-to-read); no ADMIN bypass,
+   * unlike create(), since there's no cross-user "mark read on behalf of"
+   * use case here.
+   */
+  async updateStatus(id: string, status: 'READ' | 'DISMISSED', caller: CallerIdentity) {
+    const existing = await this.repository.findById(id);
+    if (!existing) throw notFound('Notification not found.');
+    if (existing.recipientUserId !== caller.id) {
+      throw forbidden('You do not have access to this notification.');
+    }
+
+    const updated = await this.repository.updateStatus(id, caller.id, status);
+    if (!updated) {
+      // Raced with a delete between the read above and the conditional
+      // update — same outcome as a not-found, just caught a beat later.
+      throw notFound('Notification not found.');
+    }
+
+    return this.repository.findById(id);
   }
 }

--- a/apps/notification-escalation-service/src/notifications/supervisor-fanout.ts
+++ b/apps/notification-escalation-service/src/notifications/supervisor-fanout.ts
@@ -1,0 +1,42 @@
+import type { NotificationRepository } from './notification.repository';
+import type { CreateNotificationInput } from './dto/create-notification.dto';
+
+interface SakhiLookup {
+  findById(
+    sakhiId: string,
+    authorizationHeader: string,
+  ): Promise<{ supervisorId: string | null } | null>;
+}
+
+/** Notification types relevant enough to a Supervisor's own roster that she
+ * should get a copy too, distinct from purely personal decision-outcome
+ * notifications (e.g. LMP_CHANGE_UPDATE, DATA_RESTORE_UPDATE,
+ * CLOSURE_REVIEW_UPDATE, REOPEN_UPDATE) that stay Sakhi-only. */
+const SUPERVISOR_FANOUT_TYPES = new Set(['MISSED_VISIT_ESCALATION', 'BENEFICIARY_TRANSFER_NOTICE']);
+
+/**
+ * Best-effort: also creates a copy of the notification addressed to the
+ * Sakhi's assigned Supervisor, for the notification types relevant to her
+ * roster. Failures here (Sakhi lookup down, no assigned Supervisor) are
+ * logged, never thrown — the Sakhi's own notification is already created by
+ * the time this runs and must not be rolled back or blocked by this.
+ */
+export async function fanOutToSupervisor(
+  notificationRepository: NotificationRepository,
+  sakhiClient: SakhiLookup,
+  dto: CreateNotificationInput,
+  authorizationHeader: string,
+): Promise<void> {
+  if (!SUPERVISOR_FANOUT_TYPES.has(dto.notificationType)) return;
+  try {
+    const sakhi = await sakhiClient.findById(dto.recipientUserId, authorizationHeader);
+    if (sakhi?.supervisorId && sakhi.supervisorId !== dto.recipientUserId) {
+      await notificationRepository.create({ ...dto, recipientUserId: sakhi.supervisorId });
+    }
+  } catch (err) {
+    console.error(
+      `Failed to notify the Supervisor of Sakhi ${dto.recipientUserId}'s notification:`,
+      err,
+    );
+  }
+}

--- a/apps/rules-service/src/main.ts
+++ b/apps/rules-service/src/main.ts
@@ -22,4 +22,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/rules-service/src/rules/ruleVersion.routes.ts
+++ b/apps/rules-service/src/rules/ruleVersion.routes.ts
@@ -376,7 +376,10 @@ export function registerRuleVersionRoutes(doc: DocumentedRouter, service: RuleVe
       summary:
         "Evaluate the rule set's currently-published gorules ESCALATION decision graph " +
         '(missed-visit escalation, SRS §3A.2.7 FR-S-7.1) against caller-supplied ' +
-        'visitFamily/isHrVisit/consecutiveMissedCount. Never evaluates against a DRAFT version.',
+        'visitFamily/isHrVisit/consecutiveMissedCount. Never evaluates against a DRAFT version. ' +
+        "Gated by requireRoles('SAKHI', 'SYSTEM') — SYSTEM is the missed-visit/referral-followup " +
+        'cron jobs calling in via a service-account token (POST /auth/service-token), not a ' +
+        'human SAKHI request.',
       tags: ['Rules'],
       params: setIdParamsSchema,
       responses: {
@@ -395,7 +398,7 @@ export function registerRuleVersionRoutes(doc: DocumentedRouter, service: RuleVe
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI'),
+    requireRoles('SAKHI', 'SYSTEM'),
     validate(setIdParamsSchema, 'params'),
     validateBody(evaluateEscalationRequestSchema),
     controller.evaluateEscalation,


### PR DESCRIPTION
## Summary
- Adds support for system-raised and sync-delay escalations, supervisor fanout, and missing notification types in notification-escalation-service
- Allows the system role to call the escalation rule-set evaluate endpoint in rules-service
- The feature/transfer-escalation split (module: notification-escalation-service + rules-service)

## Test plan
- [x] `nx run notification-escalation-service:test` — 9 suites / 157 tests passing
- [x] `nx run rules-service:test` — 9 suites / 183 tests passing