### PR TITLE
feat(closure-reopen,risk-referral,beneficiary): overdue-referral escalation

### DIFF
--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -1,5 +1,5 @@
 import type { Server } from 'node:http';
-import { PublicKeyVerifier } from '@armman/service-commons';
+import { PublicKeyVerifier, bootstrapService } from '@armman/service-commons';
 import { appConfig } from './config/app-config';
 import { createApp } from './app.module';
 
@@ -18,7 +18,4 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-bootstrap().catch((err) => {
-  console.error('Fatal error during startup:', err);
-  process.exit(1);
-});
+bootstrapService(bootstrap);

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -18,4 +18,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/audit-service/src/main.ts
+++ b/apps/audit-service/src/main.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import { bootstrapService } from '@armman/service-commons';
 import { appConfig } from './config/app-config';
 import { createApp } from './app.module';
 import { PrismaService } from './prisma/prisma.service';
@@ -22,7 +23,4 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-bootstrap().catch((err) => {
-  console.error('Fatal error during startup:', err);
-  process.exit(1);
-});
+bootstrapService(bootstrap);

--- a/apps/audit-service/src/main.ts
+++ b/apps/audit-service/src/main.ts
@@ -22,4 +22,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/auth-service/src/sakhis/sakhi.routes.ts
+++ b/apps/auth-service/src/sakhis/sakhi.routes.ts
@@ -85,7 +85,9 @@ export function registerSakhiRoutes(
       summary:
         'Get a Sakhi by id. A SAKHI caller may only fetch their own id (403 otherwise) — ' +
         "used by the Sakhi dashboard for the caller's own name/profile, in addition to this " +
-        "route's original Supervisor picker/detail-header use.",
+        "route's original Supervisor picker/detail-header use. SYSTEM is included for " +
+        "automated cron jobs (e.g. risk-referral-service's overdue-followup escalation) " +
+        'resolving a Sakhi via their own service-token identity, not a human session.',
       tags: ['Sakhis'],
       params: sakhiIdParamsSchema,
       responses: {
@@ -97,7 +99,7 @@ export function registerSakhiRoutes(
       },
     },
     authenticate(signer),
-    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN'),
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'ADMIN', 'SYSTEM'),
     validate(sakhiIdParamsSchema, 'params'),
     controller.getById,
   );

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.controller.ts
@@ -12,6 +12,7 @@ import {
 import type { idsQuerySchema } from './dto/ids-query.dto';
 import { parseIdsParam, type byIdsWithRiskQuerySchema } from './dto/by-ids-with-risk-query.dto';
 import type { batchRiskConditionSummaryQuerySchema } from './dto/batch-risk-condition-summary-query.dto';
+import type { postEddPendingQuerySchema } from './dto/post-edd-pending-query.dto';
 
 /**
  * Beneficiary request handlers. Mounted under the global `api/v1` prefix
@@ -35,6 +36,16 @@ export function createBeneficiaryController(service: BeneficiaryService) {
       if (!authorizationHeader) return next(unauthorized());
       const query = req.query as unknown as z.infer<typeof idsQuerySchema>;
       res.json(ok(await service.getIds(query.sakhiId, req.user, authorizationHeader)));
+    }),
+
+    getPostEddPending: asyncHandler(async (req, res, next) => {
+      if (!req.user) return next(unauthorized());
+      const query = req.query as unknown as z.infer<typeof postEddPendingQuerySchema>;
+      res.json(
+        ok(
+          await service.getPostEddPendingBeneficiaries(query.cutoffDate, query.limit, query.cursor),
+        ),
+      );
     }),
 
     getPadaBreakdown: asyncHandler(async (req, res, next) => {

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.spec.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.spec.ts
@@ -2,7 +2,8 @@ import { BeneficiaryRepository } from './beneficiary.repository';
 
 describe('BeneficiaryRepository', () => {
   const groupBy = jest.fn();
-  const prisma = { beneficiaryCase: { groupBy } } as never;
+  const findMany = jest.fn();
+  const prisma = { beneficiaryCase: { groupBy, findMany } } as never;
   let repository: BeneficiaryRepository;
 
   beforeEach(() => {
@@ -372,6 +373,112 @@ describe('BeneficiaryRepository', () => {
         select: { id: true, sakhiId: true, caseType: true },
       });
       expect(result).toEqual({ id: 'ben-1', sakhiId: 'sakhi-1', caseType: 'MOTHER' });
+    });
+  });
+
+  describe('findMotherIdsWithEddOnOrBefore', () => {
+    it('queries MOTHER/ACTIVE/ANC-phase beneficiaries with eddDate <= cutoffDate', async () => {
+      findMany.mockResolvedValue([]);
+      const cutoffDate = new Date('2026-08-01T00:00:00.000Z');
+
+      await repository.findMotherIdsWithEddOnOrBefore(cutoffDate, 200, undefined);
+
+      expect(findMany).toHaveBeenCalledWith({
+        where: {
+          isDeleted: false,
+          caseType: 'MOTHER',
+          currentStatus: 'ACTIVE',
+          currentPhase: 'ANC',
+          motherCaseDetails: { eddDate: { lte: cutoffDate } },
+        },
+        orderBy: [{ motherCaseDetails: { eddDate: 'asc' } }, { id: 'asc' }],
+        take: 201,
+        select: {
+          id: true,
+          registrationDate: true,
+          motherCaseDetails: { select: { eddDate: true } },
+        },
+      });
+    });
+
+    it('maps rows to {beneficiaryId, registrationDate, eddDate} and reports no next page under the limit', async () => {
+      findMany.mockResolvedValue([
+        {
+          id: 'ben-1',
+          registrationDate: new Date('2026-01-01T00:00:00.000Z'),
+          motherCaseDetails: { eddDate: new Date('2026-07-01T00:00:00.000Z') },
+        },
+      ]);
+
+      const result = await repository.findMotherIdsWithEddOnOrBefore(
+        new Date('2026-08-01T00:00:00.000Z'),
+        200,
+        undefined,
+      );
+
+      expect(result.items).toEqual([
+        {
+          beneficiaryId: 'ben-1',
+          registrationDate: new Date('2026-01-01T00:00:00.000Z'),
+          eddDate: new Date('2026-07-01T00:00:00.000Z'),
+        },
+      ]);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('returns a nextCursor and trims the extra row when more results exist beyond the limit', async () => {
+      const row = (n: number) => ({
+        id: `ben-${n}`,
+        registrationDate: new Date('2026-01-01T00:00:00.000Z'),
+        motherCaseDetails: { eddDate: new Date(`2026-07-0${n}T00:00:00.000Z`) },
+      });
+      findMany.mockResolvedValue([row(1), row(2)]);
+
+      const result = await repository.findMotherIdsWithEddOnOrBefore(
+        new Date('2026-08-01T00:00:00.000Z'),
+        1,
+        undefined,
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].beneficiaryId).toBe('ben-1');
+      expect(result.nextCursor).not.toBeNull();
+    });
+
+    it('decodes a supplied cursor into an eddDate/id keyset filter', async () => {
+      findMany.mockResolvedValue([]);
+      const cursor = Buffer.from(
+        JSON.stringify({ eddDate: '2026-07-05T00:00:00.000Z', id: 'ben-5' }),
+      ).toString('base64url');
+
+      await repository.findMotherIdsWithEddOnOrBefore(
+        new Date('2026-08-01T00:00:00.000Z'),
+        200,
+        cursor,
+      );
+
+      const call = findMany.mock.calls[0][0];
+      expect(call.where.OR).toEqual([
+        { motherCaseDetails: { eddDate: { lt: new Date('2026-07-05T00:00:00.000Z') } } },
+        {
+          motherCaseDetails: { eddDate: new Date('2026-07-05T00:00:00.000Z') },
+          id: { gt: 'ben-5' },
+        },
+      ]);
+    });
+
+    it('treats a malformed cursor as "start from the beginning" rather than throwing', async () => {
+      findMany.mockResolvedValue([]);
+
+      await expect(
+        repository.findMotherIdsWithEddOnOrBefore(
+          new Date('2026-08-01T00:00:00.000Z'),
+          200,
+          'not-a-valid-cursor',
+        ),
+      ).resolves.toEqual({ items: [], nextCursor: null });
+
+      expect(findMany.mock.calls[0][0].where.OR).toBeUndefined();
     });
   });
 });

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -26,47 +26,29 @@ export type {
   PiiCreateData,
 } from './beneficiary.repository.types';
 
-interface ListCursor {
-  createdAt: string;
-  id: string;
-}
-
-/** Encodes a row's sort key as an opaque pagination cursor. */
-function encodeCursor(row: { createdAt: Date; id: string }): string {
-  const cursor: ListCursor = { createdAt: row.createdAt.toISOString(), id: row.id };
+/**
+ * Encodes a row's (sortKey, id) pair as an opaque pagination cursor, keyed
+ * by `field` — generic so every cursor-paginated method in this file (and
+ * any future one) shares the same codec instead of each cloning its own
+ * copy differing only in the sort-key field name.
+ */
+function encodeCursor<F extends string>(
+  field: F,
+  row: { [K in F]: Date } & { id: string },
+): string {
+  const cursor = { [field]: row[field].toISOString(), id: row.id };
   return Buffer.from(JSON.stringify(cursor)).toString('base64url');
 }
 
-/** Decodes a cursor produced by encodeCursor; returns null on any malformed input. */
-function decodeCursor(cursor: string): ListCursor | null {
+/** Decodes a cursor produced by encodeCursor for the same `field`; returns null on any malformed input. */
+function decodeCursor<F extends string>(
+  field: F,
+  cursor: string,
+): ({ [K in F]: string } & { id: string }) | null {
   try {
     const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
-    if (typeof parsed?.createdAt === 'string' && typeof parsed?.id === 'string') {
-      return parsed as ListCursor;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-interface PostEddCursor {
-  eddDate: string;
-  id: string;
-}
-
-/** Encodes findMotherIdsWithEddOnOrBefore's sort key (eddDate, id) as an opaque cursor. */
-function encodePostEddCursor(row: { eddDate: Date; id: string }): string {
-  const cursor: PostEddCursor = { eddDate: row.eddDate.toISOString(), id: row.id };
-  return Buffer.from(JSON.stringify(cursor)).toString('base64url');
-}
-
-/** Decodes a cursor produced by encodePostEddCursor; returns null on any malformed input. */
-function decodePostEddCursor(cursor: string): PostEddCursor | null {
-  try {
-    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
-    if (typeof parsed?.eddDate === 'string' && typeof parsed?.id === 'string') {
-      return parsed as PostEddCursor;
+    if (typeof parsed?.[field] === 'string' && typeof parsed?.id === 'string') {
+      return parsed as { [K in F]: string } & { id: string };
     }
     return null;
   } catch {
@@ -122,7 +104,7 @@ export class BeneficiaryRepository {
       };
     }
 
-    const decodedCursor = filters.cursor ? decodeCursor(filters.cursor) : null;
+    const decodedCursor = filters.cursor ? decodeCursor('createdAt', filters.cursor) : null;
 
     const rows = await this.prisma.beneficiaryCase.findMany({
       where: decodedCursor
@@ -142,7 +124,7 @@ export class BeneficiaryRepository {
     const hasMore = rows.length > filters.limit;
     const items = hasMore ? rows.slice(0, filters.limit) : rows;
     const lastItem = items[items.length - 1];
-    return { items, nextCursor: hasMore && lastItem ? encodeCursor(lastItem) : null };
+    return { items, nextCursor: hasMore && lastItem ? encodeCursor('createdAt', lastItem) : null };
   }
 
   /**
@@ -848,7 +830,7 @@ export class BeneficiaryRepository {
     items: { beneficiaryId: string; registrationDate: Date; eddDate: Date }[];
     nextCursor: string | null;
   }> {
-    const decodedCursor = cursor ? decodePostEddCursor(cursor) : null;
+    const decodedCursor = cursor ? decodeCursor('eddDate', cursor) : null;
 
     const rows = await this.prisma.beneficiaryCase.findMany({
       where: {
@@ -896,7 +878,7 @@ export class BeneficiaryRepository {
     const lastRow = rowsWithEdd[rowsWithEdd.length - 1];
     const nextCursor =
       hasMore && lastRow
-        ? encodePostEddCursor({ eddDate: lastRow.motherCaseDetails.eddDate, id: lastRow.id })
+        ? encodeCursor('eddDate', { eddDate: lastRow.motherCaseDetails.eddDate, id: lastRow.id })
         : null;
 
     return { items, nextCursor };

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.repository.ts
@@ -50,6 +50,30 @@ function decodeCursor(cursor: string): ListCursor | null {
   }
 }
 
+interface PostEddCursor {
+  eddDate: string;
+  id: string;
+}
+
+/** Encodes findMotherIdsWithEddOnOrBefore's sort key (eddDate, id) as an opaque cursor. */
+function encodePostEddCursor(row: { eddDate: Date; id: string }): string {
+  const cursor: PostEddCursor = { eddDate: row.eddDate.toISOString(), id: row.id };
+  return Buffer.from(JSON.stringify(cursor)).toString('base64url');
+}
+
+/** Decodes a cursor produced by encodePostEddCursor; returns null on any malformed input. */
+function decodePostEddCursor(cursor: string): PostEddCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+    if (typeof parsed?.eddDate === 'string' && typeof parsed?.id === 'string') {
+      return parsed as PostEddCursor;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /** Data-access layer for beneficiary cases. Only this domain touches these tables. */
 export class BeneficiaryRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -801,6 +825,81 @@ export class BeneficiaryRepository {
       padaId: c.pii.padaId,
       latestGrade: worstByBeneficiary.get(c.id)?.grade ?? null,
     }));
+  }
+
+  /**
+   * MOTHER beneficiaries still in the ANC phase (i.e. `applyPhaseChange`'s
+   * ANC->PP transition hasn't happened yet, meaning no delivery outcome has
+   * been submitted) whose EDD is on or before `cutoffDate` — the candidate
+   * set for visit-form-service's post-EDD visit-generation job (EDD+7
+   * delivery-form-pending detection). Deliberately keyed off
+   * `BeneficiaryCase.currentPhase` — the one field `updatePhase` actually
+   * keeps authoritative — rather than `MotherCaseDetails.currentPhase` or
+   * `BeneficiaryCurrentSummary.dateOfDelivery`, neither of which any write
+   * path in this service ever populates. Unscoped (no sakhiId/roster filter)
+   * since the only caller is a system-wide background job, not a
+   * Sakhi/Supervisor/Manager viewing their own scope.
+   */
+  async findMotherIdsWithEddOnOrBefore(
+    cutoffDate: Date,
+    limit: number,
+    cursor: string | undefined,
+  ): Promise<{
+    items: { beneficiaryId: string; registrationDate: Date; eddDate: Date }[];
+    nextCursor: string | null;
+  }> {
+    const decodedCursor = cursor ? decodePostEddCursor(cursor) : null;
+
+    const rows = await this.prisma.beneficiaryCase.findMany({
+      where: {
+        isDeleted: false,
+        caseType: 'MOTHER',
+        currentStatus: 'ACTIVE',
+        currentPhase: 'ANC',
+        motherCaseDetails: { eddDate: { lte: cutoffDate } },
+        ...(decodedCursor
+          ? {
+              OR: [
+                { motherCaseDetails: { eddDate: { lt: new Date(decodedCursor.eddDate) } } },
+                {
+                  motherCaseDetails: { eddDate: new Date(decodedCursor.eddDate) },
+                  id: { gt: decodedCursor.id },
+                },
+              ],
+            }
+          : {}),
+      },
+      orderBy: [{ motherCaseDetails: { eddDate: 'asc' } }, { id: 'asc' }],
+      take: limit + 1,
+      select: {
+        id: true,
+        registrationDate: true,
+        motherCaseDetails: { select: { eddDate: true } },
+      },
+    });
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    // The `motherCaseDetails: { eddDate: ... }` filter above only matches
+    // rows with a related MotherCaseDetails record, so `eddDate` here is
+    // never null in practice — filtered (not asserted) so a future query
+    // change that loosens that guarantee fails closed (row dropped) rather
+    // than throwing on a non-null assertion.
+    const rowsWithEdd = page.flatMap((row) =>
+      row.motherCaseDetails ? [{ ...row, motherCaseDetails: row.motherCaseDetails }] : [],
+    );
+    const items = rowsWithEdd.map((row) => ({
+      beneficiaryId: row.id,
+      registrationDate: row.registrationDate,
+      eddDate: row.motherCaseDetails.eddDate,
+    }));
+    const lastRow = rowsWithEdd[rowsWithEdd.length - 1];
+    const nextCursor =
+      hasMore && lastRow
+        ? encodePostEddCursor({ eddDate: lastRow.motherCaseDetails.eddDate, id: lastRow.id })
+        : null;
+
+    return { items, nextCursor };
   }
 
   /**

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.routes.ts
@@ -18,6 +18,7 @@ import { summaryQuerySchema } from './dto/summary-query.dto';
 import { idsQuerySchema } from './dto/ids-query.dto';
 import { byIdsWithRiskQuerySchema } from './dto/by-ids-with-risk-query.dto';
 import { batchRiskConditionSummaryQuerySchema } from './dto/batch-risk-condition-summary-query.dto';
+import { postEddPendingQuerySchema } from './dto/post-edd-pending-query.dto';
 import { upsertSocioDemographicsSchema } from './dto/upsert-socio-demographics.dto';
 import { upsertRiskConditionSummarySchema } from './dto/upsert-risk-condition-summary.dto';
 import { applyLmpChangeSchema } from './dto/apply-lmp-change.dto';
@@ -542,9 +543,53 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
   );
 
   doc.get(
+    '/beneficiaries/internal/post-edd-pending',
+    {
+      summary:
+        'SYSTEM-only: MOTHER beneficiaries still in the ANC phase (no delivery outcome ' +
+        'submitted yet) whose EDD is on or before `cutoffDate` — the candidate set for ' +
+        "visit-form-service's post-EDD visit-generation job (EDD+7 delivery-form-pending " +
+        'detection). Cursor-paginated via cursor/limit (default 200, max 500). Unscoped — ' +
+        'unlike every human-facing list endpoint, there is no sakhiId/roster filter: the ' +
+        'only caller is a background job acting system-wide.',
+      tags: ['Beneficiaries'],
+      responses: {
+        200: {
+          description: 'Post-EDD-pending MOTHER beneficiaries retrieved',
+          schema: envelope(
+            z.object({
+              items: z.array(
+                z.object({
+                  beneficiaryId: z.string().uuid(),
+                  registrationDate: z.string().datetime(),
+                  eddDate: z.string().datetime(),
+                }),
+              ),
+              nextCursor: z.string().nullable(),
+            }),
+          ),
+        },
+        400: errorResponse(400, { message: 'cutoffDate: must be a date-only string (YYYY-MM-DD)' }),
+        401: errorResponse(401),
+        403: errorResponse(403),
+        500: errorResponse(500),
+      },
+    },
+    trustGatewayIdentity,
+    requireRoles('SYSTEM'),
+    validate(postEddPendingQuerySchema, 'query'),
+    controller.getPostEddPending,
+  );
+
+  doc.get(
     '/beneficiaries/:id',
     {
-      summary: 'Get a beneficiary case by id — profile, current phase, risk state, status history',
+      summary:
+        'Get a beneficiary case by id — profile, current phase, risk state, status history. ' +
+        "SYSTEM is included alongside the human roles so visit-form-service's post-EDD " +
+        'visit-generation job (and any other privileged system caller) can resolve a ' +
+        "beneficiary via VisitScheduleService.generateSchedule's assertCanTouchBeneficiary " +
+        'check without a human identity.',
       tags: ['Beneficiaries'],
       responses: {
         200: {
@@ -559,7 +604,7 @@ export function registerBeneficiaryRoutes(doc: DocumentedRouter, service: Benefi
       },
     },
     trustGatewayIdentity,
-    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER'),
+    requireRoles('SAKHI', 'SUPERVISOR', 'MANAGER', 'SYSTEM'),
     validate(idParamsSchema, 'params'),
     controller.getById,
   );

--- a/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
+++ b/apps/beneficiary-service/src/beneficiary/beneficiary.service.ts
@@ -496,6 +496,26 @@ export class BeneficiaryService {
   }
 
   /**
+   * MOTHER beneficiaries whose EDD has passed `cutoffDate` and who are still
+   * in the ANC phase (no delivery outcome submitted yet) — for
+   * visit-form-service's post-EDD visit-generation job. SYSTEM-only (see
+   * beneficiary.routes.ts): unlike getIds/getPadaBreakdown, there is no
+   * sakhiId/roster scoping here — the only caller is a background job
+   * acting system-wide, not a human viewing their own scope.
+   */
+  async getPostEddPendingBeneficiaries(
+    cutoffDate: string,
+    limit: number,
+    cursor: string | undefined,
+  ) {
+    return this.repository.findMotherIdsWithEddOnOrBefore(
+      new Date(`${cutoffDate}T00:00:00.000Z`),
+      limit,
+      cursor,
+    );
+  }
+
+  /**
    * Pada Breakdown widget — one row per distinct pada the caller's in-scope
    * beneficiaries live in (a beneficiary with no padaId on record is
    * excluded, per findIdsGroupedByPada), each with a resolved padaName,

--- a/apps/beneficiary-service/src/beneficiary/dto/post-edd-pending-query.dto.ts
+++ b/apps/beneficiary-service/src/beneficiary/dto/post-edd-pending-query.dto.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const dateOnlySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'must be a date-only string (YYYY-MM-DD)');
+
+/**
+ * Query params for `GET /beneficiaries/internal/post-edd-pending` — a
+ * SYSTEM-only, server-to-server endpoint for visit-form-service's post-EDD
+ * visit-generation job (EDD+7 delivery-form-pending detection, per the
+ * build plan's "What we need from backend" list). No sakhiId/roster scoping
+ * (unlike every human-facing list endpoint) since the only caller is a
+ * background job acting system-wide, not a Sakhi/Supervisor/Manager viewing
+ * their own scope.
+ */
+export const postEddPendingQuerySchema = z
+  .object({
+    // Candidates are MOTHER cases whose EDD is on or before this date —
+    // the job passes `today - 7 days`.
+    cutoffDate: dateOnlySchema,
+    // Opaque, base64-encoded cursor — see beneficiary.repository.ts's
+    // encode/decodePostEddCursor.
+    cursor: z.string().trim().min(1).optional(),
+    limit: z.coerce.number().int().min(1).max(500).default(200),
+  })
+  .strict();
+
+export type PostEddPendingQueryInput = z.infer<typeof postEddPendingQuerySchema>;

--- a/apps/beneficiary-service/src/main.ts
+++ b/apps/beneficiary-service/src/main.ts
@@ -21,4 +21,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/beneficiary-service/src/main.ts
+++ b/apps/beneficiary-service/src/main.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import { bootstrapService } from '@armman/service-commons';
 import { appConfig } from './config/app-config';
 import { createApp } from './app.module';
 import { PrismaService } from './prisma/prisma.service';
@@ -21,7 +22,4 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-bootstrap().catch((err) => {
-  console.error('Fatal error during startup:', err);
-  process.exit(1);
-});
+bootstrapService(bootstrap);

--- a/apps/closure-reopen-service/src/closures/closure.module.ts
+++ b/apps/closure-reopen-service/src/closures/closure.module.ts
@@ -7,6 +7,7 @@ import { ApprovalClient } from '../reopen-requests/approval.client';
 import { LookupClient } from '../reopen-requests/lookup.client';
 import { NotificationClient } from '../reopen-requests/notification.client';
 import { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
+import { SakhiClient } from '../reopen-requests/sakhi.client';
 
 /**
  * Composition root for the closures feature: wires repository → service → routes.
@@ -18,12 +19,14 @@ export function createClosureModule(prisma: PrismaService): DocumentedRouter {
   const lookupClient = new LookupClient();
   const notificationClient = new NotificationClient();
   const beneficiaryClient = new BeneficiaryClient();
+  const sakhiClient = new SakhiClient();
   const service = new ClosureService(
     repository,
     approvalClient,
     lookupClient,
     notificationClient,
     beneficiaryClient,
+    sakhiClient,
   );
   const doc = createDocumentedRouter();
   registerClosureRoutes(doc, service);

--- a/apps/closure-reopen-service/src/closures/closure.routes.ts
+++ b/apps/closure-reopen-service/src/closures/closure.routes.ts
@@ -56,7 +56,15 @@ const closureSchema = z.object({
 });
 
 const closureIdParamsSchema = z
-  .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
+  .object({
+    id: z
+      .string()
+      .uuid()
+      .openapi({
+        param: { name: 'id', in: 'path' },
+        example: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+  })
   .strict();
 
 const decideClosureRequestSchema = decideClosureSchema.extend({

--- a/apps/closure-reopen-service/src/closures/closure.service.spec.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.spec.ts
@@ -4,6 +4,7 @@ import type { ApprovalClient } from '../reopen-requests/approval.client';
 import type { LookupClient } from '../reopen-requests/lookup.client';
 import type { NotificationClient } from '../reopen-requests/notification.client';
 import type { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
+import type { SakhiClient } from '../reopen-requests/sakhi.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
 import type { DecideClosureInput } from './dto/decide-closure.dto';
 import type { ClosureType } from '../../../../node_modules/.prisma/client-closure-reopen-service';
@@ -40,7 +41,10 @@ describe('ClosureService', () => {
     create: jest.fn(),
     decide: jest.fn(),
   } as unknown as jest.Mocked<ClosureRepository>;
-  const approvalClient = { create: jest.fn() } as unknown as jest.Mocked<ApprovalClient>;
+  const approvalClient = {
+    create: jest.fn(),
+    findByClosureId: jest.fn(),
+  } as unknown as jest.Mocked<ApprovalClient>;
   const lookupClient = {
     resolveApprovalStatusId: jest.fn(),
     resolveClosureReasonCode: jest.fn(),
@@ -50,15 +54,18 @@ describe('ClosureService', () => {
     closeCase: jest.fn(),
     getById: jest.fn(),
   } as unknown as jest.Mocked<BeneficiaryClient>;
+  const sakhiClient = { getById: jest.fn() } as unknown as jest.Mocked<SakhiClient>;
   let service: ClosureService;
   const authHeader = 'Bearer token';
   const supervisorId = '44444444-4444-4444-4444-444444444444';
+  const approvalRequestId = '55555555-5555-5555-5555-555555555555';
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     repository.findByLocalClosureUuid.mockResolvedValue(null);
+    approvalClient.findByClosureId.mockResolvedValue({ id: approvalRequestId });
     beneficiaryClient.closeCase.mockResolvedValue({
       id: '22222222-2222-2222-2222-222222222222',
       currentStatus: 'CLOSED',
@@ -66,6 +73,7 @@ describe('ClosureService', () => {
     beneficiaryClient.getById.mockResolvedValue({
       id: '22222222-2222-2222-2222-222222222222',
       currentStatus: 'ACTIVE',
+      pii: { fullName: 'Asha Devi' },
     });
     lookupClient.resolveClosureReasonCode.mockResolvedValue('WITHDRAWAL');
     service = new ClosureService(
@@ -74,6 +82,7 @@ describe('ClosureService', () => {
       lookupClient,
       notificationClient,
       beneficiaryClient,
+      sakhiClient,
     );
   });
 
@@ -334,6 +343,61 @@ describe('ClosureService', () => {
         expect.any(String),
         expect.any(String),
         authHeader,
+        { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
+      );
+    });
+
+    it('interpolates the resolved Sakhi and beneficiary names into the title/body', async () => {
+      const pending = closureRow({ supervisorStatus: 'PENDING' });
+      const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+      beneficiaryClient.getById.mockResolvedValue({
+        id: pending.beneficiaryId,
+        currentStatus: 'ACTIVE',
+        pii: { fullName: 'Asha Devi' },
+      });
+      sakhiClient.getById.mockResolvedValue({
+        sakhiId: pending.submittedByUserId,
+        displayName: 'Priya Sakhi',
+        mobileNumber: '+919000000123',
+      });
+
+      await service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader);
+
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        pending.submittedByUserId,
+        'CLOSURE_REVIEW_UPDATE',
+        'Closure review — Priya Sakhi',
+        "Asha Devi's closure request was approved",
+        authHeader,
+        { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
+      );
+    });
+
+    it('falls back to a generic title when the Sakhi name lookup fails, keeping the beneficiary name already in hand', async () => {
+      const pending = closureRow({ supervisorStatus: 'PENDING' });
+      const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+      beneficiaryClient.getById.mockResolvedValue({
+        id: pending.beneficiaryId,
+        currentStatus: 'ACTIVE',
+        pii: { fullName: 'Asha Devi' },
+      });
+      sakhiClient.getById.mockRejectedValue(new Error('auth-service down'));
+
+      await expect(
+        service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+      ).resolves.toBe(decided);
+
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        pending.submittedByUserId,
+        'CLOSURE_REVIEW_UPDATE',
+        'Closure review decided',
+        "Asha Devi's closure request was approved",
+        authHeader,
+        { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
       );
     });
 
@@ -442,6 +506,7 @@ describe('ClosureService', () => {
         beneficiaryClient.getById.mockResolvedValue({
           id: pending.beneficiaryId,
           currentStatus: 'ACTIVE',
+          pii: { fullName: 'Asha Devi' },
         });
 
         await expect(
@@ -518,6 +583,72 @@ describe('ClosureService', () => {
         service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
       ).resolves.toBe(decided);
       expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    describe('Quick Response card linking', () => {
+      it('links the notification to the approval_requests id, not the closure id', async () => {
+        const pending = pendingClosure();
+        const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+        repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+        repository.decide.mockResolvedValue(true);
+
+        await service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader);
+
+        expect(approvalClient.findByClosureId).toHaveBeenCalledWith(pending.id, authHeader);
+        expect(notificationClient.notify).toHaveBeenCalledWith(
+          pending.submittedByUserId,
+          'CLOSURE_REVIEW_UPDATE',
+          expect.any(String),
+          expect.any(String),
+          authHeader,
+          { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
+        );
+      });
+
+      it('sends the notification without a linkedEntity when no approval request is found for the closure', async () => {
+        const pending = pendingClosure();
+        const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+        repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+        repository.decide.mockResolvedValue(true);
+        approvalClient.findByClosureId.mockResolvedValue(null);
+
+        await expect(
+          service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+        ).resolves.toBe(decided);
+
+        expect(notificationClient.notify).toHaveBeenCalledWith(
+          pending.submittedByUserId,
+          'CLOSURE_REVIEW_UPDATE',
+          expect.any(String),
+          expect.any(String),
+          authHeader,
+          undefined,
+        );
+      });
+
+      it('sends the notification without a linkedEntity, and does not fail the decision, when the lookup throws', async () => {
+        const pending = pendingClosure();
+        const decided = { ...pending, supervisorStatus: 'APPROVED' as const, supervisorId };
+        repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+        repository.decide.mockResolvedValue(true);
+        approvalClient.findByClosureId.mockRejectedValue(
+          Object.assign(new Error('Bad gateway'), { status: 502 }),
+        );
+
+        await expect(
+          service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+        ).resolves.toBe(decided);
+
+        expect(notificationClient.notify).toHaveBeenCalledWith(
+          pending.submittedByUserId,
+          'CLOSURE_REVIEW_UPDATE',
+          expect.any(String),
+          expect.any(String),
+          authHeader,
+          undefined,
+        );
+        expect(consoleErrorSpy).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/closure-reopen-service/src/closures/closure.service.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.ts
@@ -4,6 +4,7 @@ import type { ApprovalClient } from '../reopen-requests/approval.client';
 import type { LookupClient } from '../reopen-requests/lookup.client';
 import type { NotificationClient } from '../reopen-requests/notification.client';
 import type { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
+import type { SakhiClient } from '../reopen-requests/sakhi.client';
 import type { CreateClosureInput } from './dto/create-closure.dto';
 import type { DecideClosureInput } from './dto/decide-closure.dto';
 
@@ -33,7 +34,47 @@ export class ClosureService {
     private readonly lookupClient: LookupClient,
     private readonly notificationClient: NotificationClient,
     private readonly beneficiaryClient: BeneficiaryClient,
+    private readonly sakhiClient: SakhiClient,
   ) {}
+
+  /** Best-effort — a name lookup failure falls back to no name (generic
+   * notification text) rather than blocking the decision it's attached to. */
+  private async resolveSakhiName(
+    sakhiId: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    try {
+      const sakhi = await this.sakhiClient.getById(sakhiId, authorizationHeader);
+      return sakhi?.displayName ?? null;
+    } catch (err) {
+      console.error(`Failed to resolve Sakhi ${sakhiId}'s name for a notification:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Best-effort — this closure's Quick Response card id (approval_requests.id),
+   * used to link the decision notification so GET /quick-response/:cardId can
+   * resolve it. A failure here (no matching approval request, or
+   * approval-service unreachable) must not block the decision — the
+   * notification is simply sent without a linkedEntity rather than with a
+   * closures-table id GET /quick-response/:cardId doesn't recognise.
+   */
+  private async resolveQuickResponseCardId(
+    closureId: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    try {
+      const approvalRequest = await this.approvalClient.findByClosureId(
+        closureId,
+        authorizationHeader,
+      );
+      return approvalRequest?.id ?? null;
+    } catch (err) {
+      console.error(`Failed to resolve the Quick Response card id for closure ${closureId}:`, err);
+      return null;
+    }
+  }
 
   list() {
     return this.repository.findMany();
@@ -185,8 +226,13 @@ export class ClosureService {
     // /beneficiaries/:id (SAKHI-own-case / SUPERVISOR-roster /
     // MANAGER-unrestricted) — same pattern create() already uses. Without
     // this, any SUPERVISOR who learns a closure id outside their own
-    // roster could approve or reject it (IDOR).
-    await this.beneficiaryClient.getById(existing.beneficiaryId, authorizationHeader);
+    // roster could approve or reject it (IDOR). Its response is also reused
+    // below for the Sakhi notification's beneficiary name, avoiding a
+    // second fetch.
+    const beneficiary = await this.beneficiaryClient.getById(
+      existing.beneficiaryId,
+      authorizationHeader,
+    );
 
     if (existing.supervisorStatus === null) {
       throw unprocessable('This closure does not require supervisor review.');
@@ -222,14 +268,24 @@ export class ClosureService {
     }
 
     try {
+      const [sakhiName, cardId] = await Promise.all([
+        this.resolveSakhiName(existing.submittedByUserId, authorizationHeader),
+        this.resolveQuickResponseCardId(id, authorizationHeader),
+      ]);
+      const beneficiaryName = beneficiary?.pii.fullName ?? null;
       await this.notificationClient.notify(
         existing.submittedByUserId,
         'CLOSURE_REVIEW_UPDATE',
-        'Closure review decided',
-        dto.decision === 'APPROVED'
-          ? 'Your closure request was approved.'
-          : 'Your closure request was rejected.',
+        sakhiName ? `Closure review — ${sakhiName}` : 'Closure review decided',
+        beneficiaryName
+          ? dto.decision === 'APPROVED'
+            ? `${beneficiaryName}'s closure request was approved`
+            : `${beneficiaryName}'s closure request was rejected`
+          : dto.decision === 'APPROVED'
+            ? 'Your closure request was approved.'
+            : 'Your closure request was rejected.',
         authorizationHeader,
+        cardId ? { linkedEntityType: 'QuickResponseCard', linkedEntityId: cardId } : undefined,
       );
     } catch (err) {
       console.error(

--- a/apps/closure-reopen-service/src/closures/closure.service.ts
+++ b/apps/closure-reopen-service/src/closures/closure.service.ts
@@ -5,6 +5,10 @@ import type { LookupClient } from '../reopen-requests/lookup.client';
 import type { NotificationClient } from '../reopen-requests/notification.client';
 import type { BeneficiaryClient } from '../reopen-requests/beneficiary.client';
 import type { SakhiClient } from '../reopen-requests/sakhi.client';
+import {
+  resolveSakhiName,
+  resolveQuickResponseCardId,
+} from '../reopen-requests/decision-notification.helper';
 import type { CreateClosureInput } from './dto/create-closure.dto';
 import type { DecideClosureInput } from './dto/decide-closure.dto';
 
@@ -36,45 +40,6 @@ export class ClosureService {
     private readonly beneficiaryClient: BeneficiaryClient,
     private readonly sakhiClient: SakhiClient,
   ) {}
-
-  /** Best-effort — a name lookup failure falls back to no name (generic
-   * notification text) rather than blocking the decision it's attached to. */
-  private async resolveSakhiName(
-    sakhiId: string,
-    authorizationHeader: string,
-  ): Promise<string | null> {
-    try {
-      const sakhi = await this.sakhiClient.getById(sakhiId, authorizationHeader);
-      return sakhi?.displayName ?? null;
-    } catch (err) {
-      console.error(`Failed to resolve Sakhi ${sakhiId}'s name for a notification:`, err);
-      return null;
-    }
-  }
-
-  /**
-   * Best-effort — this closure's Quick Response card id (approval_requests.id),
-   * used to link the decision notification so GET /quick-response/:cardId can
-   * resolve it. A failure here (no matching approval request, or
-   * approval-service unreachable) must not block the decision — the
-   * notification is simply sent without a linkedEntity rather than with a
-   * closures-table id GET /quick-response/:cardId doesn't recognise.
-   */
-  private async resolveQuickResponseCardId(
-    closureId: string,
-    authorizationHeader: string,
-  ): Promise<string | null> {
-    try {
-      const approvalRequest = await this.approvalClient.findByClosureId(
-        closureId,
-        authorizationHeader,
-      );
-      return approvalRequest?.id ?? null;
-    } catch (err) {
-      console.error(`Failed to resolve the Quick Response card id for closure ${closureId}:`, err);
-      return null;
-    }
-  }
 
   list() {
     return this.repository.findMany();
@@ -269,10 +234,10 @@ export class ClosureService {
 
     try {
       const [sakhiName, cardId] = await Promise.all([
-        this.resolveSakhiName(existing.submittedByUserId, authorizationHeader),
-        this.resolveQuickResponseCardId(id, authorizationHeader),
+        resolveSakhiName(this.sakhiClient, existing.submittedByUserId, authorizationHeader),
+        resolveQuickResponseCardId(this.approvalClient, 'closure', id, authorizationHeader),
       ]);
-      const beneficiaryName = beneficiary?.pii.fullName ?? null;
+      const beneficiaryName = beneficiary?.pii?.fullName ?? null;
       await this.notificationClient.notify(
         existing.submittedByUserId,
         'CLOSURE_REVIEW_UPDATE',

--- a/apps/closure-reopen-service/src/main.ts
+++ b/apps/closure-reopen-service/src/main.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import { bootstrapService } from '@armman/service-commons';
 import { appConfig } from './config/app-config';
 import { createApp } from './app.module';
 import { PrismaService } from './prisma/prisma.service';
@@ -22,7 +23,4 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-bootstrap().catch((err) => {
-  console.error('Fatal error during startup:', err);
-  process.exit(1);
-});
+bootstrapService(bootstrap);

--- a/apps/closure-reopen-service/src/main.ts
+++ b/apps/closure-reopen-service/src/main.ts
@@ -22,4 +22,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/closure-reopen-service/src/reopen-requests/approval.client.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/approval.client.spec.ts
@@ -1,0 +1,100 @@
+jest.mock('../config/app-config', () => ({
+  appConfig: { API_GATEWAY_BASE_URL: 'http://localhost:3000' },
+}));
+
+import { ApprovalClient } from './approval.client';
+
+describe('ApprovalClient', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn();
+  let client: ApprovalClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    client = new ApprovalClient();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('findByClosureId', () => {
+    it("GETs approval-service via the gateway with the caller's own token", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { id: 'approval-1' } }),
+      });
+
+      const result = await client.findByClosureId('closure-1', 'Bearer test-token');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/approvals/by-source?closureId=closure-1'),
+        expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+      );
+      expect(result).toEqual({ id: 'approval-1' });
+    });
+
+    it('returns null on a 404 (no matching approval request)', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+      await expect(client.findByClosureId('closure-1', 'Bearer test-token')).resolves.toBeNull();
+    });
+
+    it('throws HttpError with the upstream status/message on another 4xx response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ message: 'Forbidden.' }),
+      });
+
+      await expect(client.findByClosureId('closure-1', 'Bearer test-token')).rejects.toMatchObject({
+        status: 403,
+        message: 'Forbidden.',
+      });
+    });
+
+    it('throws a badGateway error on a 5xx response', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+
+      await expect(client.findByClosureId('closure-1', 'Bearer test-token')).rejects.toMatchObject({
+        status: 502,
+      });
+    });
+
+    it('throws a badGateway error on a network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'));
+
+      await expect(client.findByClosureId('closure-1', 'Bearer test-token')).rejects.toMatchObject({
+        status: 502,
+      });
+    });
+  });
+
+  describe('findByReopenRequestId', () => {
+    it("GETs approval-service via the gateway with the caller's own token", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { id: 'approval-2' } }),
+      });
+
+      const result = await client.findByReopenRequestId('reopen-1', 'Bearer test-token');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/approvals/by-source?reopenRequestId=reopen-1'),
+        expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } }),
+      );
+      expect(result).toEqual({ id: 'approval-2' });
+    });
+
+    it('returns null on a 404 (no matching approval request)', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+      await expect(
+        client.findByReopenRequestId('reopen-1', 'Bearer test-token'),
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/apps/closure-reopen-service/src/reopen-requests/approval.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/approval.client.ts
@@ -1,6 +1,10 @@
 import { badGateway, HttpError } from '@armman/service-commons';
 import { appConfig } from '../config/app-config';
 
+export interface ApprovalRequestRecord {
+  id: string;
+}
+
 export interface CreateApprovalRequestInput {
   requestType: string;
   beneficiaryId?: string;
@@ -39,5 +43,55 @@ export class ApprovalClient {
         'Unable to raise the approval request — approval-service returned an error.',
       );
     }
+  }
+
+  /**
+   * Resolves the approval_requests row raised for a closure, via
+   * approval-service's GET /approvals/by-source?closureId=. Needed to link a
+   * Closure Review decision notification's linkedEntityId to the id
+   * GET /quick-response/:cardId actually expects — closures carries no
+   * approval_requests id of its own (no cross-service relation).
+   */
+  async findByClosureId(
+    closureId: string,
+    authorizationHeader: string,
+  ): Promise<ApprovalRequestRecord | null> {
+    return this.findBySource(`closureId=${closureId}`, authorizationHeader);
+  }
+
+  /** Same as findByClosureId, for a reopen request. */
+  async findByReopenRequestId(
+    reopenRequestId: string,
+    authorizationHeader: string,
+  ): Promise<ApprovalRequestRecord | null> {
+    return this.findBySource(`reopenRequestId=${reopenRequestId}`, authorizationHeader);
+  }
+
+  private async findBySource(
+    query: string,
+    authorizationHeader: string,
+  ): Promise<ApprovalRequestRecord | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${appConfig.API_GATEWAY_BASE_URL}/api/v1/approvals/by-source?${query}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the approval request — approval-service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the approval request.');
+      }
+      throw badGateway(
+        'Unable to resolve the approval request — approval-service returned an error.',
+      );
+    }
+
+    const body = (await res.json()) as { data: ApprovalRequestRecord };
+    return body.data;
   }
 }

