### PR TITLE
fix(ci): Fail dev deploys when a lockfile change wasn't installed on the box

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -195,7 +195,8 @@ jobs:
           }
 
           if grep -q '^LOCKFILE_CHANGED=1' remote.out; then
-            echo "::warning::package-lock.json changed. npm ci is deliberately not run here — if a service fails to boot on a missing dependency, install manually."
+            echo "::error::package-lock.json changed. npm ci is deliberately not run here on every deploy (see the WHY THE LOGIC RUNS ON THE BOX comment above) — but a changed lockfile means a dependency may be missing from the box's node_modules, which fails the build at runtime instead of here (e.g. node-cron, 2026-09-02). Run 'npm ci' on the box in \$DEV_WORKSPACE, then re-run this deploy."
+            exit 1
           fi
           if grep -q '^UNKNOWN=' remote.out; then
             echo "::error::Unknown service(s): $(sed -n 's/^UNKNOWN=//p' remote.out)"


### PR DESCRIPTION
## Summary

- \`cd-dev.yml\` deliberately never runs \`npm ci\` on the deploy box (documented trade-off — keeps deploys fast by reusing the box's existing \`node_modules\`).
- When \`package-lock.json\` changes, the box-side detection already reports \`LOCKFILE_CHANGED=1\`, but the workflow only emitted a soft \`::warning::\` and let the deploy proceed regardless — a real new dependency then silently fails to build at deploy time instead of blocking the deploy up front.
- **Concrete incident this closes the gap on:** \`node-cron\` was added to \`package.json\` for the new cron jobs in \`apps/visit-form-service/src/jobs/\`, but never installed on the dev box — \`visit-form-service\`'s deploy failed with \`TS2307: Cannot find module 'node-cron'\`, the service went down, and the only visible signal was a wall of \`curl: (7) Failed to connect\` from the health-check poll timing out — nothing pointed at the actual cause.
- Turns the \`LOCKFILE_CHANGED=1\` check into a hard failure (\`exit 1\`) with a message naming the fix directly (\`npm ci\` on the box, then re-deploy).

Closes #213

## Out of scope

\`tools/deploy-dev.sh\` (the box-side script that actually detects \`LOCKFILE_CHANGED\`) is gitignored and hand-maintained on the box, not in this repo — it isn't touched here. A further improvement would be having that script auto-run \`npm ci\` when it detects the lockfile changed, so deploys don't need manual intervention at all; that requires box access to implement.

## Test plan

- [x] YAML syntax validated (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] Change is a single, minimal diff (2 lines) to a static \`echo\` string — no interpolation of any untrusted GitHub event data, reviewed against GitHub Actions injection risks
- [ ] Not exercised against a real \`LOCKFILE_CHANGED=1\` deploy in this PR (would require actually triggering \`cd-dev.yml\` against the dev box) — recommend a manual dry run (bump any dependency, push to a test branch pointed at this workflow, confirm the deploy now fails loudly with the new message) before/at merge