### PR TITLE
feat(auth-service,sync-service): service accounts and sync-delay escalations

### DIFF
--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -24,6 +24,13 @@ SAKHI='[{"username":"REPLACE_ME","password":"REPLACE_ME","displayName":"REPLACE_
 SUPERVISOR='[{"username":"REPLACE_ME","password":"REPLACE_ME","displayName":"REPLACE_ME"}]'
 MANAGER='[{"username":"REPLACE_ME","password":"REPLACE_ME","displayName":"REPLACE_ME"}]'
 ADMIN='[{"username":"REPLACE_ME","password":"REPLACE_ME","displayName":"REPLACE_ME"}]'
+# Machine identities for automated jobs/crons (visit-form-service,
+# risk-referral-service, sync-service) to call ADMIN/SYSTEM-only endpoints
+# via POST /auth/service-token, instead of forwarding a human's own JWT.
+# One JSON array entry per consuming service: { name, clientId, clientSecret,
+# role? } — role defaults to "SYSTEM". Existing clientId rows are never
+# updated by the seeder; rotate secrets directly in the DB.
+SERVICE_ACCOUNTS='[{"name":"visit-form-service","clientId":"visit-form-service","clientSecret":"REPLACE_ME","role":"SYSTEM"},{"name":"risk-referral-service","clientId":"risk-referral-service","clientSecret":"REPLACE_ME","role":"SYSTEM"},{"name":"sync-service","clientId":"sync-service","clientSecret":"REPLACE_ME","role":"SYSTEM"}]'
 # Base64-encoded 32-byte key (e.g. `openssl rand -base64 32`), used to decrypt
 # sakhi_profiles.bank_account_token for GET /me's maskedBankAccount field.
 # Real value lives only in the gitignored .env.