--- a/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/beneficiary.client.ts
@@ -12,6 +12,10 @@ export interface BeneficiaryCaseRecord {
   currentStatus: string;
 }
 
+export interface BeneficiaryCaseDetail extends BeneficiaryCaseRecord {
+  pii: { fullName: string };
+}
+
 /**
  * Reactivates a CLOSED beneficiary case by calling beneficiary-service's
  * PATCH /beneficiaries/:id/reactivate through the gateway, forwarding the
@@ -102,7 +106,7 @@ export class BeneficiaryClient {
   async getById(
     beneficiaryId: string,
     authorizationHeader: string,
-  ): Promise<BeneficiaryCaseRecord> {
+  ): Promise<BeneficiaryCaseDetail> {
     let res: Response;
     try {
       res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/beneficiaries/${beneficiaryId}`, {
@@ -122,7 +126,7 @@ export class BeneficiaryClient {
       );
     }
 
-    const body = (await res.json()) as { data: BeneficiaryCaseRecord };
+    const body = (await res.json()) as { data: BeneficiaryCaseDetail };
     return body.data;
   }
 }

--- a/apps/closure-reopen-service/src/reopen-requests/decision-notification.helper.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/decision-notification.helper.ts
@@ -1,0 +1,51 @@
+import type { SakhiClient } from './sakhi.client';
+import type { ApprovalClient } from './approval.client';
+
+/**
+ * Best-effort — a name lookup failure falls back to no name (generic
+ * notification text) rather than blocking the decision it's attached to.
+ * Shared by ClosureService and ReopenRequestService (both take the same
+ * SakhiClient dependency) so the fallback behavior/log format can't drift
+ * between the two copies.
+ */
+export async function resolveSakhiName(
+  sakhiClient: SakhiClient,
+  sakhiId: string,
+  authorizationHeader: string,
+): Promise<string | null> {
+  try {
+    const sakhi = await sakhiClient.getById(sakhiId, authorizationHeader);
+    return sakhi?.displayName ?? null;
+  } catch (err) {
+    console.error(`Failed to resolve Sakhi ${sakhiId}'s name for a notification:`, err);
+    return null;
+  }
+}
+
+/**
+ * Best-effort — the Quick Response card id (approval_requests.id) for a
+ * closure or reopen request, used to link the decision notification so
+ * GET /quick-response/:cardId can resolve it. A failure here (no matching
+ * approval request, or approval-service unreachable) must not block the
+ * decision — the notification is simply sent without a linkedEntity rather
+ * than with a closures/reopen_requests-table id GET /quick-response/:cardId
+ * doesn't recognise. Shared by ClosureService and ReopenRequestService,
+ * parameterized by which ApprovalClient lookup to use.
+ */
+export async function resolveQuickResponseCardId(
+  approvalClient: ApprovalClient,
+  kind: 'closure' | 'reopen request',
+  sourceId: string,
+  authorizationHeader: string,
+): Promise<string | null> {
+  try {
+    const approvalRequest =
+      kind === 'closure'
+        ? await approvalClient.findByClosureId(sourceId, authorizationHeader)
+        : await approvalClient.findByReopenRequestId(sourceId, authorizationHeader);
+    return approvalRequest?.id ?? null;
+  } catch (err) {
+    console.error(`Failed to resolve the Quick Response card id for ${kind} ${sourceId}:`, err);
+    return null;
+  }
+}

