### PR TITLE
feat(approval-service): show sakhi employee code on quick response cards

### DIFF
--- a/apps/approval-service/src/approvals/approvalRequest.service.spec.ts
+++ b/apps/approval-service/src/approvals/approvalRequest.service.spec.ts
@@ -85,6 +85,7 @@ describe('ApprovalRequestService', () => {
     displayName: 'Asha Devi',
     mobileNumber: '9999999999',
     supervisorId: '66666666-6666-6666-6666-666666666666',
+    employeeCode: 'EMP-00123',
   };
 
   const beneficiaryRecord = {

--- a/apps/approval-service/src/quick-response/quick-response.routes.ts
+++ b/apps/approval-service/src/quick-response/quick-response.routes.ts
@@ -37,6 +37,7 @@ const quickResponseCardSchema = z
     // cards' own name enrichment is owned by notification-escalation-service.
     beneficiaryName: z.string().nullable().optional(),
     sakhiName: z.string().nullable().optional(),
+    sakhiEmployeeCode: z.string().nullable().optional(),
   })
   .passthrough();
 

--- a/apps/approval-service/src/quick-response/quick-response.service.spec.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.spec.ts
@@ -249,14 +249,19 @@ describe('QuickResponseService', () => {
     });
 
     describe('batch-enriching approval_requests cards with names', () => {
-      it('populates beneficiaryName and sakhiName for approval cards on the page', async () => {
+      it('populates beneficiaryName, sakhiName, and sakhiEmployeeCode for approval cards on the page', async () => {
         repository.findMany.mockResolvedValue([approvalRequest()]);
         escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
         beneficiaryClient.getManyWithRisk.mockResolvedValue(
           new Map([['22222222-2222-2222-2222-222222222222', 'Sita Kumari']]),
         );
         sakhiClient.getManyByIds.mockResolvedValue(
-          new Map([['44444444-4444-4444-4444-444444444444', 'Asha Devi']]),
+          new Map([
+            [
+              '44444444-4444-4444-4444-444444444444',
+              { displayName: 'Asha Devi', employeeCode: 'EMP-00123' },
+            ],
+          ]),
         );
 
         const result = await service.list(
@@ -267,10 +272,44 @@ describe('QuickResponseService', () => {
         expect(result.cards[0]).toMatchObject({
           beneficiaryName: 'Sita Kumari',
           sakhiName: 'Asha Devi',
+          sakhiEmployeeCode: 'EMP-00123',
         });
       });
 
-      it('leaves escalation cards unenriched (no beneficiaryName/sakhiName fields added)', async () => {
+      it('sets sakhiEmployeeCode to null when the Sakhi is found but has no employeeCode of her own', async () => {
+        repository.findMany.mockResolvedValue([approvalRequest()]);
+        escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
+        sakhiClient.getManyByIds.mockResolvedValue(
+          new Map([
+            [
+              '44444444-4444-4444-4444-444444444444',
+              { displayName: 'Asha Devi', employeeCode: null },
+            ],
+          ]),
+        );
+
+        const result = await service.list(
+          { status: 'PENDING', limit: 50 },
+          managerCaller,
+          authHeader,
+        );
+        expect(result.cards[0]).toMatchObject({ sakhiName: 'Asha Devi', sakhiEmployeeCode: null });
+      });
+
+      it('sets sakhiName and sakhiEmployeeCode to null when the Sakhi is not found/outside scope', async () => {
+        repository.findMany.mockResolvedValue([approvalRequest()]);
+        escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
+        sakhiClient.getManyByIds.mockResolvedValue(new Map());
+
+        const result = await service.list(
+          { status: 'PENDING', limit: 50 },
+          managerCaller,
+          authHeader,
+        );
+        expect(result.cards[0]).toMatchObject({ sakhiName: null, sakhiEmployeeCode: null });
+      });
+
+      it('leaves escalation cards unenriched (no beneficiaryName/sakhiName/sakhiEmployeeCode fields added)', async () => {
         repository.findMany.mockResolvedValue([]);
         escalationClient.list.mockResolvedValue({ cards: [escalationCard()], nextCursor: null });
 
@@ -281,6 +320,7 @@ describe('QuickResponseService', () => {
         );
         expect(result.cards[0]).not.toHaveProperty('beneficiaryName');
         expect(result.cards[0]).not.toHaveProperty('sakhiName');
+        expect(result.cards[0]).not.toHaveProperty('sakhiEmployeeCode');
       });
 
       it('calls getManyWithRisk once with a deduped beneficiaryId list', async () => {
@@ -315,13 +355,18 @@ describe('QuickResponseService', () => {
         );
       });
 
-      it('resolves DATA_RESTORE sakhiName from requestedByUserId', async () => {
+      it('resolves DATA_RESTORE sakhiName and sakhiEmployeeCode from requestedByUserId', async () => {
         repository.findMany.mockResolvedValue([
           approvalRequest({ requestType: 'DATA_RESTORE', beneficiaryId: null }),
         ]);
         escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
         sakhiClient.getManyByIds.mockResolvedValue(
-          new Map([['44444444-4444-4444-4444-444444444444', 'Meena Kumari']]),
+          new Map([
+            [
+              '44444444-4444-4444-4444-444444444444',
+              { displayName: 'Meena Kumari', employeeCode: 'EMP-00456' },
+            ],
+          ]),
         );
 
         const result = await service.list(
@@ -329,7 +374,11 @@ describe('QuickResponseService', () => {
           managerCaller,
           authHeader,
         );
-        expect(result.cards[0]).toMatchObject({ sakhiName: 'Meena Kumari', beneficiaryName: null });
+        expect(result.cards[0]).toMatchObject({
+          sakhiName: 'Meena Kumari',
+          sakhiEmployeeCode: 'EMP-00456',
+          beneficiaryName: null,
+        });
       });
 
       it('sets beneficiaryName to null and excludes the row from the batch call when beneficiaryId is absent', async () => {
@@ -371,7 +420,7 @@ describe('QuickResponseService', () => {
         expect(consoleErrorSpy).toHaveBeenCalled();
       });
 
-      it('degrades sakhiName to null for the whole page, without failing list(), when the batch call throws', async () => {
+      it('degrades sakhiName and sakhiEmployeeCode to null for the whole page, without failing list(), when the batch call throws', async () => {
         repository.findMany.mockResolvedValue([approvalRequest()]);
         escalationClient.list.mockResolvedValue({ cards: [], nextCursor: null });
         sakhiClient.getManyByIds.mockRejectedValue(new Error('auth-service unreachable'));
@@ -381,7 +430,7 @@ describe('QuickResponseService', () => {
           managerCaller,
           authHeader,
         );
-        expect(result.cards[0]).toMatchObject({ sakhiName: null });
+        expect(result.cards[0]).toMatchObject({ sakhiName: null, sakhiEmployeeCode: null });
         expect(consoleErrorSpy).toHaveBeenCalled();
       });
     });
@@ -665,6 +714,7 @@ describe('QuickResponseService', () => {
         sakhiId: '88888888-8888-8888-8888-888888888888',
         displayName: 'Priya Sharma',
         mobileNumber: '+919000000123',
+        employeeCode: 'EMP-00123',
       });
       geographyClient.getById.mockResolvedValue({
         geographyUnitId: '99999999-9999-9999-9999-999999999999',
@@ -794,6 +844,7 @@ describe('QuickResponseService', () => {
       expect(result).toMatchObject({
         padaName: 'Sundarpada',
         sakhiName: 'Priya Sharma',
+        sakhiEmployeeCode: 'EMP-00123',
         beneficiaryName: 'Asha Devi',
         oldLmpDate: '2026-01-01T00:00:00.000Z',
         newLmpDate: '2026-02-01',
@@ -801,6 +852,50 @@ describe('QuickResponseService', () => {
         sakhiContactNumber: '+919000000123',
       });
       expect((result as unknown as { riskDetails: unknown[] }).riskDetails).toHaveLength(1);
+    });
+
+    it('LMP_CHANGE: sets sakhiEmployeeCode to null when the Sakhi has none of her own', async () => {
+      repository.findById.mockResolvedValue(
+        approvalRequest({
+          requestType: 'LMP_CHANGE',
+          reopenRequestId: null,
+          requestPayloadJson: { newLmpDate: '2026-02-01' },
+        }),
+      );
+      sakhiClient.getById.mockResolvedValue({
+        supervisorId: null,
+        sakhiId: '88888888-8888-8888-8888-888888888888',
+        displayName: 'Priya Sharma',
+        mobileNumber: '+919000000123',
+        employeeCode: null,
+      });
+
+      const result = await service.getCardDetail(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        authHeader,
+      );
+
+      expect(result).toMatchObject({ sakhiName: 'Priya Sharma', sakhiEmployeeCode: null });
+    });
+
+    it('LMP_CHANGE: degrades sakhiName and sakhiEmployeeCode to null when the Sakhi lookup fails', async () => {
+      repository.findById.mockResolvedValue(
+        approvalRequest({
+          requestType: 'LMP_CHANGE',
+          reopenRequestId: null,
+          requestPayloadJson: { newLmpDate: '2026-02-01' },
+        }),
+      );
+      sakhiClient.getById.mockRejectedValue(new Error('auth-service unreachable'));
+
+      const result = await service.getCardDetail(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        authHeader,
+      );
+
+      expect(result).toMatchObject({ sakhiName: null, sakhiEmployeeCode: null });
     });
 
     it('LMP_CHANGE: returns the sonography asset id when the payload carries one', async () => {
@@ -1367,7 +1462,7 @@ describe('QuickResponseService', () => {
       expect((result as unknown as { reason: string }).reason).toContain('2026-10-08');
     });
 
-    it('DATA_RESTORE: returns Sakhi name and id resolved from requestedByUserId', async () => {
+    it('DATA_RESTORE: returns Sakhi name, employeeCode, and id resolved from requestedByUserId', async () => {
       repository.findById.mockResolvedValue(
         approvalRequest({
           requestType: 'DATA_RESTORE',
@@ -1381,6 +1476,7 @@ describe('QuickResponseService', () => {
         sakhiId: 'sakhi-user-1',
         displayName: 'Meena Kumari',
         mobileNumber: '+919000000456',
+        employeeCode: 'EMP-00123',
       });
 
       const result = await service.getCardDetail(
@@ -1389,8 +1485,32 @@ describe('QuickResponseService', () => {
         authHeader,
       );
 
-      expect(result).toMatchObject({ sakhiName: 'Meena Kumari', sakhiId: 'sakhi-user-1' });
+      expect(result).toMatchObject({
+        sakhiName: 'Meena Kumari',
+        sakhiEmployeeCode: 'EMP-00123',
+        sakhiId: 'sakhi-user-1',
+      });
       expect(sakhiClient.getById).toHaveBeenCalledWith('sakhi-user-1', authHeader);
+    });
+
+    it('DATA_RESTORE: sets sakhiEmployeeCode to null when the Sakhi lookup fails', async () => {
+      repository.findById.mockResolvedValue(
+        approvalRequest({
+          requestType: 'DATA_RESTORE',
+          reopenRequestId: null,
+          beneficiaryId: null,
+          requestedByUserId: 'sakhi-user-1',
+        }),
+      );
+      sakhiClient.getById.mockRejectedValue(new Error('auth-service unreachable'));
+
+      const result = await service.getCardDetail(
+        '11111111-1111-1111-1111-111111111111',
+        managerCaller,
+        authHeader,
+      );
+
+      expect(result).toMatchObject({ sakhiName: null, sakhiEmployeeCode: null });
     });
 
     it('propagates a core beneficiary-lookup failure rather than degrading it to null', async () => {
@@ -1941,6 +2061,7 @@ describe('QuickResponseService', () => {
         sakhiId: card.requestedByUserId as string,
         displayName: 'Meena Kumari',
         mobileNumber: '+919000000456',
+        employeeCode: 'EMP-00123',
       });
 
       await service.decide(
@@ -2526,6 +2647,7 @@ describe('QuickResponseService', () => {
         sakhiId: card.requestedByUserId as string,
         displayName: 'Priya Sakhi',
         mobileNumber: '+919000000123',
+        employeeCode: 'EMP-00123',
       });
       beneficiaryClient.getById.mockResolvedValue({
         id: card.beneficiaryId as string,
@@ -2567,6 +2689,7 @@ describe('QuickResponseService', () => {
         sakhiId: card.requestedByUserId as string,
         displayName: 'Priya Sakhi',
         mobileNumber: '+919000000123',
+        employeeCode: 'EMP-00123',
       });
 
       await service.decide(
@@ -2716,6 +2839,7 @@ describe('QuickResponseService', () => {
         sakhiId: card.requestedByUserId as string,
         displayName: 'Priya Sakhi',
         mobileNumber: '+919000000123',
+        employeeCode: 'EMP-00123',
       });
 
       const result = await service.decide(
@@ -2771,6 +2895,7 @@ describe('QuickResponseService', () => {
         sakhiId: card.requestedByUserId as string,
         displayName: 'Priya Sakhi',
         mobileNumber: '+919000000123',
+        employeeCode: 'EMP-00123',
       });
 
       const pending = service.decide(
@@ -3067,6 +3192,7 @@ describe('QuickResponseService', () => {
         sakhiId: card.requestedByUserId as string,
         displayName: 'Priya Sakhi',
         mobileNumber: '+919000000123',
+        employeeCode: 'EMP-00123',
       });
       beneficiaryClient.getById.mockResolvedValue({
         id: card.beneficiaryId as string,

--- a/apps/approval-service/src/quick-response/quick-response.service.ts
+++ b/apps/approval-service/src/quick-response/quick-response.service.ts
@@ -52,6 +52,7 @@ interface ApprovalRequestCard {
   raisedAt: string;
   beneficiaryName: string | null;
   sakhiName: string | null;
+  sakhiEmployeeCode: string | null;
 }
 
 type QuickResponseCard = ApprovalRequestCard | EscalationCard;
@@ -161,16 +162,17 @@ export class QuickResponseService {
   }
 
   /**
-   * Page-level Sakhi name lookup for list() — one batch call for every
-   * unique Sakhi on the page via auth-service's GET /sakhis/by-ids, instead
-   * of one call per Sakhi (see sakhi.client.ts's getManyByIds). Best-effort:
-   * a failure here degrades the whole page's sakhiName to null rather than
-   * failing the list, matching resolveBeneficiaryNamesById's contract.
+   * Page-level Sakhi name/employeeCode lookup for list() — one batch call
+   * for every unique Sakhi on the page via auth-service's GET /sakhis/by-ids,
+   * instead of one call per Sakhi (see sakhi.client.ts's getManyByIds).
+   * Best-effort: a failure here degrades the whole page's sakhiName/
+   * sakhiEmployeeCode to null rather than failing the list, matching
+   * resolveBeneficiaryNamesById's contract.
    */
   private async resolveSakhiNamesById(
     sakhiIds: string[],
     authorizationHeader: string,
-  ): Promise<Map<string, string>> {
+  ): Promise<Map<string, { displayName: string; employeeCode: string | null }>> {
     if (sakhiIds.length === 0) return new Map();
     try {
       return await this.sakhiClient.getManyByIds(sakhiIds, authorizationHeader);
@@ -266,7 +268,7 @@ export class QuickResponseService {
     ]);
 
     let beneficiaryNames = new Map<string, string>();
-    let sakhiNames = new Map<string, string>();
+    let sakhis = new Map<string, { displayName: string; employeeCode: string | null }>();
     if (reconciledRows.length > 0) {
       const beneficiaryIds = Array.from(
         new Set(
@@ -274,7 +276,7 @@ export class QuickResponseService {
         ),
       );
       const sakhiIds = Array.from(new Set(reconciledRows.map((row) => row.requestedByUserId)));
-      [beneficiaryNames, sakhiNames] = await Promise.all([
+      [beneficiaryNames, sakhis] = await Promise.all([
         this.resolveBeneficiaryNamesById(beneficiaryIds, authorizationHeader),
         this.resolveSakhiNamesById(sakhiIds, authorizationHeader),
       ]);
@@ -287,7 +289,8 @@ export class QuickResponseService {
       beneficiaryId: row.beneficiaryId,
       raisedAt: row.createdAt.toISOString(),
       beneficiaryName: row.beneficiaryId ? (beneficiaryNames.get(row.beneficiaryId) ?? null) : null,
-      sakhiName: sakhiNames.get(row.requestedByUserId) ?? null,
+      sakhiName: sakhis.get(row.requestedByUserId)?.displayName ?? null,
+      sakhiEmployeeCode: sakhis.get(row.requestedByUserId)?.employeeCode ?? null,
     }));
 
     const merged: QuickResponseCard[] = [...approvalCards, ...escalationResult.cards].sort(
@@ -435,6 +438,7 @@ export class QuickResponseService {
       beneficiaryName: beneficiary.pii.fullName,
       padaName: pada?.name ?? null,
       sakhiName: sakhi?.displayName ?? null,
+      sakhiEmployeeCode: sakhi?.employeeCode ?? null,
       sakhiContactNumber: sakhi?.mobileNumber ?? null,
       riskDetails: beneficiary.riskConditionSummaries,
     };
@@ -470,6 +474,7 @@ export class QuickResponseService {
       return {
         ...this.thinCard(row),
         sakhiName: sakhi?.displayName ?? null,
+        sakhiEmployeeCode: sakhi?.employeeCode ?? null,
         sakhiId: row.requestedByUserId,
       };
     }
@@ -492,6 +497,7 @@ export class QuickResponseService {
         ...this.thinCard(row),
         padaName: common.padaName,
         sakhiName: common.sakhiName,
+        sakhiEmployeeCode: common.sakhiEmployeeCode,
         beneficiaryName: common.beneficiaryName,
         oldLmpDate: common.beneficiary.motherCaseDetails?.lmpDate ?? null,
         newLmpDate: payload?.newLmpDate ?? null,
@@ -516,6 +522,7 @@ export class QuickResponseService {
         ...this.thinCard(row),
         padaName: common.padaName,
         sakhiName: common.sakhiName,
+        sakhiEmployeeCode: common.sakhiEmployeeCode,
         beneficiaryName: common.beneficiaryName,
         closureType: closure?.closureType ?? null,
         closureReasonLookupValueId: closure?.closureReasonLookupValueId ?? null,
@@ -540,6 +547,7 @@ export class QuickResponseService {
         ...this.thinCard(row),
         padaName: common.padaName,
         sakhiName: common.sakhiName,
+        sakhiEmployeeCode: common.sakhiEmployeeCode,
         beneficiaryName: common.beneficiaryName,
         reasonForReopen: reopenRequest?.requestReason ?? null,
         riskDetails: common.riskDetails,
@@ -567,6 +575,7 @@ export class QuickResponseService {
         ...this.thinCard(row),
         padaName: common.padaName,
         sakhiName: common.sakhiName,
+        sakhiEmployeeCode: common.sakhiEmployeeCode,
         beneficiaryName: common.beneficiaryName,
         referralDate: referral?.referralDate ?? null,
         facilityType: referral?.facilityType ?? null,
@@ -588,6 +597,7 @@ export class QuickResponseService {
       ...this.thinCard(row),
       padaName: common.padaName,
       sakhiName: common.sakhiName,
+      sakhiEmployeeCode: common.sakhiEmployeeCode,
       beneficiaryName: common.beneficiaryName,
       visitReference: visit,
       referralsMissedCount: referral?.incompleteCount ?? null,
@@ -606,6 +616,7 @@ export class QuickResponseService {
         ...card,
         padaName: common.padaName,
         sakhiName: common.sakhiName,
+        sakhiEmployeeCode: common.sakhiEmployeeCode,
         beneficiaryName: common.beneficiaryName,
         eddDate,
         reason: eddDate ? `EDD approaching on ${eddDate.slice(0, 10)}` : null,
@@ -620,6 +631,7 @@ export class QuickResponseService {
       ...card,
       padaName: common.padaName,
       sakhiName: common.sakhiName,
+      sakhiEmployeeCode: common.sakhiEmployeeCode,
       beneficiaryName: common.beneficiaryName,
       visitType: card.escalationType,
       riskDetails: common.riskDetails,

--- a/apps/approval-service/src/quick-response/sakhi.client.ts
+++ b/apps/approval-service/src/quick-response/sakhi.client.ts
@@ -7,6 +7,7 @@ export interface SakhiRecord {
   displayName: string;
   mobileNumber: string;
   supervisorId: string | null;
+  employeeCode: string | null;
 }
 
 /**
@@ -44,17 +45,17 @@ export class SakhiClient {
   }
 
   /**
-   * Batch-resolves sakhiName for a page of Quick Response cards via
-   * auth-service's GET /sakhis/by-ids — one call per page instead of one
-   * per unique Sakhi (see resolveSakhiNamesById, the caller). Ids outside
-   * the caller's scope, or simply not found, are silently absent from the
-   * result (server-side behavior, not a 404/403), same as
+   * Batch-resolves sakhiName/sakhiEmployeeCode for a page of Quick Response
+   * cards via auth-service's GET /sakhis/by-ids — one call per page instead
+   * of one per unique Sakhi (see resolveSakhiNamesById, the caller). Ids
+   * outside the caller's scope, or simply not found, are silently absent
+   * from the result (server-side behavior, not a 404/403), same as
    * BeneficiaryClient.getManyWithRisk.
    */
   async getManyByIds(
     sakhiIds: string[],
     authorizationHeader: string,
-  ): Promise<Map<string, string>> {
+  ): Promise<Map<string, { displayName: string; employeeCode: string | null }>> {
     if (sakhiIds.length === 0) return new Map();
 
     let res: Response;
@@ -79,7 +80,12 @@ export class SakhiClient {
     }
 
     const body = (await res.json()) as { data: SakhiRecord[] };
-    return new Map(body.data.map((sakhi) => [sakhi.sakhiId, sakhi.displayName]));
+    return new Map(
+      body.data.map((sakhi) => [
+        sakhi.sakhiId,
+        { displayName: sakhi.displayName, employeeCode: sakhi.employeeCode },
+      ]),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Quick Response cards currently show a Sakhi's raw `sakhiId` to supervisors; this surfaces her `employeeCode` (e.g. `SAKHI-0001`) alongside the existing `sakhiName` instead.
- `employeeCode` already exists on `sakhi_profiles` (nullable, unique, `varchar(80)`) and is already returned by `auth-service`'s `GET /sakhis/:sakhiId` and `GET /sakhis/by-ids` — no DB migration and no `auth-service` changes needed.
- Widens `SakhiClient.getManyByIds()` to return `employeeCode` alongside `displayName`, and threads a new `sakhiEmployeeCode` field through `list()`, `resolveCommonFields()` (shared by every `approval_requests` and `escalation_events` card type), and the `DATA_RESTORE` detail branch — identical null-safety to `sakhiName` throughout (Sakhi not found, found but no employeeCode of her own, or lookup failure all degrade to `null` without failing the request).
- Notification-title-building call sites (the separate `resolveSakhiName` singular helper, used for LMP_CHANGE/REFERRAL_INCOMPLETE/ACCOMPANIED_REFERRAL/DATA_RESTORE notification text) are deliberately untouched — out of scope; this only affects card *display* data.

## Manually verified end-to-end (local dev)
- Set a real Sakhi's `employeeCode` via `PATCH /users/:id` (ADMIN) → confirmed reflected in `GET /sakhis/:sakhiId`.
- Raised a REOPEN quick-response card for that Sakhi → confirmed `sakhiEmployeeCode` appears correctly in `GET /quick-response?status=PENDING`.
- Raised a DATA_RESTORE quick-response card for the same Sakhi → confirmed `sakhiEmployeeCode` appears correctly there too (exercises the separate `getById`-based detail branch, not just the batch `list()` path).
- Confirmed `sakhiEmployeeCode: null` for a Sakhi with no employee code assigned, alongside a Sakhi that does have one, in the same list response — proving the null-safety works per-row, not just in isolation.

## Known issues / carried over from manual QA (pre-existing, not introduced or fixed by this PR)
- **Fire-and-forget `approval_requests` card creation can silently drop a card** — `closure-reopen-service`'s reopen-request `create()` (and similarly any direct `POST /reopen-requests` / `POST /approvals` call) can succeed at the source-of-truth level while the linked Quick Response card creation silently fails, leaving a genuinely `PENDING` request invisible in the Supervisor's feed. Observed again during this PR's manual testing (a `PENDING` reopen request never surfaced in `GET /quick-response`). Documented previously in PR #218; still not fixed — needs a retry/reconciliation mechanism, out of scope here.
- **`GET /reopen-requests?beneficiaryId=...` requires the exact case UUID, not the PII UUID** — easy to confuse the two IDs returned by `GET /beneficiaries`; not a bug, just a sharp edge worth documenting for API consumers (`beneficiaryId` in reopen-requests refers to the beneficiary *case* id, not `pii.id`).
- **No format is documented anywhere (SRS/HLD/ERD) for `employeeCode`** — it's free text, `min(1).max(80)`, uniqueness enforced only at the DB level. This PR treats it as opaque display data, which is consistent with how it's already stored; flagging in case product wants to standardize a format later (e.g. always `SAKHI-XXXX`).

## Test plan
- [x] `nx build approval-service` — succeeds (verified with a full cache-busting rebuild, not just cached output)
- [x] `nx lint approval-service` — clean (pre-existing unrelated warnings only, in files this PR doesn't touch)
- [x] `nx test approval-service --skip-nx-cache` — 246/246 passing across 11 suites, including new/extended tests for `sakhiEmployeeCode`'s three states (found, found-but-null, not-found/lookup-failed) in both `list()` and `getCardDetail()`
- [x] `nx affected -t lint,test,build --base=origin/develop` — only `approval-service` affected
- [x] Manually verified against a local dev backend end-to-end (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)