### PR TITLE
feat(health-education): Map SRS health-education content to real triggers

### DIFF
--- a/apps/api-gateway/src/proxy/routes.spec.ts
+++ b/apps/api-gateway/src/proxy/routes.spec.ts
@@ -6,6 +6,20 @@
 process.env.JWT_PUBLIC_KEY ??= 'test-key';
 
 const { SERVICE_ROUTES } = require('./routes') as typeof import('./routes');
+const appConfig = require('../config/app-config')
+  .appConfig as typeof import('../config/app-config').appConfig;
+
+describe('SERVICE_ROUTES coverage', () => {
+  it('proxies /form-submissions to visit-form-service, distinct from /forms', () => {
+    const formSubmissionsRoute = SERVICE_ROUTES.find((r) => r.prefix === '/form-submissions');
+    const formsRoute = SERVICE_ROUTES.find((r) => r.prefix === '/forms');
+
+    expect(formSubmissionsRoute).toBeDefined();
+    expect(formSubmissionsRoute?.target).toBe(appConfig.VISIT_FORM_SERVICE_URL);
+    expect(formSubmissionsRoute?.requiresAuth).toBe(true);
+    expect(formSubmissionsRoute).not.toBe(formsRoute);
+  });
+});
 
 describe('SERVICE_ROUTES ordering', () => {
   it('registers /visits/by-sakhi before the generic /visits prefix', () => {

--- a/apps/api-gateway/src/proxy/routes.ts
+++ b/apps/api-gateway/src/proxy/routes.ts
@@ -169,6 +169,10 @@ export const SERVICE_ROUTES: readonly ServiceRoute[] = [
   // (not auth-service) since it already owns VisitSchedule/VisitCodeType.
   { prefix: '/visit-masters', target: appConfig.VISIT_FORM_SERVICE_URL, requiresAuth: true },
   { prefix: '/forms', target: appConfig.VISIT_FORM_SERVICE_URL, requiresAuth: true },
+  // Sakhi-facing form-submission edit route (PATCH .../answers) — a distinct
+  // prefix from /forms, so it needs its own gateway entry or it 404s at the
+  // gateway despite existing and being reachable directly against the service.
+  { prefix: '/form-submissions', target: appConfig.VISIT_FORM_SERVICE_URL, requiresAuth: true },
   // Admin form-authoring routes (create/patch/publish draft versions) live
   // under /admin/forms in visit-form-service — a distinct prefix from /forms,
   // so it needs its own gateway entry or those 3 endpoints are unreachable.

--- a/apps/cms-content-service/src/health-education/healthEducation.controller.spec.ts
+++ b/apps/cms-content-service/src/health-education/healthEducation.controller.spec.ts
@@ -1,0 +1,75 @@
+import type { Request, Response } from 'express';
+import { createHealthEducationController } from './healthEducation.controller';
+import type { HealthEducationService } from './healthEducation.service';
+
+/**
+ * Controller-level coverage for the exact regression a live test caught:
+ * conditionLabel was accepted by the route schema and fully supported by
+ * the repository, but the controller's req.query destructuring never
+ * extracted it, so every conditionLabel-filtered call silently returned
+ * every message across every condition instead of the matching one(s).
+ * Only a controller-level test (not the service-level ones in
+ * healthEducation.service.spec.ts) can catch this class of bug, since the
+ * service itself was always correct — the query-param extraction was the
+ * broken layer.
+ */
+describe('HealthEducation controller — listMessages', () => {
+  function mockReqRes(query: Record<string, string | undefined>) {
+    const req = { query } as unknown as Request;
+    const json = jest.fn();
+    const res = { json } as unknown as Response;
+    return { req, res, json };
+  }
+
+  it('extracts conditionLabel from the query string and passes it to the service', async () => {
+    const service = {
+      listMessages: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<HealthEducationService>;
+    const controller = createHealthEducationController(service);
+    const { req, res } = mockReqRes({ conditionLabel: 'Anemia' });
+
+    await controller.listMessages(req, res, jest.fn());
+
+    expect(service.listMessages).toHaveBeenCalledWith({
+      riskConditionId: undefined,
+      stage: undefined,
+      conditionLabel: 'Anemia',
+    });
+  });
+
+  it('extracts riskConditionId and stage alongside conditionLabel', async () => {
+    const service = {
+      listMessages: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<HealthEducationService>;
+    const controller = createHealthEducationController(service);
+    const { req, res } = mockReqRes({
+      riskConditionId: 'condition-1',
+      stage: 'as soon as detected during ANC visit',
+      conditionLabel: 'Anemia',
+    });
+
+    await controller.listMessages(req, res, jest.fn());
+
+    expect(service.listMessages).toHaveBeenCalledWith({
+      riskConditionId: 'condition-1',
+      stage: 'as soon as detected during ANC visit',
+      conditionLabel: 'Anemia',
+    });
+  });
+
+  it('passes undefined for every filter when the query is empty', async () => {
+    const service = {
+      listMessages: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<HealthEducationService>;
+    const controller = createHealthEducationController(service);
+    const { req, res } = mockReqRes({});
+
+    await controller.listMessages(req, res, jest.fn());
+
+    expect(service.listMessages).toHaveBeenCalledWith({
+      riskConditionId: undefined,
+      stage: undefined,
+      conditionLabel: undefined,
+    });
+  });
+});

--- a/apps/cms-content-service/src/health-education/healthEducation.controller.spec.ts
+++ b/apps/cms-content-service/src/health-education/healthEducation.controller.spec.ts
@@ -2,6 +2,24 @@ import type { Request, Response } from 'express';
 import { createHealthEducationController } from './healthEducation.controller';
 import type { HealthEducationService } from './healthEducation.service';
 
+// healthEducation.controller.ts imports asyncHandler/ok from ../app.module,
+// which eagerly loads config/app-config.ts — that module calls
+// process.exit(1) at import time when required env vars (e.g. DATABASE_URL)
+// aren't set, which they never are in CI (.env is gitignored, no service
+// actually boots for a unit-test run). Mocked here with the real,
+// trivial re-exported implementations from service-commons so this spec
+// exercises the controller's actual req.query handling without pulling in
+// app.module's config-validation side effect. This is why no other
+// controller-level spec exists elsewhere in this service (or repo) —
+// every other one stops at the service layer for exactly this reason.
+jest.mock('../app.module', () => ({
+  asyncHandler:
+    (handler: (req: Request, res: Response, next: jest.Mock) => Promise<unknown>) =>
+    (req: Request, res: Response, next: jest.Mock) =>
+      handler(req, res, next).catch(next),
+  ok: (data: unknown) => ({ success: true, message: 'OK', data }),
+}));
+
 /**
  * Controller-level coverage for the exact regression a live test caught:
  * conditionLabel was accepted by the route schema and fully supported by

--- a/apps/cms-content-service/src/health-education/healthEducation.controller.ts
+++ b/apps/cms-content-service/src/health-education/healthEducation.controller.ts
@@ -8,8 +8,20 @@ import type { HealthEducationService } from './healthEducation.service';
 export function createHealthEducationController(service: HealthEducationService) {
   return {
     listMessages: asyncHandler(async (req, res) => {
-      const { riskConditionId, stage } = req.query as { riskConditionId?: string; stage?: string };
-      res.json(ok(await service.listMessages({ riskConditionId, stage })));
+      // conditionLabel was missing here even though the route schema
+      // (listMessagesQuerySchema) accepts it and the repository fully
+      // supports it — every conditionLabel-filtered call silently fell
+      // through to "no filter" and returned all messages across every
+      // condition. Found live: risk-referral-service's
+      // resolveHealthEducationMessages (the only real caller of this
+      // filter today) got all 32 seeded rows back for every risk-graded
+      // condition instead of the 1-4 that actually match.
+      const { riskConditionId, stage, conditionLabel } = req.query as {
+        riskConditionId?: string;
+        stage?: string;
+        conditionLabel?: string;
+      };
+      res.json(ok(await service.listMessages({ riskConditionId, stage, conditionLabel })));
     }),
   };
 }

--- a/apps/cms-content-service/src/health-education/healthEducation.service.spec.ts
+++ b/apps/cms-content-service/src/health-education/healthEducation.service.spec.ts
@@ -20,6 +20,7 @@ describe('HealthEducationService', () => {
     expect(repository.findMany).toHaveBeenCalledWith({
       riskConditionId: 'condition-1',
       stage: undefined,
+      conditionLabel: undefined,
     });
   });
 
@@ -31,10 +32,38 @@ describe('HealthEducationService', () => {
     expect(repository.findMany).toHaveBeenCalledWith({
       riskConditionId: undefined,
       stage: 'postpartum (PP1 or PP2 whichever is attended)',
+      conditionLabel: undefined,
     });
   });
 
-  it('passes no filters when neither is given, returning everything', async () => {
+  it('passes conditionLabel through to the repository', async () => {
+    repository.findMany.mockResolvedValue([]);
+
+    await service.listMessages({ conditionLabel: 'Anemia' });
+
+    expect(repository.findMany).toHaveBeenCalledWith({
+      riskConditionId: undefined,
+      stage: undefined,
+      conditionLabel: 'Anemia',
+    });
+  });
+
+  it('passes conditionLabel and stage together, narrowing to one message', async () => {
+    repository.findMany.mockResolvedValue([]);
+
+    await service.listMessages({
+      conditionLabel: 'Anemia',
+      stage: 'as soon as detected during ANC visit',
+    });
+
+    expect(repository.findMany).toHaveBeenCalledWith({
+      riskConditionId: undefined,
+      stage: 'as soon as detected during ANC visit',
+      conditionLabel: 'Anemia',
+    });
+  });
+
+  it('passes no filters when none are given, returning everything', async () => {
     repository.findMany.mockResolvedValue([]);
 
     await service.listMessages({});
@@ -42,6 +71,7 @@ describe('HealthEducationService', () => {
     expect(repository.findMany).toHaveBeenCalledWith({
       riskConditionId: undefined,
       stage: undefined,
+      conditionLabel: undefined,
     });
   });
 });

--- a/apps/cms-content-service/src/health-education/healthEducation.service.ts
+++ b/apps/cms-content-service/src/health-education/healthEducation.service.ts
@@ -7,7 +7,7 @@ import type { HealthEducationRepository } from './healthEducation.repository';
 export class HealthEducationService {
   constructor(private readonly repository: HealthEducationRepository) {}
 
-  listMessages(filters: { riskConditionId?: string; stage?: string }) {
+  listMessages(filters: { riskConditionId?: string; stage?: string; conditionLabel?: string }) {
     return this.repository.findMany(filters);
   }
 }

--- a/apps/risk-referral-service/prisma/migrations/20260904090000_add_risk_assessment_phase/migration.sql
+++ b/apps/risk-referral-service/prisma/migrations/20260904090000_add_risk_assessment_phase/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "risk_assessments" ADD COLUMN "risk_phase" "RiskPhase";

--- a/apps/risk-referral-service/prisma/schema.prisma
+++ b/apps/risk-referral-service/prisma/schema.prisma
@@ -189,6 +189,15 @@ model RiskAssessment {
   submissionId        String              @map("submission_id")
   // rule_versions.rule_version_id — owned by another service, no cross-service relation.
   ruleVersionId       String              @map("rule_version_id")
+  // The caller's FORM_CODE_TO_RISK_PHASE-derived phase for this submission
+  // (visit-form-service already computes and sends this as dto.riskPhase to
+  // resolve conditionIds — see riskAssessment.service.ts's create() — it just
+  // wasn't persisted before). Nullable so historical pre-migration rows are
+  // not backfilled/guessed; used to pick the stage-appropriate
+  // health-education message for a risk-graded condition (e.g. Anemia's
+  // "as soon as detected" ANC message vs its separate postpartum message) —
+  // see beneficiaryRisk.service.ts's toAssessmentView.
+  riskPhase           RiskPhase?          @map("risk_phase")
   evaluatedAt         DateTime            @map("evaluated_at")
   overallRiskCategory OverallRiskCategory @map("overall_risk_category")
   overallHighRiskFlag Boolean             @default(false) @map("overall_high_risk_flag")

--- a/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.repository.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.repository.ts
@@ -12,6 +12,11 @@ const STATE_SNAPSHOT_SELECT = {
 const ASSESSMENT_WITH_FLAGS_SELECT = {
   id: true,
   evaluatedAt: true,
+  // Which visit phase this assessment came from (ANC/PP/NN/...) — needed to
+  // pick the stage-appropriate health-education message for a risk-graded
+  // condition (see beneficiaryRisk.service.ts's toAssessmentView). Nullable
+  // on assessments created before this column existed.
+  riskPhase: true,
   overallRiskCategory: true,
   overallHighRiskFlag: true,
   hrDetectedFlag: true,

--- a/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.routes.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.routes.ts
@@ -24,14 +24,12 @@ const riskStateSnapshotSchema = z.object({
   createdAt: z.string().datetime(),
 });
 
-const educationContentSchema = z
-  .object({
-    topicCode: z.string(),
-    topicName: z.string(),
-    mediaType: z.string(),
-    contentUrl: z.string().nullable(),
-  })
-  .nullable();
+const educationContentSchema = z.object({
+  topicCode: z.string(),
+  topicName: z.string(),
+  mediaType: z.string(),
+  contentUrl: z.string().nullable(),
+});
 
 const riskFlagViewSchema = z.object({
   id: z.string().uuid(),
@@ -42,13 +40,17 @@ const riskFlagViewSchema = z.object({
   isReferralTrigger: z.boolean(),
   isEducationTrigger: z.boolean(),
   isHrVisitTrigger: z.boolean(),
-  educationContent: educationContentSchema.openapi({
+  educationContent: z.array(educationContentSchema).openapi({
     description:
-      'Resolved via cms-content-service when isEducationTrigger is true; null when ' +
+      'Resolved via cms-content-service when isEducationTrigger is true; empty array when ' +
       'isEducationTrigger is false, or when content resolution failed/degraded (this call ' +
-      'never fails the overall request — see educationContent.client.ts). Currently always ' +
-      'the same seeded "Content coming soon" placeholder topic — ARMMAN has not yet ' +
-      'delivered per-condition content (SRS Open Item 12).',
+      'never fails the overall request). For the 5 SRS-mapped conditions (Anemia, Gestational ' +
+      'Hypertension, Gestational Diabetes, Inadequate Gestational Weight Gain, Previous ' +
+      "Pregnancy Complication — see beneficiaryRisk.service.ts's CONDITION_CODE_TO_LABEL), " +
+      "returns ARMMAN's real content, ordered, filtered to the assessment's own riskPhase " +
+      '(ANC-phase gets every non-postpartum message; PP-phase gets only the postpartum one — ' +
+      "riskPhase alone can't distinguish finer ANC sub-stages). Every other condition falls " +
+      'back to the seeded "Content coming soon" placeholder topic.',
   }),
 });
 

--- a/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.spec.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.spec.ts
@@ -556,6 +556,46 @@ describe('BeneficiaryRiskService', () => {
 
         expect(resolveHealthEducationMessagesMock).toHaveBeenCalledTimes(1);
       });
+
+      it('does NOT collapse riskPhase null and riskPhase ANC onto the same cache bucket (PR #222 review finding)', async () => {
+        // Both cases share isPostpartum === false under the old, collapsed
+        // cache key (`${conditionCode}:${isPostpartum}`) — this test
+        // proves a null-phase flag (meant to get every message,
+        // undifferentiated) and an ANC-phase flag (meant to get only
+        // non-postpartum messages) resolve independently within one call,
+        // even though toAssessmentView resolves every flag concurrently
+        // via Promise.all and whichever reached the cache first would
+        // previously have silently decided both.
+        resolveHealthEducationMessagesMock.mockResolvedValue([anemiaAncMessage, anemiaPpMessage]);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({ id: 'a-legacy', riskPhase: null, riskFlags: [mappedFlag('ANEMIA')] }),
+          assessment({ id: 'a-anc', riskPhase: 'ANC', riskFlags: [mappedFlag('ANEMIA')] }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        // findAssessmentsWithFlags returns most-recent-evaluatedAt-first
+        // (see repository); both fixtures share assessment()'s default
+        // evaluatedAt, so toAssessmentView preserves the mocked array's own
+        // order — a-legacy first, a-anc second, as returned above.
+        expect(result.assessments).toHaveLength(2);
+        const [legacyAssessment, ancAssessment] = result.assessments;
+        const legacyFlag = legacyAssessment.flags[0];
+        const ancFlag = ancAssessment.flags[0];
+
+        // riskPhase null -> every message, undifferentiated (both ANC and
+        // PP messages present).
+        expect(legacyFlag.educationContent).toEqual([
+          expect.objectContaining({ topicName: anemiaAncMessage.titleEn }),
+          expect.objectContaining({ topicName: anemiaPpMessage.titleEn }),
+        ]);
+        // riskPhase 'ANC' -> only the non-postpartum message — must NOT
+        // include the postpartum one, even resolved in the same call.
+        expect(ancFlag.educationContent).toEqual([
+          expect.objectContaining({ topicName: anemiaAncMessage.titleEn }),
+        ]);
+      });
     });
   });
 

--- a/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.spec.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.spec.ts
@@ -5,10 +5,12 @@ import { BeneficiaryClient } from './beneficiary.client';
 import { listSakhiIdsForSupervisor } from './sakhi.client';
 import { resolveRiskGrades } from './riskGrade.client';
 import { resolveEducationContent } from './educationContent.client';
+import { resolveHealthEducationMessages } from './healthEducation.client';
 
 jest.mock('./sakhi.client');
 jest.mock('./riskGrade.client');
 jest.mock('./educationContent.client');
+jest.mock('./healthEducation.client');
 
 const BENEFICIARY_ID = '11111111-1111-1111-1111-111111111111';
 const AUTH_HEADER = 'Bearer test-token';
@@ -39,6 +41,7 @@ function assessment(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     id: 'assessment-1',
     evaluatedAt: new Date('2026-06-01'),
+    riskPhase: 'ANC',
     overallRiskCategory: 'HIGH',
     overallHighRiskFlag: true,
     hrDetectedFlag: true,
@@ -71,10 +74,16 @@ describe('BeneficiaryRiskService', () => {
   const listSakhiIdsForSupervisorMock = jest.mocked(listSakhiIdsForSupervisor);
   const resolveRiskGradesMock = jest.mocked(resolveRiskGrades);
   const resolveEducationContentMock = jest.mocked(resolveEducationContent);
+  const resolveHealthEducationMessagesMock = jest.mocked(resolveHealthEducationMessages);
   let service: BeneficiaryRiskService;
 
   beforeEach(() => {
     jest.resetAllMocks();
+    // Safe default for tests that trigger a mapped condition (e.g. ANEMIA)
+    // incidentally, without caring about its resolved content — matches the
+    // real client's contract of always resolving to an array, never
+    // undefined (see healthEducation.client.ts's own doc comment).
+    resolveHealthEducationMessagesMock.mockResolvedValue([]);
     service = new BeneficiaryRiskService(repository, beneficiaryClient);
   });
 
@@ -112,7 +121,7 @@ describe('BeneficiaryRiskService', () => {
               isReferralTrigger: true,
               isEducationTrigger: false,
               isHrVisitTrigger: true,
-              educationContent: null,
+              educationContent: [],
             },
           ],
         },
@@ -263,7 +272,7 @@ describe('BeneficiaryRiskService', () => {
       expect(repository.findStateSnapshots).not.toHaveBeenCalled();
     });
 
-    it('attaches educationContent to a flag with isEducationTrigger true', async () => {
+    it('attaches the COMING_SOON placeholder to a flag with isEducationTrigger true whose condition is unmapped', async () => {
       const COMING_SOON = {
         topicCode: 'COMING_SOON',
         topicName: 'Content coming soon',
@@ -274,6 +283,7 @@ describe('BeneficiaryRiskService', () => {
       repository.findStateSnapshots.mockResolvedValue([]);
       repository.findAssessmentsWithFlags.mockResolvedValue([
         assessment({
+          riskPhase: 'ANC',
           riskFlags: [
             {
               id: 'flag-1',
@@ -282,7 +292,8 @@ describe('BeneficiaryRiskService', () => {
               isReferralTrigger: false,
               isEducationTrigger: true,
               isHrVisitTrigger: false,
-              riskCondition: { conditionCode: 'ANEMIA', conditionName: 'Anemia' },
+              // APH isn't in CONDITION_CODE_TO_LABEL — falls back to COMING_SOON.
+              riskCondition: { conditionCode: 'APH', conditionName: 'Antepartum Haemorrhage' },
             },
           ],
         }),
@@ -290,25 +301,28 @@ describe('BeneficiaryRiskService', () => {
 
       const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
 
-      expect(result.assessments[0].flags[0].educationContent).toEqual(COMING_SOON);
+      expect(result.assessments[0].flags[0].educationContent).toEqual([COMING_SOON]);
       expect(resolveEducationContentMock).toHaveBeenCalledWith('COMING_SOON', AUTH_HEADER);
+      expect(resolveHealthEducationMessagesMock).not.toHaveBeenCalled();
     });
 
-    it('does not call resolveEducationContent for a flag with isEducationTrigger false', async () => {
+    it('does not resolve any content for a flag with isEducationTrigger false', async () => {
       repository.findStateSnapshots.mockResolvedValue([]);
       repository.findAssessmentsWithFlags.mockResolvedValue([assessment()] as never); // isEducationTrigger: false
 
       const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
 
-      expect(result.assessments[0].flags[0].educationContent).toBeNull();
+      expect(result.assessments[0].flags[0].educationContent).toEqual([]);
       expect(resolveEducationContentMock).not.toHaveBeenCalled();
+      expect(resolveHealthEducationMessagesMock).not.toHaveBeenCalled();
     });
 
-    it('sets educationContent to null (not an error) when cms-content-service resolution fails', async () => {
+    it('sets educationContent to an empty array (not an error) when cms-content-service resolution fails for an unmapped condition', async () => {
       resolveEducationContentMock.mockResolvedValue(null);
       repository.findStateSnapshots.mockResolvedValue([]);
       repository.findAssessmentsWithFlags.mockResolvedValue([
         assessment({
+          riskPhase: 'ANC',
           riskFlags: [
             {
               id: 'flag-1',
@@ -317,7 +331,7 @@ describe('BeneficiaryRiskService', () => {
               isReferralTrigger: false,
               isEducationTrigger: true,
               isHrVisitTrigger: false,
-              riskCondition: { conditionCode: 'ANEMIA', conditionName: 'Anemia' },
+              riskCondition: { conditionCode: 'APH', conditionName: 'Antepartum Haemorrhage' },
             },
           ],
         }),
@@ -325,10 +339,10 @@ describe('BeneficiaryRiskService', () => {
 
       const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
 
-      expect(result.assessments[0].flags[0].educationContent).toBeNull();
+      expect(result.assessments[0].flags[0].educationContent).toEqual([]);
     });
 
-    it('resolves COMING_SOON only once even with multiple triggered flags across assessments', async () => {
+    it('resolves COMING_SOON only once even with multiple triggered flags across assessments, for an unmapped condition', async () => {
       const COMING_SOON = {
         topicCode: 'COMING_SOON',
         topicName: 'Content coming soon',
@@ -344,16 +358,204 @@ describe('BeneficiaryRiskService', () => {
         isReferralTrigger: false,
         isEducationTrigger: true,
         isHrVisitTrigger: false,
-        riskCondition: { conditionCode: 'ANEMIA', conditionName: 'Anemia' },
+        riskCondition: { conditionCode: 'APH', conditionName: 'Antepartum Haemorrhage' },
       });
       repository.findAssessmentsWithFlags.mockResolvedValue([
-        assessment({ id: 'a-1', riskFlags: [triggeredFlag('flag-1'), triggeredFlag('flag-2')] }),
-        assessment({ id: 'a-2', riskFlags: [triggeredFlag('flag-3')] }),
+        assessment({
+          id: 'a-1',
+          riskPhase: 'ANC',
+          riskFlags: [triggeredFlag('flag-1'), triggeredFlag('flag-2')],
+        }),
+        assessment({ id: 'a-2', riskPhase: 'ANC', riskFlags: [triggeredFlag('flag-3')] }),
       ] as never);
 
       await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
 
       expect(resolveEducationContentMock).toHaveBeenCalledTimes(1);
+    });
+
+    describe('the 5 SRS-mapped, risk-graded conditions (real content, not COMING_SOON)', () => {
+      const anemiaAncMessage = {
+        id: 'msg-1',
+        riskConditionId: null,
+        conditionLabel: 'Anemia',
+        stage: 'as soon as detected during ANC visit',
+        messageOrder: 1,
+        titleEn: 'Understanding Anemia',
+        bodyEn: 'Low Hb...',
+        bodyMarathi: '',
+        mediaType: 'TEXT',
+        mediaFile: null,
+        sortOrder: 1,
+      };
+      const anemiaPpMessage = {
+        id: 'msg-2',
+        riskConditionId: null,
+        conditionLabel: 'Anemia',
+        stage: 'postpartum (PP1 or PP2 whichever is attended)',
+        messageOrder: 2,
+        titleEn: 'Postpartum Counselling',
+        bodyEn: 'Focus: Monitoring Hb...',
+        bodyMarathi: '',
+        mediaType: 'TEXT',
+        mediaFile: null,
+        sortOrder: 1,
+      };
+
+      const mappedFlag = (conditionCode: string) => ({
+        id: 'flag-1',
+        riskGradeLookupValueId: 'grade-1',
+        observedValueJson: null,
+        isReferralTrigger: false,
+        isEducationTrigger: true,
+        isHrVisitTrigger: false,
+        riskCondition: { conditionCode, conditionName: conditionCode },
+      });
+
+      it.each([
+        ['ANEMIA', 'Anemia'],
+        ['HYPERTENSION', 'Gestational Hypertension'],
+        ['HYPERGLYCEMIA', 'Gestational Diabetes'],
+        ['GESTATIONAL_WEIGHT_GAIN', 'Inadequate Gestational weight gain'],
+        ['BAD_OBSTETRIC_HISTORY', 'Previous pregnancy complication'],
+      ])('maps %s to conditionLabel %s and resolves real content', async (conditionCode, label) => {
+        resolveHealthEducationMessagesMock.mockResolvedValue([anemiaAncMessage]);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({ riskPhase: 'ANC', riskFlags: [mappedFlag(conditionCode)] }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(resolveHealthEducationMessagesMock).toHaveBeenCalledWith(label, AUTH_HEADER);
+        expect(result.assessments[0].flags[0].educationContent).toEqual([
+          {
+            topicCode: conditionCode,
+            topicName: 'Understanding Anemia',
+            mediaType: 'TEXT',
+            contentUrl: null,
+          },
+        ]);
+      });
+
+      it('regression: does NOT map DANGER_SIGNS or INFANT_DANGER_SIGNS here (they are Group B, stage-based, not risk-graded)', async () => {
+        const COMING_SOON = {
+          topicCode: 'COMING_SOON',
+          topicName: 'Content coming soon',
+          mediaType: 'QNA_TEXT',
+          contentUrl: null,
+        };
+        resolveEducationContentMock.mockResolvedValue(COMING_SOON);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({
+            riskPhase: 'ANC',
+            riskFlags: [mappedFlag('DANGER_SIGNS'), mappedFlag('INFANT_DANGER_SIGNS')],
+          }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(resolveHealthEducationMessagesMock).not.toHaveBeenCalled();
+        expect(result.assessments[0].flags[0].educationContent).toEqual([COMING_SOON]);
+        expect(result.assessments[0].flags[1].educationContent).toEqual([COMING_SOON]);
+      });
+
+      it('on an ANC-phase assessment, returns every non-postpartum message for the condition, ordered', async () => {
+        resolveHealthEducationMessagesMock.mockResolvedValue([anemiaPpMessage, anemiaAncMessage]); // out of order on purpose
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({ riskPhase: 'ANC', riskFlags: [mappedFlag('ANEMIA')] }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(result.assessments[0].flags[0].educationContent).toEqual([
+          {
+            topicCode: 'ANEMIA',
+            topicName: anemiaAncMessage.titleEn,
+            mediaType: anemiaAncMessage.mediaType,
+            contentUrl: null,
+          },
+        ]);
+      });
+
+      it('on a PP-phase assessment, returns only the postpartum message for the condition', async () => {
+        resolveHealthEducationMessagesMock.mockResolvedValue([anemiaAncMessage, anemiaPpMessage]);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({ riskPhase: 'PP', riskFlags: [mappedFlag('ANEMIA')] }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(result.assessments[0].flags[0].educationContent).toEqual([
+          {
+            topicCode: 'ANEMIA',
+            topicName: anemiaPpMessage.titleEn,
+            mediaType: anemiaPpMessage.mediaType,
+            contentUrl: null,
+          },
+        ]);
+      });
+
+      it('with riskPhase null (legacy pre-migration row), returns every message for the condition undifferentiated', async () => {
+        resolveHealthEducationMessagesMock.mockResolvedValue([anemiaAncMessage, anemiaPpMessage]);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({ riskPhase: null, riskFlags: [mappedFlag('ANEMIA')] }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(result.assessments[0].flags[0].educationContent).toEqual([
+          expect.objectContaining({ topicName: anemiaAncMessage.titleEn }),
+          expect.objectContaining({ topicName: anemiaPpMessage.titleEn }),
+        ]);
+      });
+
+      it('falls back to COMING_SOON when a mapped condition has zero seeded content rows', async () => {
+        const COMING_SOON = {
+          topicCode: 'COMING_SOON',
+          topicName: 'Content coming soon',
+          mediaType: 'QNA_TEXT',
+          contentUrl: null,
+        };
+        resolveEducationContentMock.mockResolvedValue(COMING_SOON);
+        resolveHealthEducationMessagesMock.mockResolvedValue([]);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({ riskPhase: 'ANC', riskFlags: [mappedFlag('ANEMIA')] }),
+        ] as never);
+
+        const result = await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(result.assessments[0].flags[0].educationContent).toEqual([COMING_SOON]);
+      });
+
+      it('resolves real content only once per (conditionCode, phase) pair, even across multiple assessments/flags', async () => {
+        resolveHealthEducationMessagesMock.mockResolvedValue([anemiaAncMessage]);
+        repository.findStateSnapshots.mockResolvedValue([]);
+        repository.findAssessmentsWithFlags.mockResolvedValue([
+          assessment({
+            id: 'a-1',
+            riskPhase: 'ANC',
+            riskFlags: [
+              { ...mappedFlag('ANEMIA'), id: 'flag-1' },
+              { ...mappedFlag('ANEMIA'), id: 'flag-2' },
+            ],
+          }),
+          assessment({
+            id: 'a-2',
+            riskPhase: 'ANC',
+            riskFlags: [{ ...mappedFlag('ANEMIA'), id: 'flag-3' }],
+          }),
+        ] as never);
+
+        await service.getRiskProfile(BENEFICIARY_ID, caller(), AUTH_HEADER);
+
+        expect(resolveHealthEducationMessagesMock).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.ts
@@ -4,6 +4,7 @@ import { BeneficiaryClient } from './beneficiary.client';
 import { listSakhiIdsForSupervisor } from './sakhi.client';
 import { resolveRiskGrades } from './riskGrade.client';
 import { resolveEducationContent, type EducationContent } from './educationContent.client';
+import { resolveHealthEducationMessages } from './healthEducation.client';
 
 type StateSnapshotRow = Awaited<
   ReturnType<BeneficiaryRiskRepository['findStateSnapshots']>
@@ -12,6 +13,42 @@ type StateSnapshotRow = Awaited<
 type AssessmentWithFlagsRow = Awaited<
   ReturnType<BeneficiaryRiskRepository['findAssessmentsWithFlags']>
 >[number];
+
+/**
+ * RiskCondition.conditionCode -> HealthEducationMessage.conditionLabel, for
+ * the 5 SRS-specified "as soon as detected" risk-graded conditions
+ * (docs/Revised_App_Form_Final_20.3.26.xlsx.md, "Health education message"
+ * table, rows 1-5) that ARMMAN's delivered content actually covers. A flag
+ * whose conditionCode isn't listed here falls back to the COMING_SOON
+ * placeholder, same as before this map existed — this is additive, not a
+ * replacement for every condition. Every other condition in that same SRS
+ * table (Danger Signs, Neonatal Care, POSTPARTUM Counselling, etc.) is
+ * stage-based rather than risk-graded and is served by visit-form-service's
+ * health-education stage resolver instead — see that resolver's own doc
+ * comment for why those don't belong in this map.
+ */
+const CONDITION_CODE_TO_LABEL: Record<string, string> = {
+  ANEMIA: 'Anemia',
+  HYPERTENSION: 'Gestational Hypertension',
+  HYPERGLYCEMIA: 'Gestational Diabetes',
+  GESTATIONAL_WEIGHT_GAIN: 'Inadequate Gestational weight gain',
+  BAD_OBSTETRIC_HISTORY: 'Previous pregnancy complication',
+};
+
+/**
+ * Every seeded stage string for these 5 conditions contains the word
+ * "postpartum" exactly when — and only when — it's the PP-phase message
+ * (verified against health-education-messages.json's seed data). This is
+ * the only stage-precision riskPhase alone can support: ANC assessments
+ * can't be told apart into "as soon as detected" vs "2nd trimester" vs
+ * "3rd trimester" sub-stages without a gestational-week calculation (that
+ * belongs to the stage resolver, not this risk-flag path) — so an ANC-phase
+ * assessment gets every non-postpartum message for the condition, and a
+ * PP-phase assessment gets only the postpartum one.
+ */
+function isPostpartumStage(stage: string): boolean {
+  return stage.toLowerCase().includes('postpartum');
+}
 
 interface RiskConditionSummaryAcc {
   riskConditionId: string;
@@ -67,19 +104,67 @@ export class BeneficiaryRiskService {
     ]);
 
     const hasTriggeredFlag = assessments.some((a) => a.riskFlags.some((f) => f.isEducationTrigger));
-    // Resolved once per call, not once per flag — every isEducationTrigger
-    // flag maps to the same COMING_SOON topic today (see this feature's
-    // implementation plan doc for why there's no per-condition mapping yet).
+    // Resolved once per call, not once per flag — the COMING_SOON fallback
+    // is identical content regardless of which unmapped condition triggered
+    // it (mapped conditions get real content below instead).
     const comingSoonContent = hasTriggeredFlag
       ? await resolveEducationContent('COMING_SOON', authorizationHeader)
       : null;
 
+    // Resolved once per distinct (conditionCode, isPostpartum) pair across
+    // the whole call, not once per flag/assessment — several assessments
+    // commonly re-trigger the same condition (e.g. Anemia flagged at every
+    // ANC visit until it resolves), and each pair maps to the same content
+    // regardless of which assessment it came from. Caches the in-flight
+    // Promise itself, not just its resolved value — toAssessmentView below
+    // resolves every flag concurrently via Promise.all, so two flags for the
+    // same (conditionCode, phase) pair can both reach this function before
+    // either has finished; caching only the settled value would let both
+    // still call resolveHealthEducationMessages.
+    const contentCache = new Map<string, Promise<EducationContent[]>>();
+    function resolveMappedContent(
+      conditionCode: string,
+      riskPhase: string | null,
+    ): Promise<EducationContent[]> {
+      const conditionLabel = CONDITION_CODE_TO_LABEL[conditionCode];
+      if (!conditionLabel) return Promise.resolve(comingSoonContent ? [comingSoonContent] : []);
+
+      const isPostpartum = riskPhase === 'PP';
+      const cacheKey = `${conditionCode}:${isPostpartum}`;
+      const cached = contentCache.get(cacheKey);
+      if (cached) return cached;
+
+      const pending = (async (): Promise<EducationContent[]> => {
+        const messages = await resolveHealthEducationMessages(conditionLabel, authorizationHeader);
+        const filtered = riskPhase
+          ? messages.filter((m) => isPostpartumStage(m.stage) === isPostpartum)
+          : messages; // riskPhase null (pre-migration row) — return every message, undifferentiated.
+        const sorted = [...filtered].sort((a, b) => a.messageOrder - b.messageOrder);
+
+        return sorted.length > 0
+          ? sorted.map((m) => ({
+              topicCode: conditionCode,
+              topicName: m.titleEn ?? m.conditionLabel,
+              mediaType: m.mediaType,
+              contentUrl: m.mediaFile,
+            }))
+          : comingSoonContent
+            ? [comingSoonContent]
+            : [];
+      })();
+
+      contentCache.set(cacheKey, pending);
+      return pending;
+    }
+
+    const assessmentViews = await Promise.all(
+      assessments.map((assessment) => this.toAssessmentView(assessment, resolveMappedContent)),
+    );
+
     return {
       beneficiaryId,
       currentState: this.toCurrentStatePerPhase(snapshots),
-      assessments: assessments.map((assessment) =>
-        this.toAssessmentView(assessment, comingSoonContent),
-      ),
+      assessments: assessmentViews,
     };
   }
 
@@ -229,17 +314,15 @@ export class BeneficiaryRiskService {
   }
 
   /** Flattens each RiskFlag's nested RiskCondition into conditionCode/conditionName. */
-  private toAssessmentView(
+  private async toAssessmentView(
     assessment: AssessmentWithFlagsRow,
-    comingSoonContent: EducationContent | null,
+    resolveMappedContent: (
+      conditionCode: string,
+      riskPhase: string | null,
+    ) => Promise<EducationContent[]>,
   ) {
-    return {
-      id: assessment.id,
-      evaluatedAt: assessment.evaluatedAt,
-      overallRiskCategory: assessment.overallRiskCategory,
-      overallHighRiskFlag: assessment.overallHighRiskFlag,
-      hrDetectedFlag: assessment.hrDetectedFlag,
-      flags: assessment.riskFlags.map((flag) => ({
+    const flags = await Promise.all(
+      assessment.riskFlags.map(async (flag) => ({
         id: flag.id,
         conditionCode: flag.riskCondition.conditionCode,
         conditionName: flag.riskCondition.conditionName,
@@ -248,8 +331,19 @@ export class BeneficiaryRiskService {
         isReferralTrigger: flag.isReferralTrigger,
         isEducationTrigger: flag.isEducationTrigger,
         isHrVisitTrigger: flag.isHrVisitTrigger,
-        educationContent: flag.isEducationTrigger ? comingSoonContent : null,
+        educationContent: flag.isEducationTrigger
+          ? await resolveMappedContent(flag.riskCondition.conditionCode, assessment.riskPhase)
+          : [],
       })),
+    );
+
+    return {
+      id: assessment.id,
+      evaluatedAt: assessment.evaluatedAt,
+      overallRiskCategory: assessment.overallRiskCategory,
+      overallHighRiskFlag: assessment.overallHighRiskFlag,
+      hrDetectedFlag: assessment.hrDetectedFlag,
+      flags,
     };
   }
 }

--- a/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/beneficiaryRisk.service.ts
@@ -36,18 +36,26 @@ const CONDITION_CODE_TO_LABEL: Record<string, string> = {
 };
 
 /**
- * Every seeded stage string for these 5 conditions contains the word
- * "postpartum" exactly when — and only when — it's the PP-phase message
- * (verified against health-education-messages.json's seed data). This is
- * the only stage-precision riskPhase alone can support: ANC assessments
- * can't be told apart into "as soon as detected" vs "2nd trimester" vs
- * "3rd trimester" sub-stages without a gestational-week calculation (that
- * belongs to the stage resolver, not this risk-flag path) — so an ANC-phase
- * assessment gets every non-postpartum message for the condition, and a
- * PP-phase assessment gets only the postpartum one.
+ * The exact seeded `stage` string that marks the PP-phase message, for each
+ * of the 5 CONDITION_CODE_TO_LABEL conditions (verified against
+ * health-education-messages.json's seed data as of this writing — every
+ * other stage string for these conditions is an ANC sub-stage: "as soon as
+ * detected during ANC visit", "2nd trimester (6th month)", etc.). Matched
+ * exactly, not by substring — a looser `stage.includes('postpartum')` match
+ * was flagged in review as fragile against a future content reword (e.g.
+ * cms-content-service's seed data changing the exact phrasing), silently
+ * degrading a PP-phase beneficiary to the COMING_SOON placeholder with no
+ * error anywhere in the pipeline. This still shares that fragility (a
+ * reworded stage string breaks the exact match the same way it would break
+ * a substring match) — the real fix is a typed `phase` column on
+ * HealthEducationMessage in cms-content-service, mirroring the RiskPhase
+ * enum this PR already added to risk_assessments, which would make this
+ * function unnecessary. Tracked as a followup, not done here (cross-service
+ * migration, out of scope for this PR's review-comment fixes).
  */
+const POSTPARTUM_STAGE = 'postpartum (PP1 or PP2 whichever is attended)';
 function isPostpartumStage(stage: string): boolean {
-  return stage.toLowerCase().includes('postpartum');
+  return stage === POSTPARTUM_STAGE;
 }
 
 interface RiskConditionSummaryAcc {
@@ -129,11 +137,18 @@ export class BeneficiaryRiskService {
       const conditionLabel = CONDITION_CODE_TO_LABEL[conditionCode];
       if (!conditionLabel) return Promise.resolve(comingSoonContent ? [comingSoonContent] : []);
 
-      const isPostpartum = riskPhase === 'PP';
-      const cacheKey = `${conditionCode}:${isPostpartum}`;
+      // 3-way discriminant, not a collapsed isPostpartum boolean — riskPhase
+      // null (legacy pre-migration row, "return every message
+      // undifferentiated") and riskPhase 'ANC' (non-postpartum) both map to
+      // isPostpartum: false, which would otherwise share one cache bucket
+      // and let whichever resolves first silently overwrite the other's
+      // filtering intent for the rest of this call.
+      const phaseKey = riskPhase === null ? 'null' : riskPhase === 'PP' ? 'PP' : 'other';
+      const cacheKey = `${conditionCode}:${phaseKey}`;
       const cached = contentCache.get(cacheKey);
       if (cached) return cached;
 
+      const isPostpartum = riskPhase === 'PP';
       const pending = (async (): Promise<EducationContent[]> => {
         const messages = await resolveHealthEducationMessages(conditionLabel, authorizationHeader);
         const filtered = riskPhase

--- a/apps/risk-referral-service/src/beneficiary-risk/healthEducation.client.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/healthEducation.client.ts
@@ -1,6 +1,14 @@
 // Read directly (not via appConfig) — see beneficiary.client.ts for why.
 const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
 
+// A slow (not down) dependency must degrade the same way an unreachable one
+// does — without this, a hung gateway/cms-content-service call blocks
+// GET /beneficiaries/:beneficiaryId/risk indefinitely, defeating the
+// "stays readable even if unreachable" guarantee this function promises.
+// Matches educationContent.client.ts's own guard in this same directory,
+// and visit-form-service's healthEducation.client.ts counterpart.
+const REQUEST_TIMEOUT_MS = 3000;
+
 export interface HealthEducationMessage {
   id: string;
   riskConditionId: string | null;
@@ -19,29 +27,31 @@ export interface HealthEducationMessage {
  * Resolves ARMMAN's delivered per-condition content via
  * cms-content-service's GET /health-education/messages?conditionLabel=...
  * (through the gateway), used only for conditionCodes present in
- * beneficiaryRisk.service.ts's CONDITION_CODE_TO_LABEL map. `stage` is
- * optional — when supplied it narrows to the stage-appropriate message(s)
- * for the assessment's own riskPhase (e.g. Anemia's "postpartum" message on
- * a PP-phase assessment, not its ANC-detection message); omitted, every
- * message for the condition is returned, letting the caller decide (used
- * for the riskPhase-is-null degradation case — see toAssessmentView).
+ * beneficiaryRisk.service.ts's CONDITION_CODE_TO_LABEL map. Always
+ * resolves every message for the condition, unfiltered — the caller
+ * (beneficiaryRisk.service.ts's isPostpartumStage) does its own
+ * phase-appropriate filtering client-side, since cms-content-service's
+ * `stage` filter matches its free-text column verbatim and this caller
+ * needs a "does this stage look like postpartum" classification the
+ * server-side filter can't express.
  *
  * Deliberately swallows every failure and returns an empty array rather
  * than throwing — same rationale as resolveEducationContent: this is
  * reference content, not critical data, so a beneficiary's risk profile
- * must stay readable even if cms-content-service is unreachable.
+ * must stay readable even if cms-content-service is unreachable or slow.
  */
 export async function resolveHealthEducationMessages(
   conditionLabel: string,
   authorizationHeader: string,
-  stage?: string,
 ): Promise<HealthEducationMessage[]> {
   try {
     const params = new URLSearchParams({ conditionLabel });
-    if (stage) params.set('stage', stage);
     const res = await fetch(
       `${API_GATEWAY_BASE_URL}/api/v1/health-education/messages?${params.toString()}`,
-      { headers: { Authorization: authorizationHeader } },
+      {
+        headers: { Authorization: authorizationHeader },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
     );
     if (!res.ok) return [];
 

--- a/apps/risk-referral-service/src/beneficiary-risk/healthEducation.client.ts
+++ b/apps/risk-referral-service/src/beneficiary-risk/healthEducation.client.ts
@@ -1,0 +1,53 @@
+// Read directly (not via appConfig) — see beneficiary.client.ts for why.
+const API_GATEWAY_BASE_URL = process.env.API_GATEWAY_BASE_URL ?? 'http://localhost:3000';
+
+export interface HealthEducationMessage {
+  id: string;
+  riskConditionId: string | null;
+  conditionLabel: string;
+  stage: string;
+  messageOrder: number;
+  titleEn: string | null;
+  bodyEn: string;
+  bodyMarathi: string;
+  mediaType: string;
+  mediaFile: string | null;
+  sortOrder: number;
+}
+
+/**
+ * Resolves ARMMAN's delivered per-condition content via
+ * cms-content-service's GET /health-education/messages?conditionLabel=...
+ * (through the gateway), used only for conditionCodes present in
+ * beneficiaryRisk.service.ts's CONDITION_CODE_TO_LABEL map. `stage` is
+ * optional — when supplied it narrows to the stage-appropriate message(s)
+ * for the assessment's own riskPhase (e.g. Anemia's "postpartum" message on
+ * a PP-phase assessment, not its ANC-detection message); omitted, every
+ * message for the condition is returned, letting the caller decide (used
+ * for the riskPhase-is-null degradation case — see toAssessmentView).
+ *
+ * Deliberately swallows every failure and returns an empty array rather
+ * than throwing — same rationale as resolveEducationContent: this is
+ * reference content, not critical data, so a beneficiary's risk profile
+ * must stay readable even if cms-content-service is unreachable.
+ */
+export async function resolveHealthEducationMessages(
+  conditionLabel: string,
+  authorizationHeader: string,
+  stage?: string,
+): Promise<HealthEducationMessage[]> {
+  try {
+    const params = new URLSearchParams({ conditionLabel });
+    if (stage) params.set('stage', stage);
+    const res = await fetch(
+      `${API_GATEWAY_BASE_URL}/api/v1/health-education/messages?${params.toString()}`,
+      { headers: { Authorization: authorizationHeader } },
+    );
+    if (!res.ok) return [];
+
+    const body = (await res.json()) as { data: HealthEducationMessage[] };
+    return body.data;
+  } catch {
+    return [];
+  }
+}

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.repository.ts
@@ -19,6 +19,10 @@ export interface RiskAssessmentCreateData {
   visitId: string | null;
   submissionId: string;
   ruleVersionId: string;
+  // The caller's FORM_CODE_TO_RISK_PHASE-derived phase for this submission —
+  // see schema.prisma's RiskAssessment.riskPhase doc comment for why this is
+  // persisted (stage-appropriate health-education message selection).
+  riskPhase: RiskPhase;
   evaluatedAt: Date;
   overallRiskCategory: 'NORMAL' | 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
   overallHighRiskFlag: boolean;
@@ -184,6 +188,7 @@ export class RiskAssessmentRepository {
           visitId: data.visitId,
           submissionId: data.submissionId,
           ruleVersionId: data.ruleVersionId,
+          riskPhase: data.riskPhase,
           evaluatedAt: data.evaluatedAt,
           overallRiskCategory: data.overallRiskCategory,
           overallHighRiskFlag: data.overallHighRiskFlag,

--- a/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
+++ b/apps/risk-referral-service/src/risk-assessments/riskAssessment.service.ts
@@ -184,6 +184,7 @@ export class RiskAssessmentService {
       visitId: dto.visitId,
       submissionId: dto.submissionId,
       ruleVersionId: evaluation.ruleVersionId,
+      riskPhase: dto.riskPhase,
       evaluatedAt,
       overallRiskCategory: evaluation.overallRiskCategory,
       overallHighRiskFlag,

--- a/apps/visit-form-service/src/forms/form.mapper.ts
+++ b/apps/visit-form-service/src/forms/form.mapper.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { FormField } from './dto/form-field.dto';
 import { BENEFICIARY_DUPLICATED_FIELD_CODES } from './beneficiary-duplicated-fields';
+import type { StageEducationContent } from './healthEducationStage.resolver';
 
 /** SHA-256 of the schema JSON, stored on form_versions.checksum for change detection. */
 export function computeChecksum(schemaJson: unknown): Buffer {
@@ -213,6 +214,7 @@ export function buildFormAnswers(
 export function toApiFormSubmission<T extends FormSubmissionRow>(
   s: T,
   childBeneficiaryIds?: string[],
+  stageEducationContent?: StageEducationContent[],
 ) {
   return {
     id: s.id,
@@ -227,5 +229,15 @@ export function toApiFormSubmission<T extends FormSubmissionRow>(
     createdAt: s.createdAt,
     updatedAt: s.updatedAt,
     ...(childBeneficiaryIds?.length ? { childBeneficiaryIds } : {}),
+    // SRS's 16 stage-based (not risk-graded) health-education conditions —
+    // see healthEducationStage.resolver.ts's own doc comment for why these
+    // are a separate mechanism from risk-referral-service's risk-flag-
+    // triggered content. Always present as an array (never omitted) once a
+    // caller passes it, even when empty — distinct from
+    // childBeneficiaryIds's "omit if empty" convention, since an empty
+    // stageEducationContent is a normal, expected outcome for most
+    // submissions (e.g. any form/visit with no matching stage content),
+    // not something worth hiding from the response shape.
+    ...(stageEducationContent !== undefined ? { stageEducationContent } : {}),
   };
 }

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -213,6 +213,22 @@ export class FormRepository {
   }
 
   /**
+   * How many non-deleted submissions exist for `beneficiaryId` against
+   * `formCode`'s form_definition — used to detect "this is the
+   * beneficiary's first-ever submission of this form" (e.g. Primigravida's
+   * first-ANC-visit-only health-education gate) by counting AFTER the
+   * current submission's own insert, so a count of exactly 1 means this
+   * submission is the first (findLatestSubmissionByBeneficiaryAndFormCode
+   * can't answer this on its own — it would always return the just-inserted
+   * row itself).
+   */
+  countSubmissionsByBeneficiaryAndFormCode(beneficiaryId: string, formCode: string) {
+    return this.prisma.formSubmission.count({
+      where: { beneficiaryId, isDeleted: false, formVersion: { formDefinition: { formCode } } },
+    });
+  }
+
+  /**
    * The most recent visit-linked submission for `beneficiaryId` across the
    * clinical-visit form codes that actually capture vitals (ANC_VISIT,
    * POSTPARTUM_VISIT, NEONATAL_VISIT, INC_VISIT, CCV_VISIT — see

--- a/apps/visit-form-service/src/forms/form.repository.ts
+++ b/apps/visit-form-service/src/forms/form.repository.ts
@@ -214,17 +214,37 @@ export class FormRepository {
 
   /**
    * How many non-deleted submissions exist for `beneficiaryId` against
-   * `formCode`'s form_definition — used to detect "this is the
-   * beneficiary's first-ever submission of this form" (e.g. Primigravida's
-   * first-ANC-visit-only health-education gate) by counting AFTER the
-   * current submission's own insert, so a count of exactly 1 means this
-   * submission is the first (findLatestSubmissionByBeneficiaryAndFormCode
-   * can't answer this on its own — it would always return the just-inserted
-   * row itself).
+   * `formCode`'s form_definition, created at or before `asOfCreatedAt` —
+   * used to detect "this WAS the beneficiary's first-ever submission of
+   * this form, at the time it was made" (e.g. Primigravida's
+   * first-ANC-visit-only health-education gate).
+   *
+   * `asOfCreatedAt` is required, not optional, specifically so a count of
+   * exactly 1 always means "first submission at that point in time" —
+   * without a cutoff, re-evaluating this on an idempotent replay long after
+   * later submissions have landed would see count>1 and wrongly conclude
+   * the original submission wasn't the first one, silently dropping
+   * first-visit-only content from the replayed response (review finding on
+   * PR #222: this exact drift). Callers pass:
+   *   - the just-created row's own `createdAt` on the fresh-submission path
+   *     (a count of exactly 1 there still means "this is the first",
+   *     since the row being counted is itself already inserted); or
+   *   - the original `existing.createdAt` on the idempotent-replay path,
+   *     so the count reflects the state at original-submission time, not
+   *     whatever has landed since.
    */
-  countSubmissionsByBeneficiaryAndFormCode(beneficiaryId: string, formCode: string) {
+  countSubmissionsByBeneficiaryAndFormCode(
+    beneficiaryId: string,
+    formCode: string,
+    asOfCreatedAt: Date,
+  ) {
     return this.prisma.formSubmission.count({
-      where: { beneficiaryId, isDeleted: false, formVersion: { formDefinition: { formCode } } },
+      where: {
+        beneficiaryId,
+        isDeleted: false,
+        formVersion: { formDefinition: { formCode } },
+        createdAt: { lte: asOfCreatedAt },
+      },
     });
   }
 

--- a/apps/visit-form-service/src/forms/form.schemas.ts
+++ b/apps/visit-form-service/src/forms/form.schemas.ts
@@ -73,4 +73,27 @@ export const formSubmissionSchema = z.object({
         'with at least one live birth. Omitted (not an empty array) otherwise.',
       example: ['34197cd7-7a54-4e7f-885c-f297313b9e81'],
     }),
+  stageEducationContent: z
+    .array(
+      z.object({
+        topicCode: z.string(),
+        topicName: z.string(),
+        mediaType: z.string(),
+        contentUrl: z.string().nullable(),
+      }),
+    )
+    .optional()
+    .openapi({
+      description:
+        "The SRS's stage-based (not risk-graded) health-education content applicable to " +
+        'this submission — e.g. Danger Signs on every ANC visit, POSTPARTUM Counselling on ' +
+        'every PP visit, Neonatal Care on NN1/NN2, gestational-week/age-gated content, and ' +
+        'pregnancy-loss content on a qualifying closure or delivery outcome. Always an ' +
+        "array (possibly empty) once present — distinct from childBeneficiaryIds's " +
+        '"omit if empty" convention. Independent of risk-referral-service\'s risk-flag-' +
+        'triggered educationContent (GET /beneficiaries/:id/risk) — see ' +
+        "healthEducationStage.resolver.ts's own doc comment for why these are two " +
+        'separate mechanisms.',
+      example: [],
+    }),
 });

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -23,6 +23,7 @@ import { createClosure, resolveClosureReasonLookupId } from '../closures/closure
 import { triggerRiskAssessment } from '../risk-assessments/riskAssessment.client';
 import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
 import { resolveVisitCompletion } from './visitCompletion.resolver';
+import { resolveHealthEducationMessagesByStage } from './healthEducation.client';
 
 jest.mock('../geography/geography.client');
 jest.mock('../beneficiaries/socio-demographics.client');
@@ -34,6 +35,7 @@ jest.mock('../closures/closure.client');
 jest.mock('../risk-assessments/riskAssessment.client');
 jest.mock('./ccvOpeningRiskState.resolver');
 jest.mock('./visitCompletion.resolver');
+jest.mock('./healthEducation.client');
 
 describe('FormService', () => {
   const repository = {
@@ -49,6 +51,7 @@ describe('FormService', () => {
     createSubmission: jest.fn(),
     findVisitById: jest.fn(),
     findLatestSubmissionByBeneficiaryAndFormCode: jest.fn(),
+    countSubmissionsByBeneficiaryAndFormCode: jest.fn(),
     findLatestVisitSubmission: jest.fn(),
     findLatestDeliverySubmission: jest.fn(),
     findSubmissionById: jest.fn(),
@@ -65,6 +68,11 @@ describe('FormService', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    // Safe defaults so tests unrelated to the stage-based health-education
+    // feature don't need to know about it — real content only in the
+    // dedicated describe block below.
+    jest.mocked(resolveHealthEducationMessagesByStage).mockResolvedValue([]);
+    repository.countSubmissionsByBeneficiaryAndFormCode.mockResolvedValue(1);
     service = new FormService(repository, visitInstanceRepository, auditClient);
   });
 
@@ -748,7 +756,7 @@ describe('FormService', () => {
       expect(repository.createSubmission).toHaveBeenCalledWith(
         expect.objectContaining({ validationStatus: 'VALID' }),
       );
-      expect(result).toEqual({ id: 'sub-1' });
+      expect(result).toEqual({ id: 'sub-1', stageEducationContent: [] });
     });
 
     describe('visit completion on submission', () => {
@@ -830,7 +838,7 @@ describe('FormService', () => {
           'Bearer test-token',
         );
 
-        expect(result).toEqual({ id: 'sub-1' });
+        expect(result).toEqual({ id: 'sub-1', stageEducationContent: [] });
         expect(repository.createSubmission).toHaveBeenCalled();
       });
     });
@@ -1553,7 +1561,7 @@ describe('FormService', () => {
           'Bearer test-token',
         );
 
-        expect(result).toEqual({ id: 'sub-1' });
+        expect(result).toEqual({ id: 'sub-1', stageEducationContent: [] });
         expect(jest.mocked(createChildBeneficiary)).not.toHaveBeenCalled();
       });
     });
@@ -2286,6 +2294,422 @@ describe('FormService', () => {
       });
     });
 
+    describe('stageEducationContent — SRS stage-based health-education wiring', () => {
+      it('resolves unconditional ANC content (Danger Signs) using registration-derived LMP for gestationalWeeks', async () => {
+        const ancVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'ANC_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(ancVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue({
+          formDataJson: { lmp_date: '2026-01-01' },
+        } as never);
+        repository.countSubmissionsByBeneficiaryAndFormCode.mockResolvedValue(3);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage === 'Show this for all the ANC visits'
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Danger Signs during Pregnancy',
+                  stage,
+                  messageOrder: 1,
+                  titleEn: 'Danger Signs',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([
+          {
+            topicCode: 'Danger Signs during Pregnancy',
+            topicName: 'Danger Signs',
+            mediaType: 'TEXT',
+            contentUrl: null,
+          },
+        ]);
+      });
+
+      it("passes isFirstVisitOfFormCode true when this is the beneficiary's only ANC_VISIT submission so far", async () => {
+        const ancVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'ANC_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(ancVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue(null);
+        repository.countSubmissionsByBeneficiaryAndFormCode.mockResolvedValue(1);
+
+        await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(repository.countSubmissionsByBeneficiaryAndFormCode).toHaveBeenCalledWith(
+          'b1',
+          'ANC_VISIT',
+        );
+      });
+
+      it('resolves Neonatal Care content for NEONATAL_VISIT, no LMP lookup needed', async () => {
+        const nnVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'NEONATAL_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(nnVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage === 'NN1 and NN2'
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Neonatal Care',
+                  stage,
+                  messageOrder: 1,
+                  titleEn: 'Neonatal Care',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([
+          expect.objectContaining({ topicCode: 'Neonatal Care' }),
+        ]);
+        expect(jest.mocked(findBeneficiaryById)).not.toHaveBeenCalled();
+      });
+
+      it("resolves age-gated INC content using the child beneficiary's date of birth", async () => {
+        const incVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'INC_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(incVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        jest.mocked(findBeneficiaryById).mockResolvedValue({
+          childDateOfBirth: '2026-01-01',
+        } as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage === 'All INC visits between 6th and 10th month'
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Infant Care: Complementary Feeding',
+                  stage,
+                  messageOrder: 3,
+                  titleEn: 'Complementary Feeding',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'INC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        // submittedAt 2026-08-01, DOB 2026-01-01 -> 7 months old, within the
+        // 6-10 month Complementary Feeding window.
+        expect(result.stageEducationContent).toEqual([
+          expect.objectContaining({ topicCode: 'Infant Care: Complementary Feeding' }),
+        ]);
+      });
+
+      it('resolves Post-loss content for a DELIVERY_VISIT submission recording a stillbirth', async () => {
+        const deliveryVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'DELIVERY_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(deliveryVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage.startsWith('If the delivery outcome')
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Post miscarriage/abortion/still birth',
+                  stage,
+                  messageOrder: 1,
+                  titleEn: 'Loss support',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'DELIVERY_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { child1_delivery_outcome: 'antepartum_still_birth_fresh' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([
+          expect.objectContaining({ topicCode: 'Post miscarriage/abortion/still birth' }),
+        ]);
+      });
+
+      it('resolves Post-loss content for an ANC_CLOSURE_VISIT submission with a miscarriage reason', async () => {
+        const closureVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'ANC_CLOSURE_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(closureVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage.startsWith('If the delivery outcome')
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Post miscarriage/abortion/still birth',
+                  stage,
+                  messageOrder: 1,
+                  titleEn: 'Loss support',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            // continue_with_closure gate not required here — stage resolution
+            // reads closure_reason directly, independent of resolveClosureRequest.
+            formData: { closure_reason: 'miscarriage' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([
+          expect.objectContaining({ topicCode: 'Post miscarriage/abortion/still birth' }),
+        ]);
+      });
+
+      it('returns an empty array for a formCode with no stage-based content (e.g. MOTHER_REGISTRATION)', async () => {
+        const version = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'MOTHER_REGISTRATION' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(version as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+
+        const result = await service.createSubmission(
+          'MOTHER_REGISTRATION',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([]);
+        expect(jest.mocked(resolveHealthEducationMessagesByStage)).not.toHaveBeenCalled();
+      });
+
+      it('degrades to an empty array (never fails the submission) when resolution throws', async () => {
+        const ancVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'ANC_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(ancVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        repository.countSubmissionsByBeneficiaryAndFormCode.mockRejectedValue(new Error('db down'));
+
+        const result = await service.createSubmission(
+          'ANC_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([]);
+      });
+
+      it('re-resolves stageEducationContent on an idempotent replay (retried localSubmissionUuid)', async () => {
+        const existing = {
+          id: 'sub-1',
+          beneficiaryId: 'b1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(existing as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage === 'NN1 and NN2'
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Neonatal Care',
+                  stage,
+                  messageOrder: 1,
+                  titleEn: 'Neonatal Care',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'retry-uuid',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([
+          expect.objectContaining({ topicCode: 'Neonatal Care' }),
+        ]);
+        expect(repository.findVersionById).not.toHaveBeenCalled();
+      });
+    });
+
     describe('FORM_CODE_TO_RISK_PHASE mapping (PR #172 review)', () => {
       // Every formCode below is given riskRuleSetId: 'rule-set-1' so
       // triggerRiskAssessment fires, and each assertion checks the actual
@@ -2923,7 +3347,7 @@ describe('FormService', () => {
           'Bearer test-token',
         );
 
-        expect(result).toEqual({ id: 'sub-1' });
+        expect(result).toEqual({ id: 'sub-1', stageEducationContent: [] });
       });
 
       it('derives localClosureUuid deterministically from localSubmissionUuid', async () => {

--- a/apps/visit-form-service/src/forms/form.service.spec.ts
+++ b/apps/visit-form-service/src/forms/form.service.spec.ts
@@ -1130,6 +1130,67 @@ describe('FormService', () => {
         expect(result).toMatchObject({ id: 'sub-winner' });
       });
 
+      it('resolves stageEducationContent for the race LOSER too, not just the sequential replay path (PR #222 review finding)', async () => {
+        const nnVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'NEONATAL_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findVersionById.mockResolvedValue(nnVersion as never);
+        repository.createSubmission.mockRejectedValue({ code: 'P2002' });
+        const winningRow = {
+          id: 'sub-winner',
+          beneficiaryId: 'b1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+          createdAt: new Date('2026-08-01T00:00:01.000Z'),
+        };
+        repository.findSubmissionByLocalUuid
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(winningRow as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockImplementation(async (stage) =>
+          stage === 'NN1 and NN2'
+            ? [
+                {
+                  id: 'm1',
+                  riskConditionId: null,
+                  conditionLabel: 'Neonatal Care',
+                  stage,
+                  messageOrder: 1,
+                  titleEn: 'Neonatal Care',
+                  bodyEn: 'x',
+                  bodyMarathi: '',
+                  mediaType: 'TEXT',
+                  mediaFile: null,
+                  sortOrder: 1,
+                },
+              ]
+            : ([] as never),
+        );
+
+        const result = await service.createSubmission(
+          'NEONATAL_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: {},
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        // Previously this response dropped stageEducationContent entirely
+        // (not even an empty array) — the race loser's response shape was
+        // inconsistent with the sequential-replay path's response, for
+        // what should be an idempotent replay of the same logical
+        // submission.
+        expect(result.stageEducationContent).toEqual([
+          expect.objectContaining({ topicCode: 'Neonatal Care' }),
+        ]);
+      });
+
       it('rethrows a P2002 when no winning row can be found on re-query', async () => {
         repository.findSubmissionByLocalUuid.mockResolvedValue(null);
         repository.findVersionById.mockResolvedValue(publishedVersion as never);
@@ -2363,11 +2424,13 @@ describe('FormService', () => {
           schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
           validationJson: [],
         };
+        const createdAt = new Date('2026-08-01T00:00:01.000Z');
         repository.findSubmissionByLocalUuid.mockResolvedValue(null);
         repository.findVersionById.mockResolvedValue(ancVersion as never);
         repository.createSubmission.mockResolvedValue({
           id: 'sub-1',
           submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+          createdAt,
         } as never);
         repository.findLatestSubmissionByBeneficiaryAndFormCode.mockResolvedValue(null);
         repository.countSubmissionsByBeneficiaryAndFormCode.mockResolvedValue(1);
@@ -2384,9 +2447,13 @@ describe('FormService', () => {
           'Bearer test-token',
         );
 
+        // createdAt is the just-created row's OWN createdAt (the count
+        // cutoff), not "now" — see countSubmissionsByBeneficiaryAndFormCode's
+        // doc comment on why this matters for replay correctness.
         expect(repository.countSubmissionsByBeneficiaryAndFormCode).toHaveBeenCalledWith(
           'b1',
           'ANC_VISIT',
+          createdAt,
         );
       });
 
@@ -2589,9 +2656,12 @@ describe('FormService', () => {
             formVersionId: 'version-1',
             beneficiaryId: 'b1',
             localSubmissionUuid: 'uuid-1',
-            // continue_with_closure gate not required here — stage resolution
-            // reads closure_reason directly, independent of resolveClosureRequest.
-            formData: { closure_reason: 'miscarriage' },
+            // continue_with_closure: 'yes' is required — closure_reason is
+            // only trusted when the Sakhi actually confirmed the closure
+            // (review finding on PR #222: reading it unconditionally could
+            // fire Post-loss content for a hidden-but-still-submitted
+            // closure_reason value even when no closure was created).
+            formData: { continue_with_closure: 'yes', closure_reason: 'miscarriage' },
           },
           'u1',
           'Bearer test-token',
@@ -2600,6 +2670,57 @@ describe('FormService', () => {
         expect(result.stageEducationContent).toEqual([
           expect.objectContaining({ topicCode: 'Post miscarriage/abortion/still birth' }),
         ]);
+      });
+
+      it('does NOT resolve Post-loss content for ANC_CLOSURE_VISIT when continue_with_closure is not yes, even if closure_reason is a loss reason', async () => {
+        const closureVersion = {
+          id: 'version-1',
+          status: 'PUBLISHED',
+          formDefinition: { formCode: 'ANC_CLOSURE_VISIT' },
+          schemaJson: [{ question_code: 'x', label: 'x', input_type: 'text', required: false }],
+          validationJson: [],
+        };
+        repository.findSubmissionByLocalUuid.mockResolvedValue(null);
+        repository.findVersionById.mockResolvedValue(closureVersion as never);
+        repository.createSubmission.mockResolvedValue({
+          id: 'sub-1',
+          submittedAt: new Date('2026-08-01T00:00:00.000Z'),
+        } as never);
+        jest.mocked(resolveHealthEducationMessagesByStage).mockResolvedValue([
+          {
+            id: 'm1',
+            riskConditionId: null,
+            conditionLabel: 'Post miscarriage/abortion/still birth',
+            stage:
+              "If the delivery outcome is 'Still birth' or 'Miscarriage' and 'Abortion' in Closure form",
+            messageOrder: 1,
+            titleEn: 'Loss support',
+            bodyEn: 'x',
+            bodyMarathi: '',
+            mediaType: 'TEXT',
+            mediaFile: null,
+            sortOrder: 1,
+          },
+        ]);
+
+        // A Sakhi who selected continue_with_closure='yes' + a loss reason,
+        // then reconsidered and set continue_with_closure='no' before
+        // submitting, but whose client didn't clear the now-hidden
+        // closure_reason field — the exact hidden-field-state scenario
+        // flagged in review.
+        const result = await service.createSubmission(
+          'ANC_CLOSURE_VISIT',
+          {
+            formVersionId: 'version-1',
+            beneficiaryId: 'b1',
+            localSubmissionUuid: 'uuid-1',
+            formData: { continue_with_closure: 'no', closure_reason: 'miscarriage' },
+          },
+          'u1',
+          'Bearer test-token',
+        );
+
+        expect(result.stageEducationContent).toEqual([]);
       });
 
       it('returns an empty array for a formCode with no stage-based content (e.g. MOTHER_REGISTRATION)', async () => {

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -27,6 +27,13 @@ import type { VisitInstanceRepository } from '../visits/visitInstance.repository
 import { resolveAndWriteCcvOpeningRiskState } from './ccvOpeningRiskState.resolver';
 import { resolveVisitCompletion } from './visitCompletion.resolver';
 import { EMPTY_VITALS, extractVitals } from './vitalsExtractor';
+import {
+  ageInMonthsAt,
+  gestationalWeeksAt,
+  hasStillbirthOutcome,
+  resolveStageEducationContent,
+  type StageEducationContent,
+} from './healthEducationStage.resolver';
 
 /**
  * Maps this service's own formCode to risk-referral-service's RiskCondition
@@ -296,7 +303,18 @@ export class FormService {
           ),
         );
       }
-      return toApiFormSubmission(existing, childBeneficiaryIds);
+      // Re-resolved on replay too — this is a read-through lookup, not a
+      // write, so there's no double-creation risk to guard against (unlike
+      // resolveDeliveryChildren/resolveClosureRequest above); recomputing it
+      // just keeps a retried request's response shape consistent with the
+      // original.
+      const stageEducationContent = await this.resolveStageEducationContentForSubmission(
+        formCode,
+        dto,
+        existing.submittedAt,
+        authorizationHeader,
+      );
+      return toApiFormSubmission(existing, childBeneficiaryIds, stageEducationContent);
     }
 
     const version = await this.repository.findVersionById(dto.formVersionId);
@@ -523,7 +541,18 @@ export class FormService {
       );
     }
 
-    return toApiFormSubmission(created, childBeneficiaryIds);
+    // SRS's 16 stage-based health-education conditions (Danger Signs,
+    // Neonatal Care, POSTPARTUM Counselling, etc.) — unlike risk grading
+    // above, not gated on visitId/riskRuleSetId; resolveStageEducationContentForSubmission
+    // itself no-ops (returns []) for a formCode with no applicable stages.
+    const stageEducationContent = await this.resolveStageEducationContentForSubmission(
+      formCode,
+      dto,
+      created.submittedAt,
+      authorizationHeader,
+    );
+
+    return toApiFormSubmission(created, childBeneficiaryIds, stageEducationContent);
   }
 
   /**
@@ -621,6 +650,86 @@ export class FormService {
       ...(typeof sickleCellStatus === 'string' ? { sickleCellStatus } : {}),
       ...(historyOfHypertension !== undefined ? { historyOfHypertension } : {}),
     };
+  }
+
+  /**
+   * Gathers the inputs healthEducationStage.resolver.ts needs and resolves
+   * the SRS's 16 stage-based health-education conditions for this
+   * submission — best-effort (every input source degrades to "gate doesn't
+   * apply" on failure, matching this method's own tolerance stance), never
+   * throws, and safe to call for a formCode the resolver has no stages for
+   * (returns []). Called for every submission, not just visit-linked ones —
+   * unlike risk grading (triggerRiskAssessment), stage-based content has no
+   * visitId/riskRuleSetId precondition in the SRS.
+   */
+  private async resolveStageEducationContentForSubmission(
+    formCode: string,
+    dto: CreateSubmissionInput,
+    submittedAt: Date,
+    authorizationHeader: string,
+  ): Promise<StageEducationContent[]> {
+    try {
+      const visitDateIso = submittedAt.toISOString();
+
+      let gestationalWeeks: number | undefined;
+      let isFirstVisitOfFormCode: boolean | undefined;
+      if (formCode === 'ANC_VISIT') {
+        const [registration, submissionCount] = await Promise.all([
+          this.resolveAncRiskRegistrationAnswers(dto.beneficiaryId),
+          this.repository.countSubmissionsByBeneficiaryAndFormCode(dto.beneficiaryId, 'ANC_VISIT'),
+        ]);
+        const lmpDate = registration.lmpDate;
+        if (typeof lmpDate === 'string') {
+          gestationalWeeks = gestationalWeeksAt(lmpDate, visitDateIso);
+        }
+        // Called after this submission's own insert, so a count of exactly
+        // 1 means this IS the first ANC_VISIT — see
+        // countSubmissionsByBeneficiaryAndFormCode's own doc comment.
+        isFirstVisitOfFormCode = submissionCount === 1;
+      }
+
+      let ageInMonths: number | undefined;
+      if (formCode === 'INC_VISIT') {
+        const beneficiary = await findBeneficiaryById(dto.beneficiaryId, authorizationHeader);
+        if (beneficiary?.childDateOfBirth) {
+          ageInMonths = ageInMonthsAt(beneficiary.childDateOfBirth, visitDateIso);
+        }
+      }
+
+      let closureReasonCode: string | undefined;
+      if (formCode === 'ANC_CLOSURE_VISIT') {
+        const reason = dto.formData.closure_reason;
+        if (typeof reason === 'string') closureReasonCode = reason;
+      }
+
+      let hasStillbirth: boolean | undefined;
+      if (formCode === 'DELIVERY_VISIT') {
+        hasStillbirth = hasStillbirthOutcome([
+          dto.formData.child1_delivery_outcome,
+          dto.formData.child2_delivery_outcome,
+          dto.formData.child3_delivery_outcome,
+        ]);
+      }
+
+      return await resolveStageEducationContent(
+        {
+          formCode,
+          gestationalWeeks,
+          ageInMonths,
+          isFirstVisitOfFormCode,
+          closureReasonCode,
+          hasStillbirthOutcome: hasStillbirth,
+        },
+        authorizationHeader,
+      );
+    } catch (err) {
+      console.error(
+        `Stage-based health-education content resolution failed for submission ` +
+          `${dto.localSubmissionUuid} (formCode ${formCode}) — degrading to no content:`,
+        err,
+      );
+      return [];
+    }
   }
 
   private async resolveDeliveryChildren(

--- a/apps/visit-form-service/src/forms/form.service.ts
+++ b/apps/visit-form-service/src/forms/form.service.ts
@@ -307,11 +307,15 @@ export class FormService {
       // write, so there's no double-creation risk to guard against (unlike
       // resolveDeliveryChildren/resolveClosureRequest above); recomputing it
       // just keeps a retried request's response shape consistent with the
-      // original.
+      // original. Passes existing.createdAt (the ORIGINAL row's insert
+      // time), not "now", so isFirstVisitOfFormCode-gated content (e.g.
+      // Primigravida) reflects the truth at original-submission time even
+      // when this replay lands long after later submissions have arrived.
       const stageEducationContent = await this.resolveStageEducationContentForSubmission(
         formCode,
         dto,
         existing.submittedAt,
+        existing.createdAt,
         authorizationHeader,
       );
       return toApiFormSubmission(existing, childBeneficiaryIds, stageEducationContent);
@@ -390,7 +394,22 @@ export class FormService {
         const existingRow = await this.repository.findSubmissionByLocalUuid(
           dto.localSubmissionUuid,
         );
-        if (existingRow) return toApiFormSubmission(existingRow);
+        if (existingRow) {
+          // Resolved here too, same as the sequential idempotent-replay
+          // path above — without this, the race LOSER's response silently
+          // dropped the stageEducationContent key entirely (not even an
+          // empty array), an inconsistent response shape for what should
+          // be an idempotent replay of the same logical submission (review
+          // finding on PR #222).
+          const stageEducationContent = await this.resolveStageEducationContentForSubmission(
+            formCode,
+            dto,
+            existingRow.submittedAt,
+            existingRow.createdAt,
+            authorizationHeader,
+          );
+          return toApiFormSubmission(existingRow, undefined, stageEducationContent);
+        }
         throw err;
       }
       // Backstop for the race the visitId check above can't close on its
@@ -491,66 +510,96 @@ export class FormService {
       }
     }
 
-    // Triggers the risk-grading pipeline for every visit-linked submission
-    // whose form has a risk_rule_set_id configured (see FormDefinition's
-    // schema comment) — a form with no ruleSetId set (e.g. SUPERVISOR/SYSTEM
-    // entityType forms) simply has nothing to evaluate. Best-effort, same
-    // stance as syncSocioDemographics above.
-    if (dto.visitId && version.formDefinition.riskRuleSetId) {
-      const riskPhase = FORM_CODE_TO_RISK_PHASE[formCode];
-      if (!riskPhase) {
-        // A form was given a riskRuleSetId out-of-band (no admin endpoint
-        // yet — see schema.prisma) without a matching FORM_CODE_TO_RISK_PHASE
-        // entry. Failing loudly here, instead of silently posting an invalid
-        // riskPhase that risk-referral-service's strict enum would reject
-        // downstream, surfaces the config gap immediately at submission time
-        // rather than as a permanently-broken, easy-to-miss best-effort
-        // console.warn (see PR #172 review).
-        throw new Error(
-          `Form "${formCode}" has a riskRuleSetId configured but no FORM_CODE_TO_RISK_PHASE ` +
-            'entry — add one before assigning this form a rule set.',
-        );
-      }
-      const answers =
-        formCode === 'ANC_VISIT'
-          ? {
-              ...dto.formData,
-              ...(await this.resolveAncRiskRegistrationAnswers(dto.beneficiaryId)),
-              // Fundal Height's GA-deviation calculation (anc-risk.rulesJson.ts)
-              // needs this visit's own date, per SRS Category 4's
-              // Floor((visit date - LMP) / 7) formula — the server-assigned
-              // submittedAt, not a client-suppliable field, so a caller can't
-              // skew its own GA calculation.
-              visitDate: created.submittedAt.toISOString(),
-            }
-          : dto.formData;
-      await triggerRiskAssessment(
-        {
-          beneficiaryId: dto.beneficiaryId,
-          visitId: dto.visitId,
-          submissionId: created.id,
-          ruleSetId: version.formDefinition.riskRuleSetId,
-          riskPhase,
-          answers,
-          // Date-only slice of the server-assigned submittedAt — needed by
-          // risk-referral-service to trigger automatic HR-visit generation
-          // (SRS FR-S-5.2(b)) when this evaluation detects an HR condition.
-          actualCompletionDate: created.submittedAt.toISOString().slice(0, 10),
-        },
-        authorizationHeader,
-      );
-    }
+    // Registration-derived answers (lmpDate, age, gravida, etc.) are needed
+    // by both the risk-trigger block below (ANC_VISIT's answers merge) and
+    // resolveStageEducationContentForSubmission (ANC_VISIT's gestational-
+    // week gate) — resolved once here and threaded into both, rather than
+    // each doing its own identical MOTHER_REGISTRATION lookup (review
+    // finding on PR #222: this was a duplicate DB read on the submission
+    // hot path). Resolved unconditionally (not just for ANC_VISIT) since
+    // it's cheap for a non-ANC formCode — resolveAncRiskRegistrationAnswers
+    // returns {} immediately for a beneficiary with no MOTHER_REGISTRATION
+    // submission, and both call sites below already gate their own use of
+    // it on formCode === 'ANC_VISIT'.
+    const registrationAnswers =
+      formCode === 'ANC_VISIT'
+        ? await this.resolveAncRiskRegistrationAnswers(dto.beneficiaryId)
+        : {};
 
-    // SRS's 16 stage-based health-education conditions (Danger Signs,
-    // Neonatal Care, POSTPARTUM Counselling, etc.) — unlike risk grading
-    // above, not gated on visitId/riskRuleSetId; resolveStageEducationContentForSubmission
-    // itself no-ops (returns []) for a formCode with no applicable stages.
-    const stageEducationContent = await this.resolveStageEducationContentForSubmission(
-      formCode,
-      dto,
-      created.submittedAt,
-      authorizationHeader,
-    );
+    // Risk grading (triggerRiskAssessment) and stage-based health-education
+    // content (resolveStageEducationContentForSubmission) are independent —
+    // neither reads the other's result — so they run concurrently rather
+    // than sequentially (review finding on PR #222: awaiting them one after
+    // another summed their DB+HTTP latency into the Sakhi-facing submission
+    // response instead of taking the max of the two).
+    const [, stageEducationContent] = await Promise.all([
+      (async () => {
+        // Triggers the risk-grading pipeline for every visit-linked
+        // submission whose form has a risk_rule_set_id configured (see
+        // FormDefinition's schema comment) — a form with no ruleSetId set
+        // (e.g. SUPERVISOR/SYSTEM entityType forms) simply has nothing to
+        // evaluate. Best-effort, same stance as syncSocioDemographics above.
+        if (!dto.visitId || !version.formDefinition.riskRuleSetId) return;
+
+        const riskPhase = FORM_CODE_TO_RISK_PHASE[formCode];
+        if (!riskPhase) {
+          // A form was given a riskRuleSetId out-of-band (no admin endpoint
+          // yet — see schema.prisma) without a matching
+          // FORM_CODE_TO_RISK_PHASE entry. Failing loudly here, instead of
+          // silently posting an invalid riskPhase that risk-referral-
+          // service's strict enum would reject downstream, surfaces the
+          // config gap immediately at submission time rather than as a
+          // permanently-broken, easy-to-miss best-effort console.warn (see
+          // PR #172 review).
+          throw new Error(
+            `Form "${formCode}" has a riskRuleSetId configured but no FORM_CODE_TO_RISK_PHASE ` +
+              'entry — add one before assigning this form a rule set.',
+          );
+        }
+        const answers =
+          formCode === 'ANC_VISIT'
+            ? {
+                ...dto.formData,
+                ...registrationAnswers,
+                // Fundal Height's GA-deviation calculation
+                // (anc-risk.rulesJson.ts) needs this visit's own date, per
+                // SRS Category 4's Floor((visit date - LMP) / 7) formula —
+                // the server-assigned submittedAt, not a client-suppliable
+                // field, so a caller can't skew its own GA calculation.
+                visitDate: created.submittedAt.toISOString(),
+              }
+            : dto.formData;
+        await triggerRiskAssessment(
+          {
+            beneficiaryId: dto.beneficiaryId,
+            visitId: dto.visitId,
+            submissionId: created.id,
+            ruleSetId: version.formDefinition.riskRuleSetId,
+            riskPhase,
+            answers,
+            // Date-only slice of the server-assigned submittedAt — needed
+            // by risk-referral-service to trigger automatic HR-visit
+            // generation (SRS FR-S-5.2(b)) when this evaluation detects an
+            // HR condition.
+            actualCompletionDate: created.submittedAt.toISOString().slice(0, 10),
+          },
+          authorizationHeader,
+        );
+      })(),
+      // SRS's 16 stage-based health-education conditions (Danger Signs,
+      // Neonatal Care, POSTPARTUM Counselling, etc.) — unlike risk grading
+      // above, not gated on visitId/riskRuleSetId;
+      // resolveStageEducationContentForSubmission itself no-ops (returns
+      // []) for a formCode with no applicable stages.
+      this.resolveStageEducationContentForSubmission(
+        formCode,
+        dto,
+        created.submittedAt,
+        created.createdAt,
+        authorizationHeader,
+        registrationAnswers,
+      ),
+    ]);
 
     return toApiFormSubmission(created, childBeneficiaryIds, stageEducationContent);
   }
@@ -666,7 +715,23 @@ export class FormService {
     formCode: string,
     dto: CreateSubmissionInput,
     submittedAt: Date,
+    // The submission ROW's own createdAt (not submittedAt, which is a
+    // client-suppliable/derived semantic date and not safe to use as a
+    // count cutoff) — the fresh-submission path passes the just-inserted
+    // row's own createdAt; the idempotent-replay path passes the ORIGINAL
+    // row's createdAt (not "now"), so isFirstVisitOfFormCode reflects the
+    // truth at original-submission time even when replayed long after
+    // later submissions have landed (review finding on PR #222).
+    createdAt: Date,
     authorizationHeader: string,
+    // Optional pre-resolved registration answers — the fresh-submission
+    // call site already resolves these once for the risk-trigger block and
+    // passes them through here too, avoiding a second identical
+    // MOTHER_REGISTRATION lookup (review finding on PR #222: this was a
+    // duplicate DB read on the submission hot path). The idempotent-replay
+    // call site has no risk-trigger block to share this with, so it's
+    // omitted there and resolved fresh inside this method instead.
+    preResolvedRegistrationAnswers?: Record<string, unknown>,
   ): Promise<StageEducationContent[]> {
     try {
       const visitDateIso = submittedAt.toISOString();
@@ -675,15 +740,21 @@ export class FormService {
       let isFirstVisitOfFormCode: boolean | undefined;
       if (formCode === 'ANC_VISIT') {
         const [registration, submissionCount] = await Promise.all([
-          this.resolveAncRiskRegistrationAnswers(dto.beneficiaryId),
-          this.repository.countSubmissionsByBeneficiaryAndFormCode(dto.beneficiaryId, 'ANC_VISIT'),
+          preResolvedRegistrationAnswers
+            ? Promise.resolve(preResolvedRegistrationAnswers)
+            : this.resolveAncRiskRegistrationAnswers(dto.beneficiaryId),
+          this.repository.countSubmissionsByBeneficiaryAndFormCode(
+            dto.beneficiaryId,
+            'ANC_VISIT',
+            createdAt,
+          ),
         ]);
         const lmpDate = registration.lmpDate;
         if (typeof lmpDate === 'string') {
           gestationalWeeks = gestationalWeeksAt(lmpDate, visitDateIso);
         }
-        // Called after this submission's own insert, so a count of exactly
-        // 1 means this IS the first ANC_VISIT — see
+        // A count of exactly 1, as of this submission's own createdAt,
+        // means this WAS the first ANC_VISIT at that point in time — see
         // countSubmissionsByBeneficiaryAndFormCode's own doc comment.
         isFirstVisitOfFormCode = submissionCount === 1;
       }
@@ -698,8 +769,20 @@ export class FormService {
 
       let closureReasonCode: string | undefined;
       if (formCode === 'ANC_CLOSURE_VISIT') {
+        // Gated on continue_with_closure, matching resolveClosureRequest's
+        // own established pattern for this exact field (see that method's
+        // doc comment) — validateSubmission/isVisible don't strip values
+        // submitted for a now-hidden field, so a Sakhi who selected
+        // continue_with_closure='yes' + closure_reason='miscarriage', then
+        // reconsidered and set continue_with_closure='no' before
+        // submitting (a common hidden-field-state UX gap on the mobile
+        // client), would otherwise still get Post-loss content fired here
+        // even though no closure was actually created — misleading content
+        // in the submission response (review finding on PR #222).
         const reason = dto.formData.closure_reason;
-        if (typeof reason === 'string') closureReasonCode = reason;
+        if (dto.formData.continue_with_closure === 'yes' && typeof reason === 'string') {
+          closureReasonCode = reason;
+        }
       }
 
       let hasStillbirth: boolean | undefined;

--- a/apps/visit-form-service/src/forms/healthEducation.client.ts
+++ b/apps/visit-form-service/src/forms/healthEducation.client.ts
@@ -1,0 +1,53 @@
+// Read directly (not via appConfig) — matches geography.client.ts's stance.
+const GATEWAY_BASE_URL = process.env.AUTH_SERVICE_BASE_URL ?? 'http://localhost:3000';
+
+const REQUEST_TIMEOUT_MS = 3000;
+
+export interface HealthEducationMessage {
+  id: string;
+  riskConditionId: string | null;
+  conditionLabel: string;
+  stage: string;
+  messageOrder: number;
+  titleEn: string | null;
+  bodyEn: string;
+  bodyMarathi: string;
+  mediaType: string;
+  mediaFile: string | null;
+  sortOrder: number;
+}
+
+/**
+ * Resolves every seeded health-education message whose `stage` matches
+ * cms-content-service's own free-text `stage` column verbatim, via
+ * `GET /health-education/messages?stage=...` (through the gateway) — used by
+ * healthEducationStage.resolver.ts for the SRS's stage-based (not
+ * risk-graded) health-education conditions (Danger Signs, Neonatal Care,
+ * POSTPARTUM Counselling, etc. — see that resolver's own doc comment for
+ * why these are a separate mechanism from risk-referral-service's
+ * risk-flag-triggered content).
+ *
+ * Deliberately swallows every failure and returns an empty array rather
+ * than throwing — this is reference content, not critical data, so a form
+ * submission must never fail because cms-content-service is unreachable.
+ */
+export async function resolveHealthEducationMessagesByStage(
+  stage: string,
+  authorizationHeader: string,
+): Promise<HealthEducationMessage[]> {
+  try {
+    const res = await fetch(
+      `${GATEWAY_BASE_URL}/api/v1/health-education/messages?stage=${encodeURIComponent(stage)}`,
+      {
+        headers: { Authorization: authorizationHeader },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    if (!res.ok) return [];
+
+    const body = (await res.json()) as { data: HealthEducationMessage[] };
+    return body.data;
+  } catch {
+    return [];
+  }
+}

--- a/apps/visit-form-service/src/forms/healthEducationStage.resolver.spec.ts
+++ b/apps/visit-form-service/src/forms/healthEducationStage.resolver.spec.ts
@@ -1,0 +1,457 @@
+import {
+  ageInMonthsAt,
+  gestationalWeeksAt,
+  hasStillbirthOutcome,
+  resolveStageEducationContent,
+} from './healthEducationStage.resolver';
+import { resolveHealthEducationMessagesByStage } from './healthEducation.client';
+
+jest.mock('./healthEducation.client');
+
+const resolveHealthEducationMessagesByStageMock = jest.mocked(
+  resolveHealthEducationMessagesByStage,
+);
+
+const AUTH_HEADER = 'Bearer test-token';
+
+function message(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'msg-1',
+    riskConditionId: null,
+    conditionLabel: 'Danger Signs during Pregnancy',
+    stage: 'Show this for all the ANC visits',
+    messageOrder: 1,
+    titleEn: 'Danger Signs',
+    bodyEn: 'Some symptoms...',
+    bodyMarathi: '',
+    mediaType: 'TEXT',
+    mediaFile: null,
+    sortOrder: 1,
+    ...overrides,
+  };
+}
+
+describe('gestationalWeeksAt', () => {
+  it('computes whole weeks pregnant, floored', () => {
+    // 70 days = exactly 10 weeks
+    expect(gestationalWeeksAt('2026-01-01', '2026-03-12')).toBe(10);
+  });
+
+  it('floors a partial week down', () => {
+    // 76 days = 10 weeks 6 days -> floors to 10
+    expect(gestationalWeeksAt('2026-01-01', '2026-03-18')).toBe(10);
+  });
+
+  it('returns undefined when visitDate precedes lmpDate', () => {
+    expect(gestationalWeeksAt('2026-03-01', '2026-01-01')).toBeUndefined();
+  });
+
+  it('returns undefined for an unparseable date', () => {
+    expect(gestationalWeeksAt('not-a-date', '2026-03-01')).toBeUndefined();
+    expect(gestationalWeeksAt('2026-01-01', 'not-a-date')).toBeUndefined();
+  });
+
+  it('returns 0 on the LMP date itself', () => {
+    expect(gestationalWeeksAt('2026-01-01', '2026-01-01')).toBe(0);
+  });
+});
+
+describe('ageInMonthsAt', () => {
+  it('computes whole months of age', () => {
+    expect(ageInMonthsAt('2026-01-15', '2026-07-15')).toBe(6);
+  });
+
+  it('rounds down when the day-of-month has not yet been reached', () => {
+    expect(ageInMonthsAt('2026-01-15', '2026-07-10')).toBe(5);
+  });
+
+  it('returns undefined when visitDate precedes birthDate', () => {
+    expect(ageInMonthsAt('2026-07-01', '2026-01-01')).toBeUndefined();
+  });
+
+  it('returns undefined for an unparseable date', () => {
+    expect(ageInMonthsAt('not-a-date', '2026-07-01')).toBeUndefined();
+  });
+
+  it('returns 0 on the birth date itself', () => {
+    expect(ageInMonthsAt('2026-01-01', '2026-01-01')).toBe(0);
+  });
+});
+
+describe('hasStillbirthOutcome', () => {
+  it('returns true when any outcome is a stillbirth value', () => {
+    expect(hasStillbirthOutcome(['live_birth', 'antepartum_still_birth_fresh'])).toBe(true);
+    expect(hasStillbirthOutcome(['intrapartum_still_birth_macerated'])).toBe(true);
+  });
+
+  it('returns false when every outcome is live_birth', () => {
+    expect(hasStillbirthOutcome(['live_birth', 'live_birth'])).toBe(false);
+  });
+
+  it('ignores non-string / undefined slots (empty child2/child3 outcome)', () => {
+    expect(hasStillbirthOutcome(['live_birth', undefined, null])).toBe(false);
+  });
+
+  it('returns false for an empty list', () => {
+    expect(hasStillbirthOutcome([])).toBe(false);
+  });
+});
+
+describe('resolveStageEducationContent', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('ANC unconditional content (Danger Signs)', () => {
+    it('is always included regardless of gestational week', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'Show this for all the ANC visits' ? [message()] : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_VISIT', gestationalWeeks: 12 },
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual([
+        {
+          topicCode: 'Danger Signs during Pregnancy',
+          topicName: 'Danger Signs',
+          mediaType: 'TEXT',
+          contentUrl: null,
+        },
+      ]);
+    });
+
+    it('is included even when gestationalWeeks is undefined (LMP unknown)', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'Show this for all the ANC visits' ? [message()] : [],
+      );
+
+      const result = await resolveStageEducationContent({ formCode: 'ANC_VISIT' }, AUTH_HEADER);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('ANC gestational-week-gated content', () => {
+    it('includes Primigravida on the first ANC visit within its GA window', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === '1st/2nd trimester (4th month)'
+          ? [message({ conditionLabel: 'Primigravida' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_VISIT', gestationalWeeks: 16, isFirstVisitOfFormCode: true },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toContain('Primigravida');
+    });
+
+    it('excludes Primigravida on a later ANC visit even within the same GA window', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === '1st/2nd trimester (4th month)'
+          ? [message({ conditionLabel: 'Primigravida' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_VISIT', gestationalWeeks: 16, isFirstVisitOfFormCode: false },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).not.toContain('Primigravida');
+    });
+
+    it('excludes Primigravida outside its GA window even on the first visit', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === '1st/2nd trimester (4th month)'
+          ? [message({ conditionLabel: 'Primigravida' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_VISIT', gestationalWeeks: 30, isFirstVisitOfFormCode: true },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).not.toContain('Primigravida');
+    });
+
+    it('includes Dehydration for any 2nd/3rd trimester week', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'All visits of 2nd and 3rd trimester'
+          ? [message({ conditionLabel: 'Dehydration' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_VISIT', gestationalWeeks: 30 },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toContain('Dehydration');
+    });
+
+    it('excludes Dehydration in the 1st trimester', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'All visits of 2nd and 3rd trimester'
+          ? [message({ conditionLabel: 'Dehydration' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_VISIT', gestationalWeeks: 10 },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).not.toContain('Dehydration');
+    });
+
+    it('omits every GA-gated stage (but keeps unconditional ones) when gestationalWeeks is undefined', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) => [
+        message({ conditionLabel: stage }),
+      ]);
+
+      const result = await resolveStageEducationContent({ formCode: 'ANC_VISIT' }, AUTH_HEADER);
+
+      // Only the unconditional "Show this for all the ANC visits" stage fires.
+      expect(result).toHaveLength(1);
+      expect(resolveHealthEducationMessagesByStageMock).toHaveBeenCalledWith(
+        'Show this for all the ANC visits',
+        AUTH_HEADER,
+      );
+    });
+  });
+
+  describe('PP-phase content', () => {
+    it('returns both POSTPARTUM Counselling messages, unconditionally', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'All PP visits'
+          ? [
+              message({ conditionLabel: 'POSTPARTUM Counselling', messageOrder: 1, sortOrder: 1 }),
+              message({
+                conditionLabel: 'POSTPARTUM Counselling',
+                messageOrder: 2,
+                sortOrder: 1,
+                id: 'msg-2',
+              }),
+            ]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'POSTPARTUM_VISIT' },
+        AUTH_HEADER,
+      );
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('NN-phase content', () => {
+    it('returns Neonatal Care content', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'NN1 and NN2' ? [message({ conditionLabel: 'Neonatal Care' })] : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'NEONATAL_VISIT' },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toEqual(['Neonatal Care']);
+    });
+  });
+
+  describe('INC-phase content', () => {
+    it('always includes Danger Signs, Immunization, and Malnutrition regardless of age', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) => {
+        if (stage === 'All INC visit') {
+          return [
+            message({ conditionLabel: 'Infant Care: Danger Signs', messageOrder: 1 }),
+            message({
+              conditionLabel: 'Infant Care: Immunization',
+              messageOrder: 2,
+              mediaType: 'VIDEO',
+            }),
+          ];
+        }
+        if (stage === 'All INC visits') {
+          return [message({ conditionLabel: 'Malnutrition in Infants', messageOrder: 4 })];
+        }
+        return [];
+      });
+
+      const result = await resolveStageEducationContent({ formCode: 'INC_VISIT' }, AUTH_HEADER);
+
+      const codes = result.map((c) => c.topicCode);
+      expect(codes).toEqual(
+        expect.arrayContaining([
+          'Infant Care: Danger Signs',
+          'Infant Care: Immunization',
+          'Malnutrition in Infants',
+        ]),
+      );
+      expect(codes).not.toContain('Infant Care: Complementary Feeding');
+    });
+
+    it('includes Complementary Feeding when age is within the 6-10 month window', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'All INC visits between 6th and 10th month'
+          ? [message({ conditionLabel: 'Infant Care: Complementary Feeding', messageOrder: 3 })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'INC_VISIT', ageInMonths: 7 },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toContain('Infant Care: Complementary Feeding');
+    });
+
+    it('excludes Complementary Feeding when age is below 6 months', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'All INC visits between 6th and 10th month'
+          ? [message({ conditionLabel: 'Infant Care: Complementary Feeding' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'INC_VISIT', ageInMonths: 3 },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).not.toContain('Infant Care: Complementary Feeding');
+    });
+
+    it('excludes Complementary Feeding when ageInMonths is undefined, but keeps unconditional INC content', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) => {
+        if (stage === 'All INC visit')
+          return [message({ conditionLabel: 'Infant Care: Danger Signs' })];
+        return [];
+      });
+
+      const result = await resolveStageEducationContent({ formCode: 'INC_VISIT' }, AUTH_HEADER);
+
+      expect(result.map((c) => c.topicCode)).toEqual(['Infant Care: Danger Signs']);
+    });
+  });
+
+  describe('closure/delivery-outcome-gated Post-loss content', () => {
+    const POST_LOSS_STAGE =
+      "If the delivery outcome is 'Still birth' or 'Miscarriage' and 'Abortion' in Closure form";
+
+    it('includes Post-loss content when closureReasonCode is miscarriage', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === POST_LOSS_STAGE
+          ? [message({ conditionLabel: 'Post miscarriage/abortion/still birth' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_CLOSURE_VISIT', closureReasonCode: 'miscarriage' },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toContain('Post miscarriage/abortion/still birth');
+    });
+
+    it('includes Post-loss content when closureReasonCode is abortion_spontaneous_induced_mtp', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === POST_LOSS_STAGE
+          ? [message({ conditionLabel: 'Post miscarriage/abortion/still birth' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_CLOSURE_VISIT', closureReasonCode: 'abortion_spontaneous_induced_mtp' },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toContain('Post miscarriage/abortion/still birth');
+    });
+
+    it('excludes Post-loss content for a non-loss closure reason', async () => {
+      resolveHealthEducationMessagesByStageMock.mockResolvedValue([
+        message({ conditionLabel: 'Post miscarriage/abortion/still birth' }),
+      ]);
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'ANC_CLOSURE_VISIT', closureReasonCode: 'migration' },
+        AUTH_HEADER,
+      );
+
+      expect(result).toHaveLength(0);
+      expect(resolveHealthEducationMessagesByStageMock).not.toHaveBeenCalled();
+    });
+
+    it('includes Post-loss content on DELIVERY_VISIT when hasStillbirthOutcome is true', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === POST_LOSS_STAGE
+          ? [message({ conditionLabel: 'Post miscarriage/abortion/still birth' })]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'DELIVERY_VISIT', hasStillbirthOutcome: true },
+        AUTH_HEADER,
+      );
+
+      expect(result.map((c) => c.topicCode)).toContain('Post miscarriage/abortion/still birth');
+    });
+
+    it('excludes Post-loss content on DELIVERY_VISIT with all live births', async () => {
+      resolveHealthEducationMessagesByStageMock.mockResolvedValue([
+        message({ conditionLabel: 'Post miscarriage/abortion/still birth' }),
+      ]);
+
+      const result = await resolveStageEducationContent(
+        { formCode: 'DELIVERY_VISIT', hasStillbirthOutcome: false },
+        AUTH_HEADER,
+      );
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('unmapped / no-content cases', () => {
+    it('returns an empty array for a formCode with no stage-based content at all (e.g. MOTHER_REGISTRATION)', async () => {
+      const result = await resolveStageEducationContent(
+        { formCode: 'MOTHER_REGISTRATION' },
+        AUTH_HEADER,
+      );
+
+      expect(result).toEqual([]);
+      expect(resolveHealthEducationMessagesByStageMock).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty array (not an error) when the client resolves nothing for an applicable stage', async () => {
+      resolveHealthEducationMessagesByStageMock.mockResolvedValue([]);
+
+      const result = await resolveStageEducationContent({ formCode: 'ANC_VISIT' }, AUTH_HEADER);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('ordering', () => {
+    it('sorts resolved content by sortOrder then messageOrder', async () => {
+      resolveHealthEducationMessagesByStageMock.mockImplementation(async (stage) =>
+        stage === 'Show this for all the ANC visits'
+          ? [
+              message({ id: 'm-2', sortOrder: 2, messageOrder: 1, titleEn: 'Second' }),
+              message({ id: 'm-1', sortOrder: 1, messageOrder: 2, titleEn: 'First' }),
+            ]
+          : [],
+      );
+
+      const result = await resolveStageEducationContent({ formCode: 'ANC_VISIT' }, AUTH_HEADER);
+
+      expect(result.map((c) => c.topicName)).toEqual(['First', 'Second']);
+    });
+  });
+});

--- a/apps/visit-form-service/src/forms/healthEducationStage.resolver.ts
+++ b/apps/visit-form-service/src/forms/healthEducationStage.resolver.ts
@@ -1,0 +1,262 @@
+import { diffInDays } from '@armman/core';
+import { resolveHealthEducationMessagesByStage } from './healthEducation.client';
+
+/**
+ * Weeks pregnant at `visitDate`, per SRS Category 4's own
+ * Floor((visitDate - lmpDate) / 7) formula — same calculation
+ * anc-risk.rulesJson.ts's Fundal Height GA-deviation check already uses
+ * server-side, duplicated here (not imported — that formula lives in
+ * rules-service, a separate deployable) rather than left unimplemented.
+ * Returns undefined when the date strings are unparseable or visitDate
+ * precedes lmpDate (same guard rules-service's own version applies) — GA-
+ * gated content is then simply omitted, never a hard error.
+ */
+export function gestationalWeeksAt(lmpDate: string, visitDate: string): number | undefined {
+  const lmp = new Date(lmpDate);
+  const visit = new Date(visitDate);
+  if (Number.isNaN(lmp.getTime()) || Number.isNaN(visit.getTime())) return undefined;
+  const days = diffInDays(lmp, visit);
+  if (days < 0) return undefined;
+  return Math.floor(days / 7);
+}
+
+/**
+ * Whole months between `birthDate` and `visitDate` — used for INC's
+ * age-in-months gating (Infant Care: Complementary Feeding, 6th-10th
+ * month). Calendar-month arithmetic (not day/30), same convention as
+ * `age_of_the_beneficiary`-style fields elsewhere in this codebase that
+ * report age in whole years/months rather than an approximation.
+ */
+export function ageInMonthsAt(birthDate: string, visitDate: string): number | undefined {
+  const birth = new Date(birthDate);
+  const visit = new Date(visitDate);
+  if (Number.isNaN(birth.getTime()) || Number.isNaN(visit.getTime())) return undefined;
+  if (visit < birth) return undefined;
+  let months =
+    (visit.getUTCFullYear() - birth.getUTCFullYear()) * 12 +
+    (visit.getUTCMonth() - birth.getUTCMonth());
+  if (visit.getUTCDate() < birth.getUTCDate()) months -= 1;
+  return Math.max(0, months);
+}
+
+export interface StageEducationContent {
+  topicCode: string;
+  topicName: string;
+  mediaType: string;
+  contentUrl: string | null;
+}
+
+/**
+ * The 16 SRS-specified health-education conditions
+ * (docs/Revised_App_Form_Final_20.3.26.xlsx.md, "Health education message"
+ * table) that are stage-based rather than risk-graded: they display
+ * unconditionally (or gated by trimester/visit-sequence/delivery-outcome)
+ * on the relevant visit type, not because a RiskFlag.isEducationTrigger
+ * fired. This is a genuinely different mechanism from
+ * risk-referral-service's beneficiaryRisk.service.ts's
+ * CONDITION_CODE_TO_LABEL map (the 5 "as soon as detected" risk-graded
+ * conditions) — see that file's own doc comment for why those don't belong
+ * here. `stage` values below are matched verbatim against cms-content-
+ * service's seeded HealthEducationMessage.stage column (health-education-
+ * messages.json) — changing either side without the other silently breaks
+ * this mapping (no referential integrity across services, per the
+ * forklift rule).
+ */
+const UNCONDITIONAL_STAGES_BY_FORM: Partial<Record<string, readonly string[]>> = {
+  // Shown on every ANC visit regardless of gestational age.
+  ANC_VISIT: ['Show this for all the ANC visits'],
+  // Shown on every PP visit (PP1 through PP5), both POSTPARTUM Counselling
+  // messages together — no PP-sequence differentiation in the seed data.
+  POSTPARTUM_VISIT: ['All PP visits'],
+  // Shown on both NN1 and NN2 — one seeded stage string covers both.
+  NEONATAL_VISIT: ['NN1 and NN2'],
+  // Shown on every INC visit — Danger Signs, Immunization, and Malnutrition
+  // in Infants are all unconditional across the INC series; Complementary
+  // Feeding is additionally age-gated (see AGE_GATED_STAGES below).
+  INC_VISIT: ['All INC visit', 'All INC visits'],
+};
+
+/**
+ * Gestational-week-gated (ANC) and infant-age-in-months-gated (INC) content.
+ * Each entry's `stage` is matched verbatim against the seed data; `minWeek`/
+ * `maxWeek` (ANC, inclusive) or `minMonth`/`maxMonth` (INC, inclusive) bound
+ * when it applies. Week/month boundaries are this resolver's own judgment
+ * call, converting the SRS table's mixed month/trimester phrasing into a
+ * single comparable unit — same kind of call risk-referral-service's
+ * commit d73eb52a already made for the 5 risk-graded conditions, documented
+ * here per condition since the SRS source doesn't give exact week cutoffs.
+ */
+interface GaGatedStage {
+  formCode: string;
+  stage: string;
+  minWeek?: number;
+  maxWeek?: number;
+  minMonth?: number;
+  maxMonth?: number;
+  /** Only fire once, on the beneficiary's first-ever submission of this
+   * formCode — Primigravida is framed in the SRS as a one-time orientation
+   * message, not something to repeat every visit. */
+  firstVisitOnly?: boolean;
+}
+
+const GA_GATED_STAGES: readonly GaGatedStage[] = [
+  // Primigravida — 1st/2nd trimester (4th month), first ANC visit only.
+  {
+    formCode: 'ANC_VISIT',
+    stage: '1st/2nd trimester (4th month)',
+    minWeek: 13,
+    maxWeek: 20,
+    firstVisitOnly: true,
+  },
+  // Birth preparedness — 2nd trimester (6th-7th month).
+  {
+    formCode: 'ANC_VISIT',
+    stage: '2nd Trimester (6th month and 7th month)',
+    minWeek: 21,
+    maxWeek: 30,
+  },
+  // Substance Use During Pregnancy — 2nd trimester (4th-6th month).
+  {
+    formCode: 'ANC_VISIT',
+    stage: '2nd Trimester (4th month and 6th month)',
+    minWeek: 13,
+    maxWeek: 26,
+  },
+  // Micronutrient Supplementation — 2nd trimester (4th-5th month).
+  {
+    formCode: 'ANC_VISIT',
+    stage: '2nd Trimester (4th month and 5th month)',
+    minWeek: 13,
+    maxWeek: 22,
+  },
+  // Nutrition during Pregnancy — 2nd trimester (5th month).
+  { formCode: 'ANC_VISIT', stage: '2nd Trimester (5th month)', minWeek: 17, maxWeek: 22 },
+  // Family Planning and Spacing — 3rd trimester (8th month).
+  { formCode: 'ANC_VISIT', stage: '3rd Trimester (8th month)', minWeek: 31, maxWeek: 35 },
+  // Breastfeeding — 3rd trimester (8th-9th month).
+  {
+    formCode: 'ANC_VISIT',
+    stage: '3rd Trimester (8th month and 9th month)',
+    minWeek: 31,
+    maxWeek: 40,
+  },
+  // Dehydration — all visits of 2nd and 3rd trimester.
+  { formCode: 'ANC_VISIT', stage: 'All visits of 2nd and 3rd trimester', minWeek: 13, maxWeek: 40 },
+  // Infant Care: Complementary Feeding — INC visits between 6th and 10th month of age.
+  {
+    formCode: 'INC_VISIT',
+    stage: 'All INC visits between 6th and 10th month',
+    minMonth: 6,
+    maxMonth: 10,
+  },
+];
+
+/** Closure-reason codes (ANC_CLOSURE_VISIT's `closure_reason`) that indicate pregnancy loss. */
+const LOSS_CLOSURE_REASONS = new Set(['miscarriage', 'abortion_spontaneous_induced_mtp']);
+
+/** DELIVERY_VISIT childN_delivery_outcome values that indicate a stillbirth. */
+const STILLBIRTH_OUTCOMES = new Set([
+  'antepartum_still_birth_fresh',
+  'intrapartum_still_birth_macerated',
+]);
+
+const POST_LOSS_STAGE =
+  "If the delivery outcome is 'Still birth' or 'Miscarriage' and 'Abortion' in Closure form";
+
+function toEducationContent(m: {
+  titleEn: string | null;
+  conditionLabel: string;
+  mediaType: string;
+  mediaFile: string | null;
+}): StageEducationContent {
+  return {
+    topicCode: m.conditionLabel,
+    topicName: m.titleEn ?? m.conditionLabel,
+    mediaType: m.mediaType,
+    contentUrl: m.mediaFile,
+  };
+}
+
+async function resolveStages(
+  stages: readonly string[],
+  authorizationHeader: string,
+): Promise<StageEducationContent[]> {
+  const results = await Promise.all(
+    stages.map((stage) => resolveHealthEducationMessagesByStage(stage, authorizationHeader)),
+  );
+  return results
+    .flat()
+    .sort((a, b) => a.sortOrder - b.sortOrder || a.messageOrder - b.messageOrder)
+    .map(toEducationContent);
+}
+
+/**
+ * Resolves the SRS's 16 stage-based health-education conditions applicable
+ * to one form submission — independent of risk grading, per this feature's
+ * implementation plan (see the module doc comment above). Never throws:
+ * every input (GA weeks, age, closure reason) is treated as
+ * "gate doesn't apply" when absent or unparseable, matching this service's
+ * existing best-effort tolerance for non-critical post-submission content
+ * (e.g. triggerRiskAssessment's own stance).
+ */
+export async function resolveStageEducationContent(
+  input: {
+    formCode: string;
+    /** Weeks pregnant at this visit — Floor((visitDate - LMP) / 7), same
+     * formula as anc-risk.rulesJson.ts's Fundal Height GA-deviation calc.
+     * Undefined when LMP is unknown (no MOTHER_REGISTRATION submission, or
+     * lmp_date unanswered) — GA-gated ANC content is then simply omitted. */
+    gestationalWeeks?: number;
+    /** Infant's age in whole months at this visit (INC only). */
+    ageInMonths?: number;
+    /** True only for the beneficiary's first-ever submission of formCode
+     * (used for Primigravida's first-visit-only gate). */
+    isFirstVisitOfFormCode?: boolean;
+    /** ANC_CLOSURE_VISIT's own `closure_reason` answer, when present. */
+    closureReasonCode?: string;
+    /** True when this DELIVERY_VISIT submission recorded a stillbirth on
+     * any child slot (child1/2/3_delivery_outcome). */
+    hasStillbirthOutcome?: boolean;
+  },
+  authorizationHeader: string,
+): Promise<StageEducationContent[]> {
+  const stagesToResolve = new Set<string>();
+
+  for (const stage of UNCONDITIONAL_STAGES_BY_FORM[input.formCode] ?? []) {
+    stagesToResolve.add(stage);
+  }
+
+  for (const gated of GA_GATED_STAGES) {
+    if (gated.formCode !== input.formCode) continue;
+    if (gated.firstVisitOnly && !input.isFirstVisitOfFormCode) continue;
+
+    if (gated.minWeek !== undefined || gated.maxWeek !== undefined) {
+      if (input.gestationalWeeks === undefined) continue;
+      if (gated.minWeek !== undefined && input.gestationalWeeks < gated.minWeek) continue;
+      if (gated.maxWeek !== undefined && input.gestationalWeeks > gated.maxWeek) continue;
+    }
+
+    if (gated.minMonth !== undefined || gated.maxMonth !== undefined) {
+      if (input.ageInMonths === undefined) continue;
+      if (gated.minMonth !== undefined && input.ageInMonths < gated.minMonth) continue;
+      if (gated.maxMonth !== undefined && input.ageInMonths > gated.maxMonth) continue;
+    }
+
+    stagesToResolve.add(gated.stage);
+  }
+
+  const isLossOutcome =
+    (input.closureReasonCode !== undefined && LOSS_CLOSURE_REASONS.has(input.closureReasonCode)) ||
+    input.hasStillbirthOutcome === true;
+  if (isLossOutcome) stagesToResolve.add(POST_LOSS_STAGE);
+
+  if (stagesToResolve.size === 0) return [];
+  return resolveStages([...stagesToResolve], authorizationHeader);
+}
+
+/** True when any of the given delivery-outcome answers is a stillbirth. */
+export function hasStillbirthOutcome(deliveryOutcomes: readonly unknown[]): boolean {
+  return deliveryOutcomes.some(
+    (outcome) => typeof outcome === 'string' && STILLBIRTH_OUTCOMES.has(outcome),
+  );
+}

--- a/tools/prisma-seed-foreach.js
+++ b/tools/prisma-seed-foreach.js
@@ -1,9 +1,21 @@
 #!/usr/bin/env node
 /**
- * Runs `prisma/seed.ts` for every service that has one, using the root .env's
- * DATABASE_URL/DIRECT_URL (all services share the `public` schema — see
- * prisma-foreach.js). Each seed script is expected to be idempotent (skip
- * when its data already exists), so re-running this is always safe.
+ * Runs `prisma/seed.ts` for every service that has one.
+ *
+ * Each service owns its own Postgres schema on the shared database (see
+ * apps/<svc>/.env's DATABASE_URL `?schema=<name>` param), the same layout
+ * prisma-foreach.js targets for `migrate`/`db push`. This script previously
+ * ignored that per-service override and always seeded against the root
+ * .env's DATABASE_URL/DIRECT_URL as-is — every service whose schema wasn't
+ * whatever the root .env happened to point to failed with a P2021 "table
+ * does not exist" error (e.g. cms-content-service's health_education_messages,
+ * risk-referral-service's risk_conditions), even though the migration itself
+ * had already run correctly in that service's own schema. Fixed to resolve
+ * and apply each service's own schema override, mirroring
+ * prisma-foreach.js's withSchema() exactly.
+ *
+ * Each seed script is expected to be idempotent (skip when its data already
+ * exists), so re-running this is always safe.
  *
  * Usage:
  *   node tools/prisma-seed-foreach.js          # seed every service that has prisma/seed.ts
@@ -22,13 +34,17 @@ function readEnvVar(file, key) {
   return undefined;
 }
 
+/** Strip any existing ?schema=/&schema= and append schema=<name>. */
+function withSchema(url, schema) {
+  const cleaned = url.replace(/([?&])schema=[^&]*/g, '$1').replace(/[?&]$/, '');
+  const sep = cleaned.includes('?') ? '&' : '?';
+  return `${cleaned}${sep}schema=${schema}`;
+}
+
 const appsDir = join(__dirname, '..', 'apps');
 const rootEnv = join(__dirname, '..', '.env');
-const env = { ...process.env };
 const rootDatabaseUrl = readEnvVar(rootEnv, 'DATABASE_URL');
-const rootDirectUrl = readEnvVar(rootEnv, 'DIRECT_URL');
-if (rootDatabaseUrl) env.DATABASE_URL = rootDatabaseUrl;
-if (rootDirectUrl) env.DIRECT_URL = rootDirectUrl;
+const rootDirectUrl = readEnvVar(rootEnv, 'DIRECT_URL') || rootDatabaseUrl;
 
 const services = readdirSync(appsDir, { withFileTypes: true })
   .filter((d) => d.isDirectory())
@@ -43,7 +59,24 @@ if (services.length === 0) {
 console.log(`Seeding ${services.length} service(s): ${services.join(', ')}`);
 let failed = 0;
 for (const service of services) {
-  const seedFile = join(appsDir, service, 'prisma', 'seed.ts');
+  const dir = join(appsDir, service);
+  const seedFile = join(dir, 'prisma', 'seed.ts');
+  const env = { ...process.env };
+  if (rootDatabaseUrl) env.DATABASE_URL = rootDatabaseUrl;
+  if (rootDirectUrl) env.DIRECT_URL = rootDirectUrl;
+
+  // Per-service schema namespace, from apps/<svc>/.env then .env.example —
+  // same resolution order as prisma-foreach.js.
+  const svcUrl =
+    readEnvVar(join(dir, '.env'), 'DATABASE_URL') ||
+    readEnvVar(join(dir, '.env.example'), 'DATABASE_URL') ||
+    '';
+  const schema = (svcUrl.match(/schema=([^&]+)/) || [])[1];
+  if (schema && rootDatabaseUrl) {
+    env.DATABASE_URL = withSchema(rootDatabaseUrl, schema);
+    env.DIRECT_URL = withSchema(rootDirectUrl, schema);
+  }
+
   console.log(`\n— ${service} —`);
   try {
     execFileSync(


### PR DESCRIPTION
## Summary

Resolves #200's items 1 and 2 for the 5 risk-graded conditions. Per SRS FR-S-5.2(c)/FR-S-13, wires all 21 SRS-specified health-education conditions (`docs/Revised_App_Form_Final_20.3.26.xlsx.md`, "Health education message" table) to real ARMMAN content instead of the `COMING_SOON` placeholder — split into the SRS's two genuinely different mechanisms:

**Group A — risk-graded, "as soon as detected" (5 conditions):** Anemia, Gestational Hypertension, Gestational Diabetes, Inadequate Gestational Weight Gain, Previous Pregnancy Complication.
- Adds `RiskAssessment.riskPhase` (migration) so `GET /beneficiaries/:id/risk` can return the stage-appropriate message(s) for each condition — ANC-phase gets every non-postpartum message, PP-phase gets only the postpartum one (riskPhase alone can't distinguish finer ANC sub-stages without a GA-week calculation, which belongs to Group B).
- Corrects an earlier unmerged draft's condition-code map, which mistakenly used `DANGER_SIGNS`/`INFANT_DANGER_SIGNS` (Group B conditions) instead of the correct `BAD_OBSTETRIC_HISTORY`.
- `educationContent` is now an array (was a single nullable object) — **behavior change**, documented in the route's OpenAPI description.

**Group B — stage-based, not risk-graded (16 conditions):** Primigravida, Birth Preparedness, Danger Signs, Substance Use, Micronutrient Supplementation, Family Planning, Nutrition, Breastfeeding, Neonatal Care, Infant Care ×3, Malnutrition in Infants, POSTPARTUM Counselling, Post-loss, Dehydration.
- New `healthEducationStage.resolver.ts` gates each condition on gestational week, infant age in months, first-visit-only, or closure/delivery outcome (stillbirth on `DELIVERY_VISIT` or miscarriage/abortion on `ANC_CLOSURE_VISIT`) — resolved independently of any risk flag.
- New `stageEducationContent` field on `POST /forms/:formCode/submissions`'s response.

## Bugs found and fixed along the way (via live end-to-end testing)

1. **cms-content-service**: `healthEducation.controller.ts` never extracted `conditionLabel` from the query string — every `conditionLabel`-filtered call silently returned all 32 seeded messages instead of the 1-4 that matched. This blocked Group A entirely. Added controller-level tests (only service-level tests existed before, which couldn't catch this).
2. **tools/prisma-seed-foreach.js**: never applied each service's own `DATABASE_URL` schema override (unlike its sibling `prisma-foreach.js`), so `npm run seed` silently seeded against the wrong Postgres schema for every service with per-schema content. Fixed to mirror `prisma-foreach.js`'s `withSchema()` exactly.

## Out of scope (explicitly, not silently dropped)

- Risk grading is still not wired onto DELIVERY_VISIT/INFANT_VISIT/REFERRAL_VISIT — only DELIVERY_VISIT's specific stillbirth→Post-loss stage trigger is added here.
- Issue #200's items 3 (risk-vs-GA-based message precedence) and 4 (Marathi/media delivery mechanism) remain open — no rule/date exists yet to build against.

## Test plan

- [x] `npx nx run-many -t build test --projects=risk-referral-service,visit-form-service,cms-content-service` — all green (766 + 286 + 14 = 1066 tests)
- [x] `npm run migrate` — clean across all 15 services after this change
- [x] `npm run seed` — clean for every schema-affected service after the tooling fix
- [x] **Live-verified end-to-end** against the dev DB with a disposable SAKHI account and beneficiary (created/deleted via the real API, per repo convention): submitted a real `ANC_VISIT` with Hb=6.0 (SEVERE anemia) at 26 weeks gestational age — confirmed the risk-graded Anemia content (1 correct message) and all 4 applicable stage-based conditions (Birth Preparedness, Danger Signs, Substance Use, Dehydration) returned correctly, with 5 out-of-window conditions correctly excluded.

Closes #200 (partially — items 1/2 resolved, items 3/4 remain and are called out above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)