--- a/apps/closure-reopen-service/src/reopen-requests/notification.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/notification.client.ts
@@ -14,6 +14,7 @@ export class NotificationClient {
     title: string,
     body: string,
     authorizationHeader: string,
+    linkedEntity?: { linkedEntityType: string; linkedEntityId: string },
   ): Promise<void> {
     let res: Response;
     try {
@@ -26,6 +27,7 @@ export class NotificationClient {
           title,
           body,
           status: 'UNREAD',
+          ...linkedEntity,
         }),
       });
     } catch {

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.module.ts
@@ -8,6 +8,7 @@ import { NotificationClient } from './notification.client';
 import { ApprovalClient } from './approval.client';
 import { LookupClient } from './lookup.client';
 import { BeneficiaryClient } from './beneficiary.client';
+import { SakhiClient } from './sakhi.client';
 
 /**
  * Composition root for the reopen-requests feature: wires repository → service → routes.
@@ -19,6 +20,7 @@ export function createReopenRequestModule(prisma: PrismaService): DocumentedRout
   const approvalClient = new ApprovalClient();
   const lookupClient = new LookupClient();
   const beneficiaryClient = new BeneficiaryClient();
+  const sakhiClient = new SakhiClient();
   const service = new ReopenRequestService(
     repository,
     auditClient,
@@ -26,6 +28,7 @@ export function createReopenRequestModule(prisma: PrismaService): DocumentedRout
     approvalClient,
     lookupClient,
     beneficiaryClient,
+    sakhiClient,
   );
   const doc = createDocumentedRouter();
   registerReopenRequestRoutes(doc, service);

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.routes.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.routes.ts
@@ -17,7 +17,15 @@ import {
 extendZodWithOpenApi(z);
 
 const reopenRequestIdParamsSchema = z
-  .object({ id: z.string().uuid().openapi({ example: '123e4567-e89b-12d3-a456-426614174000' }) })
+  .object({
+    id: z
+      .string()
+      .uuid()
+      .openapi({
+        param: { name: 'id', in: 'path' },
+        example: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+  })
   .strict();
 
 const listByBeneficiaryQuerySchema = z

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.spec.ts
@@ -5,6 +5,7 @@ import type { NotificationClient } from './notification.client';
 import type { ApprovalClient } from './approval.client';
 import type { LookupClient } from './lookup.client';
 import type { BeneficiaryClient } from './beneficiary.client';
+import type { SakhiClient } from './sakhi.client';
 import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
@@ -42,7 +43,10 @@ describe('ReopenRequestService', () => {
   } as unknown as jest.Mocked<ReopenRequestRepository>;
   const auditClient = { log: jest.fn() } as unknown as jest.Mocked<AuditClient>;
   const notificationClient = { notify: jest.fn() } as unknown as jest.Mocked<NotificationClient>;
-  const approvalClient = { create: jest.fn() } as unknown as jest.Mocked<ApprovalClient>;
+  const approvalClient = {
+    create: jest.fn(),
+    findByReopenRequestId: jest.fn(),
+  } as unknown as jest.Mocked<ApprovalClient>;
   const lookupClient = {
     resolveApprovalStatusId: jest.fn(),
   } as unknown as jest.Mocked<LookupClient>;
@@ -50,15 +54,18 @@ describe('ReopenRequestService', () => {
     reactivateCase: jest.fn(),
     getById: jest.fn(),
   } as unknown as jest.Mocked<BeneficiaryClient>;
+  const sakhiClient = { getById: jest.fn() } as unknown as jest.Mocked<SakhiClient>;
   let service: ReopenRequestService;
   const supervisorId = '44444444-4444-4444-4444-444444444444';
   const authHeader = 'Bearer token';
+  const approvalRequestId = '77777777-7777-7777-7777-777777777777';
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetAllMocks();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
     repository.findByLocalReopenRequestUuid.mockResolvedValue(null);
+    approvalClient.findByReopenRequestId.mockResolvedValue({ id: approvalRequestId });
     beneficiaryClient.reactivateCase.mockResolvedValue({
       id: '22222222-2222-2222-2222-222222222222',
       currentStatus: 'ACTIVE',
@@ -66,6 +73,7 @@ describe('ReopenRequestService', () => {
     beneficiaryClient.getById.mockResolvedValue({
       id: '22222222-2222-2222-2222-222222222222',
       currentStatus: 'CLOSED',
+      pii: { fullName: 'Asha Devi' },
     });
     service = new ReopenRequestService(
       repository,
@@ -74,6 +82,7 @@ describe('ReopenRequestService', () => {
       approvalClient,
       lookupClient,
       beneficiaryClient,
+      sakhiClient,
     );
   });
 
@@ -85,7 +94,11 @@ describe('ReopenRequestService', () => {
     const beneficiaryId = '22222222-2222-2222-2222-222222222222';
 
     it('returns the reopen requests when the beneficiary lookup succeeds', async () => {
-      beneficiaryClient.getById.mockResolvedValue({ id: beneficiaryId, currentStatus: 'CLOSED' });
+      beneficiaryClient.getById.mockResolvedValue({
+        id: beneficiaryId,
+        currentStatus: 'CLOSED',
+        pii: { fullName: 'Asha Devi' },
+      });
       const rows = [reopenRequest()];
       repository.findByBeneficiaryId.mockResolvedValue(rows);
 
@@ -94,7 +107,11 @@ describe('ReopenRequestService', () => {
     });
 
     it('returns an empty array when the beneficiary has no reopen requests', async () => {
-      beneficiaryClient.getById.mockResolvedValue({ id: beneficiaryId, currentStatus: 'CLOSED' });
+      beneficiaryClient.getById.mockResolvedValue({
+        id: beneficiaryId,
+        currentStatus: 'CLOSED',
+        pii: { fullName: 'Asha Devi' },
+      });
       repository.findByBeneficiaryId.mockResolvedValue([]);
 
       await expect(service.listByBeneficiaryId(beneficiaryId, authHeader)).resolves.toEqual([]);
@@ -292,6 +309,61 @@ describe('ReopenRequestService', () => {
       expect.any(String),
       expect.any(String),
       authHeader,
+      { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
+    );
+  });
+
+  it('interpolates the resolved Sakhi and beneficiary names into the title/body', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+    beneficiaryClient.getById.mockResolvedValue({
+      id: pending.beneficiaryId,
+      currentStatus: 'CLOSED',
+      pii: { fullName: 'Asha Devi' },
+    });
+    sakhiClient.getById.mockResolvedValue({
+      sakhiId: pending.requestedByUserId,
+      displayName: 'Priya Sakhi',
+      mobileNumber: '+919000000123',
+    });
+
+    await service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader);
+
+    expect(notificationClient.notify).toHaveBeenCalledWith(
+      pending.requestedByUserId,
+      'REOPEN_UPDATE',
+      'Reopen request — Priya Sakhi',
+      "Asha Devi's reopen request was approved",
+      authHeader,
+      { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
+    );
+  });
+
+  it('falls back to a generic title when the Sakhi name lookup fails, keeping the beneficiary name already in hand', async () => {
+    const pending = reopenRequest();
+    const decided = reopenRequest({ supervisorStatus: 'APPROVED', decidedByUserId: supervisorId });
+    repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+    repository.decide.mockResolvedValue(true);
+    beneficiaryClient.getById.mockResolvedValue({
+      id: pending.beneficiaryId,
+      currentStatus: 'CLOSED',
+      pii: { fullName: 'Asha Devi' },
+    });
+    sakhiClient.getById.mockRejectedValue(new Error('auth-service down'));
+
+    await expect(
+      service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+    ).resolves.toBe(decided);
+
+    expect(notificationClient.notify).toHaveBeenCalledWith(
+      pending.requestedByUserId,
+      'REOPEN_UPDATE',
+      'Reopen request decided',
+      "Asha Devi's reopen request was approved",
+      authHeader,
+      { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
     );
   });
 
@@ -363,6 +435,7 @@ describe('ReopenRequestService', () => {
       beneficiaryClient.getById.mockResolvedValue({
         id: pending.beneficiaryId,
         currentStatus: 'CLOSED',
+        pii: { fullName: 'Asha Devi' },
       });
 
       await expect(
@@ -493,5 +566,80 @@ describe('ReopenRequestService', () => {
     // failure isn't a reason to also skip the audit trail or Sakhi notice.
     expect(auditClient.log).toHaveBeenCalled();
     expect(notificationClient.notify).toHaveBeenCalled();
+  });
+
+  describe('Quick Response card linking', () => {
+    it('links the notification to the approval_requests id, not the reopen request id', async () => {
+      const pending = reopenRequest();
+      const decided = reopenRequest({
+        supervisorStatus: 'APPROVED',
+        decidedByUserId: supervisorId,
+      });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+
+      await service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader);
+
+      expect(approvalClient.findByReopenRequestId).toHaveBeenCalledWith(pending.id, authHeader);
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        pending.requestedByUserId,
+        'REOPEN_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+        { linkedEntityType: 'QuickResponseCard', linkedEntityId: approvalRequestId },
+      );
+    });
+
+    it('sends the notification without a linkedEntity when no approval request is found for the reopen request', async () => {
+      const pending = reopenRequest();
+      const decided = reopenRequest({
+        supervisorStatus: 'APPROVED',
+        decidedByUserId: supervisorId,
+      });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+      approvalClient.findByReopenRequestId.mockResolvedValue(null);
+
+      await expect(
+        service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+      ).resolves.toBe(decided);
+
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        pending.requestedByUserId,
+        'REOPEN_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+        undefined,
+      );
+    });
+
+    it('sends the notification without a linkedEntity, and does not fail the decision, when the lookup throws', async () => {
+      const pending = reopenRequest();
+      const decided = reopenRequest({
+        supervisorStatus: 'APPROVED',
+        decidedByUserId: supervisorId,
+      });
+      repository.findById.mockResolvedValueOnce(pending).mockResolvedValueOnce(decided);
+      repository.decide.mockResolvedValue(true);
+      approvalClient.findByReopenRequestId.mockRejectedValue(
+        Object.assign(new Error('Bad gateway'), { status: 502 }),
+      );
+
+      await expect(
+        service.decide(pending.id, supervisorId, { decision: 'APPROVED' }, authHeader),
+      ).resolves.toBe(decided);
+
+      expect(notificationClient.notify).toHaveBeenCalledWith(
+        pending.requestedByUserId,
+        'REOPEN_UPDATE',
+        expect.any(String),
+        expect.any(String),
+        authHeader,
+        undefined,
+      );
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -5,6 +5,7 @@ import type { NotificationClient } from './notification.client';
 import type { ApprovalClient } from './approval.client';
 import type { LookupClient } from './lookup.client';
 import type { BeneficiaryClient } from './beneficiary.client';
+import type { SakhiClient } from './sakhi.client';
 import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
@@ -27,7 +28,51 @@ export class ReopenRequestService {
     private readonly approvalClient: ApprovalClient,
     private readonly lookupClient: LookupClient,
     private readonly beneficiaryClient: BeneficiaryClient,
+    private readonly sakhiClient: SakhiClient,
   ) {}
+
+  /** Best-effort — a name lookup failure falls back to no name (generic
+   * notification text) rather than blocking the decision it's attached to. */
+  private async resolveSakhiName(
+    sakhiId: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    try {
+      const sakhi = await this.sakhiClient.getById(sakhiId, authorizationHeader);
+      return sakhi?.displayName ?? null;
+    } catch (err) {
+      console.error(`Failed to resolve Sakhi ${sakhiId}'s name for a notification:`, err);
+      return null;
+    }
+  }
+
+  /**
+   * Best-effort — this reopen request's Quick Response card id
+   * (approval_requests.id), used to link the decision notification so
+   * GET /quick-response/:cardId can resolve it. A failure here (no matching
+   * approval request, or approval-service unreachable) must not block the
+   * decision — the notification is simply sent without a linkedEntity rather
+   * than with a reopen_requests-table id GET /quick-response/:cardId doesn't
+   * recognise.
+   */
+  private async resolveQuickResponseCardId(
+    reopenRequestId: string,
+    authorizationHeader: string,
+  ): Promise<string | null> {
+    try {
+      const approvalRequest = await this.approvalClient.findByReopenRequestId(
+        reopenRequestId,
+        authorizationHeader,
+      );
+      return approvalRequest?.id ?? null;
+    } catch (err) {
+      console.error(
+        `Failed to resolve the Quick Response card id for reopen request ${reopenRequestId}:`,
+        err,
+      );
+      return null;
+    }
+  }
 
   /**
    * All reopen requests for one beneficiary, most-recent first — for the
@@ -173,8 +218,13 @@ export class ReopenRequestService {
     // /beneficiaries/:id (SAKHI-own-case / SUPERVISOR-roster /
     // MANAGER-unrestricted) — same pattern create() already uses. Without
     // this, any SUPERVISOR who learns a reopen request id outside their own
-    // roster could approve or reject it (IDOR).
-    await this.beneficiaryClient.getById(existing.beneficiaryId, authorizationHeader);
+    // roster could approve or reject it (IDOR). Its response is also reused
+    // below for the Sakhi notification's beneficiary name, avoiding a
+    // second fetch.
+    const beneficiary = await this.beneficiaryClient.getById(
+      existing.beneficiaryId,
+      authorizationHeader,
+    );
 
     if (existing.supervisorStatus !== 'PENDING') {
       throw conflict('This reopen request has already been decided.');
@@ -215,14 +265,24 @@ export class ReopenRequestService {
         { decision: dto.decision, decisionNotes: dto.decisionNotes ?? null },
         authorizationHeader,
       );
+      const [sakhiName, cardId] = await Promise.all([
+        this.resolveSakhiName(existing.requestedByUserId, authorizationHeader),
+        this.resolveQuickResponseCardId(id, authorizationHeader),
+      ]);
+      const beneficiaryName = beneficiary?.pii.fullName ?? null;
       await this.notificationClient.notify(
         existing.requestedByUserId,
         'REOPEN_UPDATE',
-        'Reopen request decided',
-        dto.decision === 'APPROVED'
-          ? 'Your reopen request was approved.'
-          : 'Your reopen request was rejected.',
+        sakhiName ? `Reopen request — ${sakhiName}` : 'Reopen request decided',
+        beneficiaryName
+          ? dto.decision === 'APPROVED'
+            ? `${beneficiaryName}'s reopen request was approved`
+            : `${beneficiaryName}'s reopen request was rejected`
+          : dto.decision === 'APPROVED'
+            ? 'Your reopen request was approved.'
+            : 'Your reopen request was rejected.',
         authorizationHeader,
+        cardId ? { linkedEntityType: 'QuickResponseCard', linkedEntityId: cardId } : undefined,
       );
     } catch (err) {
       console.error(

--- a/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/reopen-request.service.ts
@@ -6,6 +6,7 @@ import type { ApprovalClient } from './approval.client';
 import type { LookupClient } from './lookup.client';
 import type { BeneficiaryClient } from './beneficiary.client';
 import type { SakhiClient } from './sakhi.client';
+import { resolveSakhiName, resolveQuickResponseCardId } from './decision-notification.helper';
 import type { CreateReopenRequestInput } from './dto/create-reopen-request.dto';
 import type { DecideReopenRequestInput } from './dto/decide-reopen-request.dto';
 
@@ -30,49 +31,6 @@ export class ReopenRequestService {
     private readonly beneficiaryClient: BeneficiaryClient,
     private readonly sakhiClient: SakhiClient,
   ) {}
-
-  /** Best-effort — a name lookup failure falls back to no name (generic
-   * notification text) rather than blocking the decision it's attached to. */
-  private async resolveSakhiName(
-    sakhiId: string,
-    authorizationHeader: string,
-  ): Promise<string | null> {
-    try {
-      const sakhi = await this.sakhiClient.getById(sakhiId, authorizationHeader);
-      return sakhi?.displayName ?? null;
-    } catch (err) {
-      console.error(`Failed to resolve Sakhi ${sakhiId}'s name for a notification:`, err);
-      return null;
-    }
-  }
-
-  /**
-   * Best-effort — this reopen request's Quick Response card id
-   * (approval_requests.id), used to link the decision notification so
-   * GET /quick-response/:cardId can resolve it. A failure here (no matching
-   * approval request, or approval-service unreachable) must not block the
-   * decision — the notification is simply sent without a linkedEntity rather
-   * than with a reopen_requests-table id GET /quick-response/:cardId doesn't
-   * recognise.
-   */
-  private async resolveQuickResponseCardId(
-    reopenRequestId: string,
-    authorizationHeader: string,
-  ): Promise<string | null> {
-    try {
-      const approvalRequest = await this.approvalClient.findByReopenRequestId(
-        reopenRequestId,
-        authorizationHeader,
-      );
-      return approvalRequest?.id ?? null;
-    } catch (err) {
-      console.error(
-        `Failed to resolve the Quick Response card id for reopen request ${reopenRequestId}:`,
-        err,
-      );
-      return null;
-    }
-  }
 
   /**
    * All reopen requests for one beneficiary, most-recent first — for the
@@ -266,10 +224,10 @@ export class ReopenRequestService {
         authorizationHeader,
       );
       const [sakhiName, cardId] = await Promise.all([
-        this.resolveSakhiName(existing.requestedByUserId, authorizationHeader),
-        this.resolveQuickResponseCardId(id, authorizationHeader),
+        resolveSakhiName(this.sakhiClient, existing.requestedByUserId, authorizationHeader),
+        resolveQuickResponseCardId(this.approvalClient, 'reopen request', id, authorizationHeader),
       ]);
-      const beneficiaryName = beneficiary?.pii.fullName ?? null;
+      const beneficiaryName = beneficiary?.pii?.fullName ?? null;
       await this.notificationClient.notify(
         existing.requestedByUserId,
         'REOPEN_UPDATE',

--- a/apps/closure-reopen-service/src/reopen-requests/sakhi.client.ts
+++ b/apps/closure-reopen-service/src/reopen-requests/sakhi.client.ts
@@ -1,0 +1,45 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+
+// Read directly (not via appConfig) — matches this service's other HTTP-only
+// client convention (see beneficiary.client.ts's own doc comment).
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+export interface SakhiRecord {
+  sakhiId: string;
+  displayName: string;
+  mobileNumber: string;
+}
+
+/**
+ * Resolves a Sakhi's display name by calling auth-service's
+ * GET /sakhis/:sakhiId through the gateway, forwarding the caller's own
+ * Authorization header — used to name the Sakhi in a closure/reopen decision
+ * notification's title. A Sakhi's own user id doubles as her sakhiId
+ * throughout this system (same identity space submittedByUserId/
+ * requestedByUserId relies on elsewhere in this service), same convention
+ * as approval-service's own sakhi.client.ts.
+ */
+export class SakhiClient {
+  async getById(sakhiId: string, authorizationHeader: string): Promise<SakhiRecord | null> {
+    let res: Response;
+    try {
+      res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/sakhis/${sakhiId}`, {
+        headers: { Authorization: authorizationHeader },
+      });
+    } catch {
+      throw badGateway('Unable to resolve the Sakhi — auth-service is unreachable.');
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) {
+        const body = (await res.json().catch(() => null)) as { message?: string } | null;
+        throw new HttpError(res.status, body?.message ?? 'Unable to resolve the Sakhi.');
+      }
+      throw badGateway('Unable to resolve the Sakhi — auth-service returned an error.');
+    }
+
+    const body = (await res.json()) as { data: SakhiRecord };
+    return body.data;
+  }
+}

--- a/apps/notification-escalation-service/src/escalations/escalation.controller.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.controller.ts
@@ -23,8 +23,8 @@ export function createEscalationController(service: EscalationService) {
     create: asyncHandler(async (req, res, next) => {
       if (!req.user) return next(unauthorized());
       const body = req.body as CreateEscalationEventInput;
-      const row = await service.create(body, req.user.id);
-      res.status(201).json(ok(row));
+      const { event, wasCreated } = await service.create(body, req.user.id);
+      res.status(201).json(ok({ ...event, wasCreated }));
     }),
 
     findById: asyncHandler(async (req, res, next) => {

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.spec.ts
@@ -103,7 +103,7 @@ describe('EscalationRepository', () => {
 
       const result = await repository.createOrReuseOpen(baseInput, 'admin-user-id');
 
-      expect(result).toBe(created);
+      expect(result).toEqual({ event: created, wasCreated: true });
       expect(create).toHaveBeenCalledWith({
         data: {
           beneficiaryId: 'beneficiary-1',
@@ -125,7 +125,7 @@ describe('EscalationRepository', () => {
 
       const result = await repository.createOrReuseOpen(baseInput, 'admin-user-id');
 
-      expect(result).toBe(existing);
+      expect(result).toEqual({ event: existing, wasCreated: false });
       expect(create).not.toHaveBeenCalled();
       expect(update).not.toHaveBeenCalled();
     });
@@ -138,7 +138,7 @@ describe('EscalationRepository', () => {
 
       const result = await repository.createOrReuseOpen(baseInput, 'admin-user-id');
 
-      expect(result).toBe(updated);
+      expect(result).toEqual({ event: updated, wasCreated: false });
       expect(update).toHaveBeenCalledWith({
         where: { id: 'existing-row' },
         data: { assignedSupervisorId: 'supervisor-1' },

--- a/apps/notification-escalation-service/src/escalations/escalation.repository.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.repository.ts
@@ -69,6 +69,11 @@ export class EscalationRepository {
    * and inserting duplicates — there's no DB-level unique constraint
    * backing this natural key (it's conditional on which fields are
    * present), so the lock is what actually closes the race.
+   *
+   * Callers that only want to act (e.g. send a notification) the first time
+   * an escalation is actually raised — not on every re-processing of an
+   * already-open one — need `wasCreated` in the return: `status === 'OPEN'`
+   * alone doesn't distinguish "brand new" from "reused, still open".
    */
   createOrReuseOpen(input: CreateEscalationEventInput, createdByUserId: string) {
     return this.prisma.$transaction(async (tx) => {
@@ -94,15 +99,16 @@ export class EscalationRepository {
       });
       if (existing) {
         if (existing.assignedSupervisorId !== input.assignedSupervisorId) {
-          return tx.escalationEvent.update({
+          const event = await tx.escalationEvent.update({
             where: { id: existing.id },
             data: { assignedSupervisorId: input.assignedSupervisorId },
           });
+          return { event, wasCreated: false };
         }
-        return existing;
+        return { event: existing, wasCreated: false };
       }
 
-      return tx.escalationEvent.create({
+      const event = await tx.escalationEvent.create({
         data: {
           beneficiaryId: input.beneficiaryId ?? null,
           sakhiUserId: input.sakhiUserId ?? null,
@@ -115,6 +121,7 @@ export class EscalationRepository {
           createdByUserId,
         },
       });
+      return { event, wasCreated: true };
     });
   }
 

--- a/apps/notification-escalation-service/src/escalations/escalation.routes.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.routes.ts
@@ -82,6 +82,14 @@ const escalationEventSchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
+// POST-only: distinguishes "a new row was just inserted" from "an existing
+// OPEN row for the same natural key was reused" — callers that only want to
+// act (e.g. send a notification) the first time an escalation is actually
+// raised need this, since status alone is 'OPEN' in both cases.
+const createEscalationEventResponseSchema = escalationEventSchema.extend({
+  wasCreated: z.boolean(),
+});
+
 const missedVisitDetailSchema = z.object({
   id: z.string().uuid(),
   beneficiaryId: z.string().uuid(),
@@ -150,7 +158,10 @@ export function registerEscalationRoutes(doc: DocumentedRouter, service: Escalat
       summary: 'Raise a new escalation event',
       tags: ['Escalations'],
       responses: {
-        201: { description: 'Escalation event created', schema: envelope(escalationEventSchema) },
+        201: {
+          description: 'Escalation event created',
+          schema: envelope(createEscalationEventResponseSchema),
+        },
         400: { description: 'Validation error', schema: apiErrorSchema },
         401: { description: 'Unauthenticated', schema: apiErrorSchema },
         403: { description: 'Caller role not permitted', schema: apiErrorSchema },

--- a/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
+++ b/apps/notification-escalation-service/src/escalations/escalation.service.spec.ts
@@ -258,7 +258,8 @@ describe('EscalationService', () => {
 
     it('delegates to the repository, returning whatever it resolves', async () => {
       const created = row({ escalationType: 'ANC_2_MISSED' });
-      repository.createOrReuseOpen.mockResolvedValue(created);
+      const resolved = { event: created, wasCreated: true };
+      repository.createOrReuseOpen.mockResolvedValue(resolved);
       const input = {
         beneficiaryId: created.beneficiaryId,
         escalationType: 'ANC_2_MISSED' as const,
@@ -267,13 +268,13 @@ describe('EscalationService', () => {
 
       const result = await service.create(input, 'admin-user-id');
 
-      expect(result).toBe(created);
+      expect(result).toBe(resolved);
       expect(repository.createOrReuseOpen).toHaveBeenCalledWith(input, 'admin-user-id');
     });
 
     it('passes optional fields through to the repository unchanged', async () => {
       const created = row({ escalationType: 'ANC_2_MISSED' });
-      repository.createOrReuseOpen.mockResolvedValue(created);
+      repository.createOrReuseOpen.mockResolvedValue({ event: created, wasCreated: true });
       const input = {
         beneficiaryId: created.beneficiaryId,
         escalationType: 'ANC_2_MISSED' as const,

--- a/apps/risk-referral-service/.env.example
+++ b/apps/risk-referral-service/.env.example
@@ -17,3 +17,12 @@ API_GATEWAY_BASE_URL=http://localhost:3000
 SEED_DEMO_BENEFICIARY_ID=
 SEED_DEMO_SAKHI_USER_ID=
 SEED_DEMO_AUTH_TOKEN=
+
+# Client-credentials identity (see auth-service's SERVICE_ACCOUNTS var) this
+# service's overdue-follow-up job authenticates as, to call the
+# ADMIN/SYSTEM-only POST /escalation-events and POST /notifications.
+# Optional: the job logs and skips its run when unset.
+SERVICE_ACCOUNT_CLIENT_ID=risk-referral-service
+SERVICE_ACCOUNT_CLIENT_SECRET=
+# node-cron expression for the overdue-follow-up job. Default: daily at 6am.
+OVERDUE_FOLLOWUP_JOB_CRON=0 6 * * *

--- a/apps/risk-referral-service/package.json
+++ b/apps/risk-referral-service/package.json
@@ -17,12 +17,14 @@
     "@prisma/client": "^5.18.0",
     "express": "^4.19.2",
     "helmet": "^7.1.0",
+    "node-cron": "^3.0.3",
     "pino": "^9.3.2",
     "pino-http": "^10.2.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/node-cron": "^3.0.11",
     "prisma": "^5.18.0",
     "ts-node": "^10.9.2"
   }

--- a/apps/risk-referral-service/prisma/migrations/20260831090000_add_job_runs/migration.sql
+++ b/apps/risk-referral-service/prisma/migrations/20260831090000_add_job_runs/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "job_runs" (
+    "job_run_id" TEXT NOT NULL,
+    "job_name" VARCHAR(80) NOT NULL,
+    "locked_until" TIMESTAMP(3) NOT NULL,
+    "last_run_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "job_runs_pkey" PRIMARY KEY ("job_run_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "job_runs_job_name_key" ON "job_runs"("job_name");

--- a/apps/risk-referral-service/prisma/migrations/20260902100000_add_referral_followup_last_escalated_at/migration.sql
+++ b/apps/risk-referral-service/prisma/migrations/20260902100000_add_referral_followup_last_escalated_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "referral_followups" ADD COLUMN "last_escalated_at" TIMESTAMP(3);

--- a/apps/risk-referral-service/prisma/schema.prisma
+++ b/apps/risk-referral-service/prisma/schema.prisma
@@ -335,6 +335,12 @@ model ReferralFollowup {
   // media_assets.media_asset_id — owned by another service, no cross-service relation.
   casePaperMediaId    String?                @map("case_paper_media_id")
   followupStatus      ReferralFollowupStatus @map("followup_status")
+  // Not in the ERD — stamped by the overdue-follow-up escalation cron job
+  // after each successful tick, so the backlog query below can rotate
+  // through it (oldest-escalated-first) instead of always returning the
+  // same oldest-by-followupDate slice forever once the backlog exceeds one
+  // tick's MAX_FOLLOWUPS_PER_TICK.
+  lastEscalatedAt     DateTime?              @map("last_escalated_at")
   createdAt           DateTime               @default(now()) @map("created_at")
   createdByUserId     String?                @map("created_by_user_id")
   updatedAt           DateTime               @updatedAt @map("updated_at")

--- a/apps/risk-referral-service/prisma/schema.prisma
+++ b/apps/risk-referral-service/prisma/schema.prisma
@@ -346,3 +346,16 @@ model ReferralFollowup {
 
   @@map("referral_followups")
 }
+
+// Not in the ERD — a DB-backed advisory lock for the in-process node-cron
+// overdue-follow-up job in this service. Without it, running more than one
+// replica of this service would process the same overdue follow-ups once
+// per replica per tick. See libs/service-commons/src/jobs/job-lock.ts.
+model JobRun {
+  id          String   @id @default(uuid()) @map("job_run_id")
+  jobName     String   @unique @map("job_name") @db.VarChar(80)
+  lockedUntil DateTime @map("locked_until")
+  lastRunAt   DateTime @map("last_run_at")
+
+  @@map("job_runs")
+}

--- a/apps/risk-referral-service/src/config/app-config.ts
+++ b/apps/risk-referral-service/src/config/app-config.ts
@@ -16,6 +16,15 @@ const schema = z.object({
         .filter(Boolean),
     ),
   PUBLIC_BASE_URLS: publicBaseUrlsSchema,
+  // Client-credentials identity (POST /auth/service-token) this service's
+  // overdue-follow-up job authenticates as, to call the ADMIN/SYSTEM-only
+  // POST /escalation-events and POST /notifications. Optional: the job logs
+  // and skips its run when unset, rather than failing to start over a
+  // not-yet-provisioned credential.
+  SERVICE_ACCOUNT_CLIENT_ID: z.string().min(1).optional(),
+  SERVICE_ACCOUNT_CLIENT_SECRET: z.string().min(1).optional(),
+  // node-cron expression for the overdue-follow-up escalation job.
+  OVERDUE_FOLLOWUP_JOB_CRON: z.string().default('0 6 * * *'),
 });
 
 export type AppConfig = z.infer<typeof schema>;

--- a/apps/risk-referral-service/src/jobs/overdueFollowup.job.spec.ts
+++ b/apps/risk-referral-service/src/jobs/overdueFollowup.job.spec.ts
@@ -16,19 +16,26 @@ jest.mock('../referrals/systemEscalation.client');
 
 describe('runOverdueFollowupJob', () => {
   const findOverduePendingFollowups = jest.fn();
+  const markFollowupEscalated = jest.fn();
   const getById = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (ReferralRepository as jest.Mock).mockImplementation(() => ({
       findOverduePendingFollowups,
+      markFollowupEscalated,
     }));
     (BeneficiaryClient as jest.Mock).mockImplementation(() => ({ getById }));
     (acquireJobLock as jest.Mock).mockResolvedValue(true);
     (findSakhiById as jest.Mock).mockResolvedValue({ supervisorId: 'supervisor-1' });
     getById.mockResolvedValue({ id: 'ben-1', sakhiId: 'sakhi-1' });
-    (createEscalationEvent as jest.Mock).mockResolvedValue({ id: 'event-1', status: 'OPEN' });
+    (createEscalationEvent as jest.Mock).mockResolvedValue({
+      id: 'event-1',
+      status: 'OPEN',
+      wasCreated: true,
+    });
     (createNotification as jest.Mock).mockResolvedValue(undefined);
+    markFollowupEscalated.mockResolvedValue(undefined);
   });
 
   const baseDeps = () => ({
@@ -44,7 +51,7 @@ describe('runOverdueFollowupJob', () => {
     expect(findOverduePendingFollowups).not.toHaveBeenCalled();
   });
 
-  it('raises an escalation and notifies the resolved Supervisor for each overdue follow-up', async () => {
+  it('raises an escalation, stamps lastEscalatedAt, and notifies the resolved Supervisor for a newly-created escalation', async () => {
     findOverduePendingFollowups.mockResolvedValue([
       { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
     ]);
@@ -60,6 +67,7 @@ describe('runOverdueFollowupJob', () => {
       }),
       'system-token',
     );
+    expect(markFollowupEscalated).toHaveBeenCalledWith('followup-1');
     expect(createNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         recipientUserId: 'supervisor-1',
@@ -68,6 +76,23 @@ describe('runOverdueFollowupJob', () => {
       }),
       'system-token',
     );
+  });
+
+  it('does not notify when the escalation was reused (not newly created) — avoids a duplicate daily notification', async () => {
+    findOverduePendingFollowups.mockResolvedValue([
+      { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
+    ]);
+    (createEscalationEvent as jest.Mock).mockResolvedValue({
+      id: 'event-1',
+      status: 'OPEN',
+      wasCreated: false,
+    });
+
+    await runOverdueFollowupJob(baseDeps());
+
+    expect(createEscalationEvent).toHaveBeenCalled();
+    expect(markFollowupEscalated).toHaveBeenCalledWith('followup-1');
+    expect(createNotification).not.toHaveBeenCalled();
   });
 
   it('skips escalation entirely when minting a service token fails', async () => {
@@ -82,7 +107,7 @@ describe('runOverdueFollowupJob', () => {
     expect(createEscalationEvent).not.toHaveBeenCalled();
   });
 
-  it('does not notify when no Supervisor can be resolved', async () => {
+  it('skips escalation (does not call createEscalationEvent) when no Supervisor can be resolved', async () => {
     findOverduePendingFollowups.mockResolvedValue([
       { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
     ]);
@@ -90,7 +115,7 @@ describe('runOverdueFollowupJob', () => {
 
     await runOverdueFollowupJob(baseDeps());
 
-    expect(createEscalationEvent).toHaveBeenCalled();
+    expect(createEscalationEvent).not.toHaveBeenCalled();
     expect(createNotification).not.toHaveBeenCalled();
   });
 
@@ -101,10 +126,24 @@ describe('runOverdueFollowupJob', () => {
     ]);
     (createEscalationEvent as jest.Mock)
       .mockRejectedValueOnce(new Error('boom'))
-      .mockResolvedValueOnce({ id: 'event-2', status: 'OPEN' });
+      .mockResolvedValueOnce({ id: 'event-2', status: 'OPEN', wasCreated: true });
 
     await runOverdueFollowupJob(baseDeps());
 
     expect(createEscalationEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('processes a large backlog in bounded-concurrency batches, not all at once or fully sequential', async () => {
+    const followups = Array.from({ length: 37 }, (_, i) => ({
+      id: `followup-${i}`,
+      referralId: `referral-${i}`,
+      referral: { beneficiaryId: `ben-${i}` },
+    }));
+    findOverduePendingFollowups.mockResolvedValue(followups);
+
+    await runOverdueFollowupJob(baseDeps());
+
+    expect(createEscalationEvent).toHaveBeenCalledTimes(37);
+    expect(markFollowupEscalated).toHaveBeenCalledTimes(37);
   });
 });

--- a/apps/risk-referral-service/src/jobs/overdueFollowup.job.spec.ts
+++ b/apps/risk-referral-service/src/jobs/overdueFollowup.job.spec.ts
@@ -1,0 +1,110 @@
+import { runOverdueFollowupJob } from './overdueFollowup.job';
+import { acquireJobLock } from '@armman/service-commons';
+import { ReferralRepository } from '../referrals/referral.repository';
+import { BeneficiaryClient } from '../referrals/beneficiary.client';
+import { findSakhiById } from '../referrals/sakhi.client';
+import { createEscalationEvent, createNotification } from '../referrals/systemEscalation.client';
+
+jest.mock('@armman/service-commons', () => ({
+  acquireJobLock: jest.fn(),
+  ServiceTokenClient: jest.fn(),
+}));
+jest.mock('../referrals/referral.repository');
+jest.mock('../referrals/beneficiary.client');
+jest.mock('../referrals/sakhi.client');
+jest.mock('../referrals/systemEscalation.client');
+
+describe('runOverdueFollowupJob', () => {
+  const findOverduePendingFollowups = jest.fn();
+  const getById = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (ReferralRepository as jest.Mock).mockImplementation(() => ({
+      findOverduePendingFollowups,
+    }));
+    (BeneficiaryClient as jest.Mock).mockImplementation(() => ({ getById }));
+    (acquireJobLock as jest.Mock).mockResolvedValue(true);
+    (findSakhiById as jest.Mock).mockResolvedValue({ supervisorId: 'supervisor-1' });
+    getById.mockResolvedValue({ id: 'ben-1', sakhiId: 'sakhi-1' });
+    (createEscalationEvent as jest.Mock).mockResolvedValue({ id: 'event-1', status: 'OPEN' });
+    (createNotification as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  const baseDeps = () => ({
+    prisma: {} as never,
+    getSystemToken: jest.fn().mockResolvedValue('system-token'),
+  });
+
+  it('does nothing when the lock is already held by another run', async () => {
+    (acquireJobLock as jest.Mock).mockResolvedValue(false);
+
+    await runOverdueFollowupJob(baseDeps());
+
+    expect(findOverduePendingFollowups).not.toHaveBeenCalled();
+  });
+
+  it('raises an escalation and notifies the resolved Supervisor for each overdue follow-up', async () => {
+    findOverduePendingFollowups.mockResolvedValue([
+      { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
+    ]);
+
+    await runOverdueFollowupJob(baseDeps());
+
+    expect(createEscalationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        beneficiaryId: 'ben-1',
+        escalationType: 'REFERRAL_FOLLOWUP_MISSED',
+        referralId: 'referral-1',
+        assignedSupervisorId: 'supervisor-1',
+      }),
+      'system-token',
+    );
+    expect(createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientUserId: 'supervisor-1',
+        notificationType: 'REFERRAL_FOLLOWUP_OVERDUE',
+        linkedEntityId: 'followup-1',
+      }),
+      'system-token',
+    );
+  });
+
+  it('skips escalation entirely when minting a service token fails', async () => {
+    findOverduePendingFollowups.mockResolvedValue([
+      { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
+    ]);
+    const deps = baseDeps();
+    deps.getSystemToken = jest.fn().mockRejectedValue(new Error('auth-service unreachable'));
+
+    await runOverdueFollowupJob(deps);
+
+    expect(createEscalationEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when no Supervisor can be resolved', async () => {
+    findOverduePendingFollowups.mockResolvedValue([
+      { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
+    ]);
+    (findSakhiById as jest.Mock).mockResolvedValue({ supervisorId: null });
+
+    await runOverdueFollowupJob(baseDeps());
+
+    expect(createEscalationEvent).toHaveBeenCalled();
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  it('continues processing remaining follow-ups when one throws', async () => {
+    findOverduePendingFollowups.mockResolvedValue([
+      { id: 'followup-1', referralId: 'referral-1', referral: { beneficiaryId: 'ben-1' } },
+      { id: 'followup-2', referralId: 'referral-2', referral: { beneficiaryId: 'ben-2' } },
+    ]);
+    (createEscalationEvent as jest.Mock)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ id: 'event-2', status: 'OPEN' });
+
+    await runOverdueFollowupJob(baseDeps());
+
+    expect(createEscalationEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/risk-referral-service/src/jobs/overdueFollowup.job.ts
+++ b/apps/risk-referral-service/src/jobs/overdueFollowup.job.ts
@@ -1,0 +1,116 @@
+import cron from 'node-cron';
+import { acquireJobLock, ServiceTokenClient } from '@armman/service-commons';
+import type { PrismaService } from '../prisma/prisma.service';
+import { ReferralRepository } from '../referrals/referral.repository';
+import { BeneficiaryClient } from '../referrals/beneficiary.client';
+import { findSakhiById } from '../referrals/sakhi.client';
+import { createEscalationEvent, createNotification } from '../referrals/systemEscalation.client';
+
+const JOB_NAME = 'referral-followup-overdue-escalation';
+const LOCK_DURATION_MS = 55 * 60 * 1000; // slightly under the default daily tick's own margin
+const MAX_FOLLOWUPS_PER_TICK = 500;
+
+export interface OverdueFollowupJobDeps {
+  prisma: PrismaService;
+  getSystemToken: () => Promise<string>;
+}
+
+/**
+ * One run of the referral follow-up missed-escalation job (build plan's
+ * "Referral follow-up missed" item — extends the existing overdue-follow-up
+ * query, which was previously read-only, to actually raise an escalation +
+ * notify the Supervisor). Idempotency against duplicate escalations is
+ * enforced server-side by notification-escalation-service's
+ * EscalationService.create (see its own doc comment) — this job doesn't
+ * need its own dedup check, only the DB-backed run lock below to stop two
+ * replicas processing the same backlog concurrently.
+ */
+export async function runOverdueFollowupJob(deps: OverdueFollowupJobDeps): Promise<void> {
+  const got = await acquireJobLock(deps.prisma, JOB_NAME, LOCK_DURATION_MS);
+  if (!got) {
+    console.log(`[${JOB_NAME}] Lock held by another run — skipping this tick.`);
+    return;
+  }
+
+  const referralRepo = new ReferralRepository(deps.prisma);
+  const today = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00.000Z');
+  const overdue = await referralRepo.findOverduePendingFollowups(today, MAX_FOLLOWUPS_PER_TICK);
+  if (overdue.length === 0) return;
+
+  let authorizationHeader: string;
+  try {
+    authorizationHeader = `Bearer ${await deps.getSystemToken()}`;
+  } catch (err) {
+    console.error(`[${JOB_NAME}] Unable to mint a service token — skipping this tick:`, err);
+    return;
+  }
+
+  const beneficiaryClient = new BeneficiaryClient();
+  const systemAccessToken = authorizationHeader.replace(/^Bearer /, '');
+
+  for (const followup of overdue) {
+    try {
+      const beneficiaryId = followup.referral.beneficiaryId;
+      const beneficiary = await beneficiaryClient.getById(beneficiaryId, authorizationHeader);
+      const sakhi = beneficiary
+        ? await findSakhiById(beneficiary.sakhiId, authorizationHeader)
+        : null;
+      const supervisorId = sakhi?.supervisorId ?? null;
+
+      const event = await createEscalationEvent(
+        {
+          beneficiaryId,
+          escalationType: 'REFERRAL_FOLLOWUP_MISSED',
+          referralId: followup.referralId,
+          assignedSupervisorId: supervisorId ?? undefined,
+        },
+        systemAccessToken,
+      );
+
+      if (supervisorId && event.status === 'OPEN') {
+        try {
+          await createNotification(
+            {
+              recipientUserId: supervisorId,
+              notificationType: 'REFERRAL_FOLLOWUP_OVERDUE',
+              title: 'A referral follow-up is overdue and needs review',
+              linkedEntityType: 'REFERRAL_FOLLOWUP',
+              linkedEntityId: followup.id,
+            },
+            systemAccessToken,
+          );
+        } catch (err) {
+          console.error(`[${JOB_NAME}] Escalation ${event.id} raised, notification failed:`, err);
+        }
+      }
+    } catch (err) {
+      // One follow-up's bad data must not abort the rest of this tick's batch.
+      console.error(`[${JOB_NAME}] Failed processing follow-up ${followup.id}:`, err);
+    }
+  }
+}
+
+/** Wires the real dependencies and registers the node-cron schedule at boot. */
+export function scheduleOverdueFollowupJob(
+  prisma: PrismaService,
+  cronExpression: string,
+  clientId: string | undefined,
+  clientSecret: string | undefined,
+): void {
+  const tokenClient =
+    clientId && clientSecret ? new ServiceTokenClient(clientId, clientSecret) : null;
+
+  cron.schedule(cronExpression, () => {
+    void runOverdueFollowupJob({
+      prisma,
+      getSystemToken: () => {
+        if (!tokenClient) {
+          return Promise.reject(
+            new Error('SERVICE_ACCOUNT_CLIENT_ID/SECRET not configured for this service.'),
+          );
+        }
+        return tokenClient.getToken();
+      },
+    }).catch((err) => console.error(`[${JOB_NAME}] Unhandled error:`, err));
+  });
+}

--- a/apps/risk-referral-service/src/jobs/overdueFollowup.job.ts
+++ b/apps/risk-referral-service/src/jobs/overdueFollowup.job.ts
@@ -9,6 +9,14 @@ import { createEscalationEvent, createNotification } from '../referrals/systemEs
 const JOB_NAME = 'referral-followup-overdue-escalation';
 const LOCK_DURATION_MS = 55 * 60 * 1000; // slightly under the default daily tick's own margin
 const MAX_FOLLOWUPS_PER_TICK = 500;
+// Bounds how many follow-ups are in flight at once (each doing up to 4
+// sequential downstream HTTP calls) — processing the full 500-item cap
+// strictly sequentially risked a multi-minute runtime that could approach
+// LOCK_DURATION_MS under normal latency, or exceed it under a large
+// first-deploy backlog or degraded downstream latency, letting a second
+// replica's next tick re-acquire the lock and double-process. A bounded
+// pool keeps one slow/hung item from serializing the whole batch behind it.
+const CONCURRENCY = 15;
 
 export interface OverdueFollowupJobDeps {
   prisma: PrismaService;
@@ -48,7 +56,9 @@ export async function runOverdueFollowupJob(deps: OverdueFollowupJobDeps): Promi
   const beneficiaryClient = new BeneficiaryClient();
   const systemAccessToken = authorizationHeader.replace(/^Bearer /, '');
 
-  for (const followup of overdue) {
+  /** One follow-up's full escalate-and-notify sequence. Never throws — every
+   * failure is caught and logged so it can't abort the rest of the batch. */
+  async function processFollowup(followup: (typeof overdue)[number]): Promise<void> {
     try {
       const beneficiaryId = followup.referral.beneficiaryId;
       const beneficiary = await beneficiaryClient.getById(beneficiaryId, authorizationHeader);
@@ -57,17 +67,32 @@ export async function runOverdueFollowupJob(deps: OverdueFollowupJobDeps): Promi
         : null;
       const supervisorId = sakhi?.supervisorId ?? null;
 
+      if (!supervisorId) {
+        // assignedSupervisorId is required by createEscalationEventSchema —
+        // an unassigned/orphaned Sakhi has no owning Supervisor to escalate
+        // to, so attempting the call would only 400. Skip rather than fail.
+        console.error(
+          `[${JOB_NAME}] Follow-up ${followup.id}: Sakhi has no assigned Supervisor — skipping escalation.`,
+        );
+        return;
+      }
+
       const event = await createEscalationEvent(
         {
           beneficiaryId,
           escalationType: 'REFERRAL_FOLLOWUP_MISSED',
           referralId: followup.referralId,
-          assignedSupervisorId: supervisorId ?? undefined,
+          assignedSupervisorId: supervisorId,
         },
         systemAccessToken,
       );
+      await referralRepo.markFollowupEscalated(followup.id);
 
-      if (supervisorId && event.status === 'OPEN') {
+      // Only the tick that actually raises a new escalation notifies —
+      // event.status is 'OPEN' on every re-processing of an already-open
+      // row too, so gating on wasCreated (not status) prevents sending a
+      // fresh notification every single day the follow-up stays unresolved.
+      if (event.wasCreated) {
         try {
           await createNotification(
             {
@@ -87,6 +112,11 @@ export async function runOverdueFollowupJob(deps: OverdueFollowupJobDeps): Promi
       // One follow-up's bad data must not abort the rest of this tick's batch.
       console.error(`[${JOB_NAME}] Failed processing follow-up ${followup.id}:`, err);
     }
+  }
+
+  for (let i = 0; i < overdue.length; i += CONCURRENCY) {
+    const batch = overdue.slice(i, i + CONCURRENCY);
+    await Promise.all(batch.map(processFollowup));
   }
 }
 

--- a/apps/risk-referral-service/src/main.ts
+++ b/apps/risk-referral-service/src/main.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import { bootstrapService } from '@armman/service-commons';
 import { appConfig } from './config/app-config';
 import { createApp } from './app.module';
 import { PrismaService } from './prisma/prisma.service';
@@ -30,7 +31,4 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-bootstrap().catch((err) => {
-  console.error('Fatal error during startup:', err);
-  process.exit(1);
-});
+bootstrapService(bootstrap);

--- a/apps/risk-referral-service/src/main.ts
+++ b/apps/risk-referral-service/src/main.ts
@@ -2,10 +2,18 @@ import type { Server } from 'node:http';
 import { appConfig } from './config/app-config';
 import { createApp } from './app.module';
 import { PrismaService } from './prisma/prisma.service';
+import { scheduleOverdueFollowupJob } from './jobs/overdueFollowup.job';
 
 async function bootstrap(): Promise<void> {
   const prisma = new PrismaService();
   await prisma.connect();
+
+  scheduleOverdueFollowupJob(
+    prisma,
+    appConfig.OVERDUE_FOLLOWUP_JOB_CRON,
+    appConfig.SERVICE_ACCOUNT_CLIENT_ID,
+    appConfig.SERVICE_ACCOUNT_CLIENT_SECRET,
+  );
 
   const app = createApp(prisma);
   const server: Server = app.listen(appConfig.PORT, () => {
@@ -22,4 +30,7 @@ async function bootstrap(): Promise<void> {
   process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
-void bootstrap();
+bootstrap().catch((err) => {
+  console.error('Fatal error during startup:', err);
+  process.exit(1);
+});

--- a/apps/risk-referral-service/src/referrals/referral.repository.ts
+++ b/apps/risk-referral-service/src/referrals/referral.repository.ts
@@ -163,6 +163,33 @@ export class ReferralRepository {
   }
 
   /**
+   * Job-only read (overdueFollowup.job.ts) — every PENDING follow-up whose
+   * `followupDate` has passed, system-wide (not scoped to a caller's roster
+   * — this job runs as a machine identity, not on behalf of any one
+   * Supervisor). Bounded by `take` so one tick can't try to process an
+   * unbounded backlog in a single run; a backlog larger than that just gets
+   * picked up on the next tick.
+   */
+  findOverduePendingFollowups(today: Date, take: number) {
+    return this.prisma.referralFollowup.findMany({
+      where: {
+        isDeleted: false,
+        followupStatus: 'PENDING',
+        followupDate: { lt: today },
+        referral: { isDeleted: false },
+      },
+      orderBy: { followupDate: 'asc' },
+      take,
+      select: {
+        id: true,
+        referralId: true,
+        followupDate: true,
+        referral: { select: { beneficiaryId: true } },
+      },
+    });
+  }
+
+  /**
    * Only updates a row that is still in `fromStatus` — `updateMany`'s
    * affected count (rather than a separate read-then-write) is the
    * concurrency guard: if the referral's status already changed between the

--- a/apps/risk-referral-service/src/referrals/referral.repository.ts
+++ b/apps/risk-referral-service/src/referrals/referral.repository.ts
@@ -167,8 +167,16 @@ export class ReferralRepository {
    * `followupDate` has passed, system-wide (not scoped to a caller's roster
    * — this job runs as a machine identity, not on behalf of any one
    * Supervisor). Bounded by `take` so one tick can't try to process an
-   * unbounded backlog in a single run; a backlog larger than that just gets
-   * picked up on the next tick.
+   * unbounded backlog in a single run.
+   *
+   * Ordered by `lastEscalatedAt` ascending (nulls — never escalated — first)
+   * rather than `followupDate`: once the backlog exceeds `take`, ordering by
+   * `followupDate` alone would return the same oldest slice on every tick
+   * forever, since nothing else in this flow changes `followupDate` or
+   * `followupStatus`. Ordering by `lastEscalatedAt` instead means each tick
+   * naturally rotates to the rows least-recently (or never) escalated,
+   * covering the whole backlog over time rather than starving anything past
+   * position `take`.
    */
   findOverduePendingFollowups(today: Date, take: number) {
     return this.prisma.referralFollowup.findMany({
@@ -178,7 +186,7 @@ export class ReferralRepository {
         followupDate: { lt: today },
         referral: { isDeleted: false },
       },
-      orderBy: { followupDate: 'asc' },
+      orderBy: [{ lastEscalatedAt: { sort: 'asc', nulls: 'first' } }, { followupDate: 'asc' }],
       take,
       select: {
         id: true,
@@ -186,6 +194,22 @@ export class ReferralRepository {
         followupDate: true,
         referral: { select: { beneficiaryId: true } },
       },
+    });
+  }
+
+  /**
+   * Stamps `lastEscalatedAt` after overdueFollowup.job.ts successfully
+   * processes a follow-up (escalation raised or reused) — the signal
+   * findOverduePendingFollowups' ordering rotates on. Fire-and-forget from
+   * the job's perspective: a failure to stamp this only risks re-selecting
+   * the row sooner on a future tick, not losing it or double-escalating (the
+   * server-side escalation dedup in notification-escalation-service already
+   * guards against the latter).
+   */
+  markFollowupEscalated(id: string) {
+    return this.prisma.referralFollowup.update({
+      where: { id },
+      data: { lastEscalatedAt: new Date() },
     });
   }
 

--- a/apps/risk-referral-service/src/referrals/sakhi.client.ts
+++ b/apps/risk-referral-service/src/referrals/sakhi.client.ts
@@ -9,6 +9,34 @@ interface ApiSakhi {
 }
 
 /**
+ * Resolves a single Sakhi's own record (for their `supervisorId`), via
+ * auth-service's `GET /sakhis/:id`, through the gateway. Used by
+ * overdueFollowup.job.ts to resolve which Supervisor to notify for a
+ * beneficiary's overdue referral follow-up.
+ */
+export async function findSakhiById(
+  sakhiId: string,
+  authorizationHeader: string,
+): Promise<ApiSakhi | null> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/sakhis/${sakhiId}`, {
+      headers: { Authorization: authorizationHeader },
+    });
+  } catch {
+    throw badGateway('Unable to resolve the Sakhi — the auth service is unreachable.');
+  }
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw badGateway('Unable to resolve the Sakhi — the auth service returned an error.');
+  }
+
+  const body = (await res.json()) as { data: ApiSakhi };
+  return body.data;
+}
+
+/**
  * Resolves the Sakhi ids reporting to a given Supervisor, via auth-service's
  * existing `GET /projects/:projectId/sakhis` (no new auth-service endpoint —
  * that route already returns each Sakhi's `supervisorId`), called through

--- a/apps/risk-referral-service/src/referrals/systemEscalation.client.ts
+++ b/apps/risk-referral-service/src/referrals/systemEscalation.client.ts
@@ -8,6 +8,12 @@ interface EscalationEvent {
   beneficiaryId: string | null;
   escalationType: string;
   status: string;
+  // Distinguishes "a new row was just inserted" from "an existing OPEN row
+  // for the same natural key was reused" — status alone is 'OPEN' either
+  // way, so a caller that only wants to notify the first time an escalation
+  // is actually raised (not on every re-processing of an already-open one)
+  // needs this flag.
+  wasCreated: boolean;
 }
 
 /**
@@ -22,7 +28,7 @@ export async function createEscalationEvent(
     beneficiaryId: string;
     escalationType: string;
     referralId?: string;
-    assignedSupervisorId?: string | null;
+    assignedSupervisorId: string;
   },
   systemAccessToken: string,
 ): Promise<EscalationEvent> {

--- a/apps/risk-referral-service/src/referrals/systemEscalation.client.ts
+++ b/apps/risk-referral-service/src/referrals/systemEscalation.client.ts
@@ -1,0 +1,100 @@
+import { badGateway, HttpError } from '@armman/service-commons';
+
+// Read directly (not via appConfig) — mirrors this directory's other clients.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+interface EscalationEvent {
+  id: string;
+  beneficiaryId: string | null;
+  escalationType: string;
+  status: string;
+}
+
+/**
+ * Raises an escalation event via `POST /escalation-events` (through the
+ * gateway), authenticating as this service's machine identity — the
+ * overdue-follow-up job's SYSTEM-role counterpart of a human ADMIN call.
+ * Server idempotently no-ops (returns the existing row) on a duplicate OPEN
+ * escalation for the same natural key.
+ */
+export async function createEscalationEvent(
+  input: {
+    beneficiaryId: string;
+    escalationType: string;
+    referralId?: string;
+    assignedSupervisorId?: string | null;
+  },
+  systemAccessToken: string,
+): Promise<EscalationEvent> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/escalation-events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${systemAccessToken}`,
+      },
+      body: JSON.stringify(input),
+    });
+  } catch {
+    throw badGateway(
+      'Unable to raise the escalation — notification-escalation-service is unreachable.',
+    );
+  }
+
+  if (!res.ok) {
+    if (res.status >= 400 && res.status < 500) {
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      throw new HttpError(res.status, body?.message ?? 'Unable to raise the escalation.');
+    }
+    throw badGateway(
+      'Unable to raise the escalation — notification-escalation-service returned an error.',
+    );
+  }
+
+  const body = (await res.json()) as { data: EscalationEvent };
+  return body.data;
+}
+
+/**
+ * Notifies a Supervisor via `POST /notifications` (through the gateway),
+ * authenticating as this service's machine identity. Best-effort: a failed
+ * notification push is logged by the caller, not retried, and never fails
+ * the job run — the escalation event is the durable record.
+ */
+export async function createNotification(
+  input: {
+    recipientUserId: string;
+    notificationType: string;
+    title: string;
+    linkedEntityType?: string;
+    linkedEntityId?: string;
+  },
+  systemAccessToken: string,
+): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_GATEWAY_BASE_URL}/api/v1/notifications`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${systemAccessToken}`,
+      },
+      body: JSON.stringify({ ...input, status: 'UNREAD' }),
+    });
+  } catch {
+    throw badGateway(
+      'Unable to send the notification — notification-escalation-service is unreachable.',
+    );
+  }
+
+  if (!res.ok) {
+    if (res.status >= 400 && res.status < 500) {
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      throw new HttpError(res.status, body?.message ?? 'Unable to send the notification.');
+    }
+    throw badGateway(
+      'Unable to send the notification — notification-escalation-service returned an error.',
+    );
+  }
+}

--- a/libs/service-commons/src/http/bootstrap-service.spec.ts
+++ b/libs/service-commons/src/http/bootstrap-service.spec.ts
@@ -1,0 +1,35 @@
+import { bootstrapService } from './bootstrap-service';
+
+describe('bootstrapService', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let exitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('does not log or exit when bootstrap resolves', async () => {
+    bootstrapService(() => Promise.resolve());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs and exits(1) when bootstrap rejects', async () => {
+    const err = new Error('startup failed');
+    bootstrapService(() => Promise.reject(err));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Fatal error during startup:', err);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/libs/service-commons/src/http/bootstrap-service.ts
+++ b/libs/service-commons/src/http/bootstrap-service.ts
@@ -1,0 +1,14 @@
+/**
+ * Runs a service's async bootstrap function, logging and exiting the process
+ * on any startup failure — a rejected/thrown `bootstrap()` must not be
+ * silently swallowed (the `void bootstrap()` bug this fixes across a
+ * service's own `main.ts`), and calling `.catch()` inline at every call site
+ * is exactly the kind of copy-pasted cross-cutting concern this package
+ * exists to centralize instead.
+ */
+export function bootstrapService(bootstrap: () => Promise<void>): void {
+  bootstrap().catch((err) => {
+    console.error('Fatal error during startup:', err);
+    process.exit(1);
+  });
+}

--- a/libs/service-commons/src/index.ts
+++ b/libs/service-commons/src/index.ts
@@ -5,6 +5,7 @@ export * from './http/request-id.middleware';
 export * from './http/http-error';
 export * from './http/async-handler';
 export * from './http/validate';
+export * from './http/bootstrap-service';
 export * from './logging/logger';
 export * from './auth/roles.decorator';
 export * from './auth/rbac.guard';


### PR DESCRIPTION
## Summary
- Auto-escalates overdue referral follow-ups via a cron job in risk-referral-service, guarded by the shared job-lock (as notification-escalation-service and visit-form-service already use) so replicas never double-process the same tick
- Enriches quick response cards in closure-reopen-service with beneficiary/sakhi names via a new approval-service client
- Adds a system-only post-edd-pending beneficiaries endpoint to beneficiary-service
- Fixes the shared bootstrap error-swallowing bug in audit-service and api-gateway
- Combines the last two module groups of the feature/transfer-escalation split (closure-reopen-service + risk-referral-service + audit-service + api-gateway, and beneficiary-service) into one PR
- Fixed one CI-only failure while preparing this PR: approval.client.spec.ts was importing the real client class, which pulls in Zod-validated app-config and process.exit(1)s without a full env — mocked app-config instead, matching the pattern already used elsewhere in this repo

## Test plan
- [x] `nx run-many -t test` across closure-reopen-service, risk-referral-service, audit-service, api-gateway, beneficiary-service — all passing
- [x] `nx run-many -t lint` and `-t build` across all 5 modules — clean