### PR TITLE
fix(notification-escalation-service): allow a sakhi to notify her own assigned supervisor

### DIFF
--- a/apps/notification-escalation-service/src/notifications/notification.routes.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.routes.ts
@@ -90,8 +90,13 @@ export function registerNotificationRoutes(doc: DocumentedRouter, service: Notif
     // the caller's behalf after a Quick Response decision (forwards the
     // deciding Supervisor's own Authorization header); SYSTEM so the
     // missed-visit/referral-followup/sync-delay cron jobs can notify a
-    // Supervisor via a service-account token (POST /auth/service-token).
-    requireRoles('ADMIN', 'SUPERVISOR', 'SYSTEM'),
+    // Supervisor via a service-account token (POST /auth/service-token);
+    // SAKHI so approval-service can notify a Sakhi's assigned Supervisor on
+    // the caller's behalf after a Quick Response submission (forwards the
+    // submitting Sakhi's own Authorization header) — see
+    // NotificationService.create's ownership check for what a SAKHI caller
+    // is actually restricted to (her own assigned Supervisor only).
+    requireRoles('ADMIN', 'SUPERVISOR', 'SYSTEM', 'SAKHI'),
     validateBody(createNotificationSchema),
     controller.create,
   );

--- a/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
@@ -129,6 +129,30 @@ describe('NotificationService', () => {
     expect(repository.create).not.toHaveBeenCalled();
   });
 