--- a/apps/auth-service/prisma/migrations/20260831060000_add_service_accounts/migration.sql
+++ b/apps/auth-service/prisma/migrations/20260831060000_add_service_accounts/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "service_accounts" (
+    "service_account_id" TEXT NOT NULL,
+    "name" VARCHAR(120) NOT NULL,
+    "client_id" VARCHAR(80) NOT NULL,
+    "client_secret_hash" VARCHAR(255) NOT NULL,
+    "role" VARCHAR(50) NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "service_accounts_pkey" PRIMARY KEY ("service_account_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "service_accounts_client_id_key" ON "service_accounts"("client_id");

--- a/apps/auth-service/prisma/migrations/20260902072300_add_service_account_auth_tracking/migration.sql
+++ b/apps/auth-service/prisma/migrations/20260902072300_add_service_account_auth_tracking/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "service_accounts" ADD COLUMN "last_auth_at" TIMESTAMP(3),
+ADD COLUMN "failed_auth_count" INTEGER NOT NULL DEFAULT 0;

--- a/apps/auth-service/prisma/schema.prisma
+++ b/apps/auth-service/prisma/schema.prisma
@@ -137,6 +137,27 @@ model UserSession {
   @@map("user_sessions")
 }
 
+// Not in the ERD — added to give backend jobs/crons a real machine identity
+// (client-credentials grant) instead of forwarding a human's own JWT, which
+// was the only "server-to-server" pattern that existed before this table.
+// Deliberately separate from users/user_roles: a service account is never a
+// person, never logs in via /auth/login, and never holds a session.
+model ServiceAccount {
+  id               String    @id @default(uuid()) @map("service_account_id")
+  name             String    @db.VarChar(120)
+  clientId         String    @unique @map("client_id") @db.VarChar(80)
+  clientSecretHash String    @map("client_secret_hash") @db.VarChar(255)
+  // The single role code embedded in every token this account mints, e.g.
+  // "SYSTEM". A plain string (not a Role relation) — service accounts are
+  // intentionally outside the human role/permission model.
+  role             String    @db.VarChar(50)
+  isActive         Boolean   @default(true) @map("is_active")
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+
+  @@map("service_accounts")
+}
+
 // Column set matches ERD Appendix A.1 (funders, projects) exactly.
 
 enum FunderStatus {

--- a/apps/auth-service/prisma/schema.prisma
+++ b/apps/auth-service/prisma/schema.prisma
@@ -22,7 +22,6 @@ enum UserStatus {
   LOCKED
   PAUSED
   DELETED
-
 }
 
 enum UserRoleStatus {
@@ -30,7 +29,6 @@ enum UserRoleStatus {
   EXPIRED
   REVOKED
   INACTIVE
-
 }
 
 model User {
@@ -152,6 +150,12 @@ model ServiceAccount {
   // intentionally outside the human role/permission model.
   role             String    @db.VarChar(50)
   isActive         Boolean   @default(true) @map("is_active")
+  // Same convention as User.failedLoginCount/lastLoginAt — clientIds aren't
+  // secret (shipped in .env.example as descriptive strings like
+  // "sync-service"), so there is otherwise no record kept anywhere of
+  // repeated clientSecret guesses against POST /auth/service-token.
+  lastAuthAt       DateTime? @map("last_auth_at")
+  failedAuthCount  Int       @default(0) @map("failed_auth_count")
   createdAt        DateTime  @default(now()) @map("created_at")
   updatedAt        DateTime  @updatedAt @map("updated_at")
 
@@ -163,7 +167,6 @@ model ServiceAccount {
 enum FunderStatus {
   ACTIVE
   INACTIVE
-
 }
 
 model Funder {
@@ -187,7 +190,6 @@ enum ProjectStatus {
   ACTIVE
   PAUSED
   CLOSED
-
 }
 
 model Project {
@@ -263,13 +265,11 @@ enum GeoType {
   SUBCENTRE
   VILLAGE
   PADA
-
 }
 
 enum GeographyUnitStatus {
   ACTIVE
   INACTIVE
-
 }
 
 model GeographyUnit {
@@ -306,16 +306,16 @@ enum GeographyStatus {
 }
 
 model State {
-  stateId         String    @id @default(uuid()) @map("state_id")
-  stateCode       String    @unique @map("state_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  stateId         String          @id @default(uuid()) @map("state_id")
+  stateCode       String          @unique @map("state_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   districts District[]
 
@@ -323,18 +323,18 @@ model State {
 }
 
 model District {
-  districtId      String    @id @default(uuid()) @map("district_id")
-  stateId         String    @map("state_id")
-  state           State     @relation(fields: [stateId], references: [stateId], onDelete: Restrict)
-  districtCode    String    @map("district_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  districtId      String          @id @default(uuid()) @map("district_id")
+  stateId         String          @map("state_id")
+  state           State           @relation(fields: [stateId], references: [stateId], onDelete: Restrict)
+  districtCode    String          @map("district_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   blocks Block[]
 
@@ -343,18 +343,18 @@ model District {
 }
 
 model Block {
-  blockId         String    @id @default(uuid()) @map("block_id")
-  districtId      String    @map("district_id")
-  district        District  @relation(fields: [districtId], references: [districtId], onDelete: Restrict)
-  blockCode       String    @map("block_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  blockId         String          @id @default(uuid()) @map("block_id")
+  districtId      String          @map("district_id")
+  district        District        @relation(fields: [districtId], references: [districtId], onDelete: Restrict)
+  blockCode       String          @map("block_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   phcs Phc[]
 
@@ -363,18 +363,18 @@ model Block {
 }
 
 model Phc {
-  phcId           String    @id @default(uuid()) @map("phc_id")
-  blockId         String    @map("block_id")
-  block           Block     @relation(fields: [blockId], references: [blockId], onDelete: Restrict)
-  phcCode         String    @map("phc_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  phcId           String          @id @default(uuid()) @map("phc_id")
+  blockId         String          @map("block_id")
+  block           Block           @relation(fields: [blockId], references: [blockId], onDelete: Restrict)
+  phcCode         String          @map("phc_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   subCentres SubCentre[]
 
@@ -383,18 +383,18 @@ model Phc {
 }
 
 model SubCentre {
-  subCentreId     String    @id @default(uuid()) @map("sub_centre_id")
-  phcId           String    @map("phc_id")
-  phc             Phc       @relation(fields: [phcId], references: [phcId], onDelete: Restrict)
-  subCentreCode   String    @map("sub_centre_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  subCentreId     String          @id @default(uuid()) @map("sub_centre_id")
+  phcId           String          @map("phc_id")
+  phc             Phc             @relation(fields: [phcId], references: [phcId], onDelete: Restrict)
+  subCentreCode   String          @map("sub_centre_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   villages Village[]
 
@@ -403,18 +403,18 @@ model SubCentre {
 }
 
 model Village {
-  villageId       String    @id @default(uuid()) @map("village_id")
-  subCentreId     String    @map("sub_centre_id")
-  subCentre       SubCentre @relation(fields: [subCentreId], references: [subCentreId], onDelete: Restrict)
-  villageCode     String    @map("village_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  villageId       String          @id @default(uuid()) @map("village_id")
+  subCentreId     String          @map("sub_centre_id")
+  subCentre       SubCentre       @relation(fields: [subCentreId], references: [subCentreId], onDelete: Restrict)
+  villageCode     String          @map("village_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   padas Pada[]
 
@@ -423,18 +423,18 @@ model Village {
 }
 
 model Pada {
-  padaId          String    @id @default(uuid()) @map("pada_id")
-  villageId       String    @map("village_id")
-  village         Village   @relation(fields: [villageId], references: [villageId], onDelete: Restrict)
-  padaCode        String    @map("pada_code") @db.VarChar(80)
-  name            String    @db.VarChar(180)
+  padaId          String          @id @default(uuid()) @map("pada_id")
+  villageId       String          @map("village_id")
+  village         Village         @relation(fields: [villageId], references: [villageId], onDelete: Restrict)
+  padaCode        String          @map("pada_code") @db.VarChar(80)
+  name            String          @db.VarChar(180)
   status          GeographyStatus @default(ACTIVE)
-  createdAt       DateTime  @default(now()) @map("created_at")
-  createdByUserId String?   @map("created_by_user_id")
-  updatedAt       DateTime  @updatedAt @map("updated_at")
-  updatedByUserId String?   @map("updated_by_user_id")
-  isDeleted       Boolean   @default(false) @map("is_deleted")
-  deletedAt       DateTime? @map("deleted_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  createdByUserId String?         @map("created_by_user_id")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  updatedByUserId String?         @map("updated_by_user_id")
+  isDeleted       Boolean         @default(false) @map("is_deleted")
+  deletedAt       DateTime?       @map("deleted_at")
 
   @@unique([villageId, padaCode])
   @@map("padas")
@@ -541,7 +541,6 @@ model SupervisorProfile {
 enum DevicePlatform {
   ANDROID
   WEB
-
 }
 
 // ERD device_registry.status text is malformed ("REPLACED,PAUSED BLOCKED,Inactive");
@@ -553,7 +552,6 @@ enum DeviceStatus {
   PAUSED
   BLOCKED
   INACTIVE
-
 }
 
 // device_registry — ERD Appendix A (§4.1). Referenced by user_sessions.device_id
@@ -601,7 +599,6 @@ enum TargetPeriodType {
   QUARTERLY
   ANNUAL
   PROJECT_PERIOD
-
 }
 
 // project_registration_targets — ERD §4.1 (merged canonical definition). Per the
@@ -664,7 +661,6 @@ enum SakhiAssignmentType {
   TEMPORARY_COVERAGE
   PAUSED
   STOPPED
-
 }
 
 // sakhi_assignments — ERD Appendix A (§4.1). A Sakhi's project + geography scope.

--- a/apps/auth-service/src/auth/auth.controller.ts
+++ b/apps/auth-service/src/auth/auth.controller.ts
@@ -22,6 +22,11 @@ export function createAuthController(service: AuthService) {
       res.status(200).json(ok({ loggedOut: true }));
     }),
 
+    issueServiceToken: asyncHandler(async (req, res) => {
+      const token = await service.issueServiceToken(req.body);
+      res.status(200).json(ok(token));
+    }),
+
     createUser: asyncHandler(async (req, res, next) => {
       // authenticate(signer) runs first and calls next(unauthorized()) if it
       // fails, so req.user is always populated by the time this handler runs.

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -138,6 +138,11 @@ export class AuthRepository {
     return this.prisma.role.findUnique({ where: { roleCode } });
   }
 
+  /** Looks up a machine identity by its client id — the service-token counterpart of findUserByUsername. */
+  findServiceAccountByClientId(clientId: string) {
+    return this.prisma.serviceAccount.findUnique({ where: { clientId } });
+  }
+
   /**
    * Creates the user and their initial role assignment atomically. When
    * `sakhiProfile` is supplied (roleCode SAKHI — see AuthService.createUser),

--- a/apps/auth-service/src/auth/auth.repository.ts
+++ b/apps/auth-service/src/auth/auth.repository.ts
@@ -143,6 +143,22 @@ export class AuthRepository {
     return this.prisma.serviceAccount.findUnique({ where: { clientId } });
   }
 
+  /** Service-token counterpart of incrementFailedLoginCount. */
+  incrementServiceAccountFailedAuthCount(serviceAccountId: string) {
+    return this.prisma.serviceAccount.update({
+      where: { id: serviceAccountId },
+      data: { failedAuthCount: { increment: 1 } },
+    });
+  }
+
+  /** Service-token counterpart of recordSuccessfulLogin. */
+  recordSuccessfulServiceAuth(serviceAccountId: string) {
+    return this.prisma.serviceAccount.update({
+      where: { id: serviceAccountId },
+      data: { failedAuthCount: 0, lastAuthAt: new Date() },
+    });
+  }
+
   /**
    * Creates the user and their initial role assignment atomically. When
    * `sakhiProfile` is supplied (roleCode SAKHI — see AuthService.createUser),

--- a/apps/auth-service/src/auth/auth.routes.ts
+++ b/apps/auth-service/src/auth/auth.routes.ts
@@ -5,6 +5,7 @@ import type { AuthService } from './auth.service';
 import { createAuthController } from './auth.controller';
 import { loginSchema } from './dto/login.dto';
 import { refreshSchema } from './dto/refresh.dto';
+import { serviceTokenSchema } from './dto/service-token.dto';
 import { createUserSchema } from './dto/create-user.dto';
 import { updateUserSchema } from './dto/update-user.dto';
 import {
@@ -61,6 +62,20 @@ const authTokensSchema = z.object({
   geographyUnitId: z.string().uuid().nullable().openapi({
     description: "The primary role assignment's geography scope.",
   }),
+});
+
+const serviceTokenRequestSchema = serviceTokenSchema.extend({
+  clientId: serviceTokenSchema.shape.clientId.openapi({ example: 'visit-form-service' }),
+  clientSecret: serviceTokenSchema.shape.clientSecret.openapi({ example: 'REPLACE_ME' }),
+});
+
+const serviceTokenResponseSchema = z.object({
+  accessToken: z.string().openapi({
+    description:
+      'JWT access token (RS256), roles: ["SYSTEM"], short-lived (JWT_ADMIN_ACCESS_TOKEN_TTL).',
+  }),
+  expiresIn: z.number().openapi({ description: 'Access token lifetime in seconds.', example: 900 }),
+  roles: z.array(z.string()).openapi({ example: ['SYSTEM'] }),
 });
 
 const userProfileSchema = z.object({
@@ -193,6 +208,28 @@ export function registerAuthRoutes(
     authenticate(signer),
     validateBody(refreshSchema),
     controller.logout,
+  );
+
+  doc.post(
+    '/auth/service-token',
+    {
+      summary:
+        'Client-credentials exchange for a machine identity — used by automated jobs/crons ' +
+        'that need to call an ADMIN/SYSTEM-only endpoint without a human user. No refresh ' +
+        'token is issued; callers re-mint per run.',
+      tags: ['Auth'],
+      responses: {
+        200: { description: 'Service token issued', schema: envelope(serviceTokenResponseSchema) },
+        400: errorResponse(400, { message: 'clientSecret: Required' }),
+        401: errorResponse(401, {
+          message: 'Invalid credentials.',
+          description: 'Unauthenticated — clientId/clientSecret did not match an active account',
+        }),
+        500: errorResponse(500),
+      },
+    },
+    validateBody(serviceTokenRequestSchema),
+    controller.issueServiceToken,
   );
 
   doc.post(

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -76,6 +76,7 @@ describe('AuthService', () => {
     updateUserTransaction: jest.fn(),
     reactivateUser: jest.fn(),
     findDisplayNameById: jest.fn(),
+    findServiceAccountByClientId: jest.fn(),
   } as unknown as jest.Mocked<AuthRepository>;
 
   const signer = {
@@ -1216,6 +1217,71 @@ describe('AuthService', () => {
       await expect(service.reactivateUser('user-1', ADMIN_CALLER)).rejects.toMatchObject({
         status: 409,
       });
+    });
+  });
+
+  describe('issueServiceToken', () => {
+    const ACTIVE_SERVICE_ACCOUNT = {
+      id: 'service-account-1',
+      name: 'visit-form-service',
+      clientId: 'visit-form-service',
+      clientSecretHash: 'hashed-secret',
+      role: 'SYSTEM',
+      isActive: true,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+
+    it('issues a SYSTEM-role token on correct clientId/clientSecret', async () => {
+      repository.findServiceAccountByClientId.mockResolvedValue(ACTIVE_SERVICE_ACCOUNT as never);
+      (verifyPassword as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.issueServiceToken({
+        clientId: 'visit-form-service',
+        clientSecret: 'correct',
+      });
+
+      expect(result).toEqual({
+        accessToken: 'signed-access-token',
+        expiresIn: 900,
+        roles: ['SYSTEM'],
+      });
+      expect(signer.sign).toHaveBeenCalledWith(
+        { sub: 'service-account-1', roles: ['SYSTEM'], typ: 'service' },
+        '15m',
+      );
+    });
+
+    it('401s on an unknown clientId — same generic message as a bad secret', async () => {
+      repository.findServiceAccountByClientId.mockResolvedValue(null);
+
+      await expect(
+        service.issueServiceToken({ clientId: 'unknown', clientSecret: 'anything' }),
+      ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials.' });
+      expect(signer.sign).not.toHaveBeenCalled();
+    });
+
+    it('401s on a correct clientId with the wrong secret', async () => {
+      repository.findServiceAccountByClientId.mockResolvedValue(ACTIVE_SERVICE_ACCOUNT as never);
+      (verifyPassword as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        service.issueServiceToken({ clientId: 'visit-form-service', clientSecret: 'wrong' }),
+      ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials.' });
+      expect(signer.sign).not.toHaveBeenCalled();
+    });
+
+    it('401s on a deactivated service account, even with the correct secret', async () => {
+      repository.findServiceAccountByClientId.mockResolvedValue({
+        ...ACTIVE_SERVICE_ACCOUNT,
+        isActive: false,
+      } as never);
+      (verifyPassword as jest.Mock).mockResolvedValue(true);
+
+      await expect(
+        service.issueServiceToken({ clientId: 'visit-form-service', clientSecret: 'correct' }),
+      ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials.' });
+      expect(signer.sign).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/auth-service/src/auth/auth.service.spec.ts
+++ b/apps/auth-service/src/auth/auth.service.spec.ts
@@ -77,6 +77,8 @@ describe('AuthService', () => {
     reactivateUser: jest.fn(),
     findDisplayNameById: jest.fn(),
     findServiceAccountByClientId: jest.fn(),
+    incrementServiceAccountFailedAuthCount: jest.fn(),
+    recordSuccessfulServiceAuth: jest.fn(),
   } as unknown as jest.Mocked<AuthRepository>;
 
   const signer = {
@@ -1250,6 +1252,8 @@ describe('AuthService', () => {
         { sub: 'service-account-1', roles: ['SYSTEM'], typ: 'service' },
         '15m',
       );
+      expect(repository.recordSuccessfulServiceAuth).toHaveBeenCalledWith('service-account-1');
+      expect(repository.incrementServiceAccountFailedAuthCount).not.toHaveBeenCalled();
     });
 
     it('401s on an unknown clientId — same generic message as a bad secret', async () => {
@@ -1259,9 +1263,11 @@ describe('AuthService', () => {
         service.issueServiceToken({ clientId: 'unknown', clientSecret: 'anything' }),
       ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials.' });
       expect(signer.sign).not.toHaveBeenCalled();
+      // No account id to attach a failed-attempt count to.
+      expect(repository.incrementServiceAccountFailedAuthCount).not.toHaveBeenCalled();
     });
 
-    it('401s on a correct clientId with the wrong secret', async () => {
+    it('401s on a correct clientId with the wrong secret, and records the failed attempt', async () => {
       repository.findServiceAccountByClientId.mockResolvedValue(ACTIVE_SERVICE_ACCOUNT as never);
       (verifyPassword as jest.Mock).mockResolvedValue(false);
 
@@ -1269,9 +1275,12 @@ describe('AuthService', () => {
         service.issueServiceToken({ clientId: 'visit-form-service', clientSecret: 'wrong' }),
       ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials.' });
       expect(signer.sign).not.toHaveBeenCalled();
+      expect(repository.incrementServiceAccountFailedAuthCount).toHaveBeenCalledWith(
+        'service-account-1',
+      );
     });
 
-    it('401s on a deactivated service account, even with the correct secret', async () => {
+    it('401s on a deactivated service account, even with the correct secret, and records the failed attempt', async () => {
       repository.findServiceAccountByClientId.mockResolvedValue({
         ...ACTIVE_SERVICE_ACCOUNT,
         isActive: false,
@@ -1282,6 +1291,9 @@ describe('AuthService', () => {
         service.issueServiceToken({ clientId: 'visit-form-service', clientSecret: 'correct' }),
       ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials.' });
       expect(signer.sign).not.toHaveBeenCalled();
+      expect(repository.incrementServiceAccountFailedAuthCount).toHaveBeenCalledWith(
+        'service-account-1',
+      );
     });
   });
 });

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -112,15 +112,23 @@ export class AuthService {
     const account = await this.repository.findServiceAccountByClientId(input.clientId);
 
     // Same generic failure for "no such client" and "wrong secret" as login
-    // — never reveal which one it was.
+    // — never reveal which one it was. Also same failed-attempt tracking as
+    // login: clientIds aren't secret (shipped in .env.example as
+    // descriptive strings like "sync-service"), so without this an
+    // attacker who learns one could guess clientSecret unlimited times with
+    // no record kept anywhere and no lockout.
     if (!account || !account.isActive) {
+      if (account) await this.repository.incrementServiceAccountFailedAuthCount(account.id);
       throw unauthorized('Invalid credentials.');
     }
 
     const secretMatches = await verifyPassword(account.clientSecretHash, input.clientSecret);
     if (!secretMatches) {
+      await this.repository.incrementServiceAccountFailedAuthCount(account.id);
       throw unauthorized('Invalid credentials.');
     }
+
+    await this.repository.recordSuccessfulServiceAuth(account.id);
 
     const accessToken = await this.signer.sign(
       { sub: account.id, roles: [account.role], typ: 'service' },

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -15,6 +15,7 @@ import { toUserProfile, type AuthTokens, type CreatedUser, type UserProfile } fr
 import type { LoginInput } from './dto/login.dto';
 import type { CreateUserInput } from './dto/create-user.dto';
 import type { UpdateUserInput } from './dto/update-user.dto';
+import type { ServiceTokenInput } from './dto/service-token.dto';
 
 // Re-exported so importers of `./auth.service` keep resolving these types;
 // their definitions live in auth.mapper.ts.
@@ -24,6 +25,13 @@ export type { AuthTokens, CreatedUser, UserProfile } from './auth.mapper';
 export interface CallerScope {
   readonly id: string;
   readonly roles: string[];
+}
+
+/** Result of a client-credentials exchange — no refresh token; jobs re-mint per run. */
+export interface ServiceTokenResult {
+  accessToken: string;
+  expiresIn: number;
+  roles: string[];
 }
 
 /** Prisma unique-constraint violation code (mobileNumber/email/roleCode etc). */
@@ -91,6 +99,39 @@ export class AuthService {
     // Idempotent by design — revoking an already-revoked/non-existent session
     // is a no-op (updateMany matches zero rows), not an error.
     await this.repository.revokeSessionByRefreshTokenHash(tokenHash);
+  }
+
+  /**
+   * Client-credentials exchange for a machine identity — the real
+   * service-to-service auth this platform was missing (automated jobs
+   * previously had no way to call an ADMIN-only endpoint without forwarding
+   * a human's own token). No session/refresh token is issued: callers are
+   * short-lived jobs that just re-mint a token per run.
+   */
+  async issueServiceToken(input: ServiceTokenInput): Promise<ServiceTokenResult> {
+    const account = await this.repository.findServiceAccountByClientId(input.clientId);
+
+    // Same generic failure for "no such client" and "wrong secret" as login
+    // — never reveal which one it was.
+    if (!account || !account.isActive) {
+      throw unauthorized('Invalid credentials.');
+    }
+
+    const secretMatches = await verifyPassword(account.clientSecretHash, input.clientSecret);
+    if (!secretMatches) {
+      throw unauthorized('Invalid credentials.');
+    }
+
+    const accessToken = await this.signer.sign(
+      { sub: account.id, roles: [account.role], typ: 'service' },
+      this.adminAccessTokenTtl,
+    );
+
+    return {
+      accessToken,
+      expiresIn: Math.floor(parseDurationMs(this.adminAccessTokenTtl) / 1000),
+      roles: [account.role],
+    };
   }
 
   /**

--- a/apps/auth-service/src/auth/dto/service-token.dto.ts
+++ b/apps/auth-service/src/auth/dto/service-token.dto.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+/**
+ * Client-credentials exchange for a machine identity — the counterpart to
+ * `loginSchema` for automated jobs/crons instead of a human. `clientId` is
+ * not a secret (it identifies which service account); `clientSecret` is.
+ */
+export const serviceTokenSchema = z
+  .object({
+    clientId: z.string().min(1),
+    clientSecret: z.string().min(1),
+  })
+  .strict();
+
+export type ServiceTokenInput = z.infer<typeof serviceTokenSchema>;

--- a/apps/auth-service/src/prisma/startup-seed.ts
+++ b/apps/auth-service/src/prisma/startup-seed.ts
@@ -162,16 +162,104 @@ export async function seedAdminUsers(prisma: SeedPrismaClient): Promise<SeedResu
   return results;
 }
 
+const seedServiceAccountSchema = z.object({
+  name: z.string().min(1),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  role: z.string().min(1).default('SYSTEM'),
+});
+
+/**
+ * Parses the SERVICE_ACCOUNTS env var (a JSON array of `{ name, clientId,
+ * clientSecret, role? }`) — same shape/fail-fast convention as
+ * {@link parseAdminEnv}. `role` defaults to "SYSTEM" since that's the only
+ * machine role in use today.
+ */
+function parseServiceAccountsEnv(): z.infer<typeof seedServiceAccountSchema>[] {
+  const raw = process.env.SERVICE_ACCOUNTS;
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      'SERVICE_ACCOUNTS must be valid JSON (an array of {name, clientId, clientSecret, role?}).',
+    );
+  }
+
+  const result = z.array(seedServiceAccountSchema).safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`SERVICE_ACCOUNTS is malformed: ${result.error.message}`);
+  }
+  return result.data;
+}
+
+/**
+ * Seeds machine-identity credentials from the `SERVICE_ACCOUNTS` env var —
+ * the client-credentials counterpart of {@link seedAdminUsers}. An account
+ * already existing by `clientId` is left untouched (secret never rotated by
+ * this step); rotate by changing the DB row directly or via a future admin
+ * endpoint, not by re-running startup with a new secret in the env var.
+ */
+export async function seedServiceAccounts(prisma: SeedPrismaClient): Promise<SeedResult[]> {
+  const accounts = parseServiceAccountsEnv();
+  if (accounts.length === 0) {
+    return [
+      {
+        step: 'seedServiceAccount',
+        created: false,
+        message: 'SERVICE_ACCOUNTS not set or empty — skipped.',
+      },
+    ];
+  }
+
+  const results: SeedResult[] = [];
+  for (const account of accounts) {
+    const existing = await prisma.serviceAccount.findUnique({
+      where: { clientId: account.clientId },
+    });
+    if (existing) {
+      results.push({
+        step: `seedServiceAccount:${account.clientId}`,
+        created: false,
+        message: `Service account ${account.clientId} already exists — skipped.`,
+      });
+      continue;
+    }
+
+    const clientSecretHash = await argon2.hash(account.clientSecret);
+    await prisma.serviceAccount.create({
+      data: {
+        name: account.name,
+        clientId: account.clientId,
+        clientSecretHash,
+        role: account.role,
+      },
+    });
+    results.push({
+      step: `seedServiceAccount:${account.clientId}`,
+      created: true,
+      message: `Seeded service account ${account.clientId} (role ${account.role}).`,
+    });
+  }
+  return results;
+}
+
 /**
  * Runs at app boot (before the HTTP server starts listening): ensures role
- * master data and the platform's ADMIN user(s) exist, self-healing a fresh
- * deployment without a separate manual seed step. SAKHI/SUPERVISOR/MANAGER
- * test users are NOT seeded here — they stay behind the manual
- * `npm run prisma:seed` script (prisma/seed.ts), since they're dev/test
- * fixtures, not master data the app needs to function.
+ * master data, the platform's ADMIN user(s), and any configured service
+ * accounts exist, self-healing a fresh deployment without a separate manual
+ * seed step. SAKHI/SUPERVISOR/MANAGER test users are NOT seeded here — they
+ * stay behind the manual `npm run prisma:seed` script (prisma/seed.ts),
+ * since they're dev/test fixtures, not master data the app needs to function.
  */
 export async function seedOnStartup(prisma: SeedPrismaClient): Promise<void> {
-  const results = [await seedRoles(prisma), ...(await seedAdminUsers(prisma))];
+  const results = [
+    await seedRoles(prisma),
+    ...(await seedAdminUsers(prisma)),
+    ...(await seedServiceAccounts(prisma)),
+  ];
 
   for (const r of results) {
     console.log(`[startup-seed] [${r.created ? 'created' : 'skipped'}] ${r.step}: ${r.message}`);

--- a/apps/cms-content-service/src/main.ts
+++ b/apps/cms-content-service/src/main.ts
@@ -22,4 +22,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/sync-service/.env.example
+++ b/apps/sync-service/.env.example
@@ -8,3 +8,12 @@ CORS_ORIGINS=http://localhost:5173
 # https://staging-api.example.com,https://api.example.com. Leave empty in
 # local dev to fall back to http://localhost:$PORT.
 PUBLIC_BASE_URLS=
+# Client-credentials identity (see auth-service's SERVICE_ACCOUNTS var) this
+# service authenticates as, to raise SYNC_DELAY escalations from
+# GET /sync/last-synced/by-roster. Optional: that step is skipped (roster
+# data is still returned) when unset.
+SERVICE_ACCOUNT_CLIENT_ID=sync-service
+SERVICE_ACCOUNT_CLIENT_SECRET=
+# Hours since a Sakhi's last COMPLETED sync before she's flagged SYNC_DELAY
+# on the Supervisor roster dashboard.
+SYNC_DELAY_THRESHOLD_HOURS=48

--- a/apps/sync-service/prisma/migrations/20260902072210_add_sync_batch_last_synced_index/migration.sql
+++ b/apps/sync-service/prisma/migrations/20260902072210_add_sync_batch_last_synced_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "sync_batches_user_id_status_completed_at_idx" ON "sync_batches"("user_id", "status", "completed_at");

--- a/apps/sync-service/prisma/schema.prisma
+++ b/apps/sync-service/prisma/schema.prisma
@@ -77,6 +77,10 @@ model SyncBatch {
 
   syncItems SyncItem[]
 
+  // Supports findLastSyncedAtByUserIds's groupBy(userId, status) with
+  // _max(completedAt) — the Supervisor roster dashboard's hot-path query,
+  // run on every dashboard load for the whole roster at once.
+  @@index([userId, status, completedAt])
   @@map("sync_batches")
 }
 

--- a/apps/sync-service/src/app.module.ts
+++ b/apps/sync-service/src/app.module.ts
@@ -7,6 +7,7 @@ import {
   errorHandler,
   notFoundHandler,
   requestId,
+  ServiceTokenClient,
 } from '@armman/service-commons';
 import { appConfig } from './config/app-config';
 import { PrismaService } from './prisma/prisma.service';
@@ -53,7 +54,18 @@ export function createApp(prisma: PrismaService): Application {
   });
   app.use(requestId);
 
-  const syncBatchModule = createSyncBatchModule(prisma);
+  const serviceTokenClient =
+    appConfig.SERVICE_ACCOUNT_CLIENT_ID && appConfig.SERVICE_ACCOUNT_CLIENT_SECRET
+      ? new ServiceTokenClient(
+          appConfig.SERVICE_ACCOUNT_CLIENT_ID,
+          appConfig.SERVICE_ACCOUNT_CLIENT_SECRET,
+        )
+      : null;
+  const syncBatchModule = createSyncBatchModule(
+    prisma,
+    serviceTokenClient,
+    appConfig.SYNC_DELAY_THRESHOLD_HOURS,
+  );
 
   // All routes live under the global `api/v1` prefix.
   const api = express.Router();

--- a/apps/sync-service/src/config/app-config.ts
+++ b/apps/sync-service/src/config/app-config.ts
@@ -21,9 +21,20 @@ const schema = z.object({
   // from GET /sync/last-synced/by-roster's read-time SYNC_DELAY check.
   // Optional: that check is skipped (roster data is still returned) when
   // unset, rather than failing the whole read over a not-yet-provisioned
-  // credential.
-  SERVICE_ACCOUNT_CLIENT_ID: z.string().min(1).optional(),
-  SERVICE_ACCOUNT_CLIENT_SECRET: z.string().min(1).optional(),
+  // credential. The `.transform` treats a present-but-empty value (the
+  // .env.example convention of leaving the key present with no value) the
+  // same as the key being absent — `.optional()` alone only tolerates
+  // `undefined`, so an empty string would otherwise still fail `.min(1)`
+  // and crash the whole service at boot (loadConfig calls process.exit(1)
+  // on any schema validation failure) instead of just skipping this check.
+  SERVICE_ACCOUNT_CLIENT_ID: z
+    .string()
+    .optional()
+    .transform((v) => v || undefined),
+  SERVICE_ACCOUNT_CLIENT_SECRET: z
+    .string()
+    .optional()
+    .transform((v) => v || undefined),
   // How many hours since the last COMPLETED sync before a roster member is
   // flagged SYNC_DELAY. A plain env var for now, not a GoRules rule pack —
   // unlike the clinical/visit-scheduling thresholds this repo's other rule

--- a/apps/sync-service/src/config/app-config.ts
+++ b/apps/sync-service/src/config/app-config.ts
@@ -16,6 +16,22 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  // Client-credentials identity (POST /auth/service-token) this service
+  // authenticates as, to call the ADMIN/SYSTEM-only POST /escalation-events
+  // from GET /sync/last-synced/by-roster's read-time SYNC_DELAY check.
+  // Optional: that check is skipped (roster data is still returned) when
+  // unset, rather than failing the whole read over a not-yet-provisioned
+  // credential.
+  SERVICE_ACCOUNT_CLIENT_ID: z.string().min(1).optional(),
+  SERVICE_ACCOUNT_CLIENT_SECRET: z.string().min(1).optional(),
+  // How many hours since the last COMPLETED sync before a roster member is
+  // flagged SYNC_DELAY. A plain env var for now, not a GoRules rule pack —
+  // unlike the clinical/visit-scheduling thresholds this repo's other rule
+  // packs encode, this is a single operational number with no
+  // visitFamily-style branching, and evaluating it via a rules-service round
+  // trip on every dashboard read adds latency this check doesn't need.
+  // Revisit if this ever needs per-project/per-geography variation.
+  SYNC_DELAY_THRESHOLD_HOURS: z.coerce.number().positive().default(48),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/sync-service/src/main.ts
+++ b/apps/sync-service/src/main.ts
@@ -22,4 +22,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/sync-service/src/sync/syncBatch.controller.ts
+++ b/apps/sync-service/src/sync/syncBatch.controller.ts
@@ -30,5 +30,21 @@ export function createSyncBatchController(service: SyncBatchService) {
       );
       res.json(ok({ lastSyncedAt: lastSyncedAt ? lastSyncedAt.toISOString() : null }));
     }),
+
+    getLastSyncedAtByRoster: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const authorizationHeader = req.header('authorization');
+      if (!authorizationHeader) return next(unauthorized());
+      const roster = await service.getLastSyncedAtByRoster(req.user, authorizationHeader);
+      res.json(
+        ok(
+          roster.map((r) => ({
+            userId: r.userId,
+            lastSyncedAt: r.lastSyncedAt ? r.lastSyncedAt.toISOString() : null,
+            isDelayed: r.isDelayed,
+          })),
+        ),
+      );
+    }),
   };
 }

--- a/apps/sync-service/src/sync/syncBatch.module.ts
+++ b/apps/sync-service/src/sync/syncBatch.module.ts
@@ -1,3 +1,4 @@
+import type { ServiceTokenClient } from '@armman/service-commons';
 import { createDocumentedRouter, type DocumentedRouter } from '../app.module';
 import type { PrismaService } from '../prisma/prisma.service';
 import { SyncBatchRepository } from './syncBatch.repository';
@@ -20,9 +21,17 @@ import { registerSyncPendingRoutes } from './syncPending.routes';
  * `operations.module.ts` in supervisor-operations-service for the same
  * shared-registry pattern across multiple sub-domains).
  */
-export function createSyncBatchModule(prisma: PrismaService): DocumentedRouter {
+export function createSyncBatchModule(
+  prisma: PrismaService,
+  serviceTokenClient: ServiceTokenClient | null,
+  syncDelayThresholdHours: number,
+): DocumentedRouter {
   const batchRepository = new SyncBatchRepository(prisma);
-  const batchService = new SyncBatchService(batchRepository);
+  const batchService = new SyncBatchService(
+    batchRepository,
+    serviceTokenClient,
+    syncDelayThresholdHours,
+  );
   const pendingRepository = new SyncPendingRepository(prisma);
   const pendingService = new SyncPendingService(pendingRepository);
 

--- a/apps/sync-service/src/sync/syncBatch.repository.ts
+++ b/apps/sync-service/src/sync/syncBatch.repository.ts
@@ -27,4 +27,29 @@ export class SyncBatchRepository {
     });
     return batch?.completedAt ?? null;
   }
+
+  /**
+   * The most recent COMPLETED batch's completedAt per userId, for the
+   * Supervisor roster dashboard — the batch counterpart of
+   * findLastSyncedAt. A single query (not one per userId): every COMPLETED
+   * batch for the roster, grouped in application code to the max
+   * completedAt per user, since Prisma's `groupBy` can't express "max of a
+   * field, but return that whole row" directly. A userId with zero
+   * COMPLETED batches simply has no entry in the returned Map — the caller
+   * treats a missing entry the same as `findLastSyncedAt` returning null.
+   */
+  async findLastSyncedAtByUserIds(userIds: string[]): Promise<Map<string, Date>> {
+    if (userIds.length === 0) return new Map();
+    const rows = await this.prisma.syncBatch.findMany({
+      where: { userId: { in: userIds }, status: 'COMPLETED' },
+      select: { userId: true, completedAt: true },
+      orderBy: { completedAt: 'desc' },
+    });
+    const byUserId = new Map<string, Date>();
+    for (const row of rows) {
+      if (!row.completedAt) continue;
+      if (!byUserId.has(row.userId)) byUserId.set(row.userId, row.completedAt);
+    }
+    return byUserId;
+  }
 }

--- a/apps/sync-service/src/sync/syncBatch.repository.ts
+++ b/apps/sync-service/src/sync/syncBatch.repository.ts
@@ -31,24 +31,25 @@ export class SyncBatchRepository {
   /**
    * The most recent COMPLETED batch's completedAt per userId, for the
    * Supervisor roster dashboard — the batch counterpart of
-   * findLastSyncedAt. A single query (not one per userId): every COMPLETED
-   * batch for the roster, grouped in application code to the max
-   * completedAt per user, since Prisma's `groupBy` can't express "max of a
-   * field, but return that whole row" directly. A userId with zero
+   * findLastSyncedAt. One aggregate query (not one per userId, and not a
+   * full-table fetch reduced in application code): Prisma's `groupBy` with
+   * `_max: { completedAt: true }` asks Postgres directly for exactly the one
+   * value needed per user, instead of transferring every COMPLETED row for
+   * the roster just to keep the first one seen. A userId with zero
    * COMPLETED batches simply has no entry in the returned Map — the caller
    * treats a missing entry the same as `findLastSyncedAt` returning null.
    */
   async findLastSyncedAtByUserIds(userIds: string[]): Promise<Map<string, Date>> {
     if (userIds.length === 0) return new Map();
-    const rows = await this.prisma.syncBatch.findMany({
+    const rows = await this.prisma.syncBatch.groupBy({
+      by: ['userId'],
       where: { userId: { in: userIds }, status: 'COMPLETED' },
-      select: { userId: true, completedAt: true },
-      orderBy: { completedAt: 'desc' },
+      _max: { completedAt: true },
     });
     const byUserId = new Map<string, Date>();
     for (const row of rows) {
-      if (!row.completedAt) continue;
-      if (!byUserId.has(row.userId)) byUserId.set(row.userId, row.completedAt);
+      if (!row._max.completedAt) continue;
+      byUserId.set(row.userId, row._max.completedAt);
     }
     return byUserId;
   }

--- a/apps/sync-service/src/sync/syncBatch.routes.ts
+++ b/apps/sync-service/src/sync/syncBatch.routes.ts
@@ -53,6 +53,14 @@ const lastSyncedResponseSchema = z.object({
   lastSyncedAt: z.string().datetime().nullable(),
 });
 
+const rosterSyncStatusSchema = z.object({
+  userId: z.string().uuid(),
+  lastSyncedAt: z.string().datetime().nullable(),
+  isDelayed: z.boolean().openapi({
+    description: 'true when lastSyncedAt is null or older than SYNC_DELAY_THRESHOLD_HOURS.',
+  }),
+});
+
 function envelope<T extends z.ZodTypeAny>(data: T) {
   return z.object({ success: z.literal(true), message: z.string(), data });
 }
@@ -109,6 +117,28 @@ export function registerSyncBatchRoutes(doc: DocumentedRouter, service: SyncBatc
     requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
     validate(lastSyncedQuerySchema, 'query'),
     controller.getLastSyncedAt,
+  );
+
+  doc.get(
+    '/sync/last-synced/by-roster',
+    {
+      summary:
+        "Supervisor dashboard: last-synced status for every Sakhi in the caller's own roster. " +
+        'Best-effort raises a SYNC_DELAY escalation for each delayed Sakhi (passive list — no ' +
+        'notification push, per SRS). SUPERVISOR only; no MANAGER/ADMIN "any roster" variant yet.',
+      tags: ['Sync'],
+      responses: {
+        200: {
+          description: 'Roster sync status',
+          schema: envelope(z.array(rosterSyncStatusSchema)),
+        },
+        401: { description: 'Unauthenticated', schema: apiErrorSchema },
+        403: { description: 'Caller role not permitted', schema: apiErrorSchema },
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SUPERVISOR'),
+    controller.getLastSyncedAtByRoster,
   );
 
   doc.post(

--- a/apps/sync-service/src/sync/syncBatch.service.spec.ts
+++ b/apps/sync-service/src/sync/syncBatch.service.spec.ts
@@ -1,10 +1,12 @@
-import type { AuthenticatedUser } from '@armman/service-commons';
+import type { AuthenticatedUser, ServiceTokenClient } from '@armman/service-commons';
 import { SyncBatchService } from './syncBatch.service';
 import type { SyncBatchRepository } from './syncBatch.repository';
 import type { CreateSyncBatchInput } from './dto/create-syncBatch.dto';
 import { listSakhiIdsForSupervisor } from './sakhi.client';
+import { createSyncDelayEscalationEvent } from './systemEscalation.client';
 
 jest.mock('./sakhi.client');
+jest.mock('./systemEscalation.client');
 
 const AUTH_HEADER = 'Bearer test-token';
 const CALLER_ID = '99999999-9999-9999-9999-999999999999';
@@ -24,13 +26,15 @@ describe('SyncBatchService', () => {
     findMany: jest.fn(),
     create: jest.fn(),
     findLastSyncedAt: jest.fn(),
+    findLastSyncedAtByUserIds: jest.fn(),
   } as unknown as jest.Mocked<SyncBatchRepository>;
   const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
+  const createSyncDelayEscalationEventMock = jest.mocked(createSyncDelayEscalationEvent);
   let service: SyncBatchService;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    service = new SyncBatchService(repository);
+    service = new SyncBatchService(repository, null, 48);
   });
 
   it('lists via repository', async () => {
@@ -193,5 +197,91 @@ describe('SyncBatchService', () => {
         expect(repository.findLastSyncedAt).toHaveBeenCalledWith('some-other-user');
       },
     );
+  });
+
+  describe('getLastSyncedAtByRoster', () => {
+    const SUPERVISOR = caller({ roles: ['SUPERVISOR'], projectId: 'project-1' });
+
+    it('rejects a SUPERVISOR caller with no project scope', async () => {
+      await expect(
+        service.getLastSyncedAtByRoster(
+          caller({ roles: ['SUPERVISOR'], projectId: null }),
+          AUTH_HEADER,
+        ),
+      ).rejects.toThrow('Supervisor caller has no project scope.');
+    });
+
+    it('flags a roster member as delayed when they have never synced', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+      repository.findLastSyncedAtByUserIds.mockResolvedValue(new Map());
+
+      const result = await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
+
+      expect(result).toEqual([{ userId: 'sakhi-a', lastSyncedAt: null, isDelayed: true }]);
+    });
+
+    it('flags a roster member as delayed when their last sync exceeds the threshold', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+      const oldSync = new Date(Date.now() - 72 * 60 * 60 * 1000);
+      repository.findLastSyncedAtByUserIds.mockResolvedValue(new Map([['sakhi-a', oldSync]]));
+
+      const result = await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
+
+      expect(result).toEqual([{ userId: 'sakhi-a', lastSyncedAt: oldSync, isDelayed: true }]);
+    });
+
+    it('does not flag a roster member synced within the threshold', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+      const recentSync = new Date(Date.now() - 1 * 60 * 60 * 1000);
+      repository.findLastSyncedAtByUserIds.mockResolvedValue(new Map([['sakhi-a', recentSync]]));
+
+      const result = await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
+
+      expect(result).toEqual([{ userId: 'sakhi-a', lastSyncedAt: recentSync, isDelayed: false }]);
+    });
+
+    it('does not attempt to raise an escalation when no service token client is configured', async () => {
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+      repository.findLastSyncedAtByUserIds.mockResolvedValue(new Map());
+
+      await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
+
+      expect(createSyncDelayEscalationEventMock).not.toHaveBeenCalled();
+    });
+
+    it('raises a SYNC_DELAY escalation for each delayed roster member when a token client is configured', async () => {
+      const tokenClient = {
+        getToken: jest.fn().mockResolvedValue('system-token'),
+      } as unknown as ServiceTokenClient;
+      service = new SyncBatchService(repository, tokenClient, 48);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a', 'sakhi-b']);
+      const recentSync = new Date();
+      repository.findLastSyncedAtByUserIds.mockResolvedValue(new Map([['sakhi-b', recentSync]]));
+      createSyncDelayEscalationEventMock.mockResolvedValue({
+        id: 'event-1',
+        sakhiUserId: 'sakhi-a',
+        escalationType: 'SYNC_DELAY',
+        status: 'OPEN',
+      });
+
+      await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
+
+      expect(createSyncDelayEscalationEventMock).toHaveBeenCalledTimes(1);
+      expect(createSyncDelayEscalationEventMock).toHaveBeenCalledWith('sakhi-a', 'system-token');
+    });
+
+    it('does not fail the read when raising an escalation throws', async () => {
+      const tokenClient = {
+        getToken: jest.fn().mockResolvedValue('system-token'),
+      } as unknown as ServiceTokenClient;
+      service = new SyncBatchService(repository, tokenClient, 48);
+      listSakhiIdsForSupervisorMock.mockResolvedValue(['sakhi-a']);
+      repository.findLastSyncedAtByUserIds.mockResolvedValue(new Map());
+      createSyncDelayEscalationEventMock.mockRejectedValue(new Error('boom'));
+
+      const result = await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
+
+      expect(result).toEqual([{ userId: 'sakhi-a', lastSyncedAt: null, isDelayed: true }]);
+    });
   });
 });

--- a/apps/sync-service/src/sync/syncBatch.service.spec.ts
+++ b/apps/sync-service/src/sync/syncBatch.service.spec.ts
@@ -267,7 +267,11 @@ describe('SyncBatchService', () => {
       await service.getLastSyncedAtByRoster(SUPERVISOR, AUTH_HEADER);
 
       expect(createSyncDelayEscalationEventMock).toHaveBeenCalledTimes(1);
-      expect(createSyncDelayEscalationEventMock).toHaveBeenCalledWith('sakhi-a', 'system-token');
+      expect(createSyncDelayEscalationEventMock).toHaveBeenCalledWith(
+        'sakhi-a',
+        SUPERVISOR.id,
+        'system-token',
+      );
     });
 
     it('does not fail the read when raising an escalation throws', async () => {

--- a/apps/sync-service/src/sync/syncBatch.service.ts
+++ b/apps/sync-service/src/sync/syncBatch.service.ts
@@ -1,16 +1,34 @@
-import { forbidden, type AuthenticatedUser } from '@armman/service-commons';
+import {
+  forbidden,
+  type AuthenticatedUser,
+  type ServiceTokenClient,
+} from '@armman/service-commons';
 import type { SyncBatchRepository } from './syncBatch.repository';
 import type { CreateSyncBatchInput } from './dto/create-syncBatch.dto';
 import { listSakhiIdsForSupervisor } from './sakhi.client';
+import { createSyncDelayEscalationEvent } from './systemEscalation.client';
 
 /** MANAGER and ADMIN are unrestricted — same convention as every other service. */
 function isPrivileged(caller: AuthenticatedUser): boolean {
   return caller.roles.includes('MANAGER') || caller.roles.includes('ADMIN');
 }
 
+export interface RosterSyncStatus {
+  userId: string;
+  lastSyncedAt: Date | null;
+  isDelayed: boolean;
+}
+
 /** Sync-batch domain logic. Data access is delegated to the repository. */
 export class SyncBatchService {
-  constructor(private readonly repository: SyncBatchRepository) {}
+  constructor(
+    private readonly repository: SyncBatchRepository,
+    // Optional: SYNC_DELAY escalation-raising is skipped (roster data is
+    // still returned) when no service-account credential is configured —
+    // see app-config.ts's SERVICE_ACCOUNT_CLIENT_ID doc comment.
+    private readonly serviceTokenClient: ServiceTokenClient | null,
+    private readonly syncDelayThresholdHours: number,
+  ) {}
 
   list() {
     return this.repository.findMany();
@@ -51,5 +69,64 @@ export class SyncBatchService {
       }
     }
     return this.repository.findLastSyncedAt(userId);
+  }
+
+  /**
+   * The Supervisor dashboard's roster sync-status list (build plan's "Sync
+   * delay" item) — one row per Sakhi in the caller's own roster, each
+   * flagged `isDelayed` when their last COMPLETED sync is older than
+   * SYNC_DELAY_THRESHOLD_HOURS (or they've never synced at all). SUPERVISOR
+   * only, always the caller's own roster — unlike GET /sync/last-synced,
+   * this endpoint has no MANAGER/ADMIN "view any roster" variant yet since
+   * there's no caller-supplied supervisorId to resolve a projectId for.
+   *
+   * A passive list, not a push: per the build plan, this raises a
+   * SYNC_DELAY escalation for each delayed Sakhi (so it surfaces wherever
+   * escalations are already reviewed) but never calls POST /notifications.
+   * Escalation-raising is best-effort — a failure for one Sakhi is logged,
+   * not thrown, so a transient notification-escalation-service blip never
+   * turns a dashboard read into a 502.
+   */
+  async getLastSyncedAtByRoster(
+    caller: AuthenticatedUser,
+    authorizationHeader: string,
+  ): Promise<RosterSyncStatus[]> {
+    if (!caller.projectId) {
+      throw forbidden('Supervisor caller has no project scope.');
+    }
+    const roster = await listSakhiIdsForSupervisor(
+      caller.projectId,
+      caller.id,
+      authorizationHeader,
+    );
+    const lastSyncedByUserId = await this.repository.findLastSyncedAtByUserIds(roster);
+
+    const thresholdMs = this.syncDelayThresholdHours * 60 * 60 * 1000;
+    const now = Date.now();
+    const results: RosterSyncStatus[] = roster.map((userId) => {
+      const lastSyncedAt = lastSyncedByUserId.get(userId) ?? null;
+      const isDelayed = !lastSyncedAt || now - lastSyncedAt.getTime() > thresholdMs;
+      return { userId, lastSyncedAt, isDelayed };
+    });
+
+    if (this.serviceTokenClient) {
+      const systemToken = await this.serviceTokenClient.getToken().catch((err) => {
+        console.error('Unable to mint a service token for SYNC_DELAY escalations:', err);
+        return null;
+      });
+      if (systemToken) {
+        await Promise.all(
+          results
+            .filter((r) => r.isDelayed)
+            .map((r) =>
+              createSyncDelayEscalationEvent(r.userId, systemToken).catch((err) => {
+                console.error(`Unable to raise SYNC_DELAY escalation for ${r.userId}:`, err);
+              }),
+            ),
+        );
+      }
+    }
+
+    return results;
   }
 }

--- a/apps/sync-service/src/sync/syncBatch.service.ts
+++ b/apps/sync-service/src/sync/syncBatch.service.ts
@@ -119,7 +119,7 @@ export class SyncBatchService {
           results
             .filter((r) => r.isDelayed)
             .map((r) =>
-              createSyncDelayEscalationEvent(r.userId, systemToken).catch((err) => {
+              createSyncDelayEscalationEvent(r.userId, caller.id, systemToken).catch((err) => {
                 console.error(`Unable to raise SYNC_DELAY escalation for ${r.userId}:`, err);
               }),
             ),

--- a/apps/sync-service/src/sync/systemEscalation.client.ts
+++ b/apps/sync-service/src/sync/systemEscalation.client.ts
@@ -19,9 +19,15 @@ interface EscalationEvent {
  * sees, not a pushed notification, so no POST /notifications call exists
  * alongside this one. Server idempotently no-ops (returns the existing row)
  * on a duplicate OPEN escalation for the same sakhiUserId.
+ *
+ * `assignedSupervisorId` is required by createEscalationEventSchema (this
+ * service has no roster lookup of its own to derive it server-side) — the
+ * caller (getLastSyncedAtByRoster) already knows it: it's the Supervisor
+ * whose own roster this Sakhi belongs to.
  */
 export async function createSyncDelayEscalationEvent(
   sakhiUserId: string,
+  assignedSupervisorId: string,
   systemAccessToken: string,
 ): Promise<EscalationEvent> {
   let res: Response;
@@ -32,7 +38,7 @@ export async function createSyncDelayEscalationEvent(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${systemAccessToken}`,
       },
-      body: JSON.stringify({ sakhiUserId, escalationType: 'SYNC_DELAY' }),
+      body: JSON.stringify({ sakhiUserId, escalationType: 'SYNC_DELAY', assignedSupervisorId }),
     });
   } catch {
     throw badGateway(

--- a/apps/sync-service/src/sync/systemEscalation.client.ts
+++ b/apps/sync-service/src/sync/systemEscalation.client.ts
@@ -1,0 +1,55 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+
+// Read directly (not via appConfig) — mirrors sakhi.client.ts in this
+// same directory.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+interface EscalationEvent {
+  id: string;
+  sakhiUserId: string | null;
+  escalationType: string;
+  status: string;
+}
+
+/**
+ * Raises a SYNC_DELAY escalation via `POST /escalation-events` (through the
+ * gateway), authenticating as this service's machine identity. Called at
+ * Supervisor dashboard read time (getLastSyncedAtByRoster), not from a cron
+ * job — per the build plan, sync delay is a passive list the Supervisor
+ * sees, not a pushed notification, so no POST /notifications call exists
+ * alongside this one. Server idempotently no-ops (returns the existing row)
+ * on a duplicate OPEN escalation for the same sakhiUserId.
+ */
+export async function createSyncDelayEscalationEvent(
+  sakhiUserId: string,
+  systemAccessToken: string,
+): Promise<EscalationEvent> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/escalation-events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${systemAccessToken}`,
+      },
+      body: JSON.stringify({ sakhiUserId, escalationType: 'SYNC_DELAY' }),
+    });
+  } catch {
+    throw badGateway(
+      'Unable to raise the sync-delay escalation — notification-escalation-service is unreachable.',
+    );
+  }
+
+  if (!res.ok) {
+    if (res.status >= 400 && res.status < 500) {
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      throw new HttpError(res.status, body?.message ?? 'Unable to raise the escalation.');
+    }
+    throw badGateway(
+      'Unable to raise the sync-delay escalation — notification-escalation-service returned an error.',
+    );
+  }
+
+  const body = (await res.json()) as { data: EscalationEvent };
+  return body.data;
+}


### PR DESCRIPTION
## Summary
- Adds service accounts and POST /auth/service-token to auth-service for the m2m client-credentials exchange
- Raises sync-delay escalations from sync-service's supervisor roster dashboard via the new escalation client
- Fixes the shared bootstrap error-swallowing bug in cms-content-service's main.ts
- Depends only on service-commons content already merged via #205/#206 — no cross-PR file duplication needed here

## Test plan
- [x] `nx run-many -t test -p auth-service sync-service cms-content-service --passWithNoTests` — 26 suites / 306 tests passing (pre-existing skips)
- [x] `nx run-many -t lint -p auth-service sync-service cms-content-service` — clean
- [x] `nx run-many -t build -p auth-service sync-service cms-content-service` — clean