### PR TITLE
fix: Seed ANC/Infant RISK rule packs and grade Sickle Cell Disease

### DIFF
--- a/apps/risk-referral-service/prisma/seed-data/anc-risk-conditions.json
+++ b/apps/risk-referral-service/prisma/seed-data/anc-risk-conditions.json
@@ -131,5 +131,12 @@
     "gradeScale": "BINARY",
     "referralRequiredDefault": true,
     "educationRequiredDefault": true
+  },
+  {
+    "conditionCode": "SICKLE_CELL_DISEASE",
+    "conditionName": "Sickle Cell Disease (SCD)",
+    "gradeScale": "BINARY",
+    "referralRequiredDefault": true,
+    "educationRequiredDefault": true
   }
 ]

--- a/apps/risk-referral-service/prisma/seed-data/self-reported-conditions.json
+++ b/apps/risk-referral-service/prisma/seed-data/self-reported-conditions.json
@@ -26,6 +26,5 @@
     "conditionCode": "MENTAL_HEALTH_CONDITION",
     "conditionName": "Mental health condition (e.g., depression, anxiety)"
   },
-  { "conditionCode": "SICKLE_CELL_DISEASE", "conditionName": "Sickle Cell Disease (SCD)" },
   { "conditionCode": "SICKLE_CELL_TRAIT", "conditionName": "Sickle Cell Trait (SCT)/Carrier" }
 ]

--- a/apps/rules-service/prisma/seed.ts
+++ b/apps/rules-service/prisma/seed.ts
@@ -8,6 +8,8 @@ import { ccvRulesJson } from '../src/rules/scheduling/ccv.rulesJson';
 import { hrRulesJson } from '../src/rules/scheduling/hr.rulesJson';
 import { deliveryRulesJson } from '../src/rules/scheduling/delivery.rulesJson';
 import { escalationRulesJson } from '../src/rules/scheduling/escalation.rulesJson';
+import { ancRiskRulesJson } from '../src/rules/scheduling/anc-risk.rulesJson';
+import { infantRiskRulesJson } from '../src/rules/scheduling/infant-risk.rulesJson';
 
 const prisma = new PrismaClient();
 
@@ -147,6 +149,65 @@ async function seedEscalationRulePacks(): Promise<void> {
   }
 }
 
+// The two RISK-category clinical grading packs (ANC High-Risk grading /
+// Infant High-Risk grading — see anc-risk.rulesJson.ts and
+// infant-risk.rulesJson.ts's own doc comments). Previously created only via
+// out-of-band POST /admin/rules calls in every environment, never by this
+// seed script — meaning a fresh environment's ANC_VISIT/NEONATAL_VISIT/
+// INC_VISIT/CCV_VISIT submissions had no risk-grading RuleSet to point at
+// (visit-form-service's FormDefinition.riskRuleSetId had nothing to
+// reference) until someone manually bootstrapped one. Fixed UUIDs (distinct
+// '55555555...' prefix from SCHEDULE's '33333333...' / ESCALATION's
+// '44444444...') so visit-form-service's seed (below) can wire
+// FormDefinition.riskRuleSetId to a known id rather than a value discovered
+// after the fact. Same upsert-once pattern as the packs above: `update: {}`
+// only ever creates these on a fresh environment — an existing environment's
+// already-published RuleVersion is never silently rewritten by re-seeding;
+// a real content change is a new versionNo via POST /admin/rules/:setId/publish.
+const RISK_RULE_PACKS = [
+  {
+    ruleSetId: '55555555-5555-4555-8555-555555555551',
+    ruleVersionId: '55555555-5555-4555-8555-555555555552',
+    ruleSetName: 'Arogya Sakhi ANC Clinical Risk Grading',
+    rulesJson: ancRiskRulesJson,
+  },
+  {
+    ruleSetId: '55555555-5555-4555-8555-555555555561',
+    ruleVersionId: '55555555-5555-4555-8555-555555555562',
+    ruleSetName: 'Arogya Sakhi Infant Clinical Risk Grading',
+    rulesJson: infantRiskRulesJson,
+  },
+] as const;
+
+async function seedRiskRulePacks(): Promise<void> {
+  for (const pack of RISK_RULE_PACKS) {
+    await prisma.ruleSet.upsert({
+      where: { id: pack.ruleSetId },
+      create: {
+        id: pack.ruleSetId,
+        ruleCategory: 'RISK',
+        ruleSetName: pack.ruleSetName,
+        status: 'ACTIVE',
+      },
+      update: {},
+    });
+
+    await prisma.ruleVersion.upsert({
+      where: { id: pack.ruleVersionId },
+      create: {
+        id: pack.ruleVersionId,
+        ruleSetId: pack.ruleSetId,
+        versionNo: 'v1',
+        rulesJson: pack.rulesJson,
+        effectiveFrom: new Date('2026-08-10'),
+        checksum: createHash('sha256').update(JSON.stringify(pack.rulesJson)).digest(),
+        status: 'PUBLISHED',
+      },
+      update: {},
+    });
+  }
+}
+
 /**
  * Seeds the SCHEDULE rule set + its v1-hardcoded published version, so
  * VisitSchedule.generatedByRuleVersionId (NOT NULL, no default) has a real
@@ -204,6 +265,9 @@ async function main(): Promise<void> {
 
   await seedEscalationRulePacks();
   console.log(`Seeded ${ESCALATION_RULE_PACKS.length} escalation rule pack(s).`);
+
+  await seedRiskRulePacks();
+  console.log(`Seeded ${RISK_RULE_PACKS.length} clinical risk-grading rule pack(s) (ANC/Infant).`);
 }
 
 main()

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
@@ -540,13 +540,40 @@ describe('ancRiskRulesJson', () => {
     await expect(evaluateRulePack(ancRiskRulesJson, rest)).rejects.toThrow();
   });
 
-  it('throws when conditionIds is missing an entry the graded vitals require', async () => {
+  it('skips only the affected condition when conditionIds is missing an entry the graded vitals require, grading everything else normally', async () => {
     const incompleteIds: Record<string, string | undefined> = { ...CONDITION_IDS };
     incompleteIds.ANEMIA = undefined;
 
-    await expect(
-      evaluateRulePack(ancRiskRulesJson, { ...NORMAL_VITALS, conditionIds: incompleteIds }),
-    ).rejects.toThrow();
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      conditionIds: incompleteIds,
+    });
+
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.ANEMIA)).toBe(false);
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.AGE)).toBe(true);
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.HYPERTENSION)).toBe(
+      true,
+    );
+    expect(result.conditions.length).toBeGreaterThan(0);
+  });
+
+  it('skips Sickle Cell Disease gracefully (does not abort the rest of grading) when its conditionId mapping is missing — the realistic already-seeded-environment scenario', async () => {
+    const idsWithoutScd: Record<string, string | undefined> = { ...CONDITION_IDS };
+    idsWithoutScd.SICKLE_CELL_DISEASE = undefined;
+
+    const result = await evaluateRulePack(ancRiskRulesJson, {
+      ...NORMAL_VITALS,
+      conditionIds: idsWithoutScd,
+      sickleCellStatus: 'sickle_cell_disease_scd',
+    });
+
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.SICKLE_CELL_DISEASE),
+    ).toBe(false);
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.ANEMIA)).toBe(true);
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.HYPERTENSION)).toBe(
+      true,
+    );
   });
 
   describe('Sickle Cell Disease (interim measure pending issue #191 tier confirmation)', () => {

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.spec.ts
@@ -25,6 +25,7 @@ const CONDITION_IDS = {
   JAUNDICE: '11111111-1111-1111-1111-111111111117',
   URINE_ANALYSIS: '11111111-1111-1111-1111-111111111118',
   DANGER_SIGNS: '11111111-1111-1111-1111-111111111119',
+  SICKLE_CELL_DISEASE: '11111111-1111-1111-1111-111111111120',
 };
 
 // Real ANC_VISIT question codes (see
@@ -546,5 +547,84 @@ describe('ancRiskRulesJson', () => {
     await expect(
       evaluateRulePack(ancRiskRulesJson, { ...NORMAL_VITALS, conditionIds: incompleteIds }),
     ).rejects.toThrow();
+  });
+
+  describe('Sickle Cell Disease (interim measure pending issue #191 tier confirmation)', () => {
+    it('grades SEVERE with referral and HR-visit triggers when SCD is selected, on first instance', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        sickleCellStatus: 'sickle_cell_disease_scd',
+        isFirstInstance: { SICKLE_CELL_DISEASE: true },
+      });
+
+      const condition = findCondition(result, CONDITION_IDS.SICKLE_CELL_DISEASE);
+      expect(condition.grade).toBe('SEVERE');
+      expect(condition.isReferralTrigger).toBe(true);
+      expect(condition.isHrVisitTrigger).toBe(true);
+    });
+
+    it('grades NORMAL when sickleCellStatus is absent or a non-SCD answer', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        sickleCellStatus: 'tested_and_result_is_normal',
+      });
+
+      const condition = findCondition(result, CONDITION_IDS.SICKLE_CELL_DISEASE);
+      expect(condition.grade).toBe('NORMAL');
+      expect(condition.isReferralTrigger).toBe(false);
+      expect(condition.isHrVisitTrigger).toBe(false);
+    });
+
+    it('grades SEVERE and suppresses only the referral trigger on a repeat (non-first) instance — HR-visit trigger fires every instance, matching Age/MUAC/Stunting/BOH', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        sickleCellStatus: 'sickle_cell_disease_scd',
+        isFirstInstance: { SICKLE_CELL_DISEASE: false },
+      });
+
+      const condition = findCondition(result, CONDITION_IDS.SICKLE_CELL_DISEASE);
+      expect(condition.grade).toBe('SEVERE');
+      expect(condition.isReferralTrigger).toBe(false);
+      expect(condition.isHrVisitTrigger).toBe(true);
+    });
+
+    it('defaults to first-instance (triggers fire) when isFirstInstance omits this condition', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        sickleCellStatus: 'sickle_cell_disease_scd',
+      });
+
+      const condition = findCondition(result, CONDITION_IDS.SICKLE_CELL_DISEASE);
+      expect(condition.isReferralTrigger).toBe(true);
+      expect(condition.isHrVisitTrigger).toBe(true);
+    });
+
+    it('grades NORMAL for Sickle Cell Trait (SCT) — grading impact unconfirmed, not implemented (issue #191)', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        sickleCellStatus: 'sickle_cell_trait_sct_carrier',
+      });
+
+      expect(findCondition(result, CONDITION_IDS.SICKLE_CELL_DISEASE).grade).toBe('NORMAL');
+    });
+
+    it('is omitted entirely when sickleCellStatus is not present, matching Bad Obstetric History\'s "no registration data yet" behavior', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, NORMAL_VITALS);
+
+      expect(
+        result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.SICKLE_CELL_DISEASE),
+      ).toBe(false);
+    });
+
+    it('is present (graded NORMAL) per §D.7 whenever sickleCellStatus is supplied, even with a non-SCD answer', async () => {
+      const result = await evaluateRulePack(ancRiskRulesJson, {
+        ...NORMAL_VITALS,
+        sickleCellStatus: 'tested_and_result_is_normal',
+      });
+
+      expect(
+        result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.SICKLE_CELL_DISEASE),
+      ).toBe(true);
+    });
   });
 });

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
@@ -74,11 +74,30 @@
  * them; not implemented pending ARMMAN confirming whether new form fields
  * are needed (issue #191).
  *
- * Sickle Cell is not read or graded by this pack at all. Appendix D's
- * Anemia table ties Sickle Cell Disease to the Moderate tier (confirmed,
- * issue #191) — not yet implemented since MOTHER_REGISTRATION has no
- * sickle-cell field wired into this pack's input today. Sickle Cell
- * Trait's effect on grading, if any, is unconfirmed.
+ * Sickle Cell Disease (SCD) is graded as an INTERIM MEASURE, pending GitHub
+ * issue #191 (item 10): Appendix D's Anemia table ties SCD to the Moderate
+ * tier, but the app-form spec (Q60) says SCD selected -> Severe risk +
+ * referral — these two sources conflict and ARMMAN has not yet confirmed
+ * which is correct. This pack currently grades SCD as SEVERE, matching the
+ * app-form spec, since that's the more specific source for this exact
+ * question and matches the field's own stated risk action. If issue #191
+ * is answered as Moderate instead, this grading must be revisited. Sickle
+ * Cell Trait (SCT) is deliberately left ungraded — its effect, if any, is
+ * also unconfirmed by #191.
+ *
+ * SCD is graded at the beneficiary's first ANC_VISIT (via
+ * sickleCellStatus, merged in from MOTHER_REGISTRATION by
+ * resolveAncRiskRegistrationAnswers), not at registration itself —
+ * MOTHER_REGISTRATION has no working risk-grading pipeline: its
+ * FormDefinition.riskRuleSetId is unset, and registration submissions
+ * carry no visitId, which form.service.ts's risk-assessment trigger also
+ * requires. Wiring registration-time grading properly would need a new
+ * VisitCodeType, a new RuleSet/RuleVersion, and changes to that guard —
+ * out of scope for this interim measure. KNOWN GAP: a beneficiary who
+ * registers with SCD but never submits a follow-up ANC_VISIT is never
+ * graded, and so never gets the referral/HR visit this condition should
+ * trigger — accepted as the trade-off for this interim measure, not
+ * silently overlooked.
  *
  * Age and Bad Obstetric History are captured once at MOTHER_REGISTRATION,
  * not on the recurring ANC_VISIT form — the caller (riskAssessment.service.ts
@@ -215,6 +234,27 @@ const handler = (input, { dayjs }) => {
 
     const grade = badObstetricHistoryFlag ? 'MILD' : 'NORMAL';
     record('BAD_OBSTETRIC_HISTORY', grade, { badObstetricHistoryFlag }, {
+      onlyFirstInstance: true,
+      referralTrigger: grade !== 'NORMAL',
+      hrVisitTrigger: grade !== 'NORMAL',
+    });
+  }
+
+  // --- Sickle Cell Disease (only first instance) — INTERIM MEASURE, see
+  // this pack's top doc comment. Graded SEVERE per the app-form spec (Q60:
+  // "High risk if SCD selected... at severe risk + referral"), NOT
+  // Appendix D's Anemia table (which ties SCD to Moderate) — the two
+  // sources conflict and the correct tier is unconfirmed pending GitHub
+  // issue #191 (item 10). Sickle Cell Trait (SCT) is deliberately left
+  // ungraded — its impact, if any, is also unconfirmed by #191.
+  // sickleCellStatus is merged in by form.service.ts from
+  // MOTHER_REGISTRATION's SCD/SCT question, read at the beneficiary's
+  // first ANC_VISIT (not at registration itself — see this pack's doc
+  // comment for why registration-time grading isn't wired up).
+  const sickleCellStatus = input.sickleCellStatus;
+  if (typeof sickleCellStatus === 'string') {
+    const grade = sickleCellStatus === 'sickle_cell_disease_scd' ? 'SEVERE' : 'NORMAL';
+    record('SICKLE_CELL_DISEASE', grade, { sickleCellStatus }, {
       onlyFirstInstance: true,
       referralTrigger: grade !== 'NORMAL',
       hrVisitTrigger: grade !== 'NORMAL',

--- a/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/anc-risk.rulesJson.ts
@@ -133,23 +133,31 @@ const handler = (input, { dayjs }) => {
 
   const results = [];
 
-  function requireConditionId(code) {
-    const id = conditionIds[code];
-    if (!id) throw new Error('conditionIds is missing an entry for ' + code);
-    return id;
-  }
-
   // Pushes one graded condition result. onlyFirstInstance conditions get
   // referralTrigger/hrVisitTrigger gated by firstInstance[code]; other
   // conditions use their own trigger rule directly.
+  //
+  // A missing conditionIds entry for the given code skips ONLY this
+  // condition — every other condition's record() call still runs. Before
+  // this fix, a missing mapping threw synchronously and aborted the whole
+  // handler, silently losing every condition graded after it in source
+  // order; that is a realistic failure mode (not theoretical) whenever a
+  // new condition is added to this pack before risk_conditions/
+  // RiskCondition.phase has been backfilled in a given environment — see
+  // PR #208 review. No console/logging available in this GoRules sandbox
+  // (confirmed: no other rule pack in this repo calls console.*), so the
+  // skip is silent here; the caller (rules-service's evaluate endpoint) is
+  // where any visibility into a missing mapping would need to be added.
   function record(code, grade, observedValueJson, opts) {
+    const riskConditionId = conditionIds[code];
+    if (!riskConditionId) return;
     opts = opts || {};
     const gateByFirstInstance = opts.onlyFirstInstance === true;
     const isFirst = firstInstance[code] !== false; // default true if unknown
     const referralEligible = opts.referralTrigger === true;
     const hrEligible = opts.hrVisitTrigger === true;
     results.push({
-      riskConditionId: requireConditionId(code),
+      riskConditionId,
       grade,
       gradeRank: GRADE_RANK[grade],
       isReferralTrigger: gateByFirstInstance ? referralEligible && isFirst : referralEligible,

--- a/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.spec.ts
+++ b/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.spec.ts
@@ -422,15 +422,19 @@ describe('infantRiskRulesJson', () => {
     expect(result.overallRiskCategory).toBe('LOW');
   });
 
-  it('throws when conditionIds is missing an entry a graded input requires', async () => {
+  it('skips only the affected condition when conditionIds is missing an entry a graded input requires, grading everything else normally', async () => {
     const incompleteIds: Record<string, string | undefined> = { ...CONDITION_IDS };
     incompleteIds.WASTING = undefined;
 
-    await expect(
-      evaluateRulePack(infantRiskRulesJson, {
-        ...NORMAL_VITALS_INFANT,
-        conditionIds: incompleteIds,
-      }),
-    ).rejects.toThrow();
+    const result = await evaluateRulePack(infantRiskRulesJson, {
+      ...NORMAL_VITALS_INFANT,
+      conditionIds: incompleteIds,
+    });
+
+    expect(result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.WASTING)).toBe(false);
+    expect(
+      result.conditions.some((c) => c.riskConditionId === CONDITION_IDS.LOW_BIRTH_WEIGHT),
+    ).toBe(true);
+    expect(result.conditions.length).toBeGreaterThan(0);
   });
 });

--- a/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.ts
+++ b/apps/rules-service/src/rules/scheduling/infant-risk.rulesJson.ts
@@ -109,24 +109,29 @@ const handler = (input) => {
 
   const results = [];
 
-  function requireConditionId(code) {
-    const id = conditionIds[code];
-    if (!id) throw new Error('conditionIds is missing an entry for ' + code);
-    return id;
-  }
-
   // hrGateByFirstInstance: for Hypothermia/Hyperthermia/Danger Signs, whose
   // HR-visit trigger is "single instance" per Appendix D Part 2 (unlike the
   // nutrition conditions above them, which HR-visit-trigger every instance
   // till normal) — see PR #172 review. isFirst defaults to true when the
   // caller's isFirstInstance map has no entry for this code, matching
   // anc-risk.rulesJson.ts's same default-true convention.
+  //
+  // A missing conditionIds entry for the given code skips ONLY this
+  // condition — every other condition's record() call still runs, matching
+  // anc-risk.rulesJson.ts's identical fix (see PR #208 review — a throw
+  // here previously aborted every condition graded after it in source
+  // order, a realistic failure mode whenever a new condition is added
+  // before risk_conditions/RiskCondition.phase is backfilled). No
+  // console/logging available in this GoRules sandbox, so the skip is
+  // silent — same rationale as anc-risk.rulesJson.ts.
   function record(code, grade, observedValueJson, opts) {
+    const riskConditionId = conditionIds[code];
+    if (!riskConditionId) return;
     opts = opts || {};
     const isFirst = firstInstance[code] !== false;
     const hrEligible = opts.hrVisitTrigger === true;
     results.push({
-      riskConditionId: requireConditionId(code),
+      riskConditionId,
       grade,
       gradeRank: GRADE_RANK[grade],
       isReferralTrigger: opts.referralTrigger === true,

--- a/apps/visit-form-service/prisma/seed.ts
+++ b/apps/visit-form-service/prisma/seed.ts
@@ -27,7 +27,19 @@ interface FormDraft {
   entityType: 'MOTHER' | 'CHILD' | 'REFERRAL' | 'SYSTEM';
   versionNo: string;
   payload: { schemaJson: unknown[]; validationJson: unknown[] };
+  // rules-service's rule_sets.rule_set_id — no cross-service relation
+  // (forklift rule), so these are the fixed ids rules-service's own seed.ts
+  // assigns its RISK_RULE_PACKS entries. Omitted for every formCode with no
+  // corresponding RiskCondition.phase rule pack in code today
+  // (REGISTRATION/DELIVERY/PP) — wiring one of those would pass createSubmission's
+  // FORM_CODE_TO_RISK_PHASE guard but the rule pack itself doesn't exist,
+  // failing every submission (see form.service.ts's guard comment).
+  riskRuleSetId?: string;
 }
+
+// Must match rules-service/prisma/seed.ts's RISK_RULE_PACKS fixed ids exactly.
+const ANC_RISK_RULE_SET_ID = '55555555-5555-4555-8555-555555555551';
+const INFANT_RISK_RULE_SET_ID = '55555555-5555-4555-8555-555555555561';
 
 /** Same checksum computation as FormService — sha256 over the schema JSON. */
 function computeChecksum(schemaJson: unknown): Buffer {
@@ -70,6 +82,7 @@ const FORMS: FormDraft[] = [
     entityType: 'MOTHER',
     versionNo: 'v1',
     payload: ancVisitPayload,
+    riskRuleSetId: ANC_RISK_RULE_SET_ID,
   },
   {
     formCode: 'INFANT_VISIT',
@@ -90,6 +103,7 @@ const FORMS: FormDraft[] = [
     entityType: 'CHILD',
     versionNo: 'v1',
     payload: infantVisitPayload,
+    riskRuleSetId: INFANT_RISK_RULE_SET_ID,
   },
   // CCV (13-24m) is confirmed in SRS v3.0 to reuse INC's clinical fields and
   // HR thresholds verbatim — "No separate CCV-specific guidelines required"
@@ -102,6 +116,7 @@ const FORMS: FormDraft[] = [
     entityType: 'CHILD',
     versionNo: 'v1',
     payload: infantVisitPayload,
+    riskRuleSetId: INFANT_RISK_RULE_SET_ID,
   },
   {
     formCode: 'DELIVERY_VISIT',
@@ -123,6 +138,7 @@ const FORMS: FormDraft[] = [
     entityType: 'CHILD',
     versionNo: 'v1',
     payload: neonatalVisitPayload,
+    riskRuleSetId: INFANT_RISK_RULE_SET_ID,
   },
   // Referral, closure, and reopen workflow forms — transcribed field-for-field
   // from docs/Revised_App_Form_Final_20.3.26.xlsx.md ("Referral form",
@@ -189,6 +205,7 @@ async function seedForms(): Promise<SeedResult> {
         formName: form.formName,
         entityType: form.entityType,
         status: 'ACTIVE',
+        riskRuleSetId: form.riskRuleSetId ?? null,
         formVersions: {
           create: {
             versionNo: form.versionNo,

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -2086,6 +2086,62 @@ describe('FormService', () => {
         );
       });
 
+      it('merges sickleCellStatus from the registration submission when present', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: {
+            gravida_total_number_of_pregnancies: 2,
+            have_you_been_detected_with_sickle_cell_disease_or_sickle_cell_trait_sct:
+              'sickle_cell_disease_scd',
+          },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: expect.objectContaining({ sickleCellStatus: 'sickle_cell_disease_scd' }),
+          }),
+          'Bearer test-token',
+        );
+      });
+
+      it('omits sickleCellStatus when the registration submission has no answer for it', async () => {
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { gravida_total_number_of_pregnancies: 2 },
+        } as never);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            visitId: 'visit-1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(jest.mocked(triggerRiskAssessment)).toHaveBeenCalledWith(
+          expect.objectContaining({
+            answers: expect.not.objectContaining({ sickleCellStatus: expect.anything() }),
+          }),
+          'Bearer test-token',
+        );
+      });
+
       it('proceeds without registration-derived answers when no MOTHER_REGISTRATION submission exists', async () => {
         repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue(null);
 

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -585,6 +585,13 @@ export class FormService {
     const complications =
       answers.did_you_experience_any_complications_during_birth_delivery_in_previous_pregnancies;
     const lmpDate = answers.lmp_date;
+    // Sickle Cell Disease/Trait (MOTHER_REGISTRATION Q60) — read at the
+    // beneficiary's first ANC_VISIT rather than graded at registration
+    // itself, since anc-risk.rulesJson.ts (RISK category) is the only rule
+    // pack this beneficiary's answers are evaluated against; see that pack's
+    // top doc comment for the interim-measure rationale (issue #191).
+    const sickleCellStatus =
+      answers.have_you_been_detected_with_sickle_cell_disease_or_sickle_cell_trait_sct;
 
     return {
       ...(typeof age === 'number' ? { age } : {}),
@@ -593,6 +600,7 @@ export class FormService {
       ...(typeof abortions === 'number' ? { abortions } : {}),
       ...(Array.isArray(complications) ? { priorComplications: complications } : {}),
       ...(typeof lmpDate === 'string' ? { lmpDate } : {}),
+      ...(typeof sickleCellStatus === 'string' ? { sickleCellStatus } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

- rules-service's `prisma/seed.ts` never created the ANC/Infant RISK RuleSets — only SCHEDULE and ESCALATION packs were seeded. A fresh environment had **no working clinical risk grading at all**; the RuleSets in dev/prod only existed because someone bootstrapped them ad-hoc via the admin API, under untracked UUIDs, disconnected from the seed script.
- visit-form-service's `prisma/seed.ts` never wired `FormDefinition.riskRuleSetId` on any form — even with a RuleSet seeded, nothing pointed at it.
- Adds fixed-UUID `RISK_RULE_PACKS` (ANC + Infant) to rules-service's seed, matching the existing `SCHEDULING_RULE_PACKS`/`ESCALATION_RULE_PACKS` upsert-once pattern, and wires `ANC_VISIT`/`NEONATAL_VISIT`/`INC_VISIT`/`CCV_VISIT` to them. `MOTHER_REGISTRATION`/`CHILD_REGISTRATION`/`DELIVERY_VISIT`/`POSTPARTUM_VISIT` are deliberately left unwired — no REGISTRATION/DELIVERY/PP rule pack exists in code yet.
- Also grades **Sickle Cell Disease** (SEVERE, interim measure — see `anc-risk.rulesJson.ts`'s doc comment, pending #191's tier confirmation) at the beneficiary's first ANC_VISIT, merged in from the MOTHER_REGISTRATION answer via `form.service.ts`. Moves the `SICKLE_CELL_DISEASE` risk-referral-service seed row from `REGISTRATION` to `ANC` phase to match — it was previously seeded under a phase no risk-grading evaluation ever runs against, so it was silently never graded, which is the original bug this was found while investigating ("High Risk Visit schedule not generated after SCD detection at enrollment").

Discovered while fixing that bug: the SCD grading fix alone had zero effect until this seeding gap was found and fixed — publishing new rule content is meaningless if nothing wires the RuleSet to the form that submits against it.

Closes #207

## Test plan

- [x] `nx test rules-service` — 190/190 pass
- [x] `nx test visit-form-service` — 589/589 pass
- [x] `nx test risk-referral-service` — 234/234 pass
- [x] `nx lint` clean on all three services
- [x] `tsc --noEmit` clean on rules-service and visit-form-service
- [ ] Seed scripts not run against a live fresh DB in this PR (only the shared dev environment was available, which already has ad-hoc RISK RuleSets under different UUIDs from prior manual bootstrapping — running seed there would add parallel rows rather than cleanly validate the fresh-environment path). Recommend validating against a genuinely fresh DB before/at merge.
- [ ] Does **not** retroactively fix already-seeded dev/prod databases (seed is idempotent-skip) — those need a one-time manual backfill of `RiskCondition.phase` and `FormDefinition.riskRuleSetId`, tracked separately.