+  it('a caller who holds both ADMIN and SAKHI roles gets the ADMIN bypass, not the SAKHI ownership check', async () => {
+    const adminAndSakhi = { id: 'admin-1', roles: ['ADMIN', 'SAKHI'] };
+    repository.create.mockResolvedValue({ id: '1' } as never);
+
+    await service.create(dto, adminAndSakhi, authHeader);
+
+    expect(sakhiClient.findById).not.toHaveBeenCalled();
+    expect(repository.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('a caller who holds both SUPERVISOR and SAKHI roles gets the SUPERVISOR ownership check, not the SAKHI one', async () => {
+    const supervisorAndSakhi = { id: 'supervisor-1', roles: ['SUPERVISOR', 'SAKHI'] };
+    sakhiClient.findById.mockResolvedValue({ sakhiId: 'sakhi-1', supervisorId: 'supervisor-1' });
+    repository.create.mockResolvedValue({ id: '1' } as never);
+
+    await service.create(dto, supervisorAndSakhi, authHeader);
+
+    // Looked up by dto.recipientUserId ('sakhi-1'), not by the caller's own
+    // id — proves the SUPERVISOR branch ran, not the SAKHI one (which would
+    // have looked up the caller's own id instead).
+    expect(sakhiClient.findById).toHaveBeenCalledWith('sakhi-1', authHeader);
+    expect(repository.create).toHaveBeenCalledWith(dto);
+  });
+
   it('propagates repository errors on create', async () => {
     repository.create.mockRejectedValue(new Error('db down'));
     await expect(service.create(dto, admin, authHeader)).rejects.toThrow('db down');

--- a/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.spec.ts
@@ -77,6 +77,58 @@ describe('NotificationService', () => {
     });
   });
 
+  it('SAKHI notifying her own assigned Supervisor succeeds', async () => {
+    const sakhiToSupervisorDto: CreateNotificationInput = {
+      ...dto,
+      recipientUserId: 'supervisor-1',
+    };
+    sakhiClient.findById.mockResolvedValue({
+      sakhiId: 'jane.sakhi',
+      supervisorId: 'supervisor-1',
+    });
+    repository.create.mockResolvedValue({ id: '1' } as never);
+
+    await service.create(sakhiToSupervisorDto, sakhi, authHeader);
+
+    expect(sakhiClient.findById).toHaveBeenCalledWith('jane.sakhi', authHeader);
+    expect(repository.create).toHaveBeenCalledWith(sakhiToSupervisorDto);
+  });
+
+  it('SAKHI notifying a Supervisor who is not her own is forbidden', async () => {
+    const sakhiToOtherSupervisorDto: CreateNotificationInput = {
+      ...dto,
+      recipientUserId: 'someone-elses-supervisor',
+    };
+    sakhiClient.findById.mockResolvedValue({
+      sakhiId: 'jane.sakhi',
+      supervisorId: 'supervisor-1',
+    });
+
+    await expect(
+      service.create(sakhiToOtherSupervisorDto, sakhi, authHeader),
+    ).rejects.toMatchObject({ status: 403 });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('SAKHI notifying herself is forbidden', async () => {
+    const sakhiToSelfDto: CreateNotificationInput = { ...dto, recipientUserId: 'jane.sakhi' };
+    sakhiClient.findById.mockResolvedValue({
+      sakhiId: 'jane.sakhi',
+      supervisorId: 'supervisor-1',
+    });
+
+    await expect(service.create(sakhiToSelfDto, sakhi, authHeader)).rejects.toMatchObject({
+      status: 403,
+    });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('SAKHI caller whose own Sakhi record is not found is forbidden, not 404', async () => {
+    sakhiClient.findById.mockResolvedValue(null);
+    await expect(service.create(dto, sakhi, authHeader)).rejects.toMatchObject({ status: 403 });
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
   it('propagates repository errors on create', async () => {
     repository.create.mockRejectedValue(new Error('db down'));
     await expect(service.create(dto, admin, authHeader)).rejects.toThrow('db down');

--- a/apps/notification-escalation-service/src/notifications/notification.service.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.ts
@@ -23,22 +23,32 @@ export class NotificationService {
   /**
    * ADMIN and SYSTEM may notify anyone — SYSTEM is a machine identity (the
    * missed-visit/referral-followup/sync-delay cron jobs' service-account
-   * token, per requireRoles('ADMIN', 'SUPERVISOR', 'SYSTEM') on this route)
-   * sending recipientUserId values that are Supervisors, not Sakhis, so the
-   * Sakhi-roster ownership check below doesn't apply to it (and would always
-   * 403 it, since sakhiClient.findById on a Supervisor id resolves to
-   * nothing). A SUPERVISOR (the role widened for approval-service's Quick
-   * Response decisions to forward through) may only notify a Sakhi actually
-   * assigned to them — verified via auth-service, same ownership check
-   * supervisor-operations-service already applies to its own Sakhi-scoped
-   * endpoints. Without this, the widened role would let any Supervisor
+   * token, per requireRoles('ADMIN', 'SUPERVISOR', 'SYSTEM', 'SAKHI') on
+   * this route) sending recipientUserId values that are Supervisors, not
+   * Sakhis, so the Sakhi-roster ownership check below doesn't apply to it
+   * (and would always 403 it, since sakhiClient.findById on a Supervisor id
+   * resolves to nothing). A SUPERVISOR (the role widened for
+   * approval-service's Quick Response decisions to forward through) may
+   * only notify a Sakhi actually assigned to them — verified via
+   * auth-service, same ownership check supervisor-operations-service
+   * already applies to its own Sakhi-scoped endpoints. A SAKHI (widened for
+   * ApprovalRequestService.notifySupervisor(), which forwards the
+   * submitting Sakhi's own token) may only notify her own assigned
+   * Supervisor — the reverse direction of the SUPERVISOR check, resolved by
+   * looking up the caller's own Sakhi record rather than the recipient's.
+   * Without either check, the widened roles would let any Supervisor/Sakhi
    * notify any recipientUserId.
    *
    * For escalation/operational notification types, also best-effort fans
    * out a copy to the Sakhi's assigned Supervisor (see supervisor-fanout.ts).
    */
   async create(dto: CreateNotificationInput, caller: CallerIdentity, authorizationHeader: string) {
-    if (!caller.roles.includes('ADMIN') && !caller.roles.includes('SYSTEM')) {
+    if (caller.roles.includes('SAKHI')) {
+      const sakhi = await this.sakhiClient.findById(caller.id, authorizationHeader);
+      if (!sakhi || !sakhi.supervisorId || sakhi.supervisorId !== dto.recipientUserId) {
+        throw forbidden('You do not have access to notify this recipient.');
+      }
+    } else if (!caller.roles.includes('ADMIN') && !caller.roles.includes('SYSTEM')) {
       const sakhi = await this.sakhiClient.findById(dto.recipientUserId, authorizationHeader);
       if (!sakhi || sakhi.supervisorId !== caller.id) {
         throw forbidden('You do not have access to notify this Sakhi.');

--- a/apps/notification-escalation-service/src/notifications/notification.service.ts
+++ b/apps/notification-escalation-service/src/notifications/notification.service.ts
@@ -39,19 +39,30 @@ export class NotificationService {
    * Without either check, the widened roles would let any Supervisor/Sakhi
    * notify any recipientUserId.
    *
+   * ADMIN/SYSTEM (and then SUPERVISOR) are checked before SAKHI, not just
+   * "else if" — a caller can hold multiple concurrent role assignments
+   * (`AuthService.issueTokens` puts every active role code into the JWT's
+   * `roles` array with no precedence), so an ADMIN or SUPERVISOR who also
+   * carries a SAKHI role assignment must still get the ADMIN/SUPERVISOR
+   * behavior, not be misrouted into the restrictive SAKHI-only-notify-her-
+   * own-Supervisor branch. Same precedence AuthService.reactivateUser
+   * already applies for the same reason.
+   *
    * For escalation/operational notification types, also best-effort fans
    * out a copy to the Sakhi's assigned Supervisor (see supervisor-fanout.ts).
    */
   async create(dto: CreateNotificationInput, caller: CallerIdentity, authorizationHeader: string) {
-    if (caller.roles.includes('SAKHI')) {
-      const sakhi = await this.sakhiClient.findById(caller.id, authorizationHeader);
-      if (!sakhi || !sakhi.supervisorId || sakhi.supervisorId !== dto.recipientUserId) {
-        throw forbidden('You do not have access to notify this recipient.');
-      }
-    } else if (!caller.roles.includes('ADMIN') && !caller.roles.includes('SYSTEM')) {
+    if (caller.roles.includes('ADMIN') || caller.roles.includes('SYSTEM')) {
+      // No ownership check — may notify anyone.
+    } else if (caller.roles.includes('SUPERVISOR')) {
       const sakhi = await this.sakhiClient.findById(dto.recipientUserId, authorizationHeader);
       if (!sakhi || sakhi.supervisorId !== caller.id) {
         throw forbidden('You do not have access to notify this Sakhi.');
+      }
+    } else if (caller.roles.includes('SAKHI')) {
+      const sakhi = await this.sakhiClient.findById(caller.id, authorizationHeader);
+      if (!sakhi || !sakhi.supervisorId || sakhi.supervisorId !== dto.recipientUserId) {
+        throw forbidden('You do not have access to notify this recipient.');
       }
     }
     const created = await this.repository.create(dto);


### PR DESCRIPTION
## Summary
- `POST /notifications` only allowed `ADMIN`/`SUPERVISOR`/`SYSTEM`, so `ApprovalRequestService.notifySupervisor()` forwarding the submitting Sakhi's own token got a silent 403 on every reopen/closure/LMP/referral/accompanied-referral submission — the Supervisor never received a notification.
- Widens the role guard to include `SAKHI`, and restricts a SAKHI caller to notifying only her own assigned Supervisor (resolved via her own Sakhi record, not the recipient's) — same ownership-check shape as the existing SUPERVISOR-notifying-her-own-Sakhi branch.
- (Supersedes #216, which was built off `feature/transfer-escalation` and carried 96 unrelated files/48 commits, causing merge conflicts. This branch is built directly off current `develop` with only the 3 files this fix actually touches.)

## Test plan
- [x] 26/26 unit tests pass in `notification.service.spec.ts` (4 new: SAKHI→own supervisor succeeds; SAKHI→wrong recipient/self/unresolvable-sakhi all 403)
- [x] Lint clean
- [x] Build clean
- [x] Previously verified live end-to-end: submitted reopen requests as a Sakhi → confirmed real `SUPERVISOR_APPROVAL_REQUESTED` notifications landed on the assigned Supervisor's `GET /notifications`, with correct title/body/linked Quick Response card

